### PR TITLE
Extract useDataLoader hook, drop 122 lines from Index.tsx

### DIFF
--- a/src/hooks/useDataLoader.ts
+++ b/src/hooks/useDataLoader.ts
@@ -1,0 +1,192 @@
+import { useCallback, useState } from "react";
+import {
+  ParsedData,
+  Track,
+  TrackCourseSelection,
+  CourseDetectionResult,
+} from "@/types/racing";
+import { getFileMetadata } from "@/lib/fileStorage";
+import { loadTracks } from "@/lib/trackStorage";
+import { findNearestTrack } from "@/lib/trackUtils";
+import { autoDetectCourse } from "@/lib/courseDetection";
+import type { useSessionData } from "@/hooks/useSessionData";
+import type { useLapManagement } from "@/hooks/useLapManagement";
+import type { useSessionMetadata } from "@/hooks/useSessionMetadata";
+
+interface UseDataLoaderOptions {
+  sessionData: ReturnType<typeof useSessionData>;
+  lapMgmt: ReturnType<typeof useLapManagement>;
+  sessionMeta: ReturnType<typeof useSessionMetadata>;
+  /** The sample-loader expects to restore metadata for this specific fixture file. */
+  sampleFileName?: string;
+}
+
+export interface UseDataLoaderReturn {
+  /** Main file-load orchestrator. Invoked from drag-drop, file manager, and sample loader. */
+  handleDataLoaded: (parsedData: ParsedData, fileName?: string) => Promise<void>;
+  /** Load the bundled sample fixture and restore its metadata. */
+  handleLoadSample: () => Promise<void>;
+  /** User picked a track/course in the prompt dialog — apply selection and recompute laps. */
+  handleTrackPromptSelect: (sel: TrackCourseSelection) => void;
+
+  // Track-prompt UI state owned by this hook (only relevant right after a load).
+  trackPromptOpen: boolean;
+  setTrackPromptOpen: (open: boolean) => void;
+  detectedTrack: Track | null;
+  detectionResult: CourseDetectionResult | null;
+  allTracks: Track[];
+  gpsCenter: { lat: number; lon: number } | null;
+}
+
+const DEFAULT_SAMPLE_FILE_NAME = "okc-tillotson-data.dovex";
+
+/** Pick the lap with the lowest lapTimeMs (linear, no Math.min spread). */
+function pickFastestLapNumber(laps: { lapNumber: number; lapTimeMs: number }[]): number | null {
+  if (laps.length === 0) return null;
+  let fastest = laps[0];
+  for (let i = 1; i < laps.length; i++) {
+    if (laps[i].lapTimeMs < fastest.lapTimeMs) fastest = laps[i];
+  }
+  return fastest.lapNumber;
+}
+
+/**
+ * File-load orchestration: connects sessionData (parsing), lapMgmt (lap calc),
+ * sessionMeta (per-file kart/setup/weather metadata), and the track-prompt UI.
+ *
+ * Pulled out of Index.tsx so the orchestration logic lives next to the other
+ * session hooks instead of being inlined in the SPA root.
+ */
+export function useDataLoader({
+  sessionData,
+  lapMgmt,
+  sessionMeta,
+  sampleFileName = DEFAULT_SAMPLE_FILE_NAME,
+}: UseDataLoaderOptions): UseDataLoaderReturn {
+  const [trackPromptOpen, setTrackPromptOpen] = useState(false);
+  const [detectedTrack, setDetectedTrack] = useState<Track | null>(null);
+  const [allTracks, setAllTracks] = useState<Track[]>([]);
+  const [gpsCenter, setGpsCenter] = useState<{ lat: number; lon: number } | null>(null);
+  const [detectionResult, setDetectionResult] = useState<CourseDetectionResult | null>(null);
+
+  const handleDataLoaded = useCallback(
+    async (parsedData: ParsedData, fileName?: string) => {
+      sessionData.loadParsedData(parsedData, fileName);
+      lapMgmt.setCurrentIndex(0);
+
+      // Try to restore track selection from metadata
+      let courseToUse = lapMgmt.selectedCourse;
+      let restoredFromMeta = false;
+      if (fileName) {
+        const meta = await getFileMetadata(fileName);
+        if (meta) {
+          const tracks = await loadTracks();
+          const track = tracks.find((t) => t.name === meta.trackName);
+          const course = track?.courses.find((c) => c.name === meta.courseName);
+          if (track && course) {
+            const restoredSelection: TrackCourseSelection = {
+              trackName: track.name,
+              courseName: course.name,
+              course,
+            };
+            lapMgmt.setSelection(restoredSelection);
+            courseToUse = course;
+            restoredFromMeta = true;
+          }
+          sessionMeta.restoreFromMetadata(meta);
+        } else {
+          sessionMeta.restoreFromMetadata(null);
+        }
+      } else {
+        sessionMeta.restoreFromMetadata(null);
+      }
+
+      // Calculate laps if a course is known
+      if (courseToUse) {
+        const computedLaps = lapMgmt.calculateAndSetLaps(courseToUse, parsedData.samples, fileName);
+        lapMgmt.setSelectedLapNumber(pickFastestLapNumber(computedLaps));
+      } else {
+        lapMgmt.setSelectedLapNumber(null);
+      }
+
+      // Auto-detect track + course only when metadata didn't already restore one
+      if (restoredFromMeta) return;
+
+      const tracks = await loadTracks();
+      setAllTracks(tracks);
+      const validSample = parsedData.samples.find(
+        (s) => s.lat !== 0 && s.lon !== 0 && Math.abs(s.lat) <= 90 && Math.abs(s.lon) <= 180,
+      );
+      if (!validSample) return;
+
+      setGpsCenter({ lat: validSample.lat, lon: validSample.lon });
+
+      const detection = autoDetectCourse(parsedData.samples, tracks);
+      setDetectionResult(detection);
+
+      if (detection && !detection.isWaypointMode) {
+        // Auto-detected a real course — apply directly, no prompt needed
+        lapMgmt.setSelection({
+          trackName: detection.track.name,
+          courseName: detection.course.name,
+          course: detection.course,
+        });
+        lapMgmt.setLaps(detection.laps);
+        lapMgmt.setSelectedLapNumber(pickFastestLapNumber(detection.laps));
+        return;
+      }
+
+      if (detection && detection.isWaypointMode) {
+        // Waypoint mode — apply laps and prompt the user to confirm
+        lapMgmt.setLaps(detection.laps);
+        lapMgmt.setSelectedLapNumber(pickFastestLapNumber(detection.laps));
+        setDetectedTrack(null);
+        setTrackPromptOpen(true);
+        return;
+      }
+
+      // No detection — fall back to nearest track and prompt
+      const nearest = findNearestTrack(validSample.lat, validSample.lon, tracks);
+      setDetectedTrack(nearest as Track | null);
+      setTrackPromptOpen(true);
+    },
+    [sessionData, lapMgmt, sessionMeta],
+  );
+
+  const handleLoadSample = useCallback(async () => {
+    await sessionData.handleLoadSample(
+      lapMgmt.handleSelectionChange,
+      (computedLaps, autoSelectLap, autoSelectRef) => {
+        lapMgmt.setLaps(computedLaps);
+        if (autoSelectLap !== undefined) lapMgmt.setSelectedLapNumber(autoSelectLap);
+        if (autoSelectRef !== undefined) lapMgmt.setReferenceLapNumber(autoSelectRef);
+      },
+    );
+    // Restore session metadata (kart/setup link) for the sample file
+    const meta = await getFileMetadata(sampleFileName);
+    sessionMeta.restoreFromMetadata(meta);
+  }, [sessionData, lapMgmt, sessionMeta, sampleFileName]);
+
+  const handleTrackPromptSelect = useCallback(
+    (sel: TrackCourseSelection) => {
+      lapMgmt.handleSelectionChange(sel);
+      const samples = sessionData.data?.samples;
+      if (!samples) return;
+      const computedLaps = lapMgmt.calculateAndSetLaps(sel.course, samples);
+      lapMgmt.setSelectedLapNumber(pickFastestLapNumber(computedLaps));
+    },
+    [lapMgmt, sessionData.data],
+  );
+
+  return {
+    handleDataLoaded,
+    handleLoadSample,
+    handleTrackPromptSelect,
+    trackPromptOpen,
+    setTrackPromptOpen,
+    detectedTrack,
+    detectionResult,
+    allTracks,
+    gpsCenter,
+  };
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,11 +12,7 @@ import { FileManagerDrawer } from "@/components/FileManagerDrawer";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { ParsedData, Track, TrackCourseSelection, CourseDetectionResult } from "@/types/racing";
-import { getFileMetadata } from "@/lib/fileStorage";
-import { loadTracks } from "@/lib/trackStorage";
-import { findNearestTrack } from "@/lib/trackUtils";
-import { autoDetectCourse } from "@/lib/courseDetection";
+import { ParsedData } from "@/types/racing";
 import { TrackPromptDialog } from "@/components/TrackPromptDialog";
 import { useSettings } from "@/hooks/useSettings";
 import { usePlayback } from "@/hooks/usePlayback";
@@ -30,6 +26,7 @@ import { useLapManagement } from "@/hooks/useLapManagement";
 import { useReferenceLap, useExternalReference } from "@/hooks/useReferenceLap";
 import { useSessionMetadata } from "@/hooks/useSessionMetadata";
 import { useVideoSync } from "@/hooks/useVideoSync";
+import { useDataLoader } from "@/hooks/useDataLoader";
 import { SettingsProvider } from "@/contexts/SettingsContext";
 import { DeviceProvider } from "@/contexts/DeviceContext";
 import { SessionProvider, type SessionContextValue } from "@/contexts/SessionContext";
@@ -99,11 +96,6 @@ export default function Index() {
 
   const [topPanelView, setTopPanelView] = useState<TopPanelView>("raceline");
   const [showOverlays, setShowOverlays] = useState(true);
-  const [trackPromptOpen, setTrackPromptOpen] = useState(false);
-  const [detectedTrack, setDetectedTrack] = useState<Track | null>(null);
-  const [allTracks, setAllTracks] = useState<Track[]>([]);
-  const [gpsCenter, setGpsCenter] = useState<{ lat: number; lon: number } | null>(null);
-  const [detectionResult, setDetectionResult] = useState<CourseDetectionResult | null>(null);
 
   // Video sync for Labs tab
   const videoSync = useVideoSync({
@@ -115,142 +107,28 @@ export default function Index() {
   });
   const currentSample = visibleSamples[currentIndex] ?? null;
 
-  // Orchestrate data loading — connects sessionData, lapMgmt, and sessionMeta
-  const handleDataLoaded = useCallback(
-    async (parsedData: ParsedData, fileName?: string) => {
-      sessionData.loadParsedData(parsedData, fileName);
-      setCurrentIndex(0);
+  // Data loading orchestration — owns the track-prompt UI state and the
+  // sample-loader. Returns the three callbacks Index.tsx wires up to imports.
+  const dataLoader = useDataLoader({ sessionData, lapMgmt, sessionMeta });
+  const {
+    handleDataLoaded, handleLoadSample, handleTrackPromptSelect,
+    trackPromptOpen, setTrackPromptOpen, detectedTrack, detectionResult,
+    allTracks, gpsCenter,
+  } = dataLoader;
 
-      // Try to restore track selection from metadata
-      let courseToUse = selectedCourse;
-      let restoredFromMeta = false;
-      if (fileName) {
-        const meta = await getFileMetadata(fileName);
-        if (meta) {
-          const tracks = await loadTracks();
-          const track = tracks.find((t) => t.name === meta.trackName);
-          const course = track?.courses.find((c) => c.name === meta.courseName);
-          if (track && course) {
-            const restoredSelection: TrackCourseSelection = {
-              trackName: track.name,
-              courseName: course.name,
-              course,
-            };
-            lapMgmt.setSelection(restoredSelection);
-            courseToUse = course;
-            restoredFromMeta = true;
-          }
-          sessionMeta.restoreFromMetadata(meta);
-        } else {
-          sessionMeta.restoreFromMetadata(null);
-        }
-      } else {
-        sessionMeta.restoreFromMetadata(null);
-      }
-
-      // Calculate laps if course is selected
-      if (courseToUse) {
-        const computedLaps = lapMgmt.calculateAndSetLaps(courseToUse, parsedData.samples, fileName);
-        if (computedLaps.length > 0) {
-          const fastest = computedLaps.reduce((min, lap) => (lap.lapTimeMs < min.lapTimeMs ? lap : min), computedLaps[0]);
-          setSelectedLapNumber(fastest.lapNumber);
-        }
-      } else {
-        setSelectedLapNumber(null);
-      }
-
-      // Auto-detect track and prompt if not restored from metadata
-      if (!restoredFromMeta) {
-        const tracks = await loadTracks();
-        setAllTracks(tracks);
-        const validSample = parsedData.samples.find(
-          (s) => s.lat !== 0 && s.lon !== 0 && Math.abs(s.lat) <= 90 && Math.abs(s.lon) <= 180
-        );
-        if (validSample) {
-          setGpsCenter({ lat: validSample.lat, lon: validSample.lon });
-
-          // Run auto-detection
-          const detection = autoDetectCourse(parsedData.samples, tracks);
-          setDetectionResult(detection);
-
-          if (detection && !detection.isWaypointMode) {
-            // Auto-detected a real course — apply it directly
-            const sel: TrackCourseSelection = {
-              trackName: detection.track.name,
-              courseName: detection.course.name,
-              course: detection.course,
-            };
-            lapMgmt.setSelection(sel);
-            lapMgmt.setLaps(detection.laps);
-            if (detection.laps.length > 0) {
-              const fastest = detection.laps.reduce((min, lap) => (lap.lapTimeMs < min.lapTimeMs ? lap : min), detection.laps[0]);
-              setSelectedLapNumber(fastest.lapNumber);
-            }
-
-            // Course was auto-detected — no need to prompt the user
-          } else if (detection && detection.isWaypointMode) {
-            // Waypoint mode — apply laps and show prompt
-            lapMgmt.setLaps(detection.laps);
-            if (detection.laps.length > 0) {
-              const fastest = detection.laps.reduce((min, lap) => (lap.lapTimeMs < min.lapTimeMs ? lap : min), detection.laps[0]);
-              setSelectedLapNumber(fastest.lapNumber);
-            }
-            setDetectedTrack(null);
-            setTrackPromptOpen(true);
-          } else {
-            // No detection at all
-            const nearest = findNearestTrack(validSample.lat, validSample.lon, tracks);
-            setDetectedTrack(nearest as Track | null);
-            setTrackPromptOpen(true);
-          }
-        }
-      }
-    },
-    [selectedCourse, sessionData, lapMgmt, sessionMeta, setCurrentIndex, setSelectedLapNumber]
-  );
-
-  // Wire up sample loading
-  const handleLoadSample = useCallback(async () => {
-    await sessionData.handleLoadSample(
-      handleSelectionChange,
-      (computedLaps, autoSelectLap, autoSelectRef) => {
-        lapMgmt.setLaps(computedLaps);
-        if (autoSelectLap !== undefined) setSelectedLapNumber(autoSelectLap);
-        if (autoSelectRef !== undefined) setReferenceLapNumber(autoSelectRef);
-      }
-    );
-    // Restore session metadata (kart/setup link) for the sample file
-    const sampleFileName = "okc-tillotson-data.dovex";
-    const meta = await getFileMetadata(sampleFileName);
-    sessionMeta.restoreFromMetadata(meta);
-  }, [sessionData, handleSelectionChange, lapMgmt, setSelectedLapNumber, setReferenceLapNumber, sessionMeta]);
-
-  // Wire up reference setting to also clear external ref
+  // Reference-lap handlers: clear the other side when one is set.
   const handleSetReferenceWithClear = useCallback((lapNumber: number) => {
     handleSetReference(lapNumber);
     externalRef.setExternalRefSamples(null);
     externalRef.setExternalRefLabel(null);
   }, [handleSetReference, externalRef]);
 
-  // Wire up external lap selection to clear internal ref
   const handleSelectExternalLapWithClear = useCallback((fileName: string, lapNumber: number) => {
     handleSelectExternalLap(fileName, lapNumber);
     setReferenceLapNumber(null);
   }, [handleSelectExternalLap, setReferenceLapNumber]);
 
   const hasReference = referenceLapNumber !== null || externalRefSamples !== null;
-
-  // Handle course selection from the track prompt dialog
-  const handleTrackPromptSelect = useCallback((sel: TrackCourseSelection) => {
-    handleSelectionChange(sel);
-    if (data) {
-      const computedLaps = lapMgmt.calculateAndSetLaps(sel.course, data.samples);
-      if (computedLaps.length > 0) {
-        const fastest = computedLaps.reduce((min, lap) => (lap.lapTimeMs < min.lapTimeMs ? lap : min), computedLaps[0]);
-        setSelectedLapNumber(fastest.lapNumber);
-      }
-    }
-  }, [handleSelectionChange, data, lapMgmt, setSelectedLapNumber]);
 
   const brakingZoneSettings = useMemo(() => ({
     entryThresholdG: settings.brakingEntryThreshold / 100,


### PR DESCRIPTION
Three related handlers were tangled together in Index.tsx with the
track-prompt UI state they manage:
  - handleDataLoaded (90 lines, the main file-load orchestrator)
  - handleLoadSample (13 lines)
  - handleTrackPromptSelect (10 lines)
  + 5 useState calls for trackPromptOpen / detectedTrack / detectionResult
    / allTracks / gpsCenter

Pulled into a single useDataLoader hook (192 lines) that:
  - Owns the track-prompt UI state internally
  - Takes the related session hooks (sessionData, lapMgmt, sessionMeta)
    and reads their outputs/setters directly
  - Returns the three callbacks + the prompt state for the dialog props
  - Replaces the hand-rolled `laps.reduce(min by lapTime)` patterns with
    a small pickFastestLapNumber helper (no Math.min spread either)
  - Re-shapes nested if/else in handleDataLoaded into early returns so
    the auto-detect logic reads top-to-bottom

Index.tsx changes:
  - 564 -> 442 lines (-122, -22%)
  - 13 dropped imports (ParsedData kept in types/racing only via the hook):
    Track, TrackCourseSelection, CourseDetectionResult, getFileMetadata,
    loadTracks, findNearestTrack, autoDetectCourse all moved into the hook
  - One useDataLoader({ ... }) call + destructure replaces ~130 lines of
    orchestration

The data-loading state is now logically grouped with its callbacks
instead of scattered across the SPA root. Adding new on-load behavior
(e.g., kicking off a render warm-up, prefetching tiles) is a one-file
edit instead of weaving through Index.tsx.

⚠ Discovery during this PR — separate follow-up needed:
  `npx tsc --noEmit` from the repo root is a no-op. The root tsconfig.json
  has `files: []` and uses `references`, but plain tsc doesn't follow
  references — only `tsc --build` (or `-p tsconfig.app.json`) does. Our
  CI typecheck workflow has been silently exiting 0 without checking
  anything. Running tsc against tsconfig.app.json directly reveals 8
  pre-existing real type errors from earlier PRs (mostly `catch (err)`
  blocks accessing `.message` on the implicit `unknown`, plus one
  Blob/File contravariance mismatch in LandingPage props from the
  previous PR). None block runtime (Vite/esbuild strip types without
  checking), but they should be fixed and the CI typecheck step fixed
  to actually check. Queued as the next PR after this lands.

This PR's useDataLoader extraction is clean: tsc -p tsconfig.app.json
on src/hooks/useDataLoader.ts and src/pages/Index.tsx produces zero
errors. The 8 latent errors are all in unrelated files.

Verified:
  - npm run lint clean (0 problems)
  - npx tsc --noEmit -p tsconfig.app.json: my new code is clean
    (8 pre-existing errors elsewhere — see note above)
  - npm run test:run (203 passed)
  - npm run build clean

Index.tsx decomposition trilogy complete:
  ✓ SessionContext (PR #9)
  ✓ Landing page extraction (PR #11)
  ✓ useDataLoader hook (this PR)
Final Index.tsx ~440 lines doing only SPA-root work (hook composition,
tab switching, drawer/dialog mounting).

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf