### PR TITLE
Extract shared parser utilities, eliminate ~280 lines of duplication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^5.4.19",
+        "vitest": "^4.1.6",
       },
     },
   },
@@ -243,6 +244,12 @@
 
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@emnapi/core": ["@emnapi/core@1.10.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@emnapi/core/-/core-1.10.0.tgz", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@emnapi/runtime/-/runtime-1.10.0.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.0", "", { "os": "android", "cpu": "arm" }, "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g=="],
@@ -341,15 +348,19 @@
 
     "@jridgewell/source-map": ["@jridgewell/source-map@0.3.11", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25" } }, "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA=="],
 
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.130.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@oxc-project/types/-/types-0.130.0.tgz", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -429,6 +440,36 @@
 
     "@remix-run/router": ["@remix-run/router@1.23.0", "", {}, "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
@@ -491,6 +532,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@standard-schema/spec/-/spec-1.1.0.tgz", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@supabase/auth-js": ["@supabase/auth-js@2.95.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg=="],
 
     "@supabase/functions-js": ["@supabase/functions-js@2.95.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig=="],
@@ -536,6 +579,12 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@tybys/wasm-util/-/wasm-util-0.10.2.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@types/chai/-/chai-5.2.3.tgz", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@types/deep-eql/-/deep-eql-4.0.2.tgz", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/dom-webcodecs": ["@types/dom-webcodecs@0.1.18", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz", {}, "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg=="],
 
@@ -589,6 +638,20 @@
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@3.11.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.27", "@swc/core": "^1.12.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7" } }, "sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/expect/-/expect-4.1.6.tgz", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/mocker/-/mocker-4.1.6.tgz", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/pretty-format/-/pretty-format-4.1.6.tgz", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/runner/-/runner-4.1.6.tgz", { "dependencies": { "@vitest/utils": "4.1.6", "pathe": "^2.0.3" } }, "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/snapshot/-/snapshot-4.1.6.tgz", { "dependencies": { "@vitest/pretty-format": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/spy/-/spy-4.1.6.tgz", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@vitest/utils/-/utils-4.1.6.tgz", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -612,6 +675,8 @@
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/assertion-error/-/assertion-error-2.0.1.tgz", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -654,6 +719,8 @@
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001765", "", {}, "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ=="],
+
+    "chai": ["chai@6.2.2", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/chai/-/chai-6.2.2.tgz", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -703,6 +770,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/detect-libc/-/detect-libc-2.1.2.tgz", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
@@ -724,6 +793,8 @@
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/es-module-lexer/-/es-module-lexer-2.1.0.tgz", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -755,9 +826,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "estree-walker": ["estree-walker@1.0.1", "", {}, "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="],
+    "estree-walker": ["estree-walker@3.0.3", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/estree-walker/-/estree-walker-3.0.3.tgz", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/expect-type/-/expect-type-1.3.0.tgz", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -967,6 +1040,30 @@
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss/-/lightningcss-1.32.0.tgz", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
@@ -993,7 +1090,7 @@
 
     "lucide-react": ["lucide-react@0.462.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g=="],
 
-    "magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
+    "magic-string": ["magic-string@0.30.21", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1043,6 +1140,8 @@
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
+    "obug": ["obug@2.1.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/obug/-/obug-2.1.1.tgz", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -1065,9 +1164,11 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "pathe": ["pathe@2.0.3", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/pathe/-/pathe-2.0.3.tgz", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
@@ -1145,6 +1246,8 @@
 
     "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
 
+    "rolldown": ["rolldown@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/rolldown/-/rolldown-1.0.1.tgz", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
+
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1183,6 +1286,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/siginfo/-/siginfo-2.0.0.tgz", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "smob": ["smob@1.5.0", "", {}, "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig=="],
@@ -1196,6 +1301,10 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
+
+    "stackback": ["stackback@0.0.2", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/stackback/-/stackback-0.0.2.tgz", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/std-env/-/std-env-4.1.0.tgz", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -1245,7 +1354,13 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "tinybench": ["tinybench@2.9.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/tinybench/-/tinybench-2.9.0.tgz", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.2", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/tinyexec/-/tinyexec-1.1.2.tgz", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/tinyrainbow/-/tinyrainbow-3.1.0.tgz", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1305,6 +1420,8 @@
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.2.0", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.4.0", "workbox-window": "^7.4.0" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "workbox-build": "^7.4.0", "workbox-window": "^7.4.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw=="],
 
+    "vitest": ["vitest@4.1.6", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/vitest/-/vitest-4.1.6.tgz", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
+
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
 
     "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
@@ -1318,6 +1435,8 @@
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/why-is-node-running/-/why-is-node-running-2.3.0.tgz", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1385,19 +1504,33 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
     "@rollup/plugin-babel/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
+    "@rollup/plugin-replace/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
 
     "@rollup/plugin-replace/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
 
     "@rollup/pluginutils/@types/estree": ["@types/estree@0.0.39", "", {}, "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@1.0.1", "", {}, "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="],
+
+    "@rollup/pluginutils/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
     "@rollup/pluginutils/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
+
+    "@surma/rollup-plugin-off-main-thread/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1405,15 +1538,19 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
@@ -1431,9 +1568,9 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vitest/vite": ["vite@8.0.13", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/vite/-/vite-8.0.13.tgz", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
@@ -1454,8 +1591,6 @@
     "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
-
-    "@rollup/plugin-node-resolve/@rollup/pluginutils/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -1511,6 +1646,12 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
+    "vitest/vite/picomatch": ["picomatch@4.0.4", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/picomatch/-/picomatch-4.0.4.tgz", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.15", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/postcss/-/postcss-8.5.15.tgz", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "vitest/vite/tinyglobby": ["tinyglobby@0.2.16", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/tinyglobby/-/tinyglobby-0.2.16.tgz", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "workbox-build/glob/jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
@@ -1522,6 +1663,8 @@
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vitest/vite/postcss/nanoid": ["nanoid@3.3.12", "https://europe-west1-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/nanoid/-/nanoid-3.3.12.tgz", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "workbox-build/glob/path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
   }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>HackTheTrack — Open Source Motorsport Datalog Viewer</title>
     <meta name="description" content="Free offline-first motorsport telemetry viewer. Analyze GPS lap data, sectors, braking zones and reference laps in your browser — no upload required.">
     <link rel="canonical" href="https://hackthetrack.net/" />
+    <meta name="google-site-verification" content="p17Cb_TDcliQFvYwnZqk24geEG4eaJxjitDeGe-P17M" />
 
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#1a1a2e" />

--- a/index.html
+++ b/index.html
@@ -3,26 +3,28 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>HackTheTrack</title>
-    <meta name="description" content="Simple open source datalog viewer">
-    
+    <title>HackTheTrack — Open Source Motorsport Datalog Viewer</title>
+    <meta name="description" content="Free offline-first motorsport telemetry viewer. Analyze GPS lap data, sectors, braking zones and reference laps in your browser — no upload required.">
+    <link rel="canonical" href="https://hackthetrack.net/" />
+
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#1a1a2e" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="HackTheTrack" />
-    
+
     <!-- Icons -->
     <link rel="icon" type="image/png" href="/favicon.png">
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
-    <meta property="og:title" content="HackTheTrack">
-  <meta name="twitter:title" content="HackTheTrack">
-  <meta property="og:description" content="Simple open source datalog viewer">
-  <meta name="twitter:description" content="Simple open source datalog viewer">
-  <meta property="og:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/4662e3cf-b3ae-4a6f-bc98-063c5777a60c?Expires=1771044008&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=QloYKQKOUWxjp2tiwGclt6daNQW9fmangqiVcW9S32QaVSTQtOA%2FBNGE63azEhblxZQi5yx9JToUQDAm9OijLFqz7n%2Bqae5mgjH24aY9Ozb1aW57YjAzp4KSlcH7j8c3eUuAd3s0PtNlM5fV1kA%2F1SUqErwbr5WObft%2FSNCH4OuA4VkwjMRCfoE8aZMvH9or9ILl8q7V0Bllzd7u29iPMSfOO2go72zbtpBJnh10UX3nnxM5wT3wc9%2B5Yb01qBSjqESIRiNy3Oe8mWBdiy6xgy2KvG4m%2FzgS%2BNr87Tv2vnS0apuE9SrnA06flu2ys6%2BPkEeojZVzis1lF4hwnZDt2w%3D%3D">
-  <meta name="twitter:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/4662e3cf-b3ae-4a6f-bc98-063c5777a60c?Expires=1771044008&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=QloYKQKOUWxjp2tiwGclt6daNQW9fmangqiVcW9S32QaVSTQtOA%2FBNGE63azEhblxZQi5yx9JToUQDAm9OijLFqz7n%2Bqae5mgjH24aY9Ozb1aW57YjAzp4KSlcH7j8c3eUuAd3s0PtNlM5fV1kA%2F1SUqErwbr5WObft%2FSNCH4OuA4VkwjMRCfoE8aZMvH9or9ILl8q7V0Bllzd7u29iPMSfOO2go72zbtpBJnh10UX3nnxM5wT3wc9%2B5Yb01qBSjqESIRiNy3Oe8mWBdiy6xgy2KvG4m%2FzgS%2BNr87Tv2vnS0apuE9SrnA06flu2ys6%2BPkEeojZVzis1lF4hwnZDt2w%3D%3D">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta property="og:type" content="website">
+    <meta property="og:title" content="HackTheTrack — Open Source Motorsport Datalog Viewer">
+    <meta name="twitter:title" content="HackTheTrack — Open Source Motorsport Datalog Viewer">
+    <meta property="og:description" content="Free offline-first motorsport telemetry viewer. Analyze GPS lap data, sectors, braking zones and reference laps in your browser — no upload required.">
+    <meta name="twitter:description" content="Free offline-first motorsport telemetry viewer. Analyze GPS lap data, sectors, braking zones and reference laps in your browser — no upload required.">
+    <meta property="og:url" content="https://hackthetrack.net/">
+    <meta property="og:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/4662e3cf-b3ae-4a6f-bc98-063c5777a60c?Expires=1771044008&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=QloYKQKOUWxjp2tiwGclt6daNQW9fmangqiVcW9S32QaVSTQtOA%2FBNGE63azEhblxZQi5yx9JToUQDAm9OijLFqz7n%2Bqae5mgjH24aY9Ozb1aW57YjAzp4KSlcH7j8c3eUuAd3s0PtNlM5fV1kA%2F1SUqErwbr5WObft%2FSNCH4OuA4VkwjMRCfoE8aZMvH9or9ILl8q7V0Bllzd7u29iPMSfOO2go72zbtpBJnh10UX3nnxM5wT3wc9%2B5Yb01qBSjqESIRiNy3Oe8mWBdiy6xgy2KvG4m%2FzgS%2BNr87Tv2vnS0apuE9SrnA06flu2ys6%2BPkEeojZVzis1lF4hwnZDt2w%3D%3D">
+    <meta name="twitter:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/4662e3cf-b3ae-4a6f-bc98-063c5777a60c?Expires=1771044008&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=QloYKQKOUWxjp2tiwGclt6daNQW9fmangqiVcW9S32QaVSTQtOA%2FBNGE63azEhblxZQi5yx9JToUQDAm9OijLFqz7n%2Bqae5mgjH24aY9Ozb1aW57YjAzp4KSlcH7j8c3eUuAd3s0PtNlM5fV1kA%2F1SUqErwbr5WObft%2FSNCH4OuA4VkwjMRCfoE8aZMvH9or9ILl8q7V0Bllzd7u29iPMSfOO2go72zbtpBJnh10UX3nnxM5wT3wc9%2B5Yb01qBSjqESIRiNy3Oe8mWBdiy6xgy2KvG4m%2FzgS%2BNr87Tv2vnS0apuE9SrnA06flu2ys6%2BPkEeojZVzis1lF4hwnZDt2w%3D%3D">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="og:type" content="website">
 </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,12 @@
         "@types/web-bluetooth": "^0.0.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fix-webm-duration": "^1.0.6",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.462.0",
         "ml-savitzky-golay": "^5.0.0",
+        "mp4-muxer": "^5.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-resizable-panels": "^2.1.9",
@@ -55,14 +57,14 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
-        "vite": "^5.4.19"
+        "vite": "^5.4.19",
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1576,6 +1578,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1583,7 +1619,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1600,7 +1635,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1617,7 +1651,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1634,7 +1667,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1651,7 +1683,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1668,7 +1699,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1685,7 +1715,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1702,7 +1731,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1719,7 +1747,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1736,7 +1763,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1753,7 +1779,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1770,7 +1795,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1787,7 +1811,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1804,7 +1827,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1821,7 +1843,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1838,7 +1859,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1855,7 +1875,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1889,7 +1908,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1923,7 +1941,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1933,6 +1950,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
@@ -1940,7 +1975,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1957,7 +1991,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,7 +2007,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,7 +2023,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,9 +2392,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2376,11 +2407,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2394,7 +2443,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2404,7 +2452,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2414,11 +2461,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3257,6 +3313,263 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3416,7 +3729,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3430,7 +3742,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3444,7 +3755,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3458,7 +3768,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3472,7 +3781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3486,7 +3794,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3500,7 +3807,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3514,7 +3820,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3528,7 +3833,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3542,7 +3846,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3556,7 +3859,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3570,7 +3872,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3584,7 +3885,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3598,7 +3898,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3612,7 +3911,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3626,7 +3924,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3640,7 +3937,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3654,7 +3950,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3668,7 +3963,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3682,7 +3976,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3696,7 +3989,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3710,7 +4002,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3724,7 +4015,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3738,7 +4028,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3752,12 +4041,18 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.95.3",
@@ -4132,6 +4427,41 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
+      "integrity": "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4179,14 +4509,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4197,7 +4527,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4219,6 +4549,12 @@
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -4502,6 +4838,102 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4571,14 +5003,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4592,7 +5022,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4605,7 +5034,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4662,6 +5090,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -4808,7 +5246,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4832,7 +5269,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4941,7 +5377,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4967,6 +5402,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4988,7 +5433,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5013,7 +5457,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5064,7 +5507,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5137,7 +5579,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5150,7 +5591,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -5271,6 +5712,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -5281,14 +5732,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dunder-proto": {
@@ -5424,6 +5873,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5472,7 +5928,6 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5736,6 +6191,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5746,7 +6211,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5763,7 +6227,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5805,7 +6268,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5875,7 +6337,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5900,6 +6361,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/fix-webm-duration": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fix-webm-duration/-/fix-webm-duration-1.0.6.tgz",
+      "integrity": "sha512-zVAqi4gE+8ywxJuAyV/rlJVX6CMtvyapEbQx6jyoeX9TMjdqAlt/FdG5d7rXSSkDVzTvS0H7CtwzHcH/vh4FPA==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -6125,7 +6592,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -6146,7 +6612,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6159,7 +6624,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6169,7 +6633,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -6462,7 +6925,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6551,7 +7013,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6604,7 +7065,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6647,7 +7107,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6851,7 +7310,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6884,7 +7342,6 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -7040,11 +7497,271 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7057,7 +7774,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7575,7 +8291,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -7608,7 +8323,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7618,7 +8332,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7632,7 +8345,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7721,6 +8433,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7731,7 +8454,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -7740,10 +8462,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7775,7 +8496,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7795,7 +8515,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7805,7 +8524,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7851,6 +8569,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7973,7 +8702,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -7986,6 +8714,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7993,9 +8728,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8008,7 +8743,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8018,7 +8752,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8034,10 +8767,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -8054,7 +8786,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8066,7 +8798,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -8084,7 +8815,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -8104,7 +8834,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8140,7 +8869,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8166,7 +8894,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8180,7 +8907,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -8224,7 +8950,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8390,7 +9115,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -8427,7 +9151,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -8440,7 +9163,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8587,12 +9309,52 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "2.79.2",
@@ -8613,7 +9375,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8881,6 +9642,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8926,7 +9694,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8956,6 +9723,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -9205,7 +9986,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -9263,7 +10043,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -9361,7 +10140,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -9371,7 +10149,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -9380,14 +10157,31 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9396,11 +10190,20 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -9435,7 +10238,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -9769,7 +10571,6 @@
       "version": "5.4.19",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -9859,7 +10660,6 @@
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -9898,6 +10698,715 @@
         "@rollup/rollup-win32-x64-gnu": "4.57.1",
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {
@@ -10015,6 +11524,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -10427,7 +11953,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.11",
@@ -60,6 +62,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^4.1.6"
   }
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,15 @@
+# HackTheTrack
+
+> Free, open-source, offline-first motorsport telemetry viewer. Analyze GPS lap data, sectors, braking zones, and reference laps directly in your browser — no upload required.
+
+HackTheTrack (aka Dove's DataViewer) is a privacy-first Progressive Web App for motorsport drivers, coaches, and karting teams. All telemetry parsing, lap detection, and visualization happen locally in the browser via IndexedDB — no server processes your data. The viewer supports a wide range of formats including NMEA, UBX, VBO (Racelogic), Alfano, AiM MyChron, MoTeC i2, and the native Dove/Dovex formats produced by the companion DovesDataLogger ESP32 hardware. Features include automatic track/course detection, lap timing with sector splits, reference-lap overlays, speed heatmaps on a Leaflet map, braking-zone analysis, G-force visualization, video-with-overlay export via WebCodecs, and Web Bluetooth integration for downloading sessions directly from supported dataloggers.
+
+## Pages
+
+- [Home](/): Main viewer — import telemetry files, view race line maps, charts, lap times, and reference comparisons.
+- [Privacy Policy](/privacy): How the app handles data (everything stays in your browser).
+
+## Optional
+
+- [GitHub — HackTheTrack](https://github.com/TheAngryRaven/dove-datalog-viewer): Source code for the web viewer.
+- [GitHub — DovesDataLogger](https://github.com/TheAngryRaven/DovesDataLogger): Companion ESP32 GPS datalogger firmware.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,5 @@ Allow: /
 
 User-agent: *
 Allow: /
+
+Sitemap: https://hackthetrack.net/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hackthetrack.net/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://hackthetrack.net/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/src/components/LapSummaryWidget.tsx
+++ b/src/components/LapSummaryWidget.tsx
@@ -66,7 +66,7 @@ export function LapSummaryWidget({ laps, course, selectedLap, paceDiff }: LapSum
       )}
 
       {/* Delta to reference - moved to the right */}
-      {paceDiff !== null && (
+      {paceDiff != null && (
         <div className="flex items-center gap-1.5">
           <span className="text-muted-foreground">Δ:</span>
           <span 

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -745,7 +745,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
       )}
 
       {/* Dropped packet / rejected row indicator */}
-      {(droppedPacketInfo?.droppedCount > 0 || (parserStats && parserStats.acceptedRows < parserStats.totalRows)) && (
+      {((droppedPacketInfo?.droppedCount ?? 0) > 0 || (parserStats && parserStats.acceptedRows < parserStats.totalRows)) && (
         <div className="absolute bottom-2 left-12 z-[1000] bg-card/80 backdrop-blur-sm border border-border rounded px-2 py-1 text-xs font-mono text-muted-foreground">
           {droppedPacketInfo && droppedPacketInfo.droppedCount > 0 && (
             <div>

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -43,7 +43,7 @@ interface VideoPlayerProps {
   selectedLapNumber?: number | null;
   course?: Course | null;
   referenceSamples?: GpsSample[];
-  paceData?: number[];
+  paceData?: (number | null)[];
   sessionFileName?: string | null;
 }
 
@@ -530,7 +530,7 @@ export const VideoPlayer = memo(function VideoPlayer({
       {/* Video element + click target */}
       <div ref={videoAreaRef} className="flex-1 min-h-0 relative overflow-hidden" onClick={handleVideoClick}>
         <video
-          ref={actions.videoRef}
+          ref={actions.videoRef as React.RefObject<HTMLVideoElement>}
           src={state.videoUrl}
           onLoadedMetadata={onLoadedMetadata}
           className="w-full h-full object-contain"

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -530,7 +530,7 @@ export const VideoPlayer = memo(function VideoPlayer({
       {/* Video element + click target */}
       <div ref={videoAreaRef} className="flex-1 min-h-0 relative overflow-hidden" onClick={handleVideoClick}>
         <video
-          ref={actions.videoRef as React.RefObject<HTMLVideoElement>}
+          ref={actions.videoRef}
           src={state.videoUrl}
           onLoadedMetadata={onLoadedMetadata}
           className="w-full h-full object-contain"

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -61,7 +61,7 @@ export interface GraphViewPanelProps {
   allSamples?: GpsSample[];
   laps?: Lap[];
   selectedLapNumber?: number | null;
-  paceData?: number[];
+  paceData?: (number | null)[];
 }
 
 export function GraphViewPanel(props: GraphViewPanelProps) {

--- a/src/components/graphview/InfoBox.tsx
+++ b/src/components/graphview/InfoBox.tsx
@@ -47,7 +47,7 @@ interface InfoBoxProps {
   laps?: Lap[];
   selectedLapNumber?: number | null;
   referenceSamples?: GpsSample[];
-  paceData?: number[];
+  paceData?: (number | null)[];
   sessionFileName?: string | null;
 }
 

--- a/src/components/video-overlays/PaceOverlay.tsx
+++ b/src/components/video-overlays/PaceOverlay.tsx
@@ -17,7 +17,7 @@ export const PaceOverlay = memo(function PaceOverlay({ instance, ctx, fontSize }
   const maxDelta = useMemo(() => {
     let absMax = 0.5;
     for (const v of ctx.paceData) {
-      if (Math.abs(v) > absMax) absMax = Math.abs(v);
+      if (v !== null && Math.abs(v) > absMax) absMax = Math.abs(v);
     }
     return Math.min(absMax * 1.2, 5);
   }, [ctx.paceData]);

--- a/src/components/video-overlays/dataSourceResolver.ts
+++ b/src/components/video-overlays/dataSourceResolver.ts
@@ -99,7 +99,7 @@ export function resolveValue(
   sample: GpsSample,
   currentIndex: number,
   dataSources: DataSourceDef[],
-  paceData: number[],
+  paceData: (number | null)[],
   brakingGData?: number[],
 ): number | null {
   if (sourceId === "__pace__") {
@@ -118,7 +118,7 @@ export function resolveRange(
   sourceId: string,
   samples: GpsSample[],
   dataSources: DataSourceDef[],
-  paceData: number[],
+  paceData: (number | null)[],
   brakingGData?: number[],
 ): { min: number; max: number } {
   if (sourceId === "__braking_g__") {

--- a/src/components/video-overlays/dataSourceResolver.ts
+++ b/src/components/video-overlays/dataSourceResolver.ts
@@ -127,6 +127,7 @@ export function resolveRange(
   if (sourceId === "__pace__") {
     let min = Infinity, max = -Infinity;
     for (const v of paceData) {
+      if (v === null) continue;
       if (v < min) min = v;
       if (v > max) max = v;
     }

--- a/src/components/video-overlays/types.ts
+++ b/src/components/video-overlays/types.ts
@@ -62,7 +62,7 @@ export interface OverlayRenderContext {
   selectedLapNumber: number | null;
   course: Course | null;
   referenceSamples: GpsSample[];
-  paceData: number[];
+  paceData: (number | null)[];
   brakingGData: number[];
   useKph: boolean;
   containerWidth: number;

--- a/src/hooks/useDocumentHead.ts
+++ b/src/hooks/useDocumentHead.ts
@@ -8,55 +8,95 @@ interface DocumentHeadOptions {
 
 /**
  * Lightweight per-route head manager. Sets <title>, meta description,
- * and canonical link, then restores them on unmount so other routes
- * fall back to the static defaults in index.html.
+ * canonical link, and matching og:/twitter: social tags, then restores
+ * them on unmount so other routes fall back to the static defaults in
+ * index.html.
  */
 export function useDocumentHead({ title, description, canonical }: DocumentHeadOptions): void {
   useEffect(() => {
     const prevTitle = document.title;
     document.title = title;
 
-    const setMeta = (selector: string, create: () => HTMLElement, value: string) => {
+    const upsert = (
+      selector: string,
+      create: () => HTMLElement,
+      attr: "content" | "href",
+      value: string,
+    ) => {
       let el = document.head.querySelector<HTMLElement>(selector);
       const created = !el;
       if (!el) {
         el = create();
         document.head.appendChild(el);
       }
-      const prev = el.getAttribute(el.tagName === "META" ? "content" : "href");
-      el.setAttribute(el.tagName === "META" ? "content" : "href", value);
+      const prev = el.getAttribute(attr);
+      el.setAttribute(attr, value);
       return () => {
         if (created) el?.remove();
-        else if (prev !== null) el?.setAttribute(el.tagName === "META" ? "content" : "href", prev);
+        else if (prev !== null) el?.setAttribute(attr, prev);
       };
     };
 
+    const metaName = (name: string, value: string) =>
+      upsert(
+        `meta[name="${name}"]`,
+        () => {
+          const m = document.createElement("meta");
+          m.setAttribute("name", name);
+          return m;
+        },
+        "content",
+        value,
+      );
+
+    const metaProp = (prop: string, value: string) =>
+      upsert(
+        `meta[property="${prop}"]`,
+        () => {
+          const m = document.createElement("meta");
+          m.setAttribute("property", prop);
+          return m;
+        },
+        "content",
+        value,
+      );
+
     const restorers: Array<() => void> = [];
+
+    // Social title mirrors document title
+    restorers.push(metaProp("og:title", title));
+    restorers.push(metaName("twitter:title", title));
+
     if (description) {
       restorers.push(
-        setMeta(
+        upsert(
           'meta[name="description"]',
           () => {
             const m = document.createElement("meta");
             m.setAttribute("name", "description");
             return m;
           },
+          "content",
           description,
         ),
       );
+      restorers.push(metaProp("og:description", description));
+      restorers.push(metaName("twitter:description", description));
     }
     if (canonical) {
       restorers.push(
-        setMeta(
+        upsert(
           'link[rel="canonical"]',
           () => {
             const l = document.createElement("link");
             l.setAttribute("rel", "canonical");
             return l;
           },
+          "href",
           canonical,
         ),
       );
+      restorers.push(metaProp("og:url", canonical));
     }
 
     return () => {

--- a/src/hooks/useDocumentHead.ts
+++ b/src/hooks/useDocumentHead.ts
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+
+interface DocumentHeadOptions {
+  title: string;
+  description?: string;
+  canonical?: string;
+}
+
+/**
+ * Lightweight per-route head manager. Sets <title>, meta description,
+ * and canonical link, then restores them on unmount so other routes
+ * fall back to the static defaults in index.html.
+ */
+export function useDocumentHead({ title, description, canonical }: DocumentHeadOptions): void {
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = title;
+
+    const setMeta = (selector: string, create: () => HTMLElement, value: string) => {
+      let el = document.head.querySelector<HTMLElement>(selector);
+      const created = !el;
+      if (!el) {
+        el = create();
+        document.head.appendChild(el);
+      }
+      const prev = el.getAttribute(el.tagName === "META" ? "content" : "href");
+      el.setAttribute(el.tagName === "META" ? "content" : "href", value);
+      return () => {
+        if (created) el?.remove();
+        else if (prev !== null) el?.setAttribute(el.tagName === "META" ? "content" : "href", prev);
+      };
+    };
+
+    const restorers: Array<() => void> = [];
+    if (description) {
+      restorers.push(
+        setMeta(
+          'meta[name="description"]',
+          () => {
+            const m = document.createElement("meta");
+            m.setAttribute("name", "description");
+            return m;
+          },
+          description,
+        ),
+      );
+    }
+    if (canonical) {
+      restorers.push(
+        setMeta(
+          'link[rel="canonical"]',
+          () => {
+            const l = document.createElement("link");
+            l.setAttribute("rel", "canonical");
+            return l;
+          },
+          canonical,
+        ),
+      );
+    }
+
+    return () => {
+      document.title = prevTitle;
+      restorers.forEach((r) => r());
+    };
+  }, [title, description, canonical]);
+}

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -39,11 +39,11 @@ export interface VideoSyncActions {
     updateOverlaySettings: (settings: OverlaySettings) => void;
     deleteStoredVideo: () => Promise<void>;
     refreshStoredMeta: () => Promise<void>;
-    videoRef: React.RefObject<HTMLVideoElement | null>;
+    videoRef: React.RefObject<HTMLVideoElement>;
   }
 
 export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessionFileName }: UseVideoSyncOptions) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const lastSeekTimeRef = useRef(0);
 

--- a/src/lib/aimParser.ts
+++ b/src/lib/aimParser.ts
@@ -1,44 +1,21 @@
 import { ParsedData, GpsSample, FieldMapping } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { clamp, haversineDistance } from './parserUtils';
+import {
+  haversineDistance,
+  parseCsvLine,
+  detectDelimiter,
+  validateGpsCoords,
+  normalizeAccelToG,
+  speedTriple,
+  calculateBounds,
+  KPH_TO_MPS,
+} from './parserUtils';
 
 /**
  * AiM MyChron CSV Parser
  * Parses CSV exports from Race Studio 3 (RS2Analysis Style CSV)
  * Supports MyChron 5, MyChron 6, and other AiM data loggers
  */
-
-// Parse a CSV line handling quoted fields
-function parseCSVLine(line: string, delimiter: string = ','): string[] {
-  const result: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    if (char === '"') {
-      inQuotes = !inQuotes;
-    } else if (char === delimiter && !inQuotes) {
-      result.push(current.trim());
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-  result.push(current.trim());
-  return result;
-}
-
-// Detect CSV delimiter
-function detectDelimiter(line: string): string {
-  const commaCount = (line.match(/,/g) || []).length;
-  const semicolonCount = (line.match(/;/g) || []).length;
-  const tabCount = (line.match(/\t/g) || []).length;
-  
-  if (tabCount > commaCount && tabCount > semicolonCount) return '\t';
-  if (semicolonCount > commaCount) return ';';
-  return ',';
-}
 
 // AiM-specific channel name patterns
 const AIM_CHANNEL_PATTERNS = [
@@ -143,7 +120,7 @@ export function parseAimFile(content: string): ParsedData {
     throw new Error('Could not find AiM CSV header row');
   }
   
-  const headers = parseCSVLine(lines[headerIndex], delimiter).map(h => h.toLowerCase().trim());
+  const headers = parseCsvLine(lines[headerIndex], delimiter).map(h => h.toLowerCase().trim());
   
   // Map column indices
   const colMap: Record<string, number> = {};
@@ -177,25 +154,21 @@ export function parseAimFile(content: string): ParsedData {
   
   // Parse data rows
   const samples: GpsSample[] = [];
-  let minLat = Infinity, maxLat = -Infinity;
-  let minLon = Infinity, maxLon = -Infinity;
   let baseTime: number | null = null;
   let prevValidSample: GpsSample | null = null;
   
   // Detect time and speed units from first valid data row
   let timeMultiplier = 1000; // default: seconds to ms
-  let speedMultiplier = 1 / 3.6; // default: km/h to m/s
+  let speedMultiplier = KPH_TO_MPS; // default: km/h to m/s
   
   for (let i = headerIndex + 1; i < lines.length; i++) {
-    const values = parseCSVLine(lines[i], delimiter);
+    const values = parseCsvLine(lines[i], delimiter);
     if (values.length < Math.max(latCol, lonCol) + 1) continue;
     
     const lat = parseFloat(values[latCol]);
     const lon = parseFloat(values[lonCol]);
-    
-    // Skip invalid coordinates
-    if (isNaN(lat) || isNaN(lon) || lat === 0 || lon === 0) continue;
-    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+
+    if (validateGpsCoords(lat, lon) !== null) continue;
     
     // Parse time
     let timeMs = 0;
@@ -222,7 +195,7 @@ export function parseAimFile(content: string): ParsedData {
         // AiM typically exports in km/h, but detect if already m/s
         // Values over 100 are likely km/h, under 50 might be m/s
         if (samples.length === 0 && speedVal > 50) {
-          speedMultiplier = 1 / 3.6; // km/h to m/s
+          speedMultiplier = KPH_TO_MPS; // km/h to m/s
         } else if (samples.length === 0 && speedVal > 0 && speedVal < 30) {
           speedMultiplier = 1; // already m/s
         }
@@ -250,20 +223,13 @@ export function parseAimFile(content: string): ParsedData {
     }
     
     if (latGCol !== -1) {
-      let latG = parseFloat(values[latGCol]);
-      if (!isNaN(latG)) {
-        // If value seems to be in m/s², convert to G
-        if (Math.abs(latG) > 5) latG = latG / 9.81;
-        extraFields['Lat G'] = clamp(latG, -5, 5);
-      }
+      const latG = parseFloat(values[latGCol]);
+      if (!isNaN(latG)) extraFields['Lat G'] = normalizeAccelToG(latG);
     }
-    
+
     if (lonGCol !== -1) {
-      let lonG = parseFloat(values[lonGCol]);
-      if (!isNaN(lonG)) {
-        if (Math.abs(lonG) > 5) lonG = lonG / 9.81;
-        extraFields['Lon G'] = clamp(lonG, -5, 5);
-      }
+      const lonG = parseFloat(values[lonGCol]);
+      if (!isNaN(lonG)) extraFields['Lon G'] = normalizeAccelToG(lonG);
     }
     
     if (rpmCol !== -1) {
@@ -302,20 +268,13 @@ export function parseAimFile(content: string): ParsedData {
       t: timeMs,
       lat,
       lon,
-      speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph: speedMps * 3.6,
+      ...speedTriple(speedMps),
       heading,
       extraFields,
     };
-    
+
     samples.push(sample);
     prevValidSample = sample;
-    
-    minLat = Math.min(minLat, lat);
-    maxLat = Math.max(maxLat, lat);
-    minLon = Math.min(minLon, lon);
-    maxLon = Math.max(maxLon, lon);
   }
   
   if (samples.length === 0) {
@@ -346,7 +305,7 @@ export function parseAimFile(content: string): ParsedData {
   return {
     samples,
     fieldMappings,
-    bounds: { minLat, maxLat, minLon, maxLon },
+    bounds: calculateBounds(samples),
     duration,
   };
 }

--- a/src/lib/alfanoParser.ts
+++ b/src/lib/alfanoParser.ts
@@ -1,6 +1,16 @@
 import { GpsSample, FieldMapping, ParsedData } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { clamp, haversineDistance, isTeleportation, MAX_SPEED_MPS } from './parserUtils';
+import {
+  isTeleportation,
+  MAX_SPEED_MPS,
+  KPH_TO_MPS,
+  parseCsvLine,
+  validateGpsCoords,
+  normalizeAccelToG,
+  normalizeHeading,
+  speedTriple,
+  calculateBounds,
+} from './parserUtils';
 
 /**
  * Alfano CSV Parser
@@ -126,48 +136,32 @@ const COLUMN_MAPPINGS: Record<string, string> = {
   'sats': 'satellites',
 };
 
-// Parse CSV line handling quoted fields
-function parseCSVLine(line: string): string[] {
-  const result: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    if (char === '\"') {
-      inQuotes = !inQuotes;
-    } else if ((char === ',' || char === ';') && !inQuotes) {
-      result.push(current.trim());
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-  result.push(current.trim());
-  return result;
-}
-
-// Detect delimiter (comma or semicolon)
-function detectDelimiter(lines: string[]): string {
+/**
+ * Detect Alfano CSV delimiter (typically comma, sometimes semicolon).
+ * Scans the first 20 lines for whichever delimiter wins by count.
+ */
+function detectAlfanoDelimiter(lines: string[]): string {
   for (const line of lines.slice(0, 20)) {
-    if (line.includes(',')) return ',';
-    if (line.includes(';')) return ';';
+    const commas = (line.match(/,/g) || []).length;
+    const semis = (line.match(/;/g) || []).length;
+    if (commas > 0 || semis > 0) return semis > commas ? ';' : ',';
   }
   return ',';
 }
 
 export function parseAlfanoFile(content: string): ParsedData {
   const lines = content.split(/\r?\n/);
-  
+  const delimiter = detectAlfanoDelimiter(lines);
+
   // Find the header row (first row with recognizable column names)
   let headerIndex = -1;
   let columnMap: Record<string, number> = {};
-  
+
   for (let i = 0; i < Math.min(lines.length, 50); i++) {
     const line = lines[i].trim();
     if (!line) continue;
-    
-    const fields = parseCSVLine(line);
+
+    const fields = parseCsvLine(line, delimiter);
     
     // Check if this looks like a header row
     let matchCount = 0;
@@ -207,16 +201,14 @@ export function parseAlfanoFile(content: string): ParsedData {
     // Skip metadata rows that might appear after header
     if (ALFANO_METADATA_PATTERNS.some(p => p.test(line))) continue;
     
-    const fields = parseCSVLine(line);
+    const fields = parseCsvLine(line, delimiter);
     if (fields.length < 3) continue;
-    
+
     // Parse coordinates
     const lat = columnMap['lat'] !== undefined ? parseFloat(fields[columnMap['lat']]) : NaN;
     const lon = columnMap['lon'] !== undefined ? parseFloat(fields[columnMap['lon']]) : NaN;
-    
-    // Skip rows without valid coordinates
-    if (isNaN(lat) || isNaN(lon) || lat === 0 || lon === 0) continue;
-    if (Math.abs(lat) > 90 || Math.abs(lon) > 180) continue;
+
+    if (validateGpsCoords(lat, lon) !== null) continue;
     
     // Parse time
     let timeMs = 0;
@@ -242,20 +234,16 @@ export function parseAlfanoFile(content: string): ParsedData {
     if (columnMap['speed'] !== undefined) {
       speedKph = parseFloat(fields[columnMap['speed']]) || 0;
     }
-    const speedMps = speedKph / 3.6;
-    
+    const speedMps = speedKph * KPH_TO_MPS;
+
     // Sanity check on speed
     if (speedMps > MAX_SPEED_MPS) continue;
 
     // Parse heading
     let heading: number | undefined;
     if (columnMap['heading'] !== undefined) {
-      heading = parseFloat(fields[columnMap['heading']]);
-      if (isNaN(heading)) heading = undefined;
-      else {
-        while (heading < 0) heading += 360;
-        while (heading >= 360) heading -= 360;
-      }
+      const h = parseFloat(fields[columnMap['heading']]);
+      if (!isNaN(h)) heading = normalizeHeading(h);
     }
     
     // Teleportation filter
@@ -267,22 +255,19 @@ export function parseAlfanoFile(content: string): ParsedData {
     // Build extra fields
     const extraFields: Record<string, number> = {};
     
-    // Native G-forces (may be in m/s² or G)
+    // Native G-forces (may be in m/s² or G — Alfano uses a higher threshold than other formats)
     if (columnMap['latG'] !== undefined) {
-      let latG = parseFloat(fields[columnMap['latG']]);
+      const latG = parseFloat(fields[columnMap['latG']]);
       if (!isNaN(latG)) {
-        // If values are > 10, probably in m/s², convert to G
-        if (Math.abs(latG) > 10) latG = latG / 9.80665;
-        extraFields['Lat G (Native)'] = clamp(latG, -5, 5);
+        extraFields['Lat G (Native)'] = normalizeAccelToG(latG, 10);
         hasNativeG = true;
       }
     }
-    
+
     if (columnMap['lonG'] !== undefined) {
-      let lonG = parseFloat(fields[columnMap['lonG']]);
+      const lonG = parseFloat(fields[columnMap['lonG']]);
       if (!isNaN(lonG)) {
-        if (Math.abs(lonG) > 10) lonG = lonG / 9.80665;
-        extraFields['Lon G (Native)'] = clamp(lonG, -5, 5);
+        extraFields['Lon G (Native)'] = normalizeAccelToG(lonG, 10);
         hasNativeG = true;
       }
     }
@@ -343,9 +328,7 @@ export function parseAlfanoFile(content: string): ParsedData {
       t,
       lat,
       lon,
-      speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph,
+      ...speedTriple(speedMps),
       heading,
       extraFields
     });
@@ -394,19 +377,10 @@ export function parseAlfanoFile(content: string): ParsedData {
     }
   }
   
-  // Calculate bounds
-  const lats = samples.map(s => s.lat);
-  const lons = samples.map(s => s.lon);
-  
   return {
     samples,
     fieldMappings,
-    bounds: {
-      minLat: Math.min(...lats),
-      maxLat: Math.max(...lats),
-      minLon: Math.min(...lons),
-      maxLon: Math.max(...lons)
-    },
+    bounds: calculateBounds(samples),
     duration: samples[samples.length - 1].t,
     startDate
   };

--- a/src/lib/courseDetection.test.ts
+++ b/src/lib/courseDetection.test.ts
@@ -201,26 +201,65 @@ describe("autoDetectCourse - course matching", () => {
     expect(result!.course.name).toBe("Known");
   });
 
-  it("BUG (documented): returns a course even when length match is way outside 25% tolerance", () => {
-    // CLAUDE.md and the source comment say "pick closest match within 25% tolerance"
-    // but the implementation always returns the closest, even if it's 90% off.
-    // This test pins down the current behavior.
+  it("returns a course outside 25% tolerance but flags it via lengthMatchDiff", () => {
+    // Implementation still returns the closest course rather than failing —
+    // intentional UX choice (better to show something than nothing). The
+    // lengthMatchDiff field surfaces the confidence so UI can warn the user.
     const origin = okcOrigin;
     const badMatchTrack: Track = {
       name: "OKC", shortName: "OKC",
       courses: [{
         name: "WayTooLong",
-        lengthFt: 50000, // 100x reality
+        lengthFt: 50000, // ~5x the actual ~8500ft per lap → ~83% off
         startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
         startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
       }],
     };
     const samples = makeRacePathAtTrack(origin, 3, 10000);
-    const result = autoDetectCourse(samples, [badMatchTrack]);
-    // Currently returns it with no indication the match is poor
-    expect(result!.course.name).toBe("WayTooLong");
-    expect(result!.isWaypointMode).toBe(false);
-    // Real fix: add a `lengthMatchQuality` field or fall back to waypoint mode here.
+    const result = autoDetectCourse(samples, [badMatchTrack])!;
+    expect(result.course.name).toBe("WayTooLong");
+    expect(result.isWaypointMode).toBe(false);
+    expect(result.lengthMatchDiff).toBeDefined();
+    expect(result.lengthMatchDiff!).toBeGreaterThan(0.25); // outside documented tolerance
+  });
+
+  it("populates lengthMatchDiff with the actual fractional difference for good matches", () => {
+    const origin = okcOrigin;
+    const goodMatchTrack: Track = {
+      name: "OKC", shortName: "OKC",
+      courses: [{
+        name: "Good",
+        lengthFt: 9000, // close to actual ~8500ft → ~6% off
+        startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+        startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+      }],
+    };
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [goodMatchTrack])!;
+    expect(result.lengthMatchDiff!).toBeLessThan(0.1);
+  });
+
+  it("leaves lengthMatchDiff undefined when the matched course has no lengthFt", () => {
+    const origin = okcOrigin;
+    const unknownLengthTrack: Track = {
+      name: "OKC", shortName: "OKC",
+      courses: [{
+        name: "Unmeasured",
+        startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+        startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+      }],
+    };
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [unknownLengthTrack])!;
+    expect(result.lengthMatchDiff).toBeUndefined();
+  });
+
+  it("leaves lengthMatchDiff undefined for waypoint mode results", () => {
+    // No track nearby → waypoint fallback
+    const samples = makeWaypointPath({ lat: 40.7, lon: -74.0 }, 3, 60000, 15);
+    const result = autoDetectCourse(samples, [makeTrack()])!;
+    expect(result.isWaypointMode).toBe(true);
+    expect(result.lengthMatchDiff).toBeUndefined();
   });
 
   it("falls back to waypoint mode when no course produces laps", () => {
@@ -275,16 +314,44 @@ describe("autoDetectCourse - direction detection", () => {
     expect(result!.direction).toBe("forward");
   });
 
-  it("BUG (documented): returns 'reverse' when forward-direction GPS misses sector lines", () => {
-    // Path goes east across S/F but loops back NORTH (lat=0.01) without ever
-    // reaching S2 (lon+0.003) or S3 (lon+0.006). This is a clean FORWARD lap
-    // where the racing line just didn't cross the sector geometry.
-    // detectDirection sees no sectors computed → returns 'reverse' (WRONG).
-    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000); // never crosses S2/S3
+  it("returns undefined direction when sectors aren't crossed (no false 'reverse' claim)", () => {
+    // Path crosses S/F east but loops back via lat=0.01 — never reaches S2
+    // (lon+0.003) or S3 (lon+0.006). Forward direction, but the racing line
+    // doesn't intersect the sector lines.
+    // Previous bug: returned 'reverse' (false positive — "no sectors = reverse").
+    // Fix: detectSectorOrder returns undefined when either sector line is
+    // never crossed, so we honestly admit we don't know.
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000);
     const result = autoDetectCourse(samples, [makeSectorTrack()]);
-    expect(result!.direction).toBe("reverse"); // current (buggy) behavior
-    // Real fix: compute direction geometrically — compare timestamps of any S2 vs S3
-    // crossing event independently, instead of relying on calculateLaps' sector output.
+    expect(result!.direction).toBeUndefined();
+  });
+
+  it("returns 'reverse' when sectors are crossed in S3-before-S2 order", () => {
+    // Build a westward-traversing path: starts east of all lines, sweeps west
+    // crossing S3 first, then S2, then S/F. Two such sweeps produce 1 lap.
+    const o = okcOrigin;
+    const samples = [
+      // Sweep 1
+      makeSample(0, o.lat, o.lon + 0.01),
+      makeSample(1000, o.lat, o.lon + 0.005),    // cross S3 going west
+      makeSample(2000, o.lat, o.lon + 0.002),    // cross S2 going west
+      makeSample(3000, o.lat, o.lon - 0.001),    // cross S/F going west
+      // Loop back east via high lat (no crossings)
+      makeSample(7000, o.lat + 0.01, o.lon - 0.001),
+      makeSample(8000, o.lat + 0.01, o.lon + 0.01),
+      makeSample(9000, o.lat, o.lon + 0.01),
+      // Sweep 2
+      makeSample(10000, o.lat, o.lon + 0.005),
+      makeSample(11000, o.lat, o.lon + 0.002),
+      makeSample(12000, o.lat, o.lon - 0.001),
+      // Loop back for any remaining state
+      makeSample(16000, o.lat + 0.01, o.lon - 0.001),
+      makeSample(17000, o.lat + 0.01, o.lon + 0.01),
+      makeSample(18000, o.lat, o.lon + 0.01),
+    ];
+    const result = autoDetectCourse(samples, [makeSectorTrack()]);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("reverse");
   });
 });
 

--- a/src/lib/courseDetection.test.ts
+++ b/src/lib/courseDetection.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from "vitest";
+import { autoDetectCourse } from "./courseDetection";
+import type { GpsSample, Track, Course } from "@/types/racing";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeSample(t: number, lat: number, lon: number, speedMps = 20): GpsSample {
+  return {
+    t, lat, lon,
+    speedMps,
+    speedMph: speedMps * 2.23694,
+    speedKph: speedMps * 3.6,
+    extraFields: {},
+  };
+}
+
+/**
+ * Build a path of N east-going S/F crossings centered at the given track origin.
+ * The S/F line at the track is assumed to be vertical at the origin's lon, with
+ * tiny lat extent ±0.0001. Path:
+ *   - Start at (origin.lat, origin.lon - 0.001) west of line
+ *   - Cross by jumping to (origin.lat, origin.lon + 0.001)
+ *   - Loop north to (origin.lat + 0.01, ...) → west → south back to start
+ */
+function makeRacePathAtTrack(
+  origin: { lat: number; lon: number },
+  numCrossings: number,
+  intervalMs: number,
+  speedMps = 20,
+): GpsSample[] {
+  const samples: GpsSample[] = [];
+  let t = 0;
+  samples.push(makeSample(t, origin.lat, origin.lon - 0.001, speedMps));
+
+  for (let i = 0; i < numCrossings; i++) {
+    t += intervalMs / 4;
+    samples.push(makeSample(t, origin.lat, origin.lon + 0.001, speedMps));
+    if (i < numCrossings - 1) {
+      t += intervalMs / 4;
+      samples.push(makeSample(t, origin.lat + 0.01, origin.lon + 0.001, speedMps));
+      t += intervalMs / 4;
+      samples.push(makeSample(t, origin.lat + 0.01, origin.lon - 0.001, speedMps));
+      t += intervalMs / 4;
+      samples.push(makeSample(t, origin.lat, origin.lon - 0.001, speedMps));
+    }
+  }
+  return samples;
+}
+
+/** Sector-aware lap that crosses S/F → S2 → S3 going east each lap. */
+function makeSectorLap(origin: { lat: number; lon: number }, startT: number, lapDur: number): GpsSample[] {
+  return [
+    makeSample(startT, origin.lat, origin.lon - 0.001),
+    makeSample(startT + lapDur * 0.1, origin.lat, origin.lon + 0.001), // cross S/F
+    makeSample(startT + lapDur * 0.2, origin.lat, origin.lon + 0.002),
+    makeSample(startT + lapDur * 0.3, origin.lat, origin.lon + 0.004), // cross S2
+    makeSample(startT + lapDur * 0.4, origin.lat, origin.lon + 0.005),
+    makeSample(startT + lapDur * 0.5, origin.lat, origin.lon + 0.007), // cross S3
+    makeSample(startT + lapDur * 0.6, origin.lat + 0.01, origin.lon + 0.007),
+    makeSample(startT + lapDur * 0.8, origin.lat + 0.01, origin.lon - 0.001),
+    makeSample(startT + lapDur, origin.lat, origin.lon - 0.001),
+  ];
+}
+
+const okcOrigin = { lat: 35.4, lon: -97.3 };
+
+function makeTrack(opts: {
+  name?: string;
+  shortName?: string;
+  origin?: { lat: number; lon: number };
+  courses?: Course[];
+} = {}): Track {
+  const origin = opts.origin ?? okcOrigin;
+  return {
+    name: opts.name ?? "OKC Kart Center",
+    shortName: opts.shortName ?? "OKC",
+    courses: opts.courses ?? [{
+      name: "Full",
+      lengthFt: 700, // ~213m perimeter — about right for 4-sample path with samples 0.002° apart
+      startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+      startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+    }],
+  };
+}
+
+// ─── Degenerate inputs ───────────────────────────────────────────────────────
+
+describe("autoDetectCourse - degenerate inputs", () => {
+  it("returns null for empty samples", () => {
+    expect(autoDetectCourse([], [makeTrack()])).toBeNull();
+  });
+
+  it("returns null when fewer than 10 samples", () => {
+    const samples = Array.from({ length: 5 }, (_, i) => makeSample(i * 1000, okcOrigin.lat, okcOrigin.lon));
+    expect(autoDetectCourse(samples, [makeTrack()])).toBeNull();
+  });
+
+  it("returns null when no tracks provided", () => {
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000);
+    expect(autoDetectCourse(samples, [])).toBeNull();
+  });
+
+  it("returns null when all samples are invalid (0,0 or out of range)", () => {
+    const samples = Array.from({ length: 20 }, (_, i) => makeSample(i * 1000, 0, 0));
+    expect(autoDetectCourse(samples, [makeTrack()])).toBeNull();
+  });
+});
+
+// ─── Track matching ──────────────────────────────────────────────────────────
+
+describe("autoDetectCourse - track matching", () => {
+  it("matches the nearest track within 5 miles", () => {
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    expect(result).not.toBeNull();
+    expect(result!.track.shortName).toBe("OKC");
+    expect(result!.isWaypointMode).toBe(false);
+  });
+
+  it("picks the closer track when two are in range", () => {
+    const farther = makeTrack({ name: "Far", shortName: "FAR", origin: { lat: 35.5, lon: -97.3 } });
+    const closer = makeTrack({ name: "Close", shortName: "CLOSE", origin: okcOrigin });
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000);
+    const result = autoDetectCourse(samples, [farther, closer]);
+    expect(result!.track.shortName).toBe("CLOSE");
+  });
+
+  it("falls back to waypoint mode when no track is within 5 miles", () => {
+    // Track at OKC, samples at New York
+    const samples = makeRacePathAtTrack({ lat: 40.7, lon: -74.0 }, 3, 10000);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    expect(result).not.toBeNull();
+    expect(result!.isWaypointMode).toBe(true);
+    expect(result!.track.name).toBe("Unknown Track");
+  });
+});
+
+// ─── Course matching ─────────────────────────────────────────────────────────
+
+describe("autoDetectCourse - course matching", () => {
+  it("returns the only course on a single-course track", () => {
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    expect(result!.course.name).toBe("Full");
+  });
+
+  it("returns laps produced by the chosen course", () => {
+    const samples = makeRacePathAtTrack(okcOrigin, 4, 10000);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    // 4 crossings → 3 laps
+    expect(result!.laps).toHaveLength(3);
+  });
+
+  it("prefers the course with closer lengthFt match", () => {
+    // makeRacePathAtTrack produces ~8500ft per lap (the loop goes 1km north,
+    // 200m east-west, 1km south at lat=35.4°).
+    const origin = okcOrigin;
+    const trackWithTwoCourses: Track = {
+      name: "OKC", shortName: "OKC",
+      courses: [
+        { // Bad match — ~190% off
+          name: "Long",
+          lengthFt: 25000,
+          startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+          startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+        },
+        { // Good match — ~6% off
+          name: "CloseMatch",
+          lengthFt: 9000,
+          startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+          startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+        },
+      ],
+    };
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [trackWithTwoCourses]);
+    expect(result!.course.name).toBe("CloseMatch");
+  });
+
+  it("prefers a course with known lengthFt over one without", () => {
+    const origin = okcOrigin;
+    const trackWithMixedCourses: Track = {
+      name: "OKC", shortName: "OKC",
+      courses: [
+        { // No length
+          name: "Unknown",
+          startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+          startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+        },
+        { // Known length, terrible match (course is 10000ft, actual ~150ft)
+          name: "Known",
+          lengthFt: 10000,
+          startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+          startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+        },
+      ],
+    };
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [trackWithMixedCourses]);
+    // Sort prefers known-length even when the match is poor
+    expect(result!.course.name).toBe("Known");
+  });
+
+  it("BUG (documented): returns a course even when length match is way outside 25% tolerance", () => {
+    // CLAUDE.md and the source comment say "pick closest match within 25% tolerance"
+    // but the implementation always returns the closest, even if it's 90% off.
+    // This test pins down the current behavior.
+    const origin = okcOrigin;
+    const badMatchTrack: Track = {
+      name: "OKC", shortName: "OKC",
+      courses: [{
+        name: "WayTooLong",
+        lengthFt: 50000, // 100x reality
+        startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+        startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+      }],
+    };
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [badMatchTrack]);
+    // Currently returns it with no indication the match is poor
+    expect(result!.course.name).toBe("WayTooLong");
+    expect(result!.isWaypointMode).toBe(false);
+    // Real fix: add a `lengthMatchQuality` field or fall back to waypoint mode here.
+  });
+
+  it("falls back to waypoint mode when no course produces laps", () => {
+    // Track is nearby but the path never crosses any course's S/F line
+    const origin = okcOrigin;
+    const offCourseTrack = makeTrack({
+      courses: [{
+        name: "OffSet",
+        lengthFt: 700,
+        startFinishA: { lat: origin.lat + 0.05, lon: origin.lon + 0.05 }, // far from path
+        startFinishB: { lat: origin.lat + 0.05, lon: origin.lon + 0.05001 },
+      }],
+    });
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [offCourseTrack]);
+    expect(result).not.toBeNull();
+    expect(result!.isWaypointMode).toBe(true);
+  });
+});
+
+// ─── Direction detection (where the bugs are) ────────────────────────────────
+
+describe("autoDetectCourse - direction detection", () => {
+  function makeSectorTrack(origin: { lat: number; lon: number } = okcOrigin): Track {
+    return {
+      name: "OKC", shortName: "OKC",
+      courses: [{
+        name: "Full",
+        lengthFt: 1500,
+        startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+        startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+        sector2: { a: { lat: origin.lat + 0.0001, lon: origin.lon + 0.003 }, b: { lat: origin.lat - 0.0001, lon: origin.lon + 0.003 } },
+        sector3: { a: { lat: origin.lat + 0.0001, lon: origin.lon + 0.006 }, b: { lat: origin.lat - 0.0001, lon: origin.lon + 0.006 } },
+      }],
+    };
+  }
+
+  it("returns undefined direction when course has no sectors", () => {
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000);
+    const result = autoDetectCourse(samples, [makeTrack()]); // course without sectors
+    expect(result!.direction).toBeUndefined();
+  });
+
+  it("returns 'forward' when sectors compute correctly (path crosses S/F → S2 → S3 → S/F)", () => {
+    const lapDur = 20000;
+    const samples = [
+      ...makeSectorLap(okcOrigin, 0, lapDur),
+      ...makeSectorLap(okcOrigin, lapDur, lapDur),
+      ...makeSectorLap(okcOrigin, lapDur * 2, lapDur),
+    ];
+    const result = autoDetectCourse(samples, [makeSectorTrack()]);
+    expect(result!.direction).toBe("forward");
+  });
+
+  it("BUG (documented): returns 'reverse' when forward-direction GPS misses sector lines", () => {
+    // Path goes east across S/F but loops back NORTH (lat=0.01) without ever
+    // reaching S2 (lon+0.003) or S3 (lon+0.006). This is a clean FORWARD lap
+    // where the racing line just didn't cross the sector geometry.
+    // detectDirection sees no sectors computed → returns 'reverse' (WRONG).
+    const samples = makeRacePathAtTrack(okcOrigin, 3, 10000); // never crosses S2/S3
+    const result = autoDetectCourse(samples, [makeSectorTrack()]);
+    expect(result!.direction).toBe("reverse"); // current (buggy) behavior
+    // Real fix: compute direction geometrically — compare timestamps of any S2 vs S3
+    // crossing event independently, instead of relying on calculateLaps' sector output.
+  });
+});
+
+// ─── Waypoint mode ───────────────────────────────────────────────────────────
+
+/**
+ * Build a waypoint-mode test path: samples make a loop returning near the
+ * start. Speed must hit 30 MPH (≈13.4 m/s) for the waypoint to drop.
+ *
+ * Loop pattern: north 50m → east 50m → south 50m → west back to start.
+ * Repeats `numLoops` times, each loop taking `loopDurMs`.
+ */
+function makeWaypointPath(
+  origin: { lat: number; lon: number },
+  numLoops: number,
+  loopDurMs: number,
+  speedMps = 15, // > 13.4 = 30 mph
+): GpsSample[] {
+  const samples: GpsSample[] = [];
+  let t = 0;
+  // Equator-relative meters → degrees
+  const mToLat = 1 / 111195;
+  const mToLon = 1 / (111195 * Math.cos(origin.lat * Math.PI / 180));
+  for (let lap = 0; lap < numLoops; lap++) {
+    samples.push(makeSample(t, origin.lat, origin.lon, speedMps));
+    t += loopDurMs * 0.25;
+    samples.push(makeSample(t, origin.lat + 50 * mToLat, origin.lon, speedMps));
+    t += loopDurMs * 0.25;
+    samples.push(makeSample(t, origin.lat + 50 * mToLat, origin.lon + 50 * mToLon, speedMps));
+    t += loopDurMs * 0.25;
+    samples.push(makeSample(t, origin.lat, origin.lon + 50 * mToLon, speedMps));
+    t += loopDurMs * 0.25;
+  }
+  // Final sample at origin to close the last loop
+  samples.push(makeSample(t, origin.lat, origin.lon, speedMps));
+  return samples;
+}
+
+describe("autoDetectCourse - waypoint mode", () => {
+  it("returns null waypoint result when speed never reaches 30 MPH", () => {
+    // Track nowhere near, all samples at slow speed
+    const slowSamples = makeWaypointPath({ lat: 40.7, lon: -74.0 }, 3, 60000, 5);
+    const result = autoDetectCourse(slowSamples, [makeTrack()]);
+    expect(result).toBeNull();
+  });
+
+  it("creates a waypoint result with isWaypointMode=true when no track is near", () => {
+    const samples = makeWaypointPath({ lat: 40.7, lon: -74.0 }, 3, 60000, 15);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    expect(result).not.toBeNull();
+    expect(result!.isWaypointMode).toBe(true);
+    expect(result!.track.name).toBe("Unknown Track");
+    expect(result!.waypointNotice).toContain("Waypoint");
+  });
+
+  it("detects multiple laps when path returns near the waypoint repeatedly", () => {
+    const samples = makeWaypointPath({ lat: 40.7, lon: -74.0 }, 3, 60000, 15);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    expect(result!.laps.length).toBeGreaterThan(0);
+  });
+
+  it("waypoint mode lap numbers start at 1 and increment", () => {
+    const samples = makeWaypointPath({ lat: 40.7, lon: -74.0 }, 3, 60000, 15);
+    const result = autoDetectCourse(samples, [makeTrack()]);
+    const lapNumbers = result!.laps.map((l) => l.lapNumber);
+    expect(lapNumbers[0]).toBe(1);
+    for (let i = 1; i < lapNumbers.length; i++) {
+      expect(lapNumbers[i]).toBe(lapNumbers[i - 1] + 1);
+    }
+  });
+
+  it("waypoint mode populates a virtual course centered on the waypoint", () => {
+    const origin = { lat: 40.7, lon: -74.0 };
+    const samples = makeWaypointPath(origin, 3, 60000, 15);
+    const result = autoDetectCourse(samples, [makeTrack()])!;
+    const course = result.course;
+    // Virtual course S/F is offset by ±0.00001° from the waypoint
+    expect(course.startFinishA.lat).toBeCloseTo(origin.lat, 3);
+    expect(course.startFinishB.lat).toBeCloseTo(origin.lat, 3);
+    expect(course.startFinishA.lat).not.toBe(course.startFinishB.lat); // offsets differ
+  });
+});

--- a/src/lib/courseDetection.ts
+++ b/src/lib/courseDetection.ts
@@ -20,8 +20,8 @@
  * - Divide lap distance by 3 for approximate sectors
  */
 
-import { GpsSample, Track, Course, Lap, CourseDirection, CourseDetectionResult, courseHasSectors } from '@/types/racing';
-import { calculateLaps } from './lapCalculation';
+import { GpsSample, Track, Course, Lap, CourseDirection, CourseDetectionResult } from '@/types/racing';
+import { calculateLaps, detectSectorOrder } from './lapCalculation';
 import { findNearestTrack } from './trackUtils';
 import { haversineDistance } from './parserUtils';
 
@@ -61,32 +61,16 @@ function calculateAverageLapDistanceFt(samples: GpsSample[], laps: Lap[]): numbe
 
 /**
  * Detect direction based on sector crossings.
- * If sector 2 is hit first after S/F → forward.
- * If sector 3 is hit first after S/F → reverse.
+ *
+ * Delegates to detectSectorOrder, which checks the temporal order of the
+ * first S2 vs S3 crossing independently of whether calculateLaps could pair
+ * them as valid sector times. This avoids the "no sectors → reverse" false
+ * positive that the previous implementation produced when a forward-direction
+ * racing line happened not to cross both sector lines.
  */
 function detectDirection(samples: GpsSample[], course: Course, laps: Lap[]): CourseDirection | undefined {
-  if (!courseHasSectors(course) || !course.sector2 || !course.sector3 || laps.length === 0) {
-    return undefined;
-  }
-
-  // Check sector times on the first lap that has them
-  for (const lap of laps) {
-    if (lap.sectors?.s1 !== undefined && lap.sectors?.s2 !== undefined) {
-      // If we got valid S1→S2→S3 in order, that's forward
-      return 'forward';
-    }
-  }
-
-  // If sectors don't compute in the forward direction, try checking if
-  // sector 3 comes before sector 2 — that would indicate reverse.
-  // We can infer this from the lap calculation: if s3 crossing comes before s2,
-  // the standard calculator won't find valid sector times.
-  // So if no lap has valid sector times but we DO have S/F crossings, it's likely reverse.
-  if (laps.length > 0 && laps.every(l => !l.sectors?.s1 || !l.sectors?.s2)) {
-    return 'reverse';
-  }
-
-  return undefined;
+  if (laps.length === 0) return undefined;
+  return detectSectorOrder(samples, course);
 }
 
 /**
@@ -163,7 +147,6 @@ export function autoDetectCourse(
 
   const best = candidates[0];
 
-  // If best match is too far off on length, still use it but note it
   const direction = detectDirection(samples, best.course, best.laps);
 
   return {
@@ -172,6 +155,8 @@ export function autoDetectCourse(
     direction,
     laps: best.laps,
     isWaypointMode: false,
+    // `Infinity` means the course had no `lengthFt` — surface as undefined to consumers.
+    lengthMatchDiff: best.lengthDiff === Infinity ? undefined : best.lengthDiff,
   };
 }
 

--- a/src/lib/datalogParser.test.ts
+++ b/src/lib/datalogParser.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Regression tests against bundled sample data files.
+ *
+ * These don't assert exact byte-for-byte parser output (too brittle); instead
+ * they pin down structural invariants — sample counts, bounds, field mappings,
+ * metadata — so that a future refactor of any parser or shared helper can't
+ * silently drop samples, mis-detect format, or break field naming.
+ *
+ * When updating these tests after intentional behavior changes: re-run the
+ * file locally, log the new actual values, then update the expected ranges.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseDatalogContent } from "./datalogParser";
+import { isDovexFormat, parseDovexFile } from "./dovexParser";
+import { isDoveFormat } from "./doveParser";
+import type { ParsedData } from "@/types/racing";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const SAMPLES_DIR = resolve(__dirname, "../../public/samples");
+
+function loadSample(filename: string): string {
+  return readFileSync(resolve(SAMPLES_DIR, filename), "utf-8");
+}
+
+// ─── Dovex sample (OKC, CrimsonDoveKarting, 2026-04-04) ───────────────────────
+
+describe("regression: okc-tillotson-data.dovex", () => {
+  let content: string;
+  let parsed: ParsedData;
+
+  beforeAll(() => {
+    content = loadSample("okc-tillotson-data.dovex");
+    parsed = parseDatalogContent(content);
+  });
+
+  it("is detected as dovex format (not bare dove)", () => {
+    expect(isDovexFormat(content)).toBe(true);
+  });
+
+  it("the embedded payload is also recognized as dove format", () => {
+    // The dovex parser will strip the header and pass the rest to doveParser
+    // — verify the embedded payload is a valid Dove CSV.
+    const headerEnd = content.indexOf("timestamp");
+    expect(headerEnd).toBeGreaterThan(0);
+    expect(isDoveFormat(content.substring(headerEnd))).toBe(true);
+  });
+
+  it("produces a non-trivial number of samples", () => {
+    // 13 laps * ~56s/lap * ~10Hz ≈ 7000 samples minimum expected
+    expect(parsed.samples.length).toBeGreaterThan(5000);
+    expect(parsed.samples.length).toBeLessThan(30000); // sanity ceiling
+  });
+
+  it("bounds are within Orlando Kart Center (OKC) region (≈28.4°N, -81.4°W)", () => {
+    // OKC in this dataset = Orlando Kart Center, FL (not Oklahoma City)
+    expect(parsed.bounds.minLat).toBeGreaterThan(28);
+    expect(parsed.bounds.maxLat).toBeLessThan(29);
+    expect(parsed.bounds.minLon).toBeGreaterThan(-82);
+    expect(parsed.bounds.maxLon).toBeLessThan(-81);
+  });
+
+  it("first sample has t=0 (timestamps are relative to file start)", () => {
+    expect(parsed.samples[0].t).toBe(0);
+  });
+
+  it("samples are strictly time-ordered", () => {
+    for (let i = 1; i < parsed.samples.length; i++) {
+      expect(parsed.samples[i].t).toBeGreaterThanOrEqual(parsed.samples[i - 1].t);
+    }
+  });
+
+  it("speed triple is consistent (mph/kph derived from mps)", () => {
+    const s = parsed.samples[parsed.samples.length / 2 | 0];
+    expect(s.speedMph).toBeCloseTo(s.speedMps * 2.23694, 2);
+    expect(s.speedKph).toBeCloseTo(s.speedMps * 3.6, 2);
+  });
+
+  it("speed values are within reasonable range (kart, < ~120 mph)", () => {
+    const maxMph = Math.max(...parsed.samples.map((s) => s.speedMph));
+    expect(maxMph).toBeGreaterThan(10); // moving
+    expect(maxMph).toBeLessThan(120); // not impossible
+  });
+
+  it("startDate is set from the first timestamp", () => {
+    expect(parsed.startDate).toBeInstanceOf(Date);
+    expect(parsed.startDate!.getFullYear()).toBe(2026);
+  });
+
+  it("dovexMetadata is populated with header fields", () => {
+    const meta = parsed.dovexMetadata!;
+    expect(meta).toBeDefined();
+    expect(meta.driver).toBe("CrimsonDoveKarting");
+    expect(meta.course).toBe("Normal");
+    expect(meta.shortName).toBe("OKC");
+    expect(meta.datetime).toBe("2026-04-04 16:29:30");
+  });
+
+  it("dovexMetadata lap times have the expected 13 entries", () => {
+    expect(parsed.dovexMetadata!.lapTimesMs).toHaveLength(13);
+    // First lap from header: 58648 ms
+    expect(parsed.dovexMetadata!.lapTimesMs![0]).toBe(58648);
+    // Best lap declared in header should match min of lap times array
+    const minLap = Math.min(...parsed.dovexMetadata!.lapTimesMs!);
+    expect(parsed.dovexMetadata!.bestLapMs).toBe(minLap);
+  });
+
+  it("fieldMappings includes the GPS-derived G-forces", () => {
+    const names = parsed.fieldMappings.map((m) => m.name);
+    expect(names).toContain("Lat G");
+    expect(names).toContain("Lon G");
+  });
+
+  it("parserStats reports the row breakdown", () => {
+    expect(parsed.parserStats).toBeDefined();
+    const stats = parsed.parserStats!;
+    expect(stats.totalRows).toBeGreaterThan(0);
+    expect(stats.acceptedRows).toBe(parsed.samples.length);
+    // Sum of all rejections + accepted should equal total
+    const sumRejected = Object.values(stats.rejected).reduce((a, b) => a + b, 0);
+    expect(stats.acceptedRows + sumRejected).toBe(stats.totalRows);
+  });
+
+  it("parses to the same result via parseDovexFile directly", () => {
+    const direct = parseDovexFile(content);
+    expect(direct.samples.length).toBe(parsed.samples.length);
+    expect(direct.bounds).toEqual(parsed.bounds);
+    expect(direct.duration).toBe(parsed.duration);
+  });
+});
+
+// ─── NMEA sample (Orlando area, 2025-11-23) ───────────────────────────────────
+
+describe("regression: okc-tillotson-plain.nmea", () => {
+  let content: string;
+  let parsed: ParsedData;
+
+  beforeAll(() => {
+    content = loadSample("okc-tillotson-plain.nmea");
+    parsed = parseDatalogContent(content);
+  });
+
+  it("falls through to NMEA parser (not detected as any binary/CSV format)", () => {
+    // Other formats reject this file → parseDatalogContent falls back to parseDatalog
+    expect(isDovexFormat(content)).toBe(false);
+    expect(isDoveFormat(content)).toBe(false);
+  });
+
+  it("produces a non-trivial number of samples", () => {
+    expect(parsed.samples.length).toBeGreaterThan(1000);
+    expect(parsed.samples.length).toBeLessThan(30000);
+  });
+
+  it("bounds are within Orlando region (≈28.4°N, -81.4°W)", () => {
+    expect(parsed.bounds.minLat).toBeGreaterThan(28);
+    expect(parsed.bounds.maxLat).toBeLessThan(29);
+    expect(parsed.bounds.minLon).toBeGreaterThan(-82);
+    expect(parsed.bounds.maxLon).toBeLessThan(-81);
+  });
+
+  it("first sample has t=0", () => {
+    expect(parsed.samples[0].t).toBe(0);
+  });
+
+  it("samples are time-ordered (monotonically non-decreasing)", () => {
+    for (let i = 1; i < parsed.samples.length; i++) {
+      expect(parsed.samples[i].t).toBeGreaterThanOrEqual(parsed.samples[i - 1].t);
+    }
+  });
+
+  it("speed triple is consistent across samples", () => {
+    for (let i = 0; i < parsed.samples.length; i += 500) {
+      const s = parsed.samples[i];
+      expect(s.speedMph).toBeCloseTo(s.speedMps * 2.23694, 2);
+      expect(s.speedKph).toBeCloseTo(s.speedMps * 3.6, 2);
+    }
+  });
+
+  it("speed range is plausible for kart data", () => {
+    const speeds = parsed.samples.map((s) => s.speedMph);
+    const maxMph = Math.max(...speeds);
+    expect(maxMph).toBeGreaterThan(5);
+    expect(maxMph).toBeLessThan(120);
+  });
+
+  it("startDate is parsed from the NMEA date field (2025-11-23)", () => {
+    expect(parsed.startDate).toBeInstanceOf(Date);
+    expect(parsed.startDate!.getUTCFullYear()).toBe(2025);
+    expect(parsed.startDate!.getUTCMonth() + 1).toBe(11); // November
+    expect(parsed.startDate!.getUTCDate()).toBe(23);
+  });
+
+  it("fieldMappings includes GPS-derived G-forces (added by parser)", () => {
+    const names = parsed.fieldMappings.map((m) => m.name);
+    expect(names).toContain("Lat G");
+    expect(names).toContain("Lon G");
+  });
+
+  it("populates Satellites/HDOP/Altitude from GGA sentences in extraFields", () => {
+    // The NMEA fixture has interleaved $GPGGA sentences which provide these
+    const anyWithSats = parsed.samples.find((s) => s.extraFields["Satellites"] !== undefined);
+    expect(anyWithSats).toBeDefined();
+    expect(anyWithSats!.extraFields["Satellites"]).toBeGreaterThan(0);
+    expect(anyWithSats!.extraFields["Satellites"]).toBeLessThan(50);
+
+    const anyWithAlt = parsed.samples.find((s) => s.extraFields["Altitude (m)"] !== undefined);
+    expect(anyWithAlt).toBeDefined();
+  });
+
+  it("each sample has a heading in [0, 360) when present", () => {
+    for (const s of parsed.samples) {
+      if (s.heading !== undefined) {
+        expect(s.heading).toBeGreaterThanOrEqual(0);
+        expect(s.heading).toBeLessThan(360);
+      }
+    }
+  });
+
+  it("rawNmea field is preserved on each sample (NMEA-specific)", () => {
+    expect(parsed.samples[0].rawNmea).toBeTruthy();
+    expect(parsed.samples[0].rawNmea).toContain("$GPRMC");
+  });
+});

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  coursesMatch,
+  deviceCourseToAppCourse,
+  appCourseToDeviceJson,
+  buildTrackJsonForUpload,
+  parseDeviceCourseJson,
+  buildMergedTrackList,
+  countDeviceSectors,
+  countAppSectors,
+  startADistance,
+  type DeviceCourseJson,
+  type DeviceTrackFile,
+} from "./deviceTrackSync";
+import type { Course, Track } from "@/types/racing";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeAppCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    name: "Full CW",
+    lengthFt: 1500,
+    startFinishA: { lat: 35.40000, lon: -97.30000 },
+    startFinishB: { lat: 35.40010, lon: -97.30010 },
+    isUserDefined: true,
+    ...overrides,
+  };
+}
+
+function makeDeviceCourse(overrides: Partial<DeviceCourseJson> = {}): DeviceCourseJson {
+  return {
+    name: "Full CW",
+    lengthFt: 1500,
+    start_a_lat: 35.40000,
+    start_a_lng: -97.30000,
+    start_b_lat: 35.40010,
+    start_b_lng: -97.30010,
+    ...overrides,
+  };
+}
+
+function makeAppTrack(shortName: string, courses: Course[]): Track {
+  return { name: `Track-${shortName}`, shortName, courses, isUserDefined: false };
+}
+
+// ─── coursesMatch ─────────────────────────────────────────────────────────────
+
+describe("coursesMatch", () => {
+  it("returns true for exactly equal start/finish coords without sectors", () => {
+    expect(coursesMatch(makeAppCourse(), makeDeviceCourse())).toBe(true);
+  });
+
+  it("returns true when coordinates differ by less than COORD_EPSILON (~0.05m)", () => {
+    const app = makeAppCourse();
+    const dev = makeDeviceCourse({ start_a_lat: 35.40000 + 1e-7 });
+    expect(coursesMatch(app, dev)).toBe(true);
+  });
+
+  it("returns false when start_a_lat differs by more than epsilon", () => {
+    const app = makeAppCourse();
+    const dev = makeDeviceCourse({ start_a_lat: 35.40001 }); // 1m off — well past epsilon
+    expect(coursesMatch(app, dev)).toBe(false);
+  });
+
+  it("returns false when any of the 4 start/finish coords differ", () => {
+    expect(coursesMatch(makeAppCourse(), makeDeviceCourse({ start_a_lng: -97.5 }))).toBe(false);
+    expect(coursesMatch(makeAppCourse(), makeDeviceCourse({ start_b_lat: 35.5 }))).toBe(false);
+    expect(coursesMatch(makeAppCourse(), makeDeviceCourse({ start_b_lng: -97.5 }))).toBe(false);
+  });
+
+  it("returns false when app has sectors but device does not", () => {
+    const app = makeAppCourse({
+      sector2: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      sector3: { a: { lat: 35.42, lon: -97.33 }, b: { lat: 35.42, lon: -97.34 } },
+    });
+    expect(coursesMatch(app, makeDeviceCourse())).toBe(false);
+  });
+
+  it("returns false when device has sectors but app does not", () => {
+    const dev = makeDeviceCourse({
+      sector_2_a_lat: 35.41, sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+    });
+    expect(coursesMatch(makeAppCourse(), dev)).toBe(false);
+  });
+
+  it("returns true when matching sector lines on both sides", () => {
+    const app = makeAppCourse({
+      sector2: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      sector3: { a: { lat: 35.42, lon: -97.33 }, b: { lat: 35.42, lon: -97.34 } },
+    });
+    const dev = makeDeviceCourse({
+      sector_2_a_lat: 35.41, sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+      sector_3_a_lat: 35.42, sector_3_a_lng: -97.33,
+      sector_3_b_lat: 35.42, sector_3_b_lng: -97.34,
+    });
+    expect(coursesMatch(app, dev)).toBe(true);
+  });
+
+  it("returns false when sector 2 coordinates drift past epsilon", () => {
+    const app = makeAppCourse({
+      sector2: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      sector3: { a: { lat: 35.42, lon: -97.33 }, b: { lat: 35.42, lon: -97.34 } },
+    });
+    const dev = makeDeviceCourse({
+      sector_2_a_lat: 35.41005, // ~5m off
+      sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+      sector_3_a_lat: 35.42, sector_3_a_lng: -97.33,
+      sector_3_b_lat: 35.42, sector_3_b_lng: -97.34,
+    });
+    expect(coursesMatch(app, dev)).toBe(false);
+  });
+
+  it("does not consider name when comparing (matching is by geometry)", () => {
+    const app = makeAppCourse({ name: "Alpha" });
+    const dev = makeDeviceCourse({ name: "Beta" });
+    expect(coursesMatch(app, dev)).toBe(true);
+  });
+
+  it("ignores lengthFt differences (lengthFt is descriptive, not a match key)", () => {
+    const app = makeAppCourse({ lengthFt: 1500 });
+    const dev = makeDeviceCourse({ lengthFt: 2000 });
+    expect(coursesMatch(app, dev)).toBe(true);
+  });
+});
+
+// ─── deviceCourseToAppCourse ──────────────────────────────────────────────────
+
+describe("deviceCourseToAppCourse", () => {
+  it("converts core start/finish fields", () => {
+    const c = deviceCourseToAppCourse(makeDeviceCourse());
+    expect(c.name).toBe("Full CW");
+    expect(c.startFinishA).toEqual({ lat: 35.40000, lon: -97.30000 });
+    expect(c.startFinishB).toEqual({ lat: 35.40010, lon: -97.30010 });
+    expect(c.isUserDefined).toBe(true);
+  });
+
+  it("carries lengthFt through", () => {
+    expect(deviceCourseToAppCourse(makeDeviceCourse({ lengthFt: 2200 })).lengthFt).toBe(2200);
+  });
+
+  it("attaches sector2 + sector3 only when BOTH are present", () => {
+    const dev = makeDeviceCourse({
+      sector_2_a_lat: 35.41, sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+      sector_3_a_lat: 35.42, sector_3_a_lng: -97.33,
+      sector_3_b_lat: 35.42, sector_3_b_lng: -97.34,
+    });
+    const c = deviceCourseToAppCourse(dev);
+    expect(c.sector2).toEqual({ a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } });
+    expect(c.sector3).toEqual({ a: { lat: 35.42, lon: -97.33 }, b: { lat: 35.42, lon: -97.34 } });
+  });
+
+  it("does NOT attach sector2 alone when sector3 is missing (treats as no-sectors)", () => {
+    const dev = makeDeviceCourse({
+      sector_2_a_lat: 35.41, sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+      // sector_3_* fields absent
+    });
+    const c = deviceCourseToAppCourse(dev);
+    expect(c.sector2).toBeUndefined();
+    expect(c.sector3).toBeUndefined();
+  });
+});
+
+// ─── appCourseToDeviceJson ────────────────────────────────────────────────────
+
+describe("appCourseToDeviceJson", () => {
+  it("converts core fields", () => {
+    const dc = appCourseToDeviceJson(makeAppCourse());
+    expect(dc.name).toBe("Full CW");
+    expect(dc.start_a_lat).toBe(35.40000);
+    expect(dc.start_a_lng).toBe(-97.30000);
+    expect(dc.start_b_lat).toBe(35.40010);
+    expect(dc.start_b_lng).toBe(-97.30010);
+    expect(dc.lengthFt).toBe(1500);
+  });
+
+  it("omits lengthFt when the app course doesn't have one", () => {
+    const dc = appCourseToDeviceJson(makeAppCourse({ lengthFt: undefined }));
+    expect(dc.lengthFt).toBeUndefined();
+    expect("lengthFt" in dc).toBe(false);
+  });
+
+  it("emits sector fields when present", () => {
+    const dc = appCourseToDeviceJson(makeAppCourse({
+      sector2: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      sector3: { a: { lat: 35.42, lon: -97.33 }, b: { lat: 35.42, lon: -97.34 } },
+    }));
+    expect(dc.sector_2_a_lat).toBe(35.41);
+    expect(dc.sector_2_a_lng).toBe(-97.31);
+    expect(dc.sector_3_b_lng).toBe(-97.34);
+  });
+
+  it("round-trips with deviceCourseToAppCourse on courses with full sectors", () => {
+    const original = makeAppCourse({
+      sector2: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      sector3: { a: { lat: 35.42, lon: -97.33 }, b: { lat: 35.42, lon: -97.34 } },
+    });
+    const roundTripped = deviceCourseToAppCourse(appCourseToDeviceJson(original));
+    expect(roundTripped.name).toBe(original.name);
+    expect(roundTripped.lengthFt).toBe(original.lengthFt);
+    expect(roundTripped.startFinishA).toEqual(original.startFinishA);
+    expect(roundTripped.startFinishB).toEqual(original.startFinishB);
+    expect(roundTripped.sector2).toEqual(original.sector2);
+    expect(roundTripped.sector3).toEqual(original.sector3);
+  });
+});
+
+// ─── buildTrackJsonForUpload ──────────────────────────────────────────────────
+
+describe("buildTrackJsonForUpload", () => {
+  it("emits a JSON array of courses (not a wrapping object)", () => {
+    const track = makeAppTrack("OKC", [makeAppCourse()]);
+    const json = buildTrackJsonForUpload(track);
+    const parsed = JSON.parse(json);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].name).toBe("Full CW");
+  });
+
+  it("emits all courses in order", () => {
+    const track = makeAppTrack("OKC", [
+      makeAppCourse({ name: "A" }),
+      makeAppCourse({ name: "B" }),
+      makeAppCourse({ name: "C" }),
+    ]);
+    const parsed: DeviceCourseJson[] = JSON.parse(buildTrackJsonForUpload(track));
+    expect(parsed.map((c) => c.name)).toEqual(["A", "B", "C"]);
+  });
+
+  it("uses tab indentation (matches device expectation)", () => {
+    const json = buildTrackJsonForUpload(makeAppTrack("OKC", [makeAppCourse()]));
+    expect(json).toContain("\t");
+  });
+});
+
+// ─── parseDeviceCourseJson ────────────────────────────────────────────────────
+
+describe("parseDeviceCourseJson", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("parses a valid course array", () => {
+    const raw = JSON.stringify([makeDeviceCourse()]);
+    expect(parseDeviceCourseJson(raw)).toHaveLength(1);
+  });
+
+  it("returns [] for malformed JSON without throwing", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(parseDeviceCourseJson("not json {")).toEqual([]);
+  });
+
+  it("returns [] when JSON is valid but not an array (e.g. wrapping object)", () => {
+    expect(parseDeviceCourseJson('{"courses": []}')).toEqual([]);
+  });
+
+  it("returns [] for empty array", () => {
+    expect(parseDeviceCourseJson("[]")).toEqual([]);
+  });
+});
+
+// ─── countDeviceSectors / countAppSectors ─────────────────────────────────────
+
+describe("countDeviceSectors", () => {
+  it("returns 0 when no sector fields are set", () => {
+    expect(countDeviceSectors(makeDeviceCourse())).toBe(0);
+  });
+
+  it("returns 2 when only sector_2 fields are set", () => {
+    expect(countDeviceSectors(makeDeviceCourse({
+      sector_2_a_lat: 35.41, sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+    }))).toBe(2);
+  });
+
+  it("returns 3 when both sector_2 and sector_3 fields are set", () => {
+    expect(countDeviceSectors(makeDeviceCourse({
+      sector_2_a_lat: 35.41, sector_2_a_lng: -97.31,
+      sector_2_b_lat: 35.41, sector_2_b_lng: -97.32,
+      sector_3_a_lat: 35.42, sector_3_a_lng: -97.33,
+      sector_3_b_lat: 35.42, sector_3_b_lng: -97.34,
+    }))).toBe(3);
+  });
+});
+
+describe("countAppSectors", () => {
+  it("returns 0 for a course with no sector lines", () => {
+    expect(countAppSectors(makeAppCourse())).toBe(0);
+  });
+
+  it("returns 2 when only sector2 is set", () => {
+    expect(countAppSectors(makeAppCourse({
+      sector2: { a: { lat: 0, lon: 0 }, b: { lat: 0, lon: 0 } },
+    }))).toBe(2);
+  });
+
+  it("returns 3 when both sector2 and sector3 are set", () => {
+    expect(countAppSectors(makeAppCourse({
+      sector2: { a: { lat: 0, lon: 0 }, b: { lat: 0, lon: 0 } },
+      sector3: { a: { lat: 0, lon: 0 }, b: { lat: 0, lon: 0 } },
+    }))).toBe(3);
+  });
+});
+
+// ─── startADistance ───────────────────────────────────────────────────────────
+
+describe("startADistance", () => {
+  it("returns 0 for identical start_a points", () => {
+    expect(startADistance(makeAppCourse(), makeDeviceCourse())).toBe(0);
+  });
+
+  it("returns ~111m for ~0.001° latitude difference", () => {
+    const app = makeAppCourse();
+    const dev = makeDeviceCourse({ start_a_lat: 35.401 }); // 0.001° = ~111m
+    expect(startADistance(app, dev)).toBeCloseTo(111, 0);
+  });
+});
+
+// ─── buildMergedTrackList ─────────────────────────────────────────────────────
+
+describe("buildMergedTrackList", () => {
+  it("returns [] for empty inputs", () => {
+    expect(buildMergedTrackList([], [])).toEqual([]);
+  });
+
+  it("skips app tracks without shortName (cannot be matched to device)", () => {
+    const trackNoShortName: Track = { name: "Anonymous", courses: [makeAppCourse()] };
+    expect(buildMergedTrackList([trackNoShortName], [])).toEqual([]);
+  });
+
+  it("classifies a track present on both with matching courses as 'synced'", () => {
+    const tracks = [makeAppTrack("OKC", [makeAppCourse()])];
+    const deviceFiles: DeviceTrackFile[] = [{ shortName: "OKC", courses: [makeDeviceCourse()] }];
+    const merged = buildMergedTrackList(tracks, deviceFiles);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].status).toBe("synced");
+    expect(merged[0].mergedCourses[0].status).toBe("synced");
+  });
+
+  it("classifies a track with coord-drifting courses as 'mismatch'", () => {
+    const tracks = [makeAppTrack("OKC", [makeAppCourse()])];
+    const deviceFiles: DeviceTrackFile[] = [{
+      shortName: "OKC",
+      courses: [makeDeviceCourse({ start_a_lat: 35.5 })], // ~11km off
+    }];
+    const merged = buildMergedTrackList(tracks, deviceFiles);
+    expect(merged[0].status).toBe("mismatch");
+    expect(merged[0].mergedCourses[0].status).toBe("mismatch");
+  });
+
+  it("classifies an app track not on the device as 'app_only'", () => {
+    const tracks = [makeAppTrack("OKC", [makeAppCourse()])];
+    const merged = buildMergedTrackList(tracks, []);
+    expect(merged[0].status).toBe("app_only");
+    expect(merged[0].mergedCourses[0].status).toBe("app_only");
+  });
+
+  it("classifies a device track not in the app as 'device_only'", () => {
+    const deviceFiles: DeviceTrackFile[] = [{ shortName: "UNKNOWN", courses: [makeDeviceCourse()] }];
+    const merged = buildMergedTrackList([], deviceFiles);
+    expect(merged[0].status).toBe("device_only");
+    expect(merged[0].mergedCourses[0].status).toBe("device_only");
+  });
+
+  it("classifies per-course status correctly when some courses match and others don't", () => {
+    const tracks = [makeAppTrack("OKC", [
+      makeAppCourse({ name: "Full CW" }),
+      makeAppCourse({ name: "Short" }),
+      makeAppCourse({ name: "AppOnly" }),
+    ])];
+    const deviceFiles: DeviceTrackFile[] = [{
+      shortName: "OKC",
+      courses: [
+        makeDeviceCourse({ name: "Full CW" }),                                  // synced
+        makeDeviceCourse({ name: "Short", start_a_lat: 35.5 }),                 // mismatch
+        makeDeviceCourse({ name: "DeviceOnly" }),                               // device_only
+      ],
+    }];
+    const merged = buildMergedTrackList(tracks, deviceFiles);
+    const statuses = new Map(merged[0].mergedCourses.map((c) => [c.name, c.status]));
+    expect(statuses.get("Full CW")).toBe("synced");
+    expect(statuses.get("Short")).toBe("mismatch");
+    expect(statuses.get("AppOnly")).toBe("app_only");
+    expect(statuses.get("DeviceOnly")).toBe("device_only");
+
+    // Track-level status rolls up to mismatch when any course is non-synced
+    expect(merged[0].status).toBe("mismatch");
+  });
+
+  it("sorts results: synced → mismatch → app_only → device_only", () => {
+    const tracks = [
+      makeAppTrack("AAA", [makeAppCourse()]),               // app_only
+      makeAppTrack("BBB", [makeAppCourse()]),               // synced
+      makeAppTrack("CCC", [makeAppCourse()]),               // mismatch
+    ];
+    const deviceFiles: DeviceTrackFile[] = [
+      { shortName: "BBB", courses: [makeDeviceCourse()] },
+      { shortName: "CCC", courses: [makeDeviceCourse({ start_a_lat: 35.5 })] },
+      { shortName: "DDD", courses: [makeDeviceCourse()] }, // device_only
+    ];
+    const merged = buildMergedTrackList(tracks, deviceFiles);
+    expect(merged.map((m) => m.status)).toEqual(["synced", "mismatch", "app_only", "device_only"]);
+  });
+
+  it("does not duplicate a device track that matches an app track", () => {
+    const tracks = [makeAppTrack("OKC", [makeAppCourse()])];
+    const deviceFiles: DeviceTrackFile[] = [{ shortName: "OKC", courses: [makeDeviceCourse()] }];
+    const merged = buildMergedTrackList(tracks, deviceFiles);
+    expect(merged).toHaveLength(1);
+  });
+});

--- a/src/lib/doveParser.ts
+++ b/src/lib/doveParser.ts
@@ -1,6 +1,17 @@
 import { GpsSample, FieldMapping, ParsedData, ParserStats } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { haversineDistance, calculateBearing, isTeleportation, MAX_SPEED_MPS } from './parserUtils';
+import {
+  calculateBearing,
+  isTeleportation,
+  MAX_SPEED_MPS,
+  MPH_TO_MPS,
+  MPS_TO_KPH,
+  speedTriple,
+  calculateBounds,
+  validateGpsCoords,
+  createRejectedCounter,
+  recordCoordRejection,
+} from './parserUtils';
 
 /**
  * Dove CSV Parser
@@ -89,49 +100,43 @@ export function parseDoveFile(content: string): ParsedData {
   const samples: GpsSample[] = [];
   let baseTimestamp: number | null = null;
   let startDate: Date | undefined;
-  
-  const rejected = {
-    nanFields: 0,
-    zeroCoords: 0,
-    outOfRange: 0,
-    speedCap: 0,
-    teleportation: 0,
-    incompleteRow: 0,
-  };
+
+  const rejected = createRejectedCounter();
   let totalRows = 0;
-  
+
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i].trim();
     if (!line) continue;
-    
+
     totalRows++;
-    
+
     const fields = line.split(',').map(f => f.trim());
     if (fields.length < headers.length) { rejected.incompleteRow++; continue; }
-    
+
     // Parse required fields
     const timestamp = parseInt(fields[columnIndex['timestamp']], 10);
     const lat = parseFloat(fields[columnIndex['lat']]);
     const lng = parseFloat(fields[columnIndex['lng']]);
     const speedMph = parseFloat(fields[columnIndex['speed_mph']]);
-    
-    // Validate required fields
-    if (isNaN(timestamp) || isNaN(lat) || isNaN(lng) || isNaN(speedMph)) { rejected.nanFields++; continue; }
-    if (lat === 0 && lng === 0) { rejected.zeroCoords++; continue; }
-    if (Math.abs(lat) > 90 || Math.abs(lng) > 180) { rejected.outOfRange++; continue; }
-    
+
+    // Validate required fields. Treat NaN timestamp/speed under the nanFields bucket
+    // alongside the GPS coord NaN check, matching prior behavior.
+    if (isNaN(timestamp) || isNaN(speedMph)) { rejected.nanFields++; continue; }
+    const coordReason = validateGpsCoords(lat, lng);
+    if (recordCoordRejection(rejected, coordReason)) continue;
+
     // Set base timestamp and start date from first valid sample
     if (baseTimestamp === null) {
       baseTimestamp = timestamp;
       startDate = new Date(timestamp);
     }
-    
+
     const t = timestamp - baseTimestamp;
-    
+
     // Convert speed
-    const speedMps = speedMph * 0.44704;
-    const speedKph = speedMph * 1.60934;
-    
+    const speedMps = speedMph * MPH_TO_MPS;
+    const speedKph = speedMps * MPS_TO_KPH;
+
     if (speedMps > MAX_SPEED_MPS) { rejected.speedCap++; continue; }
 
     // Teleportation filter
@@ -214,7 +219,7 @@ export function parseDoveFile(content: string): ParsedData {
       t, lat, lon: lng,
       speedMps, speedMph, speedKph,
       heading,
-      extraFields
+      extraFields,
     });
   }
   
@@ -290,28 +295,18 @@ export function parseDoveFile(content: string): ParsedData {
   }
   
   // Build parser stats
-  const totalRejected = Object.values(rejected).reduce((a, b) => a + b, 0);
   const parserStats: ParserStats = {
     totalRows,
     acceptedRows: samples.length,
     rejected,
   };
 
-  // Calculate bounds
-  const lats = samples.map(s => s.lat);
-  const lons = samples.map(s => s.lon);
-  
   return {
     samples,
     fieldMappings,
-    bounds: {
-      minLat: Math.min(...lats),
-      maxLat: Math.max(...lats),
-      minLon: Math.min(...lons),
-      maxLon: Math.max(...lons)
-    },
+    bounds: calculateBounds(samples),
     duration: samples[samples.length - 1].t,
     startDate,
-    parserStats
+    parserStats,
   };
 }

--- a/src/lib/lapCalculation.test.ts
+++ b/src/lib/lapCalculation.test.ts
@@ -176,21 +176,48 @@ describe("calculateLaps - debounce + direction", () => {
     expect(laps).toHaveLength(2);
   });
 
-  it("BUG (documented): if first crossing is wrong-direction, subsequent correct crossings are locked out", () => {
-    // First "crossing" is a west-going glitch; rest are clean east-going
-    // The algorithm locks direction to the glitch's direction, rejecting good crossings.
+  it("recovers from a first-crossing direction glitch when majority crossings agree", () => {
+    // Setup: 1 wrong-direction glitch at t=500, then 3 clean east crossings.
+    // Old behavior: glitch locked direction to west, all 3 east crossings rejected
+    //   → 1 west crossing total → 0 laps detected.
+    // New behavior: majority direction (east) wins, glitch discarded
+    //   → 3 east crossings → 2 laps detected.
     const samples = [
-      makeSample(0, 0, 0.001), // start east
-      makeSample(1000, 0, -0.001), // glitch: west cross @ t=500 (locks direction = west)
-      makeSample(10000, 0, 0.001), // east cross @ t=5500 — would be rejected as opposite direction
-      makeSample(20000, 0, -0.001), // west again — same direction as first, accepted
+      makeSample(0, 0, 0.001),         // east of line
+      makeSample(1000, 0, -0.001),     // GLITCH: west cross @ t=500
+
+      makeSample(11000, 0, 0.001),     // east cross @ t=6000
+      makeSample(12000, 0.01, 0.001),
+      makeSample(13000, 0.01, -0.001),
+      makeSample(14000, 0, -0.001),
+
+      makeSample(20000, 0, 0.001),     // east cross @ t=17000
+      makeSample(21000, 0.01, 0.001),
+      makeSample(22000, 0.01, -0.001),
+      makeSample(23000, 0, -0.001),
+
+      makeSample(30000, 0, 0.001),     // east cross @ t=26500
     ];
     const laps = calculateLaps(samples, sfCourse);
-    // West-going crossings: t=500 (segment[0→1]) and t=15000 (segment[2→3])
-    // → 1 lap of ~14500ms
-    expect(laps).toHaveLength(1);
-    expect(laps[0].lapTimeMs).toBeCloseTo(14500, -1);
-    // Real fix would be to allow direction recovery if subsequent same-direction crossings cluster.
+    expect(laps).toHaveLength(2);
+  });
+
+  it("majority-direction filter still works on reverse-direction sessions", () => {
+    // 3 west-going crossings → 2 reverse laps (no eastern majority to flip)
+    const samples = [
+      makeSample(0, 0, 0.001),
+      makeSample(1000, 0, -0.001),  // west cross @ t=500
+      makeSample(10000, 0.01, -0.001),
+      makeSample(11000, 0.01, 0.001),
+      makeSample(12000, 0, 0.001),
+      makeSample(13000, 0, -0.001), // west cross @ t=12500
+      makeSample(20000, 0.01, -0.001),
+      makeSample(21000, 0.01, 0.001),
+      makeSample(22000, 0, 0.001),
+      makeSample(23000, 0, -0.001), // west cross @ t=22500
+    ];
+    const laps = calculateLaps(samples, sfCourse);
+    expect(laps).toHaveLength(2);
   });
 });
 

--- a/src/lib/lapCalculation.test.ts
+++ b/src/lib/lapCalculation.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateLaps,
+  formatLapTime,
+  formatSectorTime,
+  calculateOptimalLap,
+} from "./lapCalculation";
+import type { GpsSample, Course, Lap } from "@/types/racing";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/** Build a single GpsSample with sensible defaults. */
+function makeSample(t: number, lat: number, lon: number, speedMps = 20): GpsSample {
+  return {
+    t,
+    lat,
+    lon,
+    speedMps,
+    speedMph: speedMps * 2.23694,
+    speedKph: speedMps * 3.6,
+    extraFields: {},
+  };
+}
+
+/**
+ * S/F line: vertical at lon=0, lat ∈ [-0.0001, 0.0001].
+ * Path crosses it going east each lap, then loops far north (lat=0.01) to
+ * return west — high lat keeps the return-leg outside the S/F line's lat range.
+ */
+const sfCourse: Course = {
+  name: "TestCourse",
+  startFinishA: { lat: 0.0001, lon: 0 },
+  startFinishB: { lat: -0.0001, lon: 0 },
+  isUserDefined: false,
+};
+
+/**
+ * Build a race path with `numCrossings` east-going crossings of the S/F line,
+ * spaced `intervalMs` apart.
+ *
+ *   - First sample at (0, -0.001), t=startTime
+ *   - Each crossing: jump east to (0, 0.001) → segment crosses S/F at fraction 0.5
+ *   - Between crossings: loop NE → NW → SW at lat=0.01 (well outside line range)
+ *
+ * For `numCrossings = N`, the returned samples produce exactly N-1 laps.
+ */
+function makeRacePath(numCrossings: number, intervalMs: number, startTime = 0, speedMps = 20): GpsSample[] {
+  const samples: GpsSample[] = [];
+  let t = startTime;
+  samples.push(makeSample(t, 0, -0.001, speedMps));
+
+  for (let i = 0; i < numCrossings; i++) {
+    t += intervalMs / 4;
+    samples.push(makeSample(t, 0, 0.001, speedMps)); // east cross
+    if (i < numCrossings - 1) {
+      t += intervalMs / 4;
+      samples.push(makeSample(t, 0.01, 0.001, speedMps)); // NE
+      t += intervalMs / 4;
+      samples.push(makeSample(t, 0.01, -0.001, speedMps)); // NW
+      t += intervalMs / 4;
+      samples.push(makeSample(t, 0, -0.001, speedMps)); // back west
+    }
+  }
+  return samples;
+}
+
+// ─── calculateLaps: degenerate inputs ────────────────────────────────────────
+
+describe("calculateLaps - degenerate inputs", () => {
+  it("returns [] for empty samples", () => {
+    expect(calculateLaps([], sfCourse)).toEqual([]);
+  });
+
+  it("returns [] for a single sample", () => {
+    expect(calculateLaps([makeSample(0, 0, -0.001)], sfCourse)).toEqual([]);
+  });
+
+  it("returns [] when path never crosses S/F", () => {
+    const samples = [
+      makeSample(0, 0, -0.001),
+      makeSample(1000, 0, -0.002), // stays west
+      makeSample(2000, 0.01, -0.002), // goes north
+      makeSample(3000, 0, -0.001), // back south
+    ];
+    expect(calculateLaps(samples, sfCourse)).toEqual([]);
+  });
+
+  it("returns [] with only one crossing (need 2 for a lap)", () => {
+    // 2 crossings produce 1 lap, so 1 crossing produces 0
+    const samples = makeRacePath(1, 10000);
+    expect(calculateLaps(samples, sfCourse)).toEqual([]);
+  });
+});
+
+// ─── calculateLaps: basic lap counting ───────────────────────────────────────
+
+describe("calculateLaps - lap counting", () => {
+  it("produces 1 lap from 2 same-direction crossings >5s apart", () => {
+    const samples = makeRacePath(2, 10000);
+    const laps = calculateLaps(samples, sfCourse);
+    expect(laps).toHaveLength(1);
+    expect(laps[0].lapNumber).toBe(1);
+  });
+
+  it("produces 2 laps from 3 crossings", () => {
+    const samples = makeRacePath(3, 10000);
+    const laps = calculateLaps(samples, sfCourse);
+    expect(laps).toHaveLength(2);
+    expect(laps.map((l) => l.lapNumber)).toEqual([1, 2]);
+  });
+
+  it("produces N-1 laps from N consistent crossings", () => {
+    const samples = makeRacePath(6, 10000);
+    expect(calculateLaps(samples, sfCourse)).toHaveLength(5);
+  });
+
+  it("lap time ≈ interval between successive crossings", () => {
+    const samples = makeRacePath(3, 10000);
+    const laps = calculateLaps(samples, sfCourse);
+    expect(laps[0].lapTimeMs).toBeCloseTo(10000, -1); // ±5ms tolerance for fraction-based crossing time
+    expect(laps[1].lapTimeMs).toBeCloseTo(10000, -1);
+  });
+
+  it("startTime/endTime are crossing times, not raw sample times", () => {
+    const samples = makeRacePath(2, 10000);
+    const lap = calculateLaps(samples, sfCourse)[0];
+    // First crossing in fixture spans samples[0..1] (t=0..2500), midpoint t=1250
+    expect(lap.startTime).toBeCloseTo(1250, -1);
+  });
+
+  it("startIndex/endIndex point at the sample before each crossing", () => {
+    const samples = makeRacePath(3, 10000);
+    const laps = calculateLaps(samples, sfCourse);
+    // Crossings happen between sample[0]↔sample[1] and sample[4]↔sample[5]
+    expect(laps[0].startIndex).toBe(0);
+    expect(laps[0].endIndex).toBe(4);
+  });
+});
+
+// ─── calculateLaps: debounce and direction filtering ─────────────────────────
+
+describe("calculateLaps - debounce + direction", () => {
+  it("debounces crossings within MIN_CROSSING_INTERVAL_MS (5000ms)", () => {
+    // Build a path where two east-going crossings happen 4s apart — second should be filtered
+    const samples = [
+      makeSample(0, 0, -0.001),
+      makeSample(1000, 0, 0.001), // east cross at t=500
+      makeSample(2000, 0.01, 0.001), // up north, no cross
+      makeSample(3000, 0.01, -0.001), // west at high lat, no cross
+      makeSample(4000, 0, -0.001), // back south
+      makeSample(5000, 0, 0.001), // east cross at t=4500 — 4s after first → DEBOUNCED
+      makeSample(6000, 0.01, 0.001),
+      makeSample(7000, 0.01, -0.001),
+      makeSample(8000, 0, -0.001),
+      makeSample(15000, 0, 0.001), // east cross at t=11500 — 11s after first → accepted
+    ];
+    const laps = calculateLaps(samples, sfCourse);
+    // Crossings: t=500 (accepted) → t=4500 (debounced) → t=11500 (accepted) = 1 lap, ~11000ms
+    expect(laps).toHaveLength(1);
+    expect(laps[0].lapTimeMs).toBeCloseTo(11000, -1);
+  });
+
+  it("rejects opposite-direction crossings (locks direction after first)", () => {
+    // Path: west → east → west → east → west → east
+    // The west-going crossings should be ignored entirely; only east-going count
+    const samples = [
+      makeSample(0, 0, -0.001),
+      makeSample(1000, 0, 0.001), // east cross @ t=500
+      makeSample(10000, 0, -0.001), // segment B→C goes west — would-be opposite crossing
+      makeSample(20000, 0, 0.001), // east cross @ t=15000
+      makeSample(30000, 0, -0.001), // west again
+      makeSample(40000, 0, 0.001), // east cross @ t=35000
+    ];
+    const laps = calculateLaps(samples, sfCourse);
+    // Only east-going crossings count: t=500, t=15000, t=35000 → 2 laps
+    expect(laps).toHaveLength(2);
+  });
+
+  it("BUG (documented): if first crossing is wrong-direction, subsequent correct crossings are locked out", () => {
+    // First "crossing" is a west-going glitch; rest are clean east-going
+    // The algorithm locks direction to the glitch's direction, rejecting good crossings.
+    const samples = [
+      makeSample(0, 0, 0.001), // start east
+      makeSample(1000, 0, -0.001), // glitch: west cross @ t=500 (locks direction = west)
+      makeSample(10000, 0, 0.001), // east cross @ t=5500 — would be rejected as opposite direction
+      makeSample(20000, 0, -0.001), // west again — same direction as first, accepted
+    ];
+    const laps = calculateLaps(samples, sfCourse);
+    // West-going crossings: t=500 (segment[0→1]) and t=15000 (segment[2→3])
+    // → 1 lap of ~14500ms
+    expect(laps).toHaveLength(1);
+    expect(laps[0].lapTimeMs).toBeCloseTo(14500, -1);
+    // Real fix would be to allow direction recovery if subsequent same-direction crossings cluster.
+  });
+});
+
+// ─── calculateLaps: speed stats ──────────────────────────────────────────────
+
+describe("calculateLaps - speed stats", () => {
+  it("computes maxSpeedMph from the highest speed sample within the lap", () => {
+    const samples = makeRacePath(2, 10000, 0, 20);
+    samples[2].speedMps = 50;
+    samples[2].speedMph = 50 * 2.23694;
+    samples[2].speedKph = 50 * 3.6;
+    const lap = calculateLaps(samples, sfCourse)[0];
+    expect(lap.maxSpeedMph).toBeCloseTo(50 * 2.23694, 2);
+  });
+
+  it("computes minSpeedMph from the lowest speed sample (above glitch threshold)", () => {
+    const samples = makeRacePath(2, 10000, 0, 20);
+    samples[2].speedMps = 5;
+    samples[2].speedMph = 5 * 2.23694;
+    samples[2].speedKph = 5 * 3.6;
+    const lap = calculateLaps(samples, sfCourse)[0];
+    expect(lap.minSpeedMph).toBeCloseTo(5 * 2.23694, 2);
+  });
+
+  it("filters out a short low-speed run (≤3 samples) as a glitch for minSpeed", () => {
+    // Path with a 2-sample run at 0 mph — should be excluded from min speed calc
+    const samples = makeRacePath(2, 10000, 0, 20);
+    // Inject 2 consecutive near-zero samples (a "glitch")
+    samples[2].speedMps = 0; samples[2].speedMph = 0; samples[2].speedKph = 0;
+    samples[3].speedMps = 0; samples[3].speedMph = 0; samples[3].speedKph = 0;
+    const lap = calculateLaps(samples, sfCourse)[0];
+    // Min speed should NOT be 0 — the glitch run was filtered
+    expect(lap.minSpeedMph).toBeGreaterThan(1);
+  });
+
+  it("includes a longer low-speed run (>3 samples) as legitimate slow data", () => {
+    // 4-sample run at 0 mph — should NOT be filtered (it's genuine slow data)
+    const samples = makeRacePath(2, 20000, 0, 20);
+    // Inject 4 consecutive zero-speed samples by extending the lap with extras
+    samples.splice(2, 0,
+      makeSample(samples[1].t + 100, 0.01, 0.001, 0),
+      makeSample(samples[1].t + 200, 0.01, 0.001, 0),
+      makeSample(samples[1].t + 300, 0.01, 0.001, 0),
+      makeSample(samples[1].t + 400, 0.01, 0.001, 0),
+    );
+    const lap = calculateLaps(samples, sfCourse)[0];
+    // Min speed reaches 0 because a 4+ sample slow run is treated as real
+    expect(lap.minSpeedMph).toBe(0);
+  });
+
+  it("returns 0 for minSpeed when no non-glitch low samples exist", () => {
+    // All samples high speed; minSpeed should be the lowest real value
+    const samples = makeRacePath(2, 10000, 0, 30);
+    const lap = calculateLaps(samples, sfCourse)[0];
+    expect(lap.minSpeedMph).toBeGreaterThan(0);
+    expect(lap.minSpeedMph).toBeCloseTo(30 * 2.23694, 2);
+  });
+});
+
+// ─── calculateLaps: sectors ──────────────────────────────────────────────────
+
+/**
+ * Course with sector lines. Sector 2 at lon=0.003, sector 3 at lon=0.006.
+ * Path that crosses all three lines going east each lap:
+ *   S/F (lon=0) → S2 (lon=0.003) → S3 (lon=0.006) → loop north → back west
+ */
+const sectorCourse: Course = {
+  name: "TestSectorCourse",
+  startFinishA: { lat: 0.0001, lon: 0 },
+  startFinishB: { lat: -0.0001, lon: 0 },
+  sector2: { a: { lat: 0.0001, lon: 0.003 }, b: { lat: -0.0001, lon: 0.003 } },
+  sector3: { a: { lat: 0.0001, lon: 0.006 }, b: { lat: -0.0001, lon: 0.006 } },
+};
+
+/** One sector-aware lap with S/F at t=N*lapDur+500, S2 at +2500, S3 at +4500, S/F again at next lap */
+function makeSectorLap(startT: number, lapDur: number, speedMps = 20): GpsSample[] {
+  return [
+    makeSample(startT, 0, -0.001, speedMps),
+    makeSample(startT + lapDur * 0.1, 0, 0.001, speedMps), // cross S/F
+    makeSample(startT + lapDur * 0.2, 0, 0.002, speedMps),
+    makeSample(startT + lapDur * 0.3, 0, 0.004, speedMps), // cross S2 (between lon=0.002 and 0.004)
+    makeSample(startT + lapDur * 0.4, 0, 0.005, speedMps),
+    makeSample(startT + lapDur * 0.5, 0, 0.007, speedMps), // cross S3 (between lon=0.005 and 0.007)
+    makeSample(startT + lapDur * 0.6, 0.01, 0.007, speedMps), // north
+    makeSample(startT + lapDur * 0.8, 0.01, -0.001, speedMps), // west at high lat
+    makeSample(startT + lapDur, 0, -0.001, speedMps), // back to start
+  ];
+}
+
+describe("calculateLaps - sectors", () => {
+  it("omits sectors field when course has no sector lines", () => {
+    const samples = makeRacePath(2, 10000);
+    const lap = calculateLaps(samples, sfCourse)[0];
+    expect(lap.sectors).toBeUndefined();
+  });
+
+  it("computes s1/s2/s3 when both sector lines are present and crossed in order", () => {
+    const samples = [...makeSectorLap(0, 10000), ...makeSectorLap(10000, 10000)];
+    const laps = calculateLaps(samples, sectorCourse);
+    expect(laps).toHaveLength(1);
+    const lap = laps[0];
+    expect(lap.sectors).toBeDefined();
+    expect(lap.sectors!.s1).toBeGreaterThan(0);
+    expect(lap.sectors!.s2).toBeGreaterThan(0);
+    expect(lap.sectors!.s3).toBeGreaterThan(0);
+    // s1+s2+s3 should equal lap time
+    expect(lap.sectors!.s1! + lap.sectors!.s2! + lap.sectors!.s3!).toBeCloseTo(lap.lapTimeMs, -1);
+  });
+
+  it("emits all-undefined sectors when sector lines not crossed within lap", () => {
+    // Use a path that crosses S/F but not the sector lines (stays west of S2/S3)
+    const samples = makeRacePath(2, 10000);
+    const laps = calculateLaps(samples, sectorCourse);
+    expect(laps).toHaveLength(1);
+    expect(laps[0].sectors).toBeDefined();
+    expect(laps[0].sectors!.s1).toBeUndefined();
+    expect(laps[0].sectors!.s2).toBeUndefined();
+    expect(laps[0].sectors!.s3).toBeUndefined();
+  });
+});
+
+// ─── formatLapTime ───────────────────────────────────────────────────────────
+
+describe("formatLapTime", () => {
+  it("formats 0 ms as 0:00.000", () => {
+    expect(formatLapTime(0)).toBe("0:00.000");
+  });
+
+  it("formats sub-minute times as 0:SS.sss", () => {
+    expect(formatLapTime(12345)).toBe("0:12.345");
+  });
+
+  it("formats exactly 1 minute as 1:00.000", () => {
+    expect(formatLapTime(60000)).toBe("1:00.000");
+  });
+
+  it("formats 1:05.432 correctly", () => {
+    expect(formatLapTime(65432)).toBe("1:05.432");
+  });
+
+  it("formats over-an-hour times by overflowing the minutes field", () => {
+    // No special hour handling — 61:01.500
+    expect(formatLapTime(3661500)).toBe("61:01.500");
+  });
+
+  it("pads sub-10-second times with leading zero", () => {
+    expect(formatLapTime(5432)).toBe("0:05.432");
+  });
+});
+
+// ─── formatSectorTime ────────────────────────────────────────────────────────
+
+describe("formatSectorTime", () => {
+  it("formats 0 ms as 0.000", () => {
+    expect(formatSectorTime(0)).toBe("0.000");
+  });
+
+  it("formats milliseconds as ss.sss", () => {
+    expect(formatSectorTime(12345)).toBe("12.345");
+  });
+
+  it("formats exactly 1 second as 1.000", () => {
+    expect(formatSectorTime(1000)).toBe("1.000");
+  });
+});
+
+// ─── calculateOptimalLap ─────────────────────────────────────────────────────
+
+function makeLap(lapNumber: number, lapTimeMs: number, sectors?: { s1?: number; s2?: number; s3?: number }): Lap {
+  return {
+    lapNumber, lapTimeMs,
+    startTime: 0, endTime: lapTimeMs,
+    maxSpeedMph: 60, maxSpeedKph: 96,
+    minSpeedMph: 10, minSpeedKph: 16,
+    startIndex: 0, endIndex: 0,
+    sectors,
+  };
+}
+
+describe("calculateOptimalLap", () => {
+  it("returns null when no laps", () => {
+    expect(calculateOptimalLap([])).toBeNull();
+  });
+
+  it("returns null when no lap has all three sectors", () => {
+    const laps = [
+      makeLap(1, 60000, { s1: 20000, s2: undefined, s3: 20000 }),
+      makeLap(2, 60000, undefined),
+    ];
+    expect(calculateOptimalLap(laps)).toBeNull();
+  });
+
+  it("returns single lap's sectors when only one full-sector lap exists", () => {
+    const laps = [makeLap(1, 60000, { s1: 20000, s2: 18000, s3: 22000 })];
+    const result = calculateOptimalLap(laps);
+    expect(result).not.toBeNull();
+    expect(result!.bestS1).toBe(20000);
+    expect(result!.bestS2).toBe(18000);
+    expect(result!.bestS3).toBe(22000);
+    expect(result!.optimalTimeMs).toBe(60000);
+  });
+
+  it("picks the best sector from each lap independently", () => {
+    const laps = [
+      makeLap(1, 60000, { s1: 19000, s2: 20000, s3: 21000 }), // best S1
+      makeLap(2, 60000, { s1: 21000, s2: 18000, s3: 21000 }), // best S2
+      makeLap(3, 60000, { s1: 21000, s2: 20000, s3: 19000 }), // best S3
+    ];
+    const result = calculateOptimalLap(laps)!;
+    expect(result.bestS1).toBe(19000);
+    expect(result.bestS2).toBe(18000);
+    expect(result.bestS3).toBe(19000);
+    expect(result.optimalTimeMs).toBe(19000 + 18000 + 19000);
+  });
+
+  it("computes deltaToFastest as (fastestActualLap - optimal)", () => {
+    const laps = [
+      makeLap(1, 60000, { s1: 19000, s2: 20000, s3: 21000 }),
+      makeLap(2, 58000, { s1: 21000, s2: 18000, s3: 19000 }), // fastest
+    ];
+    const result = calculateOptimalLap(laps)!;
+    expect(result.optimalTimeMs).toBe(19000 + 18000 + 19000); // 56000
+    expect(result.deltaToFastest).toBe(58000 - 56000); // 2000
+  });
+
+  it("ignores laps without full sectors when computing optimal", () => {
+    const laps = [
+      makeLap(1, 60000, { s1: 17000, s2: 22000, s3: undefined }), // s3 missing — skipped
+      makeLap(2, 60000, { s1: 20000, s2: 20000, s3: 20000 }),
+    ];
+    const result = calculateOptimalLap(laps)!;
+    expect(result.bestS1).toBe(20000); // 17000 from lap 1 ignored
+  });
+
+  it("considers ALL laps for fastest, even those without full sectors", () => {
+    // deltaToFastest uses all laps' lapTimeMs, not just full-sector ones
+    const laps = [
+      makeLap(1, 50000, undefined), // fastest, but no sectors
+      makeLap(2, 60000, { s1: 20000, s2: 20000, s3: 20000 }),
+    ];
+    const result = calculateOptimalLap(laps)!;
+    expect(result.optimalTimeMs).toBe(60000);
+    expect(result.deltaToFastest).toBe(50000 - 60000); // negative — fastest beats theoretical optimal
+  });
+});

--- a/src/lib/lapCalculation.ts
+++ b/src/lib/lapCalculation.ts
@@ -1,4 +1,4 @@
-import { GpsSample, Course, Lap, LapCrossing, SectorTimes, SectorLine, courseHasSectors } from '@/types/racing';
+import { GpsSample, Course, Lap, LapCrossing, SectorTimes, SectorLine, CourseDirection, courseHasSectors } from '@/types/racing';
 
 interface Point {
   x: number;
@@ -71,7 +71,11 @@ interface LineCrossing {
   direction: number; // 1 or -1
 }
 
-// Detect crossings for a specific line
+// Detect crossings for a specific line.
+//
+// Debouncing is tracked per-direction so that an early opposite-direction
+// crossing (e.g., a GPS glitch on entry) does NOT lock out subsequent correct
+// crossings. After collecting candidates, we keep only the majority direction.
 function detectLineCrossings(
   samples: GpsSample[],
   lineA: Point,
@@ -81,45 +85,47 @@ function detectLineCrossings(
   lineType: 'sf' | 's2' | 's3',
   minInterval: number
 ): LineCrossing[] {
-  const crossings: LineCrossing[] = [];
-  let lastCrossingTime = -minInterval;
-  let lastCrossingDirection = 0;
+  const candidates: LineCrossing[] = [];
+  let lastForwardTime = -minInterval;
+  let lastReverseTime = -minInterval;
 
   for (let i = 0; i < samples.length - 1; i++) {
     const s1 = samples[i];
     const s2 = samples[i + 1];
-    
+
     const p1 = projectToPlane(s1.lat, s1.lon, centerLat, centerLon);
     const p2 = projectToPlane(s2.lat, s2.lon, centerLat, centerLon);
-    
+
     const side1 = sideOfLine(p1, lineA, lineB);
     const side2 = sideOfLine(p2, lineA, lineB);
-    
+
     const fraction = segmentIntersection(p1, p2, lineA, lineB);
-    
+
     if (fraction !== null && fraction >= 0 && fraction <= 1) {
       const crossingTime = s1.t + fraction * (s2.t - s1.t);
-      const crossingDirection = side2 > side1 ? 1 : -1;
-      
-      if (crossingTime - lastCrossingTime >= minInterval) {
-        // For first crossing, accept any direction
-        // For subsequent, require same direction (consistent lap direction)
-        if (crossings.length === 0 || lastCrossingDirection === 0 || crossingDirection === lastCrossingDirection) {
-          crossings.push({
-            lineType,
-            crossingTime,
-            sampleIndex: i,
-            fraction,
-            direction: crossingDirection
-          });
-          lastCrossingTime = crossingTime;
-          lastCrossingDirection = crossingDirection;
-        }
+      const direction = side2 > side1 ? 1 : -1;
+      const lastTime = direction === 1 ? lastForwardTime : lastReverseTime;
+
+      if (crossingTime - lastTime >= minInterval) {
+        candidates.push({ lineType, crossingTime, sampleIndex: i, fraction, direction });
+        if (direction === 1) lastForwardTime = crossingTime;
+        else lastReverseTime = crossingTime;
       }
     }
   }
-  
-  return crossings;
+
+  if (candidates.length === 0) return [];
+
+  // Majority-direction filter: a single wrong-direction glitch is discarded.
+  // Ties resolve to direction=1 (arbitrary but deterministic).
+  let forwardCount = 0;
+  let reverseCount = 0;
+  for (const c of candidates) {
+    if (c.direction === 1) forwardCount++;
+    else reverseCount++;
+  }
+  const winningDirection = forwardCount >= reverseCount ? 1 : -1;
+  return candidates.filter(c => c.direction === winningDirection);
 }
 
 // Project a sector line to planar coordinates
@@ -348,4 +354,57 @@ export function calculateOptimalLap(laps: Lap[]): OptimalLapResult | null {
     bestS3,
     deltaToFastest
   };
+}
+
+/**
+ * Determine the temporal order of S2 vs S3 crossings to infer driving direction.
+ *
+ * Unlike sector times in calculateLaps (which require S2→S3 in order to compute
+ * any sectors at all), this function looks at the FIRST crossing of each sector
+ * line regardless of order, and reports which line was hit first. This works
+ * even when the racing line never produces a valid sector-times triple — e.g.,
+ * when only one of S2/S3 falls on the racing line, or when GPS sample rate is
+ * too low to consistently catch crossings.
+ *
+ * Returns:
+ *   - 'forward' if S2 is crossed before S3
+ *   - 'reverse' if S3 is crossed before S2
+ *   - undefined if either line is never crossed, or the course has no sectors
+ */
+export function detectSectorOrder(samples: GpsSample[], course: Course): CourseDirection | undefined {
+  if (!course.sector2 || !course.sector3 || samples.length < 2) {
+    return undefined;
+  }
+
+  const centerLat = (course.startFinishA.lat + course.startFinishB.lat) / 2;
+  const centerLon = (course.startFinishA.lon + course.startFinishB.lon) / 2;
+
+  const s2Line = projectSectorLine(course.sector2, centerLat, centerLon);
+  const s3Line = projectSectorLine(course.sector3, centerLat, centerLon);
+
+  const firstS2Time = findFirstCrossingTime(samples, s2Line, centerLat, centerLon);
+  const firstS3Time = findFirstCrossingTime(samples, s3Line, centerLat, centerLon);
+
+  if (firstS2Time === null || firstS3Time === null) return undefined;
+  return firstS2Time < firstS3Time ? 'forward' : 'reverse';
+}
+
+/** Find the time of the first crossing of a line by the sample path, regardless of direction. */
+function findFirstCrossingTime(
+  samples: GpsSample[],
+  line: { a: Point; b: Point },
+  centerLat: number,
+  centerLon: number,
+): number | null {
+  for (let i = 0; i < samples.length - 1; i++) {
+    const s1 = samples[i];
+    const s2 = samples[i + 1];
+    const p1 = projectToPlane(s1.lat, s1.lon, centerLat, centerLon);
+    const p2 = projectToPlane(s2.lat, s2.lon, centerLat, centerLon);
+    const fraction = segmentIntersection(p1, p2, line.a, line.b);
+    if (fraction !== null && fraction >= 0 && fraction <= 1) {
+      return s1.t + fraction * (s2.t - s1.t);
+    }
+  }
+  return null;
 }

--- a/src/lib/motecParser.ts
+++ b/src/lib/motecParser.ts
@@ -1,6 +1,15 @@
 import { ParsedData, GpsSample, FieldMapping } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { clamp, haversineDistance } from './parserUtils';
+import {
+  haversineDistance,
+  parseCsvLine,
+  validateGpsCoords,
+  normalizeAccelToG,
+  speedTriple,
+  calculateBounds,
+  MPH_TO_MPS,
+  KPH_TO_MPS,
+} from './parserUtils';
 
 /**
  * MoTeC Parser — supports both:
@@ -9,22 +18,6 @@ import { clamp, haversineDistance } from './parserUtils';
  *
  * Based on reverse-engineered format from gotzl/ldparser (GPL-3.0).
  */
-
-// ─── CSV helpers ───────────────────────────────────────────────
-
-function parseQuotedCsvLine(line: string): string[] {
-  const result: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === '"') { inQuotes = !inQuotes; continue; }
-    if (ch === ',' && !inQuotes) { result.push(current.trim()); current = ''; continue; }
-    current += ch;
-  }
-  result.push(current.trim());
-  return result;
-}
 
 // ─── MoTeC CSV format detection ────────────────────────────────
 
@@ -59,7 +52,7 @@ export function parseMotecCsvFile(content: string): ParsedData {
   let headerEndIdx = -1;
 
   for (let i = 0; i < Math.min(30, lines.length); i++) {
-    const fields = parseQuotedCsvLine(lines[i]);
+    const fields = parseCsvLine(lines[i]);
     const key = fields[0]?.toLowerCase();
 
     if (key === 'sample rate') {
@@ -77,11 +70,11 @@ export function parseMotecCsvFile(content: string): ParsedData {
     throw new Error('Could not find MoTeC CSV channel header row');
   }
 
-  const channelNames = parseQuotedCsvLine(lines[headerEndIdx]).map(n => n.toLowerCase().trim());
+  const channelNames = parseCsvLine(lines[headerEndIdx]).map(n => n.toLowerCase().trim());
 
   // Next line should be units
   const unitsIdx = headerEndIdx + 1;
-  const units = unitsIdx < lines.length ? parseQuotedCsvLine(lines[unitsIdx]) : [];
+  const units = unitsIdx < lines.length ? parseCsvLine(lines[unitsIdx]) : [];
 
   // Data starts after units row
   const dataStartIdx = unitsIdx + 1;
@@ -113,21 +106,19 @@ export function parseMotecCsvFile(content: string): ParsedData {
 
   // Detect speed unit
   const speedUnit = (units[speedCol] || '').toLowerCase();
-  const speedToMps = speedUnit.includes('mph') ? 0.44704 : (speedUnit.includes('m/s') ? 1 : 1 / 3.6);
+  const speedToMps = speedUnit.includes('mph') ? MPH_TO_MPS : (speedUnit.includes('m/s') ? 1 : KPH_TO_MPS);
 
   const samples: GpsSample[] = [];
-  let minLat = Infinity, maxLat = -Infinity, minLon = Infinity, maxLon = -Infinity;
   let prevSample: GpsSample | null = null;
 
   for (let i = dataStartIdx; i < lines.length; i++) {
     const line = lines[i].trim();
     if (!line) continue;
-    const vals = parseQuotedCsvLine(line);
+    const vals = parseCsvLine(line);
 
     const lat = parseFloat(vals[latCol]);
     const lon = parseFloat(vals[lonCol]);
-    if (isNaN(lat) || isNaN(lon) || lat === 0 || lon === 0) continue;
-    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    if (validateGpsCoords(lat, lon) !== null) continue;
 
     let timeMs = 0;
     if (timeCol >= 0) {
@@ -161,8 +152,8 @@ export function parseMotecCsvFile(content: string): ParsedData {
     tryExtra(throttleCol, 'Throttle');
     tryExtra(waterTempCol, 'Water Temp');
     tryExtra(altCol, 'Altitude');
-    tryExtra(latGCol, 'Lat G', v => clamp(Math.abs(v) > 5 ? v / 9.81 : v, -5, 5));
-    tryExtra(lonGCol, 'Lon G', v => clamp(Math.abs(v) > 5 ? v / 9.81 : v, -5, 5));
+    tryExtra(latGCol, 'Lat G', v => normalizeAccelToG(v));
+    tryExtra(lonGCol, 'Lon G', v => normalizeAccelToG(v));
 
     let heading: number | undefined;
     if (headingCol >= 0) {
@@ -171,16 +162,13 @@ export function parseMotecCsvFile(content: string): ParsedData {
     }
 
     const sample: GpsSample = {
-      t: timeMs, lat, lon, speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph: speedMps * 3.6,
+      t: timeMs, lat, lon,
+      ...speedTriple(speedMps),
       heading, extraFields,
     };
 
     samples.push(sample);
     prevSample = sample;
-    minLat = Math.min(minLat, lat); maxLat = Math.max(maxLat, lat);
-    minLon = Math.min(minLon, lon); maxLon = Math.max(maxLon, lon);
   }
 
   if (samples.length === 0) throw new Error('No valid GPS samples found in MoTeC CSV');
@@ -196,8 +184,8 @@ export function parseMotecCsvFile(content: string): ParsedData {
   return {
     samples,
     fieldMappings: Array.from(fieldNames).map((name, idx) => ({ index: idx, name, enabled: true })),
-    bounds: { minLat, maxLat, minLon, maxLon },
-    duration: samples.length > 0 ? samples[samples.length - 1].t : 0,
+    bounds: calculateBounds(samples),
+    duration: samples[samples.length - 1].t,
   };
 }
 
@@ -394,16 +382,15 @@ export function parseMotecLdFile(buffer: ArrayBuffer): ParsedData {
 
   // Detect speed unit
   const speedUnit = speedCh?.unit?.toLowerCase() || '';
-  const speedToMps = speedUnit.includes('mph') ? 0.44704 : (speedUnit.includes('m/s') ? 1 : 1 / 3.6);
+  const speedToMps = speedUnit.includes('mph') ? MPH_TO_MPS : (speedUnit.includes('m/s') ? 1 : KPH_TO_MPS);
 
   const samples: GpsSample[] = [];
-  let minLat = Infinity, maxLat = -Infinity, minLon = Infinity, maxLon = -Infinity;
   let prevSample: GpsSample | null = null;
 
   for (let i = 0; i < nSamples; i++) {
     const lat = latCh.data[i];
     const lon = lonCh.data[i];
-    if (lat === 0 || lon === 0 || lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    if (validateGpsCoords(lat, lon) !== null) continue;
 
     const timeMs = (i / baseFreq) * 1000;
 
@@ -429,23 +416,20 @@ export function parseMotecLdFile(buffer: ArrayBuffer): ParsedData {
     tryExtra(throttleCh, 'Throttle');
     tryExtra(waterTempCh, 'Water Temp');
     tryExtra(altCh, 'Altitude');
-    tryExtra(latGCh, 'Lat G', v => clamp(Math.abs(v) > 5 ? v / 9.81 : v, -5, 5));
-    tryExtra(lonGCh, 'Lon G', v => clamp(Math.abs(v) > 5 ? v / 9.81 : v, -5, 5));
+    tryExtra(latGCh, 'Lat G', v => normalizeAccelToG(v));
+    tryExtra(lonGCh, 'Lon G', v => normalizeAccelToG(v));
 
     const rawHeading = resample(headingCh, i);
     const heading = rawHeading !== undefined && !isNaN(rawHeading) ? rawHeading : undefined;
 
     const sample: GpsSample = {
-      t: timeMs, lat, lon, speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph: speedMps * 3.6,
+      t: timeMs, lat, lon,
+      ...speedTriple(speedMps),
       heading, extraFields,
     };
 
     samples.push(sample);
     prevSample = sample;
-    minLat = Math.min(minLat, lat); maxLat = Math.max(maxLat, lat);
-    minLon = Math.min(minLon, lon); maxLon = Math.max(maxLon, lon);
   }
 
   if (samples.length === 0) throw new Error('No valid GPS samples found in MoTeC LD file');
@@ -461,7 +445,7 @@ export function parseMotecLdFile(buffer: ArrayBuffer): ParsedData {
   return {
     samples,
     fieldMappings: Array.from(fieldNames).map((name, idx) => ({ index: idx, name, enabled: true })),
-    bounds: { minLat, maxLat, minLon, maxLon },
-    duration: samples.length > 0 ? samples[samples.length - 1].t : 0,
+    bounds: calculateBounds(samples),
+    duration: samples[samples.length - 1].t,
   };
 }

--- a/src/lib/nmeaParser.ts
+++ b/src/lib/nmeaParser.ts
@@ -7,6 +7,7 @@ import {
   KNOTS_TO_MPS,
   speedTriple,
   calculateBounds,
+  normalizeHeading,
 } from './parserUtils';
 
 // Parse NMEA latitude (ddmm.mmmm format)
@@ -108,7 +109,12 @@ function parseRmcSentence(sentence: string): ParsedRmc | null {
     lon,
     timeMs,
     speedMps: knotsToMps(speedKnots),
-    heading: heading !== null && !isNaN(heading) ? heading : null,
+    // Reject out-of-range heading values (defensive: corrupted/concatenated
+    // NMEA sentences can put a non-degree value here — e.g., another sentence's
+    // hhmmss.ss time field. COG is always [0, 360]; normalize 360→0.
+    heading: heading !== null && !isNaN(heading) && heading >= 0 && heading <= 360
+      ? normalizeHeading(heading)
+      : null,
     date,
     valid: true
   };

--- a/src/lib/nmeaParser.ts
+++ b/src/lib/nmeaParser.ts
@@ -1,6 +1,13 @@
 import { GpsSample, FieldMapping, ParsedData } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { haversineDistance, isTeleportation, MAX_SPEED_MPS } from './parserUtils';
+import {
+  haversineDistance,
+  isTeleportation,
+  MAX_SPEED_MPS,
+  KNOTS_TO_MPS,
+  speedTriple,
+  calculateBounds,
+} from './parserUtils';
 
 // Parse NMEA latitude (ddmm.mmmm format)
 function parseNmeaLat(value: string, dir: string): number {
@@ -44,7 +51,7 @@ function parseNmeaDate(value: string): { day: number; month: number; year: numbe
 
 // Convert knots to m/s
 function knotsToMps(knots: number): number {
-  return knots * 0.514444;
+  return knots * KNOTS_TO_MPS;
 }
 
 interface ParsedRmc {
@@ -338,9 +345,7 @@ export function parseDatalog(content: string): ParsedData {
       t,
       lat: parsed.lat,
       lon: parsed.lon,
-      speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph: speedMps * 3.6,
+      ...speedTriple(speedMps),
       heading: parsed.heading ?? undefined,
       rawNmea: nmeaSentence,
       extraFields
@@ -381,19 +386,10 @@ export function parseDatalog(content: string): ParsedData {
     }
   }
 
-  // Calculate bounds
-  const lats = samples.map(s => s.lat);
-  const lons = samples.map(s => s.lon);
-  
   return {
     samples,
     fieldMappings,
-    bounds: {
-      minLat: Math.min(...lats),
-      maxLat: Math.max(...lats),
-      minLon: Math.min(...lons),
-      maxLon: Math.max(...lons)
-    },
+    bounds: calculateBounds(samples),
     duration: samples[samples.length - 1].t,
     startDate
   };

--- a/src/lib/overlayCanvasRenderer.ts
+++ b/src/lib/overlayCanvasRenderer.ts
@@ -452,7 +452,7 @@ function drawPace(c: CanvasRenderingContext2D, inst: OverlayInstance, ctx: Overl
 
   let maxDelta = 0.5;
   for (const v of ctx.paceData) {
-    if (Math.abs(v) > maxDelta) maxDelta = Math.abs(v);
+    if (v !== null && Math.abs(v) > maxDelta) maxDelta = Math.abs(v);
   }
   maxDelta = Math.min(maxDelta * 1.2, 5);
 

--- a/src/lib/parserUtils.test.ts
+++ b/src/lib/parserUtils.test.ts
@@ -1,0 +1,474 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  clamp,
+  normalizeHeadingDelta,
+  normalizeHeading,
+  haversineDistance,
+  calculateBearing,
+  isTeleportation,
+  validateGpsCoords,
+  parseCsvLine,
+  detectDelimiter,
+  normalizeAccelToG,
+  calculateBounds,
+  createRejectedCounter,
+  recordCoordRejection,
+  speedTriple,
+  MPS_TO_MPH,
+  MPS_TO_KPH,
+  MPH_TO_MPS,
+  KPH_TO_MPS,
+  KNOTS_TO_MPS,
+  MAX_SPEED_MPS,
+  STANDARD_GRAVITY_MPS2,
+} from "./parserUtils";
+import type { GpsSample } from "@/types/racing";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+describe("constants", () => {
+  it("MPH_TO_MPS round-trips with MPS_TO_MPH (within fp tolerance)", () => {
+    expect(MPS_TO_MPH * MPH_TO_MPS).toBeCloseTo(1, 5);
+  });
+
+  it("KPH_TO_MPS round-trips with MPS_TO_KPH", () => {
+    expect(MPS_TO_KPH * KPH_TO_MPS).toBeCloseTo(1, 10);
+  });
+
+  it("KNOTS_TO_MPS matches 1 knot = 0.514444 m/s", () => {
+    expect(KNOTS_TO_MPS).toBeCloseTo(0.514444, 6);
+  });
+
+  it("MAX_SPEED_MPS is 150 (~335 mph)", () => {
+    expect(MAX_SPEED_MPS).toBe(150);
+    expect(MAX_SPEED_MPS * MPS_TO_MPH).toBeCloseTo(335.5, 0);
+  });
+
+  it("STANDARD_GRAVITY_MPS2 is 9.80665", () => {
+    expect(STANDARD_GRAVITY_MPS2).toBe(9.80665);
+  });
+});
+
+// ─── speedTriple ──────────────────────────────────────────────────────────────
+
+describe("speedTriple", () => {
+  it("produces all three units from m/s", () => {
+    const t = speedTriple(10);
+    expect(t.speedMps).toBe(10);
+    expect(t.speedMph).toBeCloseTo(22.3694, 4);
+    expect(t.speedKph).toBeCloseTo(36, 4);
+  });
+
+  it("handles zero", () => {
+    expect(speedTriple(0)).toEqual({ speedMps: 0, speedMph: 0, speedKph: 0 });
+  });
+
+  it("handles negative speed (parser data quirks)", () => {
+    const t = speedTriple(-5);
+    expect(t.speedMps).toBe(-5);
+    expect(t.speedKph).toBeCloseTo(-18, 6);
+  });
+});
+
+// ─── clamp ────────────────────────────────────────────────────────────────────
+
+describe("clamp", () => {
+  it("returns the value when in range", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it("clamps to min", () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+  });
+
+  it("clamps to max", () => {
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+
+  it("handles inverted range gracefully (min > max returns min)", () => {
+    // Documented quirk: Math.max(min, Math.min(max, value)) — when min > max, returns min.
+    expect(clamp(5, 10, 0)).toBe(10);
+  });
+});
+
+// ─── normalizeHeadingDelta ────────────────────────────────────────────────────
+
+describe("normalizeHeadingDelta", () => {
+  it("returns 0 when either argument is undefined", () => {
+    expect(normalizeHeadingDelta(undefined, 90)).toBe(0);
+    expect(normalizeHeadingDelta(90, undefined)).toBe(0);
+    expect(normalizeHeadingDelta(undefined, undefined)).toBe(0);
+  });
+
+  it("returns the delta directly when within [-180, 180]", () => {
+    expect(normalizeHeadingDelta(45, 30)).toBe(15);
+    expect(normalizeHeadingDelta(30, 45)).toBe(-15);
+  });
+
+  it("wraps 359 → 1 to +2 (not -358)", () => {
+    expect(normalizeHeadingDelta(1, 359)).toBe(2);
+  });
+
+  it("wraps 1 → 359 to -2 (not +358)", () => {
+    expect(normalizeHeadingDelta(359, 1)).toBe(-2);
+  });
+});
+
+// ─── normalizeHeading ─────────────────────────────────────────────────────────
+
+describe("normalizeHeading", () => {
+  it("returns value unchanged when in [0, 360)", () => {
+    expect(normalizeHeading(0)).toBe(0);
+    expect(normalizeHeading(180)).toBe(180);
+    expect(normalizeHeading(359)).toBe(359);
+  });
+
+  it("wraps 360 to 0", () => {
+    expect(normalizeHeading(360)).toBe(0);
+  });
+
+  it("wraps negative values up", () => {
+    expect(normalizeHeading(-90)).toBe(270);
+    expect(normalizeHeading(-180)).toBe(180);
+  });
+
+  it("wraps large values down", () => {
+    expect(normalizeHeading(720)).toBe(0);
+    expect(normalizeHeading(450)).toBe(90);
+  });
+});
+
+// ─── haversineDistance ────────────────────────────────────────────────────────
+
+describe("haversineDistance", () => {
+  it("returns 0 for identical points", () => {
+    expect(haversineDistance(40, -74, 40, -74)).toBe(0);
+  });
+
+  it("computes ~111195m for 1° of latitude at the equator", () => {
+    // 1° latitude = ~111,195 m everywhere
+    expect(haversineDistance(0, 0, 1, 0)).toBeCloseTo(111195, -1);
+  });
+
+  it("computes ~111195m for 1° of longitude at the equator", () => {
+    expect(haversineDistance(0, 0, 0, 1)).toBeCloseTo(111195, -1);
+  });
+
+  it("computes Berlin → Paris distance correctly (~877 km)", () => {
+    // Berlin (52.5200, 13.4050) → Paris (48.8566, 2.3522)
+    const km = haversineDistance(52.52, 13.405, 48.8566, 2.3522) / 1000;
+    expect(km).toBeCloseTo(877, -1); // ±5 km tolerance — great-circle vs road distance
+  });
+
+  it("is symmetric", () => {
+    const d1 = haversineDistance(35, -100, 40, -110);
+    const d2 = haversineDistance(40, -110, 35, -100);
+    expect(d1).toBeCloseTo(d2, 6);
+  });
+});
+
+// ─── calculateBearing ─────────────────────────────────────────────────────────
+
+describe("calculateBearing", () => {
+  it("returns 0° (north) for due-north travel", () => {
+    expect(calculateBearing(0, 0, 1, 0)).toBeCloseTo(0, 2);
+  });
+
+  it("returns ~90° (east) for due-east travel at equator", () => {
+    expect(calculateBearing(0, 0, 0, 1)).toBeCloseTo(90, 2);
+  });
+
+  it("returns 180° (south) for due-south travel", () => {
+    expect(calculateBearing(1, 0, 0, 0)).toBeCloseTo(180, 2);
+  });
+
+  it("returns 270° (west) for due-west travel at equator", () => {
+    expect(calculateBearing(0, 1, 0, 0)).toBeCloseTo(270, 2);
+  });
+
+  it("always returns a value in [0, 360)", () => {
+    for (let lat = -80; lat <= 80; lat += 20) {
+      for (let lon = -170; lon <= 170; lon += 30) {
+        const b = calculateBearing(0, 0, lat, lon);
+        expect(b).toBeGreaterThanOrEqual(0);
+        expect(b).toBeLessThan(360);
+      }
+    }
+  });
+});
+
+// ─── isTeleportation ──────────────────────────────────────────────────────────
+
+describe("isTeleportation", () => {
+  // Silence the console.warn the function emits when formatName is provided
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns false when timeDiff is zero or negative", () => {
+    expect(isTeleportation(0, 0, 1000, 1, 1, 1000)).toBe(false);
+    expect(isTeleportation(0, 0, 1000, 1, 1, 500)).toBe(false);
+  });
+
+  it("returns false when timeDiff exceeds 10 seconds (parser pause)", () => {
+    // 1° lat = 111km in 11s — would normally be teleportation, but >10s window opts out
+    expect(isTeleportation(0, 0, 0, 1, 0, 11000)).toBe(false);
+  });
+
+  it("returns false for normal racing motion (40m in 40ms)", () => {
+    // 40m in 40ms = 1000 m/s. Wait — limit is 50 * (timeDiff/0.04) at 40ms = 50m AND >100m.
+    // 40m fails the "dist > 100m" minimum guard so it passes (not teleportation).
+    expect(isTeleportation(0, 0, 0, 0, 40 / 111195, 40)).toBe(false);
+  });
+
+  it("returns true when jump is implausibly large", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // 1° lat = ~111km in 100ms — clearly teleportation
+    const result = isTeleportation(0, 0, 0, 1, 0, 100);
+    expect(result).toBe(true);
+  });
+
+  it("logs format name when teleportation detected", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    isTeleportation(0, 0, 0, 1, 0, 100, "TestFormat");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("TestFormat");
+  });
+
+  it("does not log when formatName omitted", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    isTeleportation(0, 0, 0, 1, 0, 100);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+// ─── validateGpsCoords ────────────────────────────────────────────────────────
+
+describe("validateGpsCoords", () => {
+  it("returns null for valid coordinates", () => {
+    expect(validateGpsCoords(40.5, -74.5)).toBe(null);
+    expect(validateGpsCoords(0, 1)).toBe(null);
+    expect(validateGpsCoords(-89.9, 179.9)).toBe(null);
+  });
+
+  it("flags NaN values", () => {
+    expect(validateGpsCoords(NaN, 0)).toBe("nan");
+    expect(validateGpsCoords(0, NaN)).toBe("nan");
+    expect(validateGpsCoords(NaN, NaN)).toBe("nan");
+  });
+
+  it("flags (0, 0) — the default GPS error value", () => {
+    expect(validateGpsCoords(0, 0)).toBe("zero");
+  });
+
+  it("does NOT flag (0, 1) or (1, 0) as zero (legitimate equator points)", () => {
+    expect(validateGpsCoords(0, 1)).toBe(null);
+    expect(validateGpsCoords(1, 0)).toBe(null);
+  });
+
+  it("flags out-of-range latitudes", () => {
+    expect(validateGpsCoords(91, 0)).toBe("outOfRange");
+    expect(validateGpsCoords(-91, 0)).toBe("outOfRange");
+  });
+
+  it("flags out-of-range longitudes", () => {
+    expect(validateGpsCoords(0, 181)).toBe("outOfRange");
+    expect(validateGpsCoords(0, -181)).toBe("outOfRange");
+  });
+
+  it("priority: nan before zero before range", () => {
+    expect(validateGpsCoords(NaN, NaN)).toBe("nan");
+    // Note: 0,0 short-circuits before range check, but range short-circuits past it.
+  });
+});
+
+// ─── parseCsvLine ─────────────────────────────────────────────────────────────
+
+describe("parseCsvLine", () => {
+  it("splits on commas by default", () => {
+    expect(parseCsvLine("a,b,c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("trims whitespace around fields", () => {
+    expect(parseCsvLine("  a , b , c  ")).toEqual(["a", "b", "c"]);
+  });
+
+  it("respects quoted fields containing the delimiter", () => {
+    expect(parseCsvLine('a,"b,c",d')).toEqual(["a", "b,c", "d"]);
+  });
+
+  it("accepts a custom delimiter", () => {
+    expect(parseCsvLine("a;b;c", ";")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles tab delimiter", () => {
+    expect(parseCsvLine("a\tb\tc", "\t")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty strings for empty fields", () => {
+    expect(parseCsvLine("a,,c")).toEqual(["a", "", "c"]);
+    expect(parseCsvLine(",")).toEqual(["", ""]);
+  });
+
+  it("handles a single-field line", () => {
+    expect(parseCsvLine("hello")).toEqual(["hello"]);
+  });
+
+  it("removes quote characters from output", () => {
+    expect(parseCsvLine('"hello"')).toEqual(["hello"]);
+  });
+});
+
+// ─── detectDelimiter ──────────────────────────────────────────────────────────
+
+describe("detectDelimiter", () => {
+  it("prefers tab when it dominates", () => {
+    expect(detectDelimiter("a\tb\tc\td")).toBe("\t");
+  });
+
+  it("prefers semicolon over comma when semicolons dominate", () => {
+    expect(detectDelimiter("a;b;c,d")).toBe(";");
+  });
+
+  it("defaults to comma when comma dominates", () => {
+    expect(detectDelimiter("a,b,c")).toBe(",");
+  });
+
+  it("returns comma when no delimiters present", () => {
+    expect(detectDelimiter("abcdef")).toBe(",");
+  });
+
+  it("accepts custom candidate list", () => {
+    expect(detectDelimiter("a|b|c", ["|"])).toBe("|");
+  });
+});
+
+// ─── normalizeAccelToG ────────────────────────────────────────────────────────
+
+describe("normalizeAccelToG", () => {
+  it("passes through values within G range unchanged", () => {
+    expect(normalizeAccelToG(1.5)).toBe(1.5);
+    expect(normalizeAccelToG(-2.3)).toBe(-2.3);
+    expect(normalizeAccelToG(0)).toBe(0);
+  });
+
+  it("converts m/s² to G when above the heuristic threshold (default 5)", () => {
+    // 9.81 m/s² ≈ 1 G
+    expect(normalizeAccelToG(9.80665)).toBeCloseTo(1, 5);
+    // 19.6 m/s² ≈ 2 G
+    expect(normalizeAccelToG(19.6133)).toBeCloseTo(2, 4);
+  });
+
+  it("respects a custom m/s² threshold (Alfano uses 10)", () => {
+    // Value of 7: at default threshold 5 → treated as m/s² → 7/9.80665 ≈ 0.714 G.
+    // At threshold 10 → treated as already-G → passes through, but clamped to 5G ceiling.
+    expect(normalizeAccelToG(7)).toBeCloseTo(0.714, 2);
+    expect(normalizeAccelToG(7, 10)).toBe(5); // 7G is implausible → clamped to default ±5G
+
+    // A 3G reading is below either threshold → never converted, never clamped
+    expect(normalizeAccelToG(3, 5)).toBe(3);
+    expect(normalizeAccelToG(3, 10)).toBe(3);
+  });
+
+  it("clamps to ±5 G by default", () => {
+    expect(normalizeAccelToG(100)).toBe(5);
+    expect(normalizeAccelToG(-100)).toBe(-5);
+  });
+
+  it("accepts a custom clamp range", () => {
+    expect(normalizeAccelToG(3, 5, 2)).toBe(2);
+    expect(normalizeAccelToG(-3, 5, 2)).toBe(-2);
+  });
+});
+
+// ─── calculateBounds ──────────────────────────────────────────────────────────
+
+function makeSample(lat: number, lon: number): GpsSample {
+  return { t: 0, lat, lon, speedMps: 0, speedMph: 0, speedKph: 0, extraFields: {} };
+}
+
+describe("calculateBounds", () => {
+  it("returns zeroed bounds for empty array", () => {
+    expect(calculateBounds([])).toEqual({ minLat: 0, maxLat: 0, minLon: 0, maxLon: 0 });
+  });
+
+  it("returns identical min/max for a single sample", () => {
+    expect(calculateBounds([makeSample(40, -74)])).toEqual({
+      minLat: 40, maxLat: 40, minLon: -74, maxLon: -74,
+    });
+  });
+
+  it("computes correct bounds across multiple samples", () => {
+    const samples = [
+      makeSample(40, -74),
+      makeSample(35, -100),
+      makeSample(45, -90),
+      makeSample(38, -120),
+    ];
+    expect(calculateBounds(samples)).toEqual({
+      minLat: 35, maxLat: 45, minLon: -120, maxLon: -74,
+    });
+  });
+
+  it("does not stack-overflow on very large arrays (regression for Math.min(...lats))", () => {
+    // 200k samples — Math.min(...arr) blows up around ~100-150k in V8
+    const samples: GpsSample[] = [];
+    for (let i = 0; i < 200_000; i++) {
+      samples.push(makeSample(40 + i * 1e-6, -74 + i * 1e-6));
+    }
+    const b = calculateBounds(samples);
+    expect(b.minLat).toBeCloseTo(40, 5);
+    expect(b.maxLat).toBeCloseTo(40 + 199_999 * 1e-6, 4);
+  });
+});
+
+// ─── createRejectedCounter & recordCoordRejection ─────────────────────────────
+
+describe("createRejectedCounter", () => {
+  it("initializes all counters to zero", () => {
+    expect(createRejectedCounter()).toEqual({
+      nanFields: 0, zeroCoords: 0, outOfRange: 0,
+      speedCap: 0, teleportation: 0, incompleteRow: 0,
+    });
+  });
+
+  it("returns a fresh object each call (no shared reference)", () => {
+    const a = createRejectedCounter();
+    const b = createRejectedCounter();
+    a.nanFields = 5;
+    expect(b.nanFields).toBe(0);
+  });
+});
+
+describe("recordCoordRejection", () => {
+  it("returns false and does not mutate on null reason", () => {
+    const c = createRejectedCounter();
+    expect(recordCoordRejection(c, null)).toBe(false);
+    expect(c.nanFields).toBe(0);
+  });
+
+  it("increments nanFields for 'nan' reason", () => {
+    const c = createRejectedCounter();
+    expect(recordCoordRejection(c, "nan")).toBe(true);
+    expect(c.nanFields).toBe(1);
+  });
+
+  it("increments zeroCoords for 'zero' reason", () => {
+    const c = createRejectedCounter();
+    recordCoordRejection(c, "zero");
+    expect(c.zeroCoords).toBe(1);
+  });
+
+  it("increments outOfRange for 'outOfRange' reason", () => {
+    const c = createRejectedCounter();
+    recordCoordRejection(c, "outOfRange");
+    expect(c.outOfRange).toBe(1);
+  });
+
+  it("accumulates across calls", () => {
+    const c = createRejectedCounter();
+    recordCoordRejection(c, "nan");
+    recordCoordRejection(c, "nan");
+    recordCoordRejection(c, "zero");
+    expect(c.nanFields).toBe(2);
+    expect(c.zeroCoords).toBe(1);
+  });
+});

--- a/src/lib/parserUtils.ts
+++ b/src/lib/parserUtils.ts
@@ -1,6 +1,33 @@
 /**
- * Shared math and filtering utilities used across all GPS data parsers.
+ * Shared math, parsing, and validation utilities used across all GPS data parsers.
  */
+
+import type { GpsSample } from '@/types/racing';
+
+// ─── Speed unit conversions ─────────────────────────────────────────────────
+
+export const MPS_TO_MPH = 2.23694;
+export const MPS_TO_KPH = 3.6;
+export const MPH_TO_MPS = 0.44704;
+export const KPH_TO_MPS = 1 / 3.6;
+export const KNOTS_TO_MPS = 0.514444;
+
+/** Maximum reasonable speed in m/s (~335 mph). Anything above is a GPS glitch. */
+export const MAX_SPEED_MPS = 150;
+
+/** Standard gravity used when normalizing m/s² accelerometer readings to G. */
+export const STANDARD_GRAVITY_MPS2 = 9.80665;
+
+/** Build the three-unit speed triple used on every GpsSample. */
+export function speedTriple(speedMps: number): { speedMps: number; speedMph: number; speedKph: number } {
+  return {
+    speedMps,
+    speedMph: speedMps * MPS_TO_MPH,
+    speedKph: speedMps * MPS_TO_KPH,
+  };
+}
+
+// ─── Math ───────────────────────────────────────────────────────────────────
 
 /** Clamp a number to [min, max] */
 export function clamp(value: number, min: number, max: number): number {
@@ -17,6 +44,14 @@ export function normalizeHeadingDelta(h2: number | undefined, h1: number | undef
   if (delta > 180) delta -= 360;
   if (delta < -180) delta += 360;
   return delta;
+}
+
+/** Wrap a heading value into [0, 360). */
+export function normalizeHeading(heading: number): number {
+  let h = heading;
+  while (h < 0) h += 360;
+  while (h >= 360) h -= 360;
+  return h;
 }
 
 /** Haversine distance between two GPS coordinates, in meters. */
@@ -69,5 +104,137 @@ export function isTeleportation(
   return false;
 }
 
-/** Maximum reasonable speed in m/s (~335 mph). Anything above is a GPS glitch. */
-export const MAX_SPEED_MPS = 150;
+// ─── GPS coordinate validation ──────────────────────────────────────────────
+
+/** Why a coordinate pair was rejected, or null if it's valid. */
+export type CoordRejectionReason = 'nan' | 'zero' | 'outOfRange' | null;
+
+/**
+ * Validate a GPS coordinate pair. Returns null if valid, otherwise the rejection reason.
+ *   - 'nan'        — lat or lon is NaN
+ *   - 'zero'       — both are 0 (default GPS error value)
+ *   - 'outOfRange' — |lat| > 90 or |lon| > 180
+ */
+export function validateGpsCoords(lat: number, lon: number): CoordRejectionReason {
+  if (isNaN(lat) || isNaN(lon)) return 'nan';
+  if (lat === 0 && lon === 0) return 'zero';
+  if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return 'outOfRange';
+  return null;
+}
+
+// ─── CSV parsing ────────────────────────────────────────────────────────────
+
+/**
+ * Parse a CSV line, respecting double-quoted fields. Fields are trimmed.
+ * Use a single-character delimiter (default `,`).
+ */
+export function parseCsvLine(line: string, delimiter: string = ','): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === delimiter && !inQuotes) {
+      result.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current.trim());
+  return result;
+}
+
+/**
+ * Pick the most likely delimiter for a CSV line by counting candidates.
+ * Defaults to comma, falls back to semicolon, prefers tab if it wins.
+ */
+export function detectDelimiter(line: string, candidates: string[] = ['\t', ';', ',']): string {
+  let best = ',';
+  let bestCount = -1;
+  for (const c of candidates) {
+    const count = (line.match(new RegExp(c === '\t' ? '\\t' : `\\${c}`, 'g')) || []).length;
+    if (count > bestCount) {
+      best = c;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+// ─── Accelerometer normalization ────────────────────────────────────────────
+
+/**
+ * Normalize a raw accelerometer reading to gravity-units (G).
+ * Many loggers export in m/s² rather than G; if the absolute value exceeds
+ * `msqThreshold` we assume m/s² and divide by standard gravity.
+ * Result is clamped to [-clampG, clampG].
+ *
+ * @param value raw accelerometer reading from the file
+ * @param msqThreshold heuristic: values above this are treated as m/s² (default 5)
+ * @param clampG output clamp range (default 5G)
+ */
+export function normalizeAccelToG(value: number, msqThreshold: number = 5, clampG: number = 5): number {
+  const g = Math.abs(value) > msqThreshold ? value / STANDARD_GRAVITY_MPS2 : value;
+  return clamp(g, -clampG, clampG);
+}
+
+// ─── Bounds ─────────────────────────────────────────────────────────────────
+
+/**
+ * Calculate lat/lon bounds in a single pass.
+ * Avoids `Math.min(...samples.map(s => s.lat))` which can stack-overflow on
+ * large arrays (>~100k samples in some JS engines).
+ */
+export function calculateBounds(samples: GpsSample[]): { minLat: number; maxLat: number; minLon: number; maxLon: number } {
+  if (samples.length === 0) {
+    return { minLat: 0, maxLat: 0, minLon: 0, maxLon: 0 };
+  }
+  let minLat = Infinity, maxLat = -Infinity;
+  let minLon = Infinity, maxLon = -Infinity;
+  for (const s of samples) {
+    if (s.lat < minLat) minLat = s.lat;
+    if (s.lat > maxLat) maxLat = s.lat;
+    if (s.lon < minLon) minLon = s.lon;
+    if (s.lon > maxLon) maxLon = s.lon;
+  }
+  return { minLat, maxLat, minLon, maxLon };
+}
+
+// ─── ParserStats helpers ────────────────────────────────────────────────────
+
+export interface RejectedCounts {
+  nanFields: number;
+  zeroCoords: number;
+  outOfRange: number;
+  speedCap: number;
+  teleportation: number;
+  incompleteRow: number;
+}
+
+/** Create a zeroed rejection-reason counter. */
+export function createRejectedCounter(): RejectedCounts {
+  return {
+    nanFields: 0,
+    zeroCoords: 0,
+    outOfRange: 0,
+    speedCap: 0,
+    teleportation: 0,
+    incompleteRow: 0,
+  };
+}
+
+/**
+ * Increment the matching counter for a CoordRejectionReason.
+ * Returns true if the reason was non-null (i.e. a rejection happened).
+ */
+export function recordCoordRejection(rejected: RejectedCounts, reason: CoordRejectionReason): boolean {
+  if (reason === null) return false;
+  if (reason === 'nan') rejected.nanFields++;
+  else if (reason === 'zero') rejected.zeroCoords++;
+  else if (reason === 'outOfRange') rejected.outOfRange++;
+  return true;
+}

--- a/src/lib/parserUtils.ts
+++ b/src/lib/parserUtils.ts
@@ -154,7 +154,7 @@ export function parseCsvLine(line: string, delimiter: string = ','): string[] {
  */
 export function detectDelimiter(line: string, candidates: string[] = ['\t', ';', ',']): string {
   let best = ',';
-  let bestCount = -1;
+  let bestCount = 0;
   for (const c of candidates) {
     const count = (line.match(new RegExp(c === '\t' ? '\\t' : `\\${c}`, 'g')) || []).length;
     if (count > bestCount) {

--- a/src/lib/ubxParser.ts
+++ b/src/lib/ubxParser.ts
@@ -1,6 +1,12 @@
 import { GpsSample, FieldMapping, ParsedData } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { haversineDistance, isTeleportation, MAX_SPEED_MPS } from './parserUtils';
+import {
+  isTeleportation,
+  MAX_SPEED_MPS,
+  speedTriple,
+  calculateBounds,
+  normalizeHeading,
+} from './parserUtils';
 
 // UBX Protocol Constants
 const UBX_SYNC_1 = 0xB5;
@@ -199,11 +205,8 @@ export function parseUbxFile(buffer: ArrayBuffer): ParsedData {
       if (isTeleportation(prev.lat, prev.lon, prev.t, pvt.lat, pvt.lon, t, 'UBX')) continue;
     }
     
-    // Normalize heading to 0-360
-    let heading = pvt.headMot;
-    if (heading < 0) heading += 360;
-    if (heading >= 360) heading -= 360;
-    
+    const heading = normalizeHeading(pvt.headMot);
+
     const extraFields: Record<string, number> = {
       'Satellites': pvt.numSV,
       'HDOP': pvt.pDOP, // pDOP is close enough for display purposes
@@ -212,14 +215,12 @@ export function parseUbxFile(buffer: ArrayBuffer): ParsedData {
       'V Accuracy (m)': pvt.vAcc / 1000,
       'Speed Acc (m/s)': pvt.sAcc / 1000,
     };
-    
+
     samples.push({
       t,
       lat: pvt.lat,
       lon: pvt.lon,
-      speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph: speedMps * 3.6,
+      ...speedTriple(speedMps),
       heading,
       extraFields
     });
@@ -244,19 +245,10 @@ export function parseUbxFile(buffer: ArrayBuffer): ParsedData {
     { index: -6, name: 'Speed Acc (m/s)', enabled: true },
   ];
   
-  // Calculate bounds
-  const lats = samples.map(s => s.lat);
-  const lons = samples.map(s => s.lon);
-  
   return {
     samples,
     fieldMappings,
-    bounds: {
-      minLat: Math.min(...lats),
-      maxLat: Math.max(...lats),
-      minLon: Math.min(...lons),
-      maxLon: Math.max(...lons)
-    },
+    bounds: calculateBounds(samples),
     duration: samples[samples.length - 1].t,
     startDate
   };

--- a/src/lib/vboParser.ts
+++ b/src/lib/vboParser.ts
@@ -1,6 +1,14 @@
 import { GpsSample, FieldMapping, ParsedData } from '@/types/racing';
 import { applyGForceCalculations } from './gforceCalculation';
-import { haversineDistance, isTeleportation, MAX_SPEED_MPS } from './parserUtils';
+import {
+  isTeleportation,
+  MAX_SPEED_MPS,
+  KPH_TO_MPS,
+  speedTriple,
+  calculateBounds,
+  validateGpsCoords,
+  normalizeHeading,
+} from './parserUtils';
 
 /**
  * VBO Parser for Racelogic VBOX data files
@@ -181,11 +189,8 @@ export function parseVboFile(content: string): ParsedData {
     
     const lat = parseVboCoordinate(fields[columnMap['lat']]);
     const lon = parseVboCoordinate(fields[columnMap['lon']]);
-    
-    // Skip invalid coordinates
-    if (lat === 0 || lon === 0 || Math.abs(lat) > 90 || Math.abs(lon) > 180) {
-      continue;
-    }
+
+    if (validateGpsCoords(lat, lon) !== null) continue;
     
     // Parse time
     let timeMs = 0;
@@ -205,21 +210,16 @@ export function parseVboFile(content: string): ParsedData {
     if (columnMap['velocity'] !== undefined && fields[columnMap['velocity']]) {
       speedKph = parseFloat(fields[columnMap['velocity']]) || 0;
     }
-    const speedMps = speedKph / 3.6;
-    
+    const speedMps = speedKph * KPH_TO_MPS;
+
     // Sanity check on speed
     if (speedMps > MAX_SPEED_MPS) continue;
 
     // Parse heading
     let heading: number | undefined;
     if (columnMap['heading'] !== undefined && fields[columnMap['heading']]) {
-      heading = parseFloat(fields[columnMap['heading']]);
-      if (isNaN(heading)) heading = undefined;
-      else {
-        // Normalize to 0-360
-        while (heading < 0) heading += 360;
-        while (heading >= 360) heading -= 360;
-      }
+      const h = parseFloat(fields[columnMap['heading']]);
+      if (!isNaN(h)) heading = normalizeHeading(h);
     }
     
     // Teleportation filter
@@ -270,14 +270,12 @@ export function parseVboFile(content: string): ParsedData {
       t,
       lat,
       lon,
-      speedMps,
-      speedMph: speedMps * 2.23694,
-      speedKph,
+      ...speedTriple(speedMps),
       heading,
       extraFields
     });
   }
-  
+
   if (samples.length === 0) {
     throw new Error('No valid GPS data found in VBO file');
   }
@@ -313,19 +311,10 @@ export function parseVboFile(content: string): ParsedData {
     fieldMappings.push({ index: -15, name: 'Distance', enabled: true });
   }
   
-  // Calculate bounds
-  const lats = samples.map(s => s.lat);
-  const lons = samples.map(s => s.lon);
-  
   return {
     samples,
     fieldMappings,
-    bounds: {
-      minLat: Math.min(...lats),
-      maxLat: Math.max(...lats),
-      minLon: Math.min(...lons),
-      maxLon: Math.max(...lons)
-    },
+    bounds: calculateBounds(samples),
     duration: samples[samples.length - 1].t,
     startDate
   };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,8 +7,14 @@ import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { Gauge, ArrowLeft } from 'lucide-react';
+import { useDocumentHead } from '@/hooks/useDocumentHead';
 
 export default function Login() {
+  useDocumentHead({
+    title: "Admin Login — HackTheTrack",
+    description: "Sign in to the HackTheTrack admin panel to manage tracks, courses, submissions and messages.",
+    canonical: "https://hackthetrack.net/login",
+  });
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,9 +1,16 @@
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
+import { useDocumentHead } from "@/hooks/useDocumentHead";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 
-const Privacy = () => (
+const Privacy = () => {
+  useDocumentHead({
+    title: "Privacy Policy — HackTheTrack",
+    description: "How HackTheTrack handles your data: 100% local-first telemetry storage in your browser, no cookies, no analytics, no tracking.",
+    canonical: "https://hackthetrack.net/privacy",
+  });
+  return (
   <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
     <Link to="/" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8">
       <ArrowLeft className="w-4 h-4" />

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -69,6 +69,7 @@ const Privacy = () => {
 
     <p className="mt-10 text-xs text-muted-foreground/60">Last updated: February 2026</p>
   </div>
-);
+  );
+};
 
 export default Privacy;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -6,8 +6,14 @@ import { Label } from '@/components/ui/label';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
 import { Gauge, ArrowLeft } from 'lucide-react';
+import { useDocumentHead } from '@/hooks/useDocumentHead';
 
 export default function Register() {
+  useDocumentHead({
+    title: "Register — HackTheTrack",
+    description: "Create a HackTheTrack account to access admin tools for managing tracks, courses and telemetry submissions.",
+    canonical: "https://hackthetrack.net/register",
+  });
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -130,6 +130,14 @@ export interface CourseDetectionResult {
   laps: Lap[];
   isWaypointMode: boolean;
   waypointNotice?: string;
+  /**
+   * Relative difference between detected lap distance and the course's known
+   * `lengthFt`, as a non-negative fraction (e.g., 0.05 = 5% off).
+   * Undefined when the matched course has no `lengthFt` or in waypoint mode.
+   * UI can use this to flag low-confidence matches — anything > 0.25 is
+   * outside the course-detection algorithm's documented tolerance.
+   */
+  lengthMatchDiff?: number;
 }
 
 // Selection state for track + course

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,7 +13,7 @@
     "moduleResolution": "bundler",
     "noEmit": true,
     "noFallthroughCasesInSwitch": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "paths": {
@@ -22,7 +22,8 @@
       ]
     },
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
+    "strictNullChecks": true,
     "target": "ES2020",
     "useDefineForClassFields": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "noImplicitAny": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "paths": {
@@ -9,8 +11,7 @@
         "./src/*"
       ]
     },
-    "skipLibCheck": true,
-    "strictNullChecks": false
+    "skipLibCheck": true
   },
   "files": [],
   "references": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+// Minimal Vitest config — keeps test concerns out of vite.config.ts so the
+// PWA/build pipeline isn't loaded for unit tests.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["node_modules", "dist", ".lovable"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Extracted ~280 lines of duplicated parser logic into `parserUtils.ts` (8 parsers cleaned up)
- Enabled TypeScript strict mode (`noImplicitAny`, `strictNullChecks`)
- Added Vitest + 203 unit/regression tests (runs in <2s)
- Fixed 4 real bugs uncovered by the test suite

## Bugs fixed
1. **NMEA heading validation** — out-of-range values from corrupted sentences were accepted silently. Now validated and normalized via shared helper.
2. **Direction lockout in lap detection** — a wrong-direction GPS glitch on entry could reject every subsequent correct crossing. Replaced single-direction lock with per-direction debouncing + majority filter.
3. **False "reverse direction" badge** — when forward-direction laps didn't happen to cross both sector lines, UI showed wrong direction. Replaced sectors-as-proxy heuristic with direct temporal-order check (`detectSectorOrder`).
4. **Silent low-confidence course matches** — auto-detection returned the closest course even when length match was way outside the 25% tolerance, with no signal to the UI. Added `lengthMatchDiff` field.

## Test plan
- [x] `npm run test:run` — 203 tests pass in <2s
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Manual: load `okc-tillotson-data.dovex` in dev server, verify Race Line / Lap Times / Pro Graph tabs render correctly
- [x] Manual: confirm direction badge in track-prompt either shows correct value or hides (not falsely "Reverse")