### PR TITLE
Fix CI typecheck (was a no-op) and 8 latent type errors

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,7 +11,11 @@ concurrency:
 
 jobs:
   typecheck:
-    name: tsc --noEmit
+    # `tsc -b` (build mode) is required to follow the root tsconfig.json's
+    # project references — plain `tsc --noEmit` from repo root is a no-op
+    # because the root config has `files: []` and only references the app/node
+    # configs. Both referenced configs have `noEmit: true` so nothing emits.
+    name: tsc -b
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,4 +24,4 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npx tsc --noEmit
+      - run: npm run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# TypeScript incremental build info (created by `tsc -b`)
+*.tsbuildinfo
+
 # Environment — see .env.example for the schema
 .env
 .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,13 +365,20 @@ Key settings: `useKph`, `gForceSmoothing`, `gForceSmoothingStrength`, `brakingZo
 ## Commands
 
 ```bash
-npm run dev       # Dev server on :8080
-npm run build     # Production build → dist/
-npm run lint      # ESLint
-npm run preview   # Preview production build
-npm test          # Vitest in watch mode
-npm run test:run  # Vitest single pass (CI-style)
+npm run dev        # Dev server on :8080
+npm run build      # Production build → dist/
+npm run lint       # ESLint
+npm run typecheck  # tsc -b (must use build mode to follow project references)
+npm run preview    # Preview production build
+npm test           # Vitest in watch mode
+npm run test:run   # Vitest single pass (CI-style)
 ```
+
+> **Why `tsc -b`?** The root `tsconfig.json` has `files: []` and only uses
+> `references` to point at `tsconfig.app.json` + `tsconfig.node.json`. Plain
+> `tsc --noEmit` from repo root silently exits 0 without checking anything.
+> `tsc -b` (build mode) follows references; both referenced configs have
+> `noEmit: true` so nothing is emitted.
 
 CI is split into four parallel workflows under `.github/workflows/`
 (`lint.yml`, `typecheck.yml`, `test.yml`, `build.yml`). Each runs on every PR

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "typecheck": "tsc -b"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.11",

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -14,7 +14,7 @@ interface LandingPageProps {
   onDataLoaded: (data: ParsedData, fileName?: string) => void;
   onOpenFileManager: () => void;
   autoSave: boolean;
-  autoSaveFile: (fileName: string, file: File) => Promise<void>;
+  autoSaveFile: (name: string, blob: Blob) => Promise<void>;
   onLoadSample: () => void;
   isLoadingSample: boolean;
   enableAdmin: boolean;

--- a/src/components/drawer/DeviceSettingsTab.tsx
+++ b/src/components/drawer/DeviceSettingsTab.tsx
@@ -52,7 +52,7 @@ export function DeviceSettingsTab({ connection, onResetComplete }: DeviceSetting
         }))
       );
     } catch (err) {
-      setFetchError(err?.message ?? "Failed to read settings");
+      setFetchError((err instanceof Error ? err.message : "Failed to read settings"));
     } finally {
       setLoading(false);
     }
@@ -92,7 +92,7 @@ export function DeviceSettingsTab({ connection, onResetComplete }: DeviceSetting
       setRows((prev) =>
         prev.map((r, i) => (i === index ? { ...r, saving: false } : r))
       );
-      toast.error(`Failed to save: ${err?.message ?? "Unknown error"}`);
+      toast.error(`Failed to save: ${(err instanceof Error ? err.message : "Unknown error")}`);
     }
   };
 
@@ -107,7 +107,7 @@ export function DeviceSettingsTab({ connection, onResetComplete }: DeviceSetting
       toast.success("Settings reset to defaults — device is rebooting");
       onResetComplete?.();
     } catch (err) {
-      toast.error(`Reset failed: ${err?.message ?? "Unknown error"}`);
+      toast.error(`Reset failed: ${(err instanceof Error ? err.message : "Unknown error")}`);
       setResetting(false);
       setConfirmReset(false);
     }

--- a/src/components/drawer/DeviceTracksTab.tsx
+++ b/src/components/drawer/DeviceTracksTab.tsx
@@ -268,7 +268,7 @@ export function DeviceTracksTab({ connection }: DeviceTracksTabProps) {
         await uploadTrackFile(connection, entry.shortName + ".json", data);
       } catch (err) {
         console.error(`Resync failed for ${entry.shortName}:`, err);
-        toast.error(`Failed to sync ${entry.shortName}: ${err?.message || "Unknown"}`);
+        toast.error(`Failed to sync ${entry.shortName}: ${err instanceof Error ? err.message : "Unknown"}`);
       }
     }
 

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -167,7 +167,8 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
         persistSync(syncOffsetMsRef.current, handle, file.name);
         return;
       } catch (e) {
-        if (e.name === "AbortError") return;
+        // User cancelled the file picker — DOMException("AbortError"). Swallow.
+        if (e instanceof Error && e.name === "AbortError") return;
       }
     }
     if (!fileInputRef.current) {

--- a/src/lib/videoExport.ts
+++ b/src/lib/videoExport.ts
@@ -364,7 +364,7 @@ async function runWebCodecsExport(
 
     callbacks.onComplete(blob);
   } catch (e) {
-    callbacks.onError(e.message || "Export failed");
+    callbacks.onError(e instanceof Error ? e.message : "Export failed");
   }
 }
 
@@ -498,7 +498,7 @@ async function runFallbackExport(
       requestAnimationFrame(drawFrame);
     }
   } catch (e) {
-    callbacks.onError(e.message || "Export failed");
+    callbacks.onError(e instanceof Error ? e.message : "Export failed");
   }
 }
 


### PR DESCRIPTION
Discovered during the useDataLoader PR: our typecheck step in CI
(`npx tsc --noEmit`) has been silently passing without checking
anything. Root cause: the root `tsconfig.json` has `files: []` and
only uses `references` to point at `tsconfig.app.json` and
`tsconfig.node.json`. Plain `tsc` does NOT follow references — only
`tsc --build` (aka `tsc -b`) does. So `tsc --noEmit` from repo root
found nothing to compile and exited 0 every time.

This meant any real type error that hadn't been caught locally went to
main unchallenged. Switching CI to `tsc -b` surfaced 8 such errors that
had accumulated across earlier PRs.

CI / script changes:
  - Added `npm run typecheck` -> `tsc -b` to package.json.
    Both referenced configs already have `noEmit: true` so nothing
    emits. Uses `-b` (build mode) which respects project references.
  - .github/workflows/typecheck.yml now runs `npm run typecheck`
    (was `npx tsc --noEmit`, a no-op).
  - .gitignore adds `*.tsbuildinfo` — `tsc -b` writes incremental
    build state files alongside the configs.
  - CLAUDE.md Commands section updated with `npm run typecheck` and a
    note explaining why `-b` is required here.

The 8 latent errors fixed:

  src/components/LandingPage.tsx:97
    `autoSaveFile` prop was typed `(fileName: string, file: File) =>
    Promise<void>` but the actual fileManager.saveFile is
    `(name: string, blob: Blob) => Promise<void>`. Function parameter
    types are contravariant, so a `(File) => void` is not assignable
    to a `(Blob) => void` slot. Widened the prop to `Blob` to match.

  src/components/drawer/DeviceSettingsTab.tsx (3 sites: 55, 95, 110)
  src/components/drawer/DeviceTracksTab.tsx (1 site: 271)
  src/lib/videoExport.ts (2 sites: 367, 501)
  src/hooks/useVideoSync.ts (1 site: 170)
    All `catch (err)` blocks that accessed `.message` directly on
    `err`, which strict mode types as `unknown`. Replaced with
    `err instanceof Error ? err.message : "<fallback>"` per the
    pattern already established by the lint-cleanup PR — the prior
    regex pass missed these because they used slightly different
    syntax (`err?.message ?? "..."` vs `err?.message || "..."`).
    useVideoSync's AbortError check now narrows via
    `e instanceof Error && e.name === "AbortError"`.

Verified:
  - npm run lint clean (0 problems)
  - npm run typecheck (the real one) clean — 0 errors
  - npm run test:run (203 passed)
  - npm run build clean

Going forward, every PR will have a typecheck step that actually
typechecks. This was an embarrassing find but also the kind of thing
this whole refactor pass was designed to surface — silent no-ops in
the safety net.

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf