### PR TITLE
Add BLE protocol tests: 63 new tests across all 4 modules

### DIFF
--- a/src/lib/ble/__test__/mockBle.ts
+++ b/src/lib/ble/__test__/mockBle.ts
@@ -1,0 +1,141 @@
+/// <reference types="web-bluetooth" />
+
+/**
+ * Vitest-side mock for Web Bluetooth.
+ *
+ * Provides a `BleConnection`-shaped object whose characteristics are
+ * test-controllable: each characteristic records `writeValue` calls and
+ * exposes a `simulate()` helper that fires a `characteristicvaluechanged`
+ * event with arbitrary payload bytes. This lets every protocol test be
+ * written as:
+ *
+ *   const conn = createMockConnection();
+ *   const result = requestX(conn);             // start the operation
+ *   await flushMicrotasks();                   // let the async setup settle
+ *   expect(lastWritten(...)).toBe("X");        // verify command sent
+ *   conn.characteristics.fileStatus.simulate("X-RESPONSE\n");
+ *   await expect(result).resolves.toEqual(...);
+ *
+ * The mock is intentionally minimal — it only implements the surface the
+ * protocols actually use (startNotifications, addEventListener / remove,
+ * writeValue) plus a test-only `simulate`. It is NOT a faithful Web
+ * Bluetooth emulation.
+ */
+
+import type { BleConnection } from "../types";
+
+/**
+ * Test-only extras layered on top of BluetoothRemoteGATTCharacteristic.
+ * Kept as a separate interface (NOT extending) to avoid this-type variance
+ * issues on `oncharacteristicvaluechanged` when widening.
+ */
+export interface MockCharacteristic {
+  /** Notifications enabled flag (set when startNotifications is awaited). */
+  notificationsStarted: boolean;
+  /** Cumulative log of payloads passed to writeValue, in call order. */
+  written: Uint8Array[];
+  /** Fire a `characteristicvaluechanged` event with the given payload. */
+  simulate(payload: string | Uint8Array): void;
+}
+
+/** Connection-side view: each characteristic IS a real one + the test extras. */
+type MockedChar = BluetoothRemoteGATTCharacteristic & MockCharacteristic;
+
+/** Decode the most recent writeValue payload as UTF-8 text. */
+export function lastWritten(char: MockedChar): string {
+  const last = char.written.at(-1);
+  if (!last) throw new Error("No writeValue calls recorded");
+  return new TextDecoder().decode(last);
+}
+
+/** Returns the count of writeValue calls so far. */
+export function writeCount(char: MockedChar): number {
+  return char.written.length;
+}
+
+/**
+ * Allow the protocol's async setup (startNotifications + writeValue awaits) to
+ * settle before the test simulates a response. A few rounds of microtask flush
+ * is enough — none of our mocks yield to the macrotask queue.
+ */
+export async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
+function createMockCharacteristic(): MockedChar {
+  // Use a plain object built around an EventTarget. EventTarget gives us
+  // addEventListener / removeEventListener / dispatchEvent for free.
+  const target = new EventTarget();
+  const written: Uint8Array[] = [];
+  // `value` is read by the protocols on the dispatched event's target; we set
+  // it just before dispatching simulate() payloads.
+  let currentValue: DataView | null = null;
+
+  const characteristic = {
+    // BLE methods we actually use
+    notificationsStarted: false,
+    written,
+    async startNotifications() {
+      this.notificationsStarted = true;
+      return this as unknown as BluetoothRemoteGATTCharacteristic;
+    },
+    async writeValue(data: BufferSource) {
+      const bytes = data instanceof Uint8Array
+        ? data
+        : ArrayBuffer.isView(data)
+          ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+          : new Uint8Array(data);
+      // Copy so later mutations to the source don't change what we recorded
+      written.push(new Uint8Array(bytes));
+    },
+    get value(): DataView | null {
+      return currentValue;
+    },
+    // Delegate event-target methods to the internal EventTarget
+    addEventListener: target.addEventListener.bind(target),
+    removeEventListener: target.removeEventListener.bind(target),
+    dispatchEvent: target.dispatchEvent.bind(target),
+    simulate(payload: string | Uint8Array) {
+      const bytes = typeof payload === "string"
+        ? new TextEncoder().encode(payload)
+        : payload;
+      // Build a fresh ArrayBuffer so the DataView has clean byteOffset semantics
+      const buf = new ArrayBuffer(bytes.byteLength);
+      new Uint8Array(buf).set(bytes);
+      currentValue = new DataView(buf);
+      const event = new Event("characteristicvaluechanged");
+      // event.target is the dispatching EventTarget; the protocols cast it to
+      // BluetoothRemoteGATTCharacteristic and read .value — which we just set.
+      // Override target so it points back at the characteristic (the mock) and
+      // .value is reachable.
+      Object.defineProperty(event, "target", { value: characteristic, configurable: true });
+      target.dispatchEvent(event);
+    },
+  };
+
+  return characteristic as unknown as MockedChar;
+}
+
+export function createMockConnection(): BleConnection & {
+  characteristics: {
+    fileList: MockedChar;
+    fileRequest: MockedChar;
+    fileData: MockedChar;
+    fileStatus: MockedChar;
+  };
+} {
+  const characteristics = {
+    fileList: createMockCharacteristic(),
+    fileRequest: createMockCharacteristic(),
+    fileData: createMockCharacteristic(),
+    fileStatus: createMockCharacteristic(),
+  };
+  // The protocols only touch `.characteristics`, so the device/server/service
+  // fields are stub shapes that satisfy the type but are never read.
+  return {
+    device: { gatt: { connected: true } } as unknown as BluetoothDevice,
+    server: {} as BluetoothRemoteGATTServer,
+    service: {} as BluetoothRemoteGATTService,
+    characteristics,
+  };
+}

--- a/src/lib/ble/battery.test.ts
+++ b/src/lib/ble/battery.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { requestBatteryLevel } from "./battery";
+import { createMockConnection, flushMicrotasks, lastWritten } from "./__test__/mockBle";
+
+describe("requestBatteryLevel — BATT protocol", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("sends 'BATT' on fileRequest", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("BATT");
+
+    // Resolve the in-flight promise so the test doesn't hang
+    conn.characteristics.fileStatus.simulate("BATT:50,3.7\n");
+    await promise;
+  });
+
+  it("enables notifications on fileStatus before sending the command", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    expect(conn.characteristics.fileStatus.notificationsStarted).toBe(true);
+
+    conn.characteristics.fileStatus.simulate("BATT:50,3.7\n");
+    await promise;
+  });
+
+  it("resolves with parsed percent + voltage", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("BATT:85,3.98\n");
+
+    await expect(promise).resolves.toEqual({ percent: 85, voltage: 3.98 });
+  });
+
+  it("handles a response without a trailing newline", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("BATT:12,3.55");
+
+    await expect(promise).resolves.toEqual({ percent: 12, voltage: 3.55 });
+  });
+
+  it("handles BATT line surrounded by other status text (multi-line notification)", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    // Device sometimes batches several status lines into one notification.
+    conn.characteristics.fileStatus.simulate("SVAL:foo=bar\nBATT:70,3.8\nSOK:foo\n");
+
+    await expect(promise).resolves.toEqual({ percent: 70, voltage: 3.8 });
+  });
+
+  it("ignores non-BATT lines (keeps waiting until a valid BATT line arrives)", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("RANDOM_NOISE\n");
+    conn.characteristics.fileStatus.simulate("SOK:something\n");
+    conn.characteristics.fileStatus.simulate("BATT:25,3.6\n");
+
+    await expect(promise).resolves.toEqual({ percent: 25, voltage: 3.6 });
+  });
+
+  it("ignores a malformed BATT line and waits for a well-formed one", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    // Garbage payload that fails parseInt/parseFloat — should be skipped, not crash
+    conn.characteristics.fileStatus.simulate("BATT:not,a-number\n");
+    conn.characteristics.fileStatus.simulate("BATT:90,4.1\n");
+
+    await expect(promise).resolves.toEqual({ percent: 90, voltage: 4.1 });
+  });
+
+  it("rejects after 5 seconds if no BATT response arrives", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    // Sanity: command was sent
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("BATT");
+
+    // Trigger the 5s timeout
+    vi.advanceTimersByTime(5000);
+
+    await expect(promise).rejects.toThrow("Battery request timed out");
+  });
+
+  it("removes the notification listener after resolving (no lingering handlers)", async () => {
+    const conn = createMockConnection();
+    const promise = requestBatteryLevel(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("BATT:50,3.7\n");
+    await promise;
+
+    // A second simulate() should be a no-op now — no listener to receive it
+    conn.characteristics.fileStatus.simulate("BATT:99,4.2\n");
+    // (no assertion needed — if a stale listener fired, it'd try to resolve an
+    // already-settled promise; we're verifying via "no error / no crash" here)
+  });
+});

--- a/src/lib/ble/fileTransfer.test.ts
+++ b/src/lib/ble/fileTransfer.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { requestFileList, downloadFile } from "./fileTransfer";
+import { createMockConnection, flushMicrotasks, lastWritten } from "./__test__/mockBle";
+
+afterEach(() => vi.useRealTimers());
+
+// ─── LIST ────────────────────────────────────────────────────────────────────
+
+describe("requestFileList — LIST protocol", () => {
+  it("sends 'LIST' on fileRequest", async () => {
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("LIST");
+
+    conn.characteristics.fileList.simulate("END");
+    await promise;
+  });
+
+  it("parses 'name:size|name:size|...' format on END (END as its own notification)", async () => {
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    // Real device sends END as its own short notification (it's 3 bytes,
+    // well under MTU). Data is accumulated across earlier notifications.
+    conn.characteristics.fileList.simulate("LOG_001.dove:1024|LOG_002.dove:2048|");
+    conn.characteristics.fileList.simulate("END");
+
+    await expect(promise).resolves.toEqual([
+      { name: "LOG_001.dove", size: 1024 },
+      { name: "LOG_002.dove", size: 2048 },
+    ]);
+  });
+
+  it("filters out SETTINGS.JSON from the returned list", async () => {
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileList.simulate("LOG_001.dove:100|SETTINGS.json:50|LOG_002.dove:200|");
+    conn.characteristics.fileList.simulate("END");
+
+    await expect(promise).resolves.toEqual([
+      { name: "LOG_001.dove", size: 100 },
+      { name: "LOG_002.dove", size: 200 },
+    ]);
+  });
+
+  it("accumulates list across multiple chunked notifications (small BLE MTU)", async () => {
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    // Simulate the small MTU case — entries split across notifications.
+    // END still arrives as its own notification.
+    conn.characteristics.fileList.simulate("LOG_001.dove:1024|LOG_");
+    conn.characteristics.fileList.simulate("002.dove:2048|LOG_003.dove:");
+    conn.characteristics.fileList.simulate("4096|");
+    conn.characteristics.fileList.simulate("END");
+
+    await expect(promise).resolves.toEqual([
+      { name: "LOG_001.dove", size: 1024 },
+      { name: "LOG_002.dove", size: 2048 },
+      { name: "LOG_003.dove", size: 4096 },
+    ]);
+  });
+
+  it("BUG (documented): drops data if END arrives batched in the same notification", async () => {
+    // The current protocol detects END via `chunk.includes("END")`, then parses
+    // the PREVIOUSLY-accumulated `fileListBuffer` — without first appending the
+    // current chunk. If the device ever batches "data|END" into one
+    // notification (it doesn't today; END is its own 3-byte packet), the data
+    // portion of that final chunk is lost.
+    //
+    // Fix would be: always accumulate first, then check for END, and strip
+    // trailing |END from the assembled buffer.
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileList.simulate("LOG_FIRST.dove:100|");
+    conn.characteristics.fileList.simulate("LOG_LOST.dove:200|END");
+
+    // Current (buggy) behavior: only the first chunk's data is parsed.
+    // LOG_LOST.dove is silently dropped.
+    await expect(promise).resolves.toEqual([
+      { name: "LOG_FIRST.dove", size: 100 },
+    ]);
+  });
+
+  it("resolves with [] for an empty file list (just 'END')", async () => {
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileList.simulate("END");
+
+    await expect(promise).resolves.toEqual([]);
+  });
+
+  it("safety-resolves after 2s of silence (no END marker)", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    // Device sends partial data then goes silent — protocol waits 2s then
+    // resolves with what it has
+    conn.characteristics.fileList.simulate("LOG_A.dove:50|");
+    vi.advanceTimersByTime(2000);
+
+    await expect(promise).resolves.toEqual([{ name: "LOG_A.dove", size: 50 }]);
+  });
+
+  it("rejects with timeout if no response in 10s", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestFileList(conn);
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(10000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+
+describe("downloadFile — GET protocol", () => {
+  it("sends 'GET:<filename>' on fileRequest", async () => {
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "LOG_001.dove");
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("GET:LOG_001.dove");
+
+    conn.characteristics.fileStatus.simulate("SIZE:0");
+    conn.characteristics.fileStatus.simulate("DONE");
+    await promise;
+  });
+
+  it("subscribes to both fileData (chunks) and fileStatus (control) notifications", async () => {
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "x.dove");
+    await flushMicrotasks();
+
+    expect(conn.characteristics.fileData.notificationsStarted).toBe(true);
+    expect(conn.characteristics.fileStatus.notificationsStarted).toBe(true);
+
+    conn.characteristics.fileStatus.simulate("SIZE:0");
+    conn.characteristics.fileStatus.simulate("DONE");
+    await promise;
+  });
+
+  it("resolves with concatenated file bytes on DONE", async () => {
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "hello.dove");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:5");
+    conn.characteristics.fileData.simulate(new Uint8Array([0x68, 0x65, 0x6c])); // "hel"
+    conn.characteristics.fileData.simulate(new Uint8Array([0x6c, 0x6f])); // "lo"
+    conn.characteristics.fileStatus.simulate("DONE");
+
+    const result = await promise;
+    expect(new TextDecoder().decode(result)).toBe("hello");
+  });
+
+  it("handles SIZE arriving as a separate notification from the first data chunk", async () => {
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "f");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:4");
+    conn.characteristics.fileData.simulate(new Uint8Array([1, 2, 3, 4]));
+    conn.characteristics.fileStatus.simulate("DONE");
+
+    const result = await promise;
+    expect(Array.from(result)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("rejects on ERROR status (e.g., device can't open the file)", async () => {
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "missing.dove");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("ERROR");
+
+    await expect(promise).rejects.toThrow(/Error opening file/);
+  });
+
+  it("rejects with timeout after 5 minutes if transfer never completes", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "stalled.dove");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:1000000");
+    vi.advanceTimersByTime(300_000);
+
+    await expect(promise).rejects.toThrow(/Download timeout/);
+  });
+
+  it("calls onProgress with received/total/percent as chunks arrive", async () => {
+    const conn = createMockConnection();
+    const onProgress = vi.fn();
+    const promise = downloadFile(conn, "f.dove", onProgress);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:10");
+    conn.characteristics.fileData.simulate(new Uint8Array([1, 2, 3, 4, 5]));
+
+    // Yield to rAF macrotask
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(onProgress).toHaveBeenCalled();
+    const call = onProgress.mock.calls.at(-1)![0];
+    expect(call.received).toBe(5);
+    expect(call.total).toBe(10);
+    expect(call.percent).toBe(50);
+
+    conn.characteristics.fileData.simulate(new Uint8Array([6, 7, 8, 9, 10]));
+    conn.characteristics.fileStatus.simulate("DONE");
+    await promise;
+  });
+
+  it("calls onStatusChange at key transitions", async () => {
+    const conn = createMockConnection();
+    const onStatus = vi.fn();
+    const promise = downloadFile(conn, "f.dove", undefined, onStatus);
+    await flushMicrotasks();
+
+    // Initial "Requesting" status fires before the await
+    expect(onStatus).toHaveBeenCalledWith(expect.stringMatching(/Requesting/));
+
+    onStatus.mockClear();
+    conn.characteristics.fileStatus.simulate("SIZE:0");
+    expect(onStatus).toHaveBeenCalledWith(expect.stringMatching(/Receiving f\.dove/));
+
+    conn.characteristics.fileStatus.simulate("DONE");
+    await promise;
+  });
+
+  it("does not corrupt data when chunks reuse the underlying ArrayBuffer", async () => {
+    // Real Web Bluetooth reuses the DataView's underlying buffer across
+    // notifications, so the protocol must COPY each chunk on receipt.
+    // We mimic that contract here: send a Uint8Array, mutate it after,
+    // verify the result still has the original bytes.
+    const conn = createMockConnection();
+    const promise = downloadFile(conn, "buf.dove");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:3");
+    const reused = new Uint8Array([10, 20, 30]);
+    conn.characteristics.fileData.simulate(reused);
+    // Mutate the source — the protocol should have copied already
+    reused[0] = 99;
+    reused[1] = 99;
+    reused[2] = 99;
+    conn.characteristics.fileStatus.simulate("DONE");
+
+    const result = await promise;
+    expect(Array.from(result)).toEqual([10, 20, 30]);
+  });
+});

--- a/src/lib/ble/settings.test.ts
+++ b/src/lib/ble/settings.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  requestSettingsList,
+  getDeviceSetting,
+  setDeviceSetting,
+  resetDeviceSettings,
+} from "./settings";
+import { createMockConnection, flushMicrotasks, lastWritten } from "./__test__/mockBle";
+
+afterEach(() => vi.useRealTimers());
+
+// ─── SLIST ───────────────────────────────────────────────────────────────────
+
+describe("requestSettingsList — SLIST protocol", () => {
+  it("sends 'SLIST' and resolves with parsed settings on SEND", async () => {
+    const conn = createMockConnection();
+    const promise = requestSettingsList(conn);
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("SLIST");
+
+    conn.characteristics.fileStatus.simulate("SVAL:wifi_ssid=Home\nSVAL:wifi_pass=secret\nSEND\n");
+
+    await expect(promise).resolves.toEqual({
+      wifi_ssid: "Home",
+      wifi_pass: "secret",
+    });
+  });
+
+  it("accumulates SVAL values across multiple notifications, finalizes on SEND", async () => {
+    const conn = createMockConnection();
+    const promise = requestSettingsList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SVAL:a=1\n");
+    conn.characteristics.fileStatus.simulate("SVAL:b=2\nSVAL:c=3\n");
+    conn.characteristics.fileStatus.simulate("SEND\n");
+
+    await expect(promise).resolves.toEqual({ a: "1", b: "2", c: "3" });
+  });
+
+  it("handles values containing '=' correctly (only splits on the first one)", async () => {
+    const conn = createMockConnection();
+    const promise = requestSettingsList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SVAL:formula=x=y+z\nSEND\n");
+
+    await expect(promise).resolves.toEqual({ formula: "x=y+z" });
+  });
+
+  it("ignores SVAL lines without an '=' (malformed)", async () => {
+    const conn = createMockConnection();
+    const promise = requestSettingsList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SVAL:bogus\nSVAL:good=ok\nSEND\n");
+
+    await expect(promise).resolves.toEqual({ good: "ok" });
+  });
+
+  it("resolves with collected settings if device goes silent for >3s (safety timeout)", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestSettingsList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SVAL:a=1\n");
+    conn.characteristics.fileStatus.simulate("SVAL:b=2\n");
+
+    // No SEND ever arrives — safety timeout (3s after last message) resolves
+    vi.advanceTimersByTime(3000);
+
+    await expect(promise).resolves.toEqual({ a: "1", b: "2" });
+  });
+
+  it("rejects with timeout if no response in 10s", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestSettingsList(conn);
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(10000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});
+
+// ─── SGET ────────────────────────────────────────────────────────────────────
+
+describe("getDeviceSetting — SGET protocol", () => {
+  it("sends 'SGET:<key>' and resolves with the value for that key", async () => {
+    const conn = createMockConnection();
+    const promise = getDeviceSetting(conn, "wifi_ssid");
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("SGET:wifi_ssid");
+
+    conn.characteristics.fileStatus.simulate("SVAL:wifi_ssid=HomeNetwork\n");
+
+    await expect(promise).resolves.toBe("HomeNetwork");
+  });
+
+  it("only resolves for the requested key (ignores other SVAL lines)", async () => {
+    const conn = createMockConnection();
+    const promise = getDeviceSetting(conn, "target");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SVAL:other=ignore\n");
+    conn.characteristics.fileStatus.simulate("SVAL:also_ignore=junk\n");
+    conn.characteristics.fileStatus.simulate("SVAL:target=found\n");
+
+    await expect(promise).resolves.toBe("found");
+  });
+
+  it("rejects on SERR with the error message", async () => {
+    const conn = createMockConnection();
+    const promise = getDeviceSetting(conn, "missing_key");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SERR:NOT_FOUND\n");
+
+    await expect(promise).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("rejects with timeout after 5s of no response", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = getDeviceSetting(conn, "k");
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(5000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});
+
+// ─── SSET ────────────────────────────────────────────────────────────────────
+
+describe("setDeviceSetting — SSET protocol", () => {
+  it("sends 'SSET:<key>=<value>' and resolves on SOK", async () => {
+    const conn = createMockConnection();
+    const promise = setDeviceSetting(conn, "wifi_ssid", "HomeNetwork");
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("SSET:wifi_ssid=HomeNetwork");
+
+    conn.characteristics.fileStatus.simulate("SOK:wifi_ssid\n");
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("accepts 'SOK: <key>' with a space (device firmware quirk)", async () => {
+    const conn = createMockConnection();
+    const promise = setDeviceSetting(conn, "k", "v");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SOK: k\n");
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("rejects on SERR with the error message", async () => {
+    const conn = createMockConnection();
+    const promise = setDeviceSetting(conn, "readonly_key", "x");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SERR:WRITE_FAIL\n");
+
+    await expect(promise).rejects.toThrow("WRITE_FAIL");
+  });
+
+  it("ignores SOK for a different key (waits for matching SOK)", async () => {
+    const conn = createMockConnection();
+    const promise = setDeviceSetting(conn, "target_key", "v");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SOK:wrong_key\n");
+    conn.characteristics.fileStatus.simulate("SOK:target_key\n");
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("rejects with timeout after 5s of no response", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = setDeviceSetting(conn, "k", "v");
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(5000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});
+
+// ─── SRESET ──────────────────────────────────────────────────────────────────
+
+describe("resetDeviceSettings — SRESET protocol", () => {
+  it("sends 'SRESET' and resolves on SOK:RESET", async () => {
+    const conn = createMockConnection();
+    const promise = resetDeviceSettings(conn);
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("SRESET");
+
+    conn.characteristics.fileStatus.simulate("SOK:RESET\n");
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("rejects on SERR with the error message", async () => {
+    const conn = createMockConnection();
+    const promise = resetDeviceSettings(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SERR:RESET_FAILED\n");
+
+    await expect(promise).rejects.toThrow("RESET_FAILED");
+  });
+
+  it("ignores unrelated SOK lines (only SOK:RESET resolves)", async () => {
+    const conn = createMockConnection();
+    const promise = resetDeviceSettings(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SOK:somethingelse\n");
+    conn.characteristics.fileStatus.simulate("SOK:RESET\n");
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("rejects with timeout after 10s of no response", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = resetDeviceSettings(conn);
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(10000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});

--- a/src/lib/ble/trackSync.test.ts
+++ b/src/lib/ble/trackSync.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  requestTrackFileList,
+  downloadTrackFile,
+  uploadTrackFile,
+  deleteTrackFile,
+} from "./trackSync";
+import { createMockConnection, flushMicrotasks, lastWritten, writeCount } from "./__test__/mockBle";
+
+afterEach(() => vi.useRealTimers());
+
+// ─── TLIST ───────────────────────────────────────────────────────────────────
+
+describe("requestTrackFileList — TLIST protocol", () => {
+  it("sends 'TLIST' and resolves with filenames on TEND", async () => {
+    const conn = createMockConnection();
+    const promise = requestTrackFileList(conn);
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("TLIST");
+
+    conn.characteristics.fileStatus.simulate("TFILE:OKC.json\nTFILE:TEST.json\nTEND\n");
+
+    await expect(promise).resolves.toEqual(["OKC.json", "TEST.json"]);
+  });
+
+  it("resolves with [] when device has no track files (just TEND)", async () => {
+    const conn = createMockConnection();
+    const promise = requestTrackFileList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TEND\n");
+
+    await expect(promise).resolves.toEqual([]);
+  });
+
+  it("accumulates TFILE entries across multiple notifications", async () => {
+    const conn = createMockConnection();
+    const promise = requestTrackFileList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TFILE:a.json\n");
+    conn.characteristics.fileStatus.simulate("TFILE:b.json\nTFILE:c.json\n");
+    conn.characteristics.fileStatus.simulate("TEND\n");
+
+    await expect(promise).resolves.toEqual(["a.json", "b.json", "c.json"]);
+  });
+
+  it("safety-resolves with collected entries after 3s of silence (no TEND)", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestTrackFileList(conn);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TFILE:OKC.json\n");
+    vi.advanceTimersByTime(3000);
+
+    await expect(promise).resolves.toEqual(["OKC.json"]);
+  });
+
+  it("rejects with timeout if no response in 10s", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = requestTrackFileList(conn);
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(10000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});
+
+// ─── TGET ────────────────────────────────────────────────────────────────────
+
+describe("downloadTrackFile — TGET protocol", () => {
+  it("sends 'TGET:<name>' and resolves with concatenated file bytes on DONE", async () => {
+    const conn = createMockConnection();
+    const promise = downloadTrackFile(conn, "OKC.json");
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("TGET:OKC.json");
+
+    // Device protocol: SIZE on fileStatus → bytes on fileData → DONE on fileStatus
+    conn.characteristics.fileStatus.simulate("SIZE:11\n");
+    conn.characteristics.fileData.simulate(new Uint8Array([104, 101, 108, 108, 111])); // "hello"
+    conn.characteristics.fileData.simulate(new Uint8Array([45, 119, 111, 114, 108, 100])); // "-world"
+    conn.characteristics.fileStatus.simulate("DONE\n");
+
+    const result = await promise;
+    expect(new TextDecoder().decode(result)).toBe("hello-world");
+  });
+
+  it("handles SIZE arriving in the same notification as the first DONE check", async () => {
+    const conn = createMockConnection();
+    const promise = downloadTrackFile(conn, "x.json");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:3\n");
+    conn.characteristics.fileData.simulate(new Uint8Array([65, 66, 67]));
+    conn.characteristics.fileStatus.simulate("DONE\n");
+
+    const result = await promise;
+    expect(Array.from(result)).toEqual([65, 66, 67]);
+  });
+
+  it("rejects on TERR:<reason> with the error message", async () => {
+    const conn = createMockConnection();
+    const promise = downloadTrackFile(conn, "missing.json");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TERR:FILE_NOT_FOUND\n");
+
+    await expect(promise).rejects.toThrow("FILE_NOT_FOUND");
+  });
+
+  it("rejects on generic ERROR line", async () => {
+    const conn = createMockConnection();
+    const promise = downloadTrackFile(conn, "broken.json");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("ERROR\n");
+
+    await expect(promise).rejects.toThrow(/Error downloading track file/);
+  });
+
+  it("rejects with timeout after 60s if the transfer never completes", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = downloadTrackFile(conn, "stalled.json");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:1000\n");
+    // No data ever arrives
+    vi.advanceTimersByTime(60000);
+
+    await expect(promise).rejects.toThrow(/timeout/i);
+  });
+
+  it("invokes the progress callback when chunks arrive", async () => {
+    // Progress is throttled via requestAnimationFrame (polyfilled to
+    // setTimeout(0) in vitest.setup.ts). Run with real timers and let the
+    // macrotask queue drain naturally.
+    const conn = createMockConnection();
+    const onProgress = vi.fn();
+    const promise = downloadTrackFile(conn, "f.json", onProgress);
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("SIZE:6\n");
+    conn.characteristics.fileData.simulate(new Uint8Array([1, 2, 3]));
+
+    // Yield to the macrotask queue so the rAF callback runs
+    await new Promise((r) => setTimeout(r, 5));
+    expect(onProgress).toHaveBeenCalled();
+    const lastProgressCall = onProgress.mock.calls.at(-1)![0];
+    expect(lastProgressCall.received).toBe(3);
+    expect(lastProgressCall.total).toBe(6);
+    expect(lastProgressCall.percent).toBe(50);
+
+    conn.characteristics.fileData.simulate(new Uint8Array([4, 5, 6]));
+    conn.characteristics.fileStatus.simulate("DONE\n");
+    await promise;
+  });
+});
+
+// ─── TPUT ────────────────────────────────────────────────────────────────────
+
+describe("uploadTrackFile — TPUT protocol", () => {
+  it("sends 'TPUT:<name>' first, waits for TREADY, then sends chunks + TDONE, resolves on TOK", async () => {
+    const conn = createMockConnection();
+    const data = new Uint8Array(Array.from({ length: 100 }, (_, i) => i));
+    const promise = uploadTrackFile(conn, "new.json", data);
+    await flushMicrotasks();
+
+    // Phase 1: TPUT command sent, awaiting TREADY
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("TPUT:new.json");
+    const writesBeforeReady = writeCount(conn.characteristics.fileRequest);
+    expect(writesBeforeReady).toBe(1);
+
+    // Phase 2: send TREADY → protocol starts uploading 64-byte chunks
+    conn.characteristics.fileStatus.simulate("TREADY\n");
+    // The protocol's sendChunks() runs async with 10ms inter-chunk delay; let
+    // it complete. 100 bytes / 64 = 2 chunks + TDONE = 3 more writes.
+    await vi.waitFor(
+      () => expect(writeCount(conn.characteristics.fileRequest)).toBe(1 + 2 + 1),
+      { timeout: 1000 },
+    );
+
+    // Final write should be 'TDONE'
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("TDONE");
+
+    // Phase 3: device acknowledges with TOK → resolves
+    conn.characteristics.fileStatus.simulate("TOK\n");
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("rejects on TERR before TREADY (device refuses to accept upload)", async () => {
+    const conn = createMockConnection();
+    const promise = uploadTrackFile(conn, "bad.json", new Uint8Array([1, 2, 3]));
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TERR:DISK_FULL\n");
+
+    await expect(promise).rejects.toThrow("DISK_FULL");
+  });
+
+  it("rejects on TERR after TREADY (device errors mid-upload)", async () => {
+    const conn = createMockConnection();
+    const promise = uploadTrackFile(conn, "x.json", new Uint8Array([1, 2]));
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TREADY\n");
+    // Wait for sendChunks to complete and send TDONE
+    await vi.waitFor(() => expect(lastWritten(conn.characteristics.fileRequest)).toBe("TDONE"));
+
+    conn.characteristics.fileStatus.simulate("TERR:WRITE_FAILED\n");
+
+    await expect(promise).rejects.toThrow("WRITE_FAILED");
+  });
+
+  it("rejects with timeout if TREADY never arrives (10s)", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = uploadTrackFile(conn, "ghosted.json", new Uint8Array([1]));
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(10000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});
+
+// ─── TDEL ────────────────────────────────────────────────────────────────────
+
+describe("deleteTrackFile — TDEL protocol", () => {
+  it("sends 'TDEL:<name>' and resolves on TOK", async () => {
+    const conn = createMockConnection();
+    const promise = deleteTrackFile(conn, "old.json");
+    await flushMicrotasks();
+
+    expect(lastWritten(conn.characteristics.fileRequest)).toBe("TDEL:old.json");
+
+    conn.characteristics.fileStatus.simulate("TOK\n");
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("rejects on TERR with the error message", async () => {
+    const conn = createMockConnection();
+    const promise = deleteTrackFile(conn, "locked.json");
+    await flushMicrotasks();
+
+    conn.characteristics.fileStatus.simulate("TERR:READ_ONLY\n");
+
+    await expect(promise).rejects.toThrow("READ_ONLY");
+  });
+
+  it("rejects with timeout after 10s of no response", async () => {
+    vi.useFakeTimers();
+    const conn = createMockConnection();
+    const promise = deleteTrackFile(conn, "x.json");
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(10000);
+
+    await expect(promise).rejects.toThrow(/Timeout/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["node_modules", "dist", ".lovable"],
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest global setup — runs before any test imports.
+ *
+ * Polyfills browser globals that protocol code touches but Node doesn't ship:
+ *   - requestAnimationFrame / cancelAnimationFrame (used by BLE downloadFile
+ *     and downloadTrackFile to throttle progress callbacks)
+ *
+ * These are minimal shims — they just schedule via setTimeout(0). Tests that
+ * care about timing should use vi.useFakeTimers() and drive the clock
+ * explicitly; tests that don't care don't need to.
+ */
+
+if (typeof globalThis.requestAnimationFrame === "undefined") {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number =>
+    setTimeout(() => cb(performance.now()), 0) as unknown as number;
+  globalThis.cancelAnimationFrame = (handle: number): void => {
+    clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+  };
+}


### PR DESCRIPTION
Now that bleDatalogger.ts is split per-protocol, each module is testable
in isolation via a small mock of the Web Bluetooth surface.

New test infrastructure (one file):
  src/lib/ble/__test__/mockBle.ts
    - MockCharacteristic: test-only extras (notificationsStarted, written,
      simulate). Kept as a separate interface — NOT extending
      BluetoothRemoteGATTCharacteristic — to avoid this-type variance
      issues on oncharacteristicvaluechanged.
    - createMockConnection(): returns a BleConnection where each
      characteristic is intersection-typed (real surface + mock extras).
    - lastWritten(), writeCount(): post-hoc assertions on writeValue calls.
    - flushMicrotasks(): drain a few rounds of Promise.resolve() so the
      protocol's async setup (await startNotifications + await writeValue)
      settles before the test simulates a response.

Per-protocol test files:
  src/lib/ble/battery.test.ts        9 tests
  src/lib/ble/settings.test.ts      19 tests
  src/lib/ble/trackSync.test.ts     18 tests
  src/lib/ble/fileTransfer.test.ts  17 tests

Coverage highlights:
  - Each protocol's "happy path" (command sent + parsed response → resolve)
  - Multi-line notification batching ("SVAL:a=1\\nSVAL:b=2\\nSEND\\n")
  - Chunked notifications across small BLE MTU
  - Error responses (SERR, TERR, ERROR) → reject with parsed message
  - Timeout paths via vi.useFakeTimers() + vi.advanceTimersByTime()
  - TPUT's three-phase state machine (TPUT → TREADY → chunks+TDONE → TOK)
  - Progress callback throttling via requestAnimationFrame polyfill
  - Buffer-reuse contract: DataView buffers are copied on receipt so
    upstream mutation doesn't corrupt the assembled file

Vitest setup:
  Added vitest.setup.ts that polyfills requestAnimationFrame /
  cancelAnimationFrame (Node doesn't ship them; downloadFile and
  downloadTrackFile use them for throttled progress). Wired via the
  new `setupFiles` entry in vitest.config.ts.

Real bug uncovered + documented (NOT fixed in this PR):
  fileTransfer.requestFileList drops data if END arrives batched in the
  same BLE notification as the last data segment. The check
  `chunk.includes("END")` enters the END branch before appending the
  current chunk to `fileListBuffer`, so the chunk's data portion is lost.
  Doesn't trigger in practice (END is 3 bytes, the device sends it as
  its own notification), but the latent bug is now pinned by a
  "BUG (documented)" test. Fix is straightforward: accumulate first,
  then check the assembled buffer for "END" and strip the trailing
  "|END" with a regex. Queued as the next follow-up.

Verified:
  - npm run lint clean
  - npm run typecheck clean
  - npm run test:run: 266 passed (was 203; +63 BLE tests, +1.5s runtime)
  - npm run build clean

This was the last big-ticket item from the original review's roadmap.
The BLE module is now both smaller (per-protocol files) AND testable
(every protocol's wire format has explicit named test cases).

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf