### PR TITLE
Add CI workflow: typecheck + tests + build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# Runs typecheck + tests + build on every PR and every push to main.
+# Lint is intentionally NOT in this workflow yet — the codebase has 100
+# pre-existing lint problems (76 errors, 24 warnings) and adding `npm run
+# lint` here would make CI red from day one. Fix those in a follow-up PR,
+# then add the lint step.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-progress runs when a new commit is pushed to the same ref.
+# Saves Actions minutes on rapid-fire pushes to a PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Typecheck, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,12 @@ npm run dev       # Dev server on :8080
 npm run build     # Production build → dist/
 npm run lint      # ESLint
 npm run preview   # Preview production build
+npm test          # Vitest in watch mode
+npm run test:run  # Vitest single pass (CI-style)
 ```
+
+CI (`.github/workflows/ci.yml`) runs typecheck + `test:run` + build on every PR
+and push to `main`. Lint is not yet enforced in CI — see workflow comments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Open source motorsport data acquisition and analytics**
 
+[![CI](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/ci.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/ci.yml)
+
 🌐 **Live Demo:** [HackTheTrack.net](https://hackthetrack.net)  
 🔧 **Hardware Project:** [DovesDataLogger on GitHub](https://github.com/TheAngryRaven/DovesDataLogger)
 


### PR DESCRIPTION
Locks in the 203-test safety net added in #5 — without CI, those tests only ran when someone manually invoked them and could silently regress on incoming PRs.

Workflow (.github/workflows/ci.yml):
  - Runs on push to main and on all pull requests
  - Concurrency control cancels in-progress runs when new commits land on the same ref (saves Actions minutes during rapid-fire PR pushes)
  - Single job: npm ci → tsc --noEmit → test:run → vite build
  - Node 20 LTS with npm cache enabled

Lint intentionally NOT in the workflow yet. The codebase has 100 pre-existing lint problems (76 errors, 24 warnings — mostly @typescript-eslint/no-explicit-any from before strict mode and some prefer-const / no-empty). Adding `npm run lint` would make CI red from day one and erode the "CI green = ship it" signal. Fix those in a follow-up PR, then add the lint step.

Also:
  - README.md: CI status badge
  - CLAUDE.md: documented `npm test` / `npm run test:run` in Commands section + noted CI presence

Verified the full pipeline locally:
  ✓ tsc --noEmit
  ✓ npm run test:run (203 passed, 1.85s)
  ✓ npm run build

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf