### PR TITLE
Extract LandingPage + dialog components, drop ~308 lines from Index.tsx

### DIFF
--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -1,0 +1,90 @@
+import { Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+
+const SECTIONS: Array<{ heading: string; body: React.ReactNode }> = [
+  {
+    heading: "Works Offline & Can Be Installed",
+    body: (
+      <>
+        HackTheTrack is a fully offline-capable web application. Once loaded, it works without an internet connection — perfect for the track. You can <strong className="text-foreground">install it like a native app</strong> on your phone, tablet, or computer by using the "Install" option in your browser menu (or the prompt that appears at the bottom of the page).
+      </>
+    ),
+  },
+  {
+    heading: "Your Data Stays on Your Device",
+    body: <>All data processing happens entirely in your browser. Your log files, session notes, kart setups, and video sync data are saved locally on your device — nothing is uploaded to any server.</>,
+  },
+  {
+    heading: "Community Track Database",
+    body: <>Don't see your track? You can define custom track and course layouts in the editor, then submit them to the site-wide database for everyone to use. Submissions are reviewed before being added.</>,
+  },
+  {
+    heading: "Free & Open Source",
+    body: <>Every feature in HackTheTrack is completely free. The source code is open and available on GitHub. If cloud-saving is added in the future, that may carry a small cost to cover server fees — but all local features will always remain free.</>,
+  },
+];
+
+const FEATURES = [
+  "Multi-format file support (NMEA, UBX, VBO, MoTeC, AiM, Alfano, Dove, Dovex)",
+  "Automatic track & course detection within 5 miles",
+  "Automatic driving direction detection (forward/reverse)",
+  "Waypoint mode — lap timing anywhere, no track needed",
+  "Interactive race line map with speed heatmap",
+  "Braking zone detection & visualization",
+  "Automatic lap detection via start/finish line",
+  "3-sector split timing with optimal lap",
+  "Pro graph view with multi-series telemetry charts",
+  "Reference lap overlay & pace delta comparison",
+  "Video sync with telemetry playback",
+  "9 overlay gauge types (digital, analog, graph, bar, bubble, map, pace, sector, lap time)",
+  "MP4 video export with overlays & audio (H.264 + AAC)",
+  "Vehicle profiles & setup sheet management",
+  "Session notes per file",
+  "BLE device integration (DovesDataLogger)",
+  "Device track sync over Bluetooth",
+  "Custom track & course editor with community submissions",
+  "Local weather lookup",
+  "Dark & light mode",
+  "PWA — installable & fully offline",
+];
+
+export function AboutDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Info className="w-4 h-4" />
+          <span className="hidden sm:inline">About</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>About HackTheTrack</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 text-sm text-muted-foreground">
+          {SECTIONS.map((s) => (
+            <div key={s.heading}>
+              <h3 className="font-semibold text-foreground mb-1">{s.heading}</h3>
+              <p>{s.body}</p>
+            </div>
+          ))}
+
+          <div className="border-t border-border pt-4 mt-4">
+            <h3 className="font-semibold text-foreground mb-2">Features</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+              {FEATURES.map((feat, i) => (
+                <div key={i} className="flex items-start gap-1.5">
+                  <span className="text-primary mt-0.5">•</span>
+                  <span>{feat}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -1,0 +1,58 @@
+import { BookOpen, ExternalLink } from "lucide-react";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+
+const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
+  ["React", "https://react.dev"],
+  ["Vite", "https://vite.dev"],
+  ["TypeScript", "https://www.typescriptlang.org"],
+  ["Tailwind CSS", "https://tailwindcss.com"],
+  ["shadcn/ui", "https://ui.shadcn.com"],
+  ["Radix UI", "https://www.radix-ui.com"],
+  ["Leaflet", "https://leafletjs.com"],
+  ["OpenStreetMap", "https://www.openstreetmap.org"],
+  ["Lucide Icons", "https://lucide.dev"],
+  ["TanStack Query", "https://tanstack.com/query"],
+  ["IEM ASOS (Iowa State)", "https://mesonet.agron.iastate.edu"],
+  ["NWS API", "https://www.weather.gov/documentation/services-web-api"],
+  ["Savitzky-Golay (ml.js)", "https://github.com/mljs/savitzky-golay"],
+  ["Sonner", "https://sonner.emilkowal.dev"],
+  ["react-resizable-panels", "https://github.com/bvaughn/react-resizable-panels"],
+  ["MoTeC i2", "https://www.motec.com.au"],
+];
+
+export function CreditsDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+          <BookOpen className="w-3 h-3" />
+          Credits
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Credits</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground mb-4">
+          Built on the shoulders of these incredible open-source projects and free services.
+        </p>
+        <div className="grid grid-cols-1 gap-2">
+          {CREDITS.map(([name, url]) => (
+            <a
+              key={name}
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between px-3 py-2 rounded-md hover:bg-accent transition-colors text-sm"
+            >
+              <span className="font-medium text-foreground">{name}</span>
+              <ExternalLink className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            </a>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,155 @@
+import { Gauge, Github, Heart, Shield, BookOpen, Play, Loader2 } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { FileImport } from "@/components/FileImport";
+import { LocalWeatherDialog } from "@/components/LocalWeatherDialog";
+import { BrowserCompatDialog } from "@/components/BrowserCompatDialog";
+import { ContactDialog } from "@/components/ContactDialog";
+import { SupportedFilesDialog } from "@/components/SupportedFilesDialog";
+import { AboutDialog } from "@/components/AboutDialog";
+import { CreditsDialog } from "@/components/CreditsDialog";
+import type { ParsedData } from "@/types/racing";
+
+interface LandingPageProps {
+  onDataLoaded: (data: ParsedData, fileName?: string) => void;
+  onOpenFileManager: () => void;
+  autoSave: boolean;
+  autoSaveFile: (fileName: string, file: File) => Promise<void>;
+  onLoadSample: () => void;
+  isLoadingSample: boolean;
+  enableAdmin: boolean;
+}
+
+const GITHUB_LINKS: Array<{ href: string; label: string }> = [
+  { href: "https://github.com/TheAngryRaven/DovesDataViewer", label: "View on GitHub" },
+  { href: "https://github.com/TheAngryRaven/DovesDataLogger", label: "View Datalogger" },
+  { href: "https://github.com/TheAngryRaven/DovesLapTimer", label: "View Timer Library" },
+];
+
+/**
+ * The pre-data-load view shown by Index.tsx when no telemetry file is loaded.
+ * Self-contained content (header, file import, sample loader, footer) plus
+ * the three content-only dialogs (Supported Files, About, Credits).
+ *
+ * Index.tsx owns the surrounding providers (DeviceProvider, etc.) and the
+ * FileManagerDrawer, which can also be opened from this landing page via
+ * `onOpenFileManager`.
+ */
+export function LandingPage({
+  onDataLoaded,
+  onOpenFileManager,
+  autoSave,
+  autoSaveFile,
+  onLoadSample,
+  isLoadingSample,
+  enableAdmin,
+}: LandingPageProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <header className="border-b border-border px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Gauge className="w-8 h-8 text-primary" />
+            <div>
+              <h1 className="text-xl font-semibold text-foreground">HackTheTrack.net</h1>
+              <p className="text-sm text-muted-foreground">Experimental Data Viewer</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <SupportedFilesDialog />
+            <AboutDialog />
+            <ContactDialog variant="header" />
+            <a
+              href="https://github.com/sponsors/TheAngryRaven"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button variant="outline" size="sm" className="gap-2">
+                <Heart className="w-4 h-4 text-pink-500" />
+                <span className="hidden sm:inline">Sponsor</span>
+              </Button>
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center p-8">
+        <div className="w-full max-w-xl space-y-6">
+          <div className="flex justify-end items-center gap-2">
+            <LocalWeatherDialog />
+          </div>
+
+          <div className="text-center space-y-2">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
+              Free Online VBO, MoTeC, AiM &amp; NMEA Telemetry Viewer
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Open any Racelogic VBO, MoTeC i2 (LD/CSV), AiM MyChron, Alfano, u-blox UBX, NMEA or Dove datalog right in your browser. 100% offline — your files never leave your device.
+            </p>
+          </div>
+
+          <FileImport
+            onDataLoaded={onDataLoaded}
+            onOpenFileManager={onOpenFileManager}
+            autoSave={autoSave}
+            autoSaveFile={autoSaveFile}
+          />
+
+          <div className="text-center text-sm text-muted-foreground space-y-3">
+            <div className="mt-4 p-4 bg-primary/5 rounded-lg border border-primary/20">
+              <h3 className="font-medium text-foreground mb-2">Try it out!</h3>
+              <p className="text-xs mb-3">Load sample data from Orlando Kart Center to see how the viewer works.</p>
+              <Button variant="default" size="sm" onClick={onLoadSample} disabled={isLoadingSample}>
+                {isLoadingSample ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <Play className="w-4 h-4 mr-2" />
+                )}
+                {isLoadingSample ? "Loading..." : "Load Sample Data"}
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex justify-center mt-3">
+            <BrowserCompatDialog />
+          </div>
+
+          <div className="flex items-center justify-center gap-8 mt-4">
+            {GITHUB_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <Github className="w-5 h-5" />
+                <span className="text-sm">{link.label}</span>
+              </a>
+            ))}
+          </div>
+
+          <div className="flex items-center justify-center gap-6 mt-3 flex-wrap">
+            <Link to="/privacy" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+              <Shield className="w-3 h-3" />
+              Privacy Policy
+            </Link>
+            <ContactDialog />
+            <CreditsDialog />
+            {enableAdmin && (
+              <button
+                onClick={() => navigate('/admin')}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+              >
+                <Shield className="w-3 h-3" />
+                Track Management
+              </button>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/SupportedFilesDialog.tsx
+++ b/src/components/SupportedFilesDialog.tsx
@@ -1,0 +1,78 @@
+import { FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+
+const PRIMARY_FORMATS = [
+  {
+    name: "Dove CSV",
+    body: <>Simple CSV with millisecond Unix timestamps, GPS data, RPM, and hardware accelerometer readings. The native format of <a href="https://github.com/TheAngryRaven/DovesDataLogger" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">DovesDataLogger</a>. Extension: <code className="text-primary">.dove</code></>,
+  },
+  {
+    name: "Dovex (Extended Dove)",
+    body: <>Extended Dove format with a 4096-byte metadata header containing session info (driver, course, lap times) followed by standard Dove CSV GPS data. Extension: <code className="text-primary">.dovex</code></>,
+  },
+  {
+    name: "NMEA / CSV (Tab-Delimited)",
+    body: <>Tab-delimited CSV with NMEA sentences — the legacy format used by our earlier custom dataloggers. Extensions: <code className="text-primary">.nmea</code>, <code className="text-primary">.csv</code>, <code className="text-primary">.txt</code></>,
+  },
+];
+
+const SECONDARY_FORMATS: Array<{ name: string; experimental?: boolean; body: React.ReactNode }> = [
+  { name: "u-blox UBX Binary", body: <>Binary NAV-PVT messages from u-blox GPS receivers. Extension: <code className="text-primary">.ubx</code></> },
+  { name: "Racelogic VBO", body: <>Racelogic VBOX and RaceBox export format. Extension: <code className="text-primary">.vbo</code></> },
+  { name: "MoTeC LD Binary", experimental: true, body: <>Binary data from MoTeC data loggers and sim racing exports (ACC, iRacing, etc.). Extension: <code className="text-primary">.ld</code></> },
+  { name: "MoTeC CSV", experimental: true, body: <>CSV exports from MoTeC i2 Pro analysis software. Extension: <code className="text-primary">.csv</code></> },
+  { name: "Alfano CSV", experimental: true, body: <>CSV exports from the Alfano ADA app. Extension: <code className="text-primary">.csv</code></> },
+  { name: "AiM MyChron CSV", experimental: true, body: <>CSV exports from Race Studio 3 (RS2Analysis style) for MyChron 5/6. Extension: <code className="text-primary">.csv</code></> },
+];
+
+function ExperimentalBadge() {
+  return (
+    <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-600 dark:text-yellow-400 font-medium">
+      Experimental
+    </span>
+  );
+}
+
+export function SupportedFilesDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <FileText className="w-4 h-4" />
+          <span className="hidden sm:inline">Supported Files</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Supported File Formats</DialogTitle>
+          <DialogDescription>
+            All parsing is done locally in your browser — nothing is uploaded.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 text-sm">
+          {PRIMARY_FORMATS.map((f) => (
+            <div key={f.name} className="p-3 rounded-md border border-primary/30 bg-primary/5">
+              <p className="font-semibold text-foreground">{f.name}</p>
+              <p className="text-xs text-muted-foreground mt-1">{f.body}</p>
+            </div>
+          ))}
+
+          <div className="border-t border-border my-2" />
+
+          {SECONDARY_FORMATS.map((f) => (
+            <div key={f.name} className="p-3 rounded-md border border-border bg-muted/30">
+              <div className="flex items-center gap-2">
+                <p className="font-semibold text-foreground">{f.name}</p>
+                {f.experimental && <ExperimentalBadge />}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">{f.body}</p>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,17 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Loader2, Github, Eye, EyeOff, Heart, FlaskConical, BookOpen, ExternalLink, Shield, Download, Info, FileText } from "lucide-react";
-import { useNavigate, Link } from "react-router-dom";
-import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
-import { ContactDialog } from "@/components/ContactDialog";
-import { FileImport } from "@/components/FileImport";
-import { LocalWeatherDialog } from "@/components/LocalWeatherDialog";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical } from "lucide-react";
+import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { RaceLineTab } from "@/components/tabs/RaceLineTab";
 import { LapTimesTab } from "@/components/tabs/LapTimesTab";
 import { GraphViewTab } from "@/components/tabs/GraphViewTab";
 import { LabsTab } from "@/components/tabs/LabsTab";
 import { InstallPrompt } from "@/components/InstallPrompt";
-import { BrowserCompatDialog } from "@/components/BrowserCompatDialog";
 import { SettingsModal } from "@/components/SettingsModal";
 import { FileManagerDrawer } from "@/components/FileManagerDrawer";
 import { Button } from "@/components/ui/button";
@@ -50,7 +45,6 @@ export default function Index() {
   const vehicleManager = useVehicleManager();
   const setupManager = useSetupManager();
   const templateManager = useTemplateManager();
-  const navigate = useNavigate();
   const useKph = settings.useKph;
 
   // Sync dark mode class when settings change (global init is in App.tsx)
@@ -422,326 +416,24 @@ export default function Index() {
   if (!data) {
     return (
       <DeviceProvider>
-      <>
-        <InstallPrompt />
-        <div className="min-h-screen bg-background flex flex-col">
-        <header className="border-b border-border px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Gauge className="w-8 h-8 text-primary" />
-              <div>
-                <h1 className="text-xl font-semibold text-foreground">HackTheTrack.net</h1>
-                <p className="text-sm text-muted-foreground">Experimental Data Viewer</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button variant="outline" size="sm" className="gap-2">
-                    <FileText className="w-4 h-4" />
-                    <span className="hidden sm:inline">Supported Files</span>
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-h-[80vh] overflow-y-auto">
-                  <DialogHeader>
-                    <DialogTitle>Supported File Formats</DialogTitle>
-                    <DialogDescription>
-                      All parsing is done locally in your browser — nothing is uploaded.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="space-y-3 text-sm">
-                    <div className="p-3 rounded-md border border-primary/30 bg-primary/5">
-                      <p className="font-semibold text-foreground">Dove CSV</p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Simple CSV with millisecond Unix timestamps, GPS data, RPM, and hardware accelerometer readings. The native format of <a href="https://github.com/TheAngryRaven/DovesDataLogger" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">DovesDataLogger</a>. Extension: <code className="text-primary">.dove</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-primary/30 bg-primary/5">
-                      <p className="font-semibold text-foreground">Dovex (Extended Dove)</p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Extended Dove format with a 4096-byte metadata header containing session info (driver, course, lap times) followed by standard Dove CSV GPS data. Extension: <code className="text-primary">.dovex</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-primary/30 bg-primary/5">
-                      <p className="font-semibold text-foreground">NMEA / CSV (Tab-Delimited)</p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Tab-delimited CSV with NMEA sentences — the legacy format used by our earlier custom dataloggers. Extensions: <code className="text-primary">.nmea</code>, <code className="text-primary">.csv</code>, <code className="text-primary">.txt</code>
-                      </p>
-                    </div>
-
-                    <div className="border-t border-border my-2" />
-
-                    <div className="p-3 rounded-md border border-border bg-muted/30">
-                      <p className="font-semibold text-foreground">u-blox UBX Binary</p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Binary NAV-PVT messages from u-blox GPS receivers. Extension: <code className="text-primary">.ubx</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-border bg-muted/30">
-                      <p className="font-semibold text-foreground">Racelogic VBO</p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Racelogic VBOX and RaceBox export format. Extension: <code className="text-primary">.vbo</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-border bg-muted/30">
-                      <div className="flex items-center gap-2">
-                        <p className="font-semibold text-foreground">MoTeC LD Binary</p>
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-600 dark:text-yellow-400 font-medium">Experimental</span>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Binary data from MoTeC data loggers and sim racing exports (ACC, iRacing, etc.). Extension: <code className="text-primary">.ld</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-border bg-muted/30">
-                      <div className="flex items-center gap-2">
-                        <p className="font-semibold text-foreground">MoTeC CSV</p>
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-600 dark:text-yellow-400 font-medium">Experimental</span>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        CSV exports from MoTeC i2 Pro analysis software. Extension: <code className="text-primary">.csv</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-border bg-muted/30">
-                      <div className="flex items-center gap-2">
-                        <p className="font-semibold text-foreground">Alfano CSV</p>
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-600 dark:text-yellow-400 font-medium">Experimental</span>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        CSV exports from the Alfano ADA app. Extension: <code className="text-primary">.csv</code>
-                      </p>
-                    </div>
-                    <div className="p-3 rounded-md border border-border bg-muted/30">
-                      <div className="flex items-center gap-2">
-                        <p className="font-semibold text-foreground">AiM MyChron CSV</p>
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-600 dark:text-yellow-400 font-medium">Experimental</span>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        CSV exports from Race Studio 3 (RS2Analysis style) for MyChron 5/6. Extension: <code className="text-primary">.csv</code>
-                      </p>
-                    </div>
-                  </div>
-                </DialogContent>
-              </Dialog>
-
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button variant="outline" size="sm" className="gap-2">
-                    <Info className="w-4 h-4" />
-                    <span className="hidden sm:inline">About</span>
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-h-[80vh] overflow-y-auto">
-                  <DialogHeader>
-                    <DialogTitle>About HackTheTrack</DialogTitle>
-                  </DialogHeader>
-                  <div className="space-y-4 text-sm text-muted-foreground">
-                    <div>
-                      <h3 className="font-semibold text-foreground mb-1">Works Offline &amp; Can Be Installed</h3>
-                      <p>
-                        HackTheTrack is a fully offline-capable web application. Once loaded, it works without an internet connection — perfect for the track. You can <strong className="text-foreground">install it like a native app</strong> on your phone, tablet, or computer by using the "Install" option in your browser menu (or the prompt that appears at the bottom of the page).
-                      </p>
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-foreground mb-1">Your Data Stays on Your Device</h3>
-                      <p>
-                        All data processing happens entirely in your browser. Your log files, session notes, kart setups, and video sync data are saved locally on your device — nothing is uploaded to any server.
-                      </p>
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-foreground mb-1">Community Track Database</h3>
-                      <p>
-                        Don't see your track? You can define custom track and course layouts in the editor, then submit them to the site-wide database for everyone to use. Submissions are reviewed before being added.
-                      </p>
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-foreground mb-1">Free &amp; Open Source</h3>
-                      <p>
-                        Every feature in HackTheTrack is completely free. The source code is open and available on GitHub. If cloud-saving is added in the future, that may carry a small cost to cover server fees — but all local features will always remain free.
-                      </p>
-                    </div>
-
-                    <div className="border-t border-border pt-4 mt-4">
-                      <h3 className="font-semibold text-foreground mb-2">Features</h3>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
-                        {[
-                          "Multi-format file support (NMEA, UBX, VBO, MoTeC, AiM, Alfano, Dove, Dovex)",
-                          "Automatic track & course detection within 5 miles",
-                          "Automatic driving direction detection (forward/reverse)",
-                          "Waypoint mode — lap timing anywhere, no track needed",
-                          "Interactive race line map with speed heatmap",
-                          "Braking zone detection & visualization",
-                          "Automatic lap detection via start/finish line",
-                          "3-sector split timing with optimal lap",
-                          "Pro graph view with multi-series telemetry charts",
-                          "Reference lap overlay & pace delta comparison",
-                          "Video sync with telemetry playback",
-                          "9 overlay gauge types (digital, analog, graph, bar, bubble, map, pace, sector, lap time)",
-                          "MP4 video export with overlays & audio (H.264 + AAC)",
-                          "Vehicle profiles & setup sheet management",
-                          "Session notes per file",
-                          "BLE device integration (DovesDataLogger)",
-                          "Device track sync over Bluetooth",
-                          "Custom track & course editor with community submissions",
-                          "Local weather lookup",
-                          "Dark & light mode",
-                          "PWA — installable & fully offline",
-                        ].map((feat, i) => (
-                          <div key={i} className="flex items-start gap-1.5">
-                            <span className="text-primary mt-0.5">•</span>
-                            <span>{feat}</span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </DialogContent>
-              </Dialog>
-              <ContactDialog variant="header" />
-
-              <a
-                href="https://github.com/sponsors/TheAngryRaven"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Button variant="outline" size="sm" className="gap-2">
-                  <Heart className="w-4 h-4 text-pink-500" />
-                  <span className="hidden sm:inline">Sponsor</span>
-                </Button>
-              </a>
-            </div>
-          </div>
-        </header>
-
-        <main className="flex-1 flex items-center justify-center p-8">
-          <div className="w-full max-w-xl space-y-6">
-            <div className="flex justify-end items-center gap-2">
-              <LocalWeatherDialog />
-            </div>
-
-            <div className="text-center space-y-2">
-              <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-                Free Online VBO, MoTeC, AiM & NMEA Telemetry Viewer
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                Open any Racelogic VBO, MoTeC i2 (LD/CSV), AiM MyChron, Alfano, u-blox UBX, NMEA or Dove datalog right in your browser. 100% offline — your files never leave your device.
-              </p>
-            </div>
-
-
-            <FileImport
-              onDataLoaded={handleDataLoaded}
-              onOpenFileManager={fileManager.open}
-              autoSave={settings.autoSaveFiles}
-              autoSaveFile={fileManager.saveFile}
-            />
-
-            <div className="text-center text-sm text-muted-foreground space-y-3">
-              <div className="mt-4 p-4 bg-primary/5 rounded-lg border border-primary/20">
-                <h3 className="font-medium text-foreground mb-2">Try it out!</h3>
-                <p className="text-xs mb-3">Load sample data from Orlando Kart Center to see how the viewer works.</p>
-                <Button variant="default" size="sm" onClick={handleLoadSample} disabled={isLoadingSample}>
-                  {isLoadingSample ? (
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  ) : (
-                    <Play className="w-4 h-4 mr-2" />
-                  )}
-                  {isLoadingSample ? "Loading..." : "Load Sample Data"}
-                </Button>
-              </div>
-
-            </div>
-
-            <div className="flex justify-center mt-3">
-              <BrowserCompatDialog />
-            </div>
-
-            <div className="flex items-center justify-center gap-8 mt-4">
-              <a href="https://github.com/TheAngryRaven/DovesDataViewer" target="_blank" rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors">
-                <Github className="w-5 h-5" /><span className="text-sm">View on GitHub</span>
-              </a>
-              <a href="https://github.com/TheAngryRaven/DovesDataLogger" target="_blank" rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors">
-                <Github className="w-5 h-5" /><span className="text-sm">View Datalogger</span>
-              </a>
-              <a href="https://github.com/TheAngryRaven/DovesLapTimer" target="_blank" rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors">
-                <Github className="w-5 h-5" /><span className="text-sm">View Timer Library</span>
-              </a>
-            </div>
-
-            <div className="flex items-center justify-center gap-6 mt-3 flex-wrap">
-              <Link to="/privacy" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-                <Shield className="w-3 h-3" />
-                Privacy Policy
-              </Link>
-              <ContactDialog />
-              <Dialog>
-                <DialogTrigger asChild>
-                  <button className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-                    <BookOpen className="w-3 h-3" />
-                    Credits
-                  </button>
-                </DialogTrigger>
-                <DialogContent className="max-h-[80vh] overflow-y-auto">
-                  <DialogHeader>
-                    <DialogTitle>Credits</DialogTitle>
-                  </DialogHeader>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Built on the shoulders of these incredible open-source projects and free services.
-                  </p>
-                  <div className="grid grid-cols-1 gap-2">
-                    {[
-                      ["React", "https://react.dev"],
-                      ["Vite", "https://vite.dev"],
-                      ["TypeScript", "https://www.typescriptlang.org"],
-                      ["Tailwind CSS", "https://tailwindcss.com"],
-                      ["shadcn/ui", "https://ui.shadcn.com"],
-                      ["Radix UI", "https://www.radix-ui.com"],
-                      ["Leaflet", "https://leafletjs.com"],
-                      ["OpenStreetMap", "https://www.openstreetmap.org"],
-                      ["Lucide Icons", "https://lucide.dev"],
-                      ["TanStack Query", "https://tanstack.com/query"],
-                      ["IEM ASOS (Iowa State)", "https://mesonet.agron.iastate.edu"],
-                      ["NWS API", "https://www.weather.gov/documentation/services-web-api"],
-                      ["Savitzky-Golay (ml.js)", "https://github.com/mljs/savitzky-golay"],
-                      ["Sonner", "https://sonner.emilkowal.dev"],
-                      ["react-resizable-panels", "https://github.com/bvaughn/react-resizable-panels"],
-                      ["MoTeC i2", "https://www.motec.com.au"],
-                    ].map(([name, url]) => (
-                      <a
-                        key={name}
-                        href={url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center justify-between px-3 py-2 rounded-md hover:bg-accent transition-colors text-sm"
-                      >
-                        <span className="font-medium text-foreground">{name}</span>
-                        <ExternalLink className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-                      </a>
-                    ))}
-                  </div>
-                </DialogContent>
-              </Dialog>
-              {enableAdmin && (
-                <button
-                  onClick={() => navigate('/admin')}
-                  className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
-                >
-                  <Shield className="w-3 h-3" />
-                  Track Management
-                </button>
-              )}
-            </div>
-          </div>
-        </main>
-      </div>
-      <FileManagerDrawer {...fileManagerProps} />
-      </>
+        <>
+          <InstallPrompt />
+          <LandingPage
+            onDataLoaded={handleDataLoaded}
+            onOpenFileManager={fileManager.open}
+            autoSave={settings.autoSaveFiles}
+            autoSaveFile={fileManager.saveFile}
+            onLoadSample={handleLoadSample}
+            isLoadingSample={isLoadingSample}
+            enableAdmin={enableAdmin}
+          />
+          <FileManagerDrawer {...fileManagerProps} />
+        </>
       </DeviceProvider>
     );
   }
 
+  
   // Data loaded - show main view
     return (
     <DeviceProvider>


### PR DESCRIPTION
Index.tsx's no-data branch was 322 lines of mostly-static JSX (header, file import, sample loader, three large content dialogs, footer links). Pulled it out into focused components:

  src/components/SupportedFilesDialog.tsx (78 lines)
    Self-contained dialog listing the 9 supported file formats. Data
    moved to module-level PRIMARY_FORMATS / SECONDARY_FORMATS arrays;
    the 9 hand-repeated <div> blocks collapse into 2 short loops.

  src/components/AboutDialog.tsx (90 lines)
    Self-contained dialog with the 4 about sections and 21-item feature
    grid. Sections + features pulled to module-level constants;
    rendering is now two small loops.

  src/components/CreditsDialog.tsx (58 lines)
    Self-contained credits dialog. 16-entry credits list moved to a
    module-level tuple array.

  src/components/LandingPage.tsx (155 lines)
    The full no-data view: header (with the three dialogs and Sponsor
    button), the SEO h1, FileImport, sample loader, BrowserCompat link,
    GitHub link bar (pulled to a constant), and footer (privacy /
    contact / credits / optional admin). Owns the navigate() call for
    the admin button so Index.tsx no longer needs useNavigate.

Props the LandingPage takes (7): onDataLoaded, onOpenFileManager, autoSave, autoSaveFile, onLoadSample, isLoadingSample, enableAdmin. Everything else is internal.

Index.tsx changes:
  - No-data branch went from 322 lines to ~16 lines (one LandingPage call wrapped in DeviceProvider + the existing FileManagerDrawer).
  - File total: 873 -> 564 lines (-309, -35%).
  - Imports cleaned up: dropped 16 now-unused names (FileText, Info, Heart, Github, BookOpen, Shield, Link, Loader2, ExternalLink, Download, Dialog primitives, ContactDialog, BrowserCompatDialog, FileImport, LocalWeatherDialog) and the unused useNavigate.

Behavior preserved — no JSX content changed, just moved. Dialogs are still mounted via Radix's <Dialog> primitive (no open/close state to preserve), so the user-visible behavior is unchanged.

Verified:
  - npm run lint clean (0 problems)
  - tsc --noEmit clean
  - npm run test:run (203 passed)
  - npm run build clean

Remaining on the Index.tsx decomposition roadmap:
  - useDataLoader() hook for the 90-line handleDataLoaded orchestration. That brings Index.tsx down to roughly the 350-line target.

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf