### PR TITLE
Dedupe magic constants: name only what's actually shared

### DIFF
--- a/src/components/LapTable.tsx
+++ b/src/components/LapTable.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ExternalRefBar } from '@/components/ExternalRefBar';
 import { FileEntry } from '@/lib/fileStorage';
 import { useSettingsContext } from '@/contexts/SettingsContext';
-import { haversineDistance } from '@/lib/parserUtils';
+import { haversineDistance, METERS_TO_FEET } from '@/lib/parserUtils';
 
 interface LapTableProps {
   laps: Lap[];
@@ -260,7 +260,7 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
             <div>
               <span className="text-muted-foreground">Avg Lap Length: </span>
               <span className="font-mono text-foreground font-semibold">
-                {`${(avgLapLength * 3.28084).toLocaleString(undefined, { maximumFractionDigits: 0 })} ft / ${avgLapLength.toLocaleString(undefined, { maximumFractionDigits: 0 })} m`}
+                {`${(avgLapLength * METERS_TO_FEET).toLocaleString(undefined, { maximumFractionDigits: 0 })} ft / ${avgLapLength.toLocaleString(undefined, { maximumFractionDigits: 0 })} m`}
               </span>
             </div>
           )}

--- a/src/components/admin/CoursesTab.tsx
+++ b/src/components/admin/CoursesTab.tsx
@@ -13,6 +13,7 @@ import type { GpsPoint } from '@/components/track-editor/VisualEditor';
 import { VisualEditor, EditorModeToggle } from '@/components/track-editor/VisualEditor';
 import { Plus, Edit2, Check, X, Trash2, Star } from 'lucide-react';
 import { calculatePolylineLength, formatTrackLength } from '@/lib/trackUtils';
+import { METERS_TO_FEET } from '@/lib/parserUtils';
 import L from 'leaflet';
 
 type EditorMode = 'manual' | 'visual';
@@ -488,7 +489,7 @@ export function CoursesTab() {
             {courses.map((course) => {
               const layout = trackLayouts.find(l => l.course_id === course.id);
               const calculatedFt = layout && layout.layout_data.length >= 2
-                ? Math.round(calculatePolylineLength(layout.layout_data) * 3.28084)
+                ? Math.round(calculatePolylineLength(layout.layout_data) * METERS_TO_FEET)
                 : null;
               // eslint-disable-next-line @typescript-eslint/no-explicit-any -- length_ft_override column not in generated types; remove on next regen
               const overrideVal = (course as any).length_ft_override as number | null;

--- a/src/lib/brakingZones.ts
+++ b/src/lib/brakingZones.ts
@@ -1,4 +1,5 @@
 import { GpsSample } from '@/types/racing';
+import { MAX_SPEED_MPS, STANDARD_GRAVITY_MPS2, MPH_TO_MPS } from './parserUtils';
 import savitzkyGolay from 'ml-savitzky-golay';
 
 export interface BrakingZone {
@@ -23,9 +24,7 @@ export const DEFAULT_BRAKING_CONFIG: BrakingZoneConfig = {
   smoothingAlpha: 0.4,
 };
 
-const GRAVITY_MPS2 = 9.80665;
 const MIN_SPEED_MPS = 2.0;      // Below this, accel is too noisy (matches gforceCalculation)
-const MAX_SPEED_MPS = 150;       // Reject GPS glitch speeds (matches speed sanity check)
 const MIN_DT_S = 0.02;           // Supports GPS up to 50Hz
 const MAX_DT_S = 2.0;            // Maximum time delta (GPS gap)
 const MAX_ACCEL_G = 3.0;         // Clamp raw accel to ±3G (matches gforceCalculation)
@@ -74,15 +73,15 @@ export function detectBrakingZones(
     }
 
     // Calculate longitudinal acceleration from scalar speed change
-    const speedMpsCurr = curr.speedMph * 0.44704; // mph to m/s
-    const speedMpsPrev = prev.speedMph * 0.44704;
+    const speedMpsCurr = curr.speedMph * MPH_TO_MPS; // mph to m/s
+    const speedMpsPrev = prev.speedMph * MPH_TO_MPS;
 
     // Speed sanity: reject impossible speeds or too-slow samples
     if (speedMpsCurr > MAX_SPEED_MPS || speedMpsPrev > MAX_SPEED_MPS) continue;
     if (speedMpsCurr < MIN_SPEED_MPS && speedMpsPrev < MIN_SPEED_MPS) continue;
 
     const accelG = Math.max(-MAX_ACCEL_G, Math.min(MAX_ACCEL_G,
-      (speedMpsCurr - speedMpsPrev) / dtS / GRAVITY_MPS2
+      (speedMpsCurr - speedMpsPrev) / dtS / STANDARD_GRAVITY_MPS2
     ));
 
     // Apply exponential smoothing
@@ -151,8 +150,8 @@ export function computeBrakingGSeries(
       continue;
     }
 
-    const speedMpsCurr = curr.speedMph * 0.44704;
-    const speedMpsPrev = prev.speedMph * 0.44704;
+    const speedMpsCurr = curr.speedMph * MPH_TO_MPS;
+    const speedMpsPrev = prev.speedMph * MPH_TO_MPS;
 
     // Speed sanity: reject impossible speeds (GPS glitch)
     if (speedMpsCurr > MAX_SPEED_MPS || speedMpsPrev > MAX_SPEED_MPS) {
@@ -168,7 +167,7 @@ export function computeBrakingGSeries(
 
     // Raw longitudinal acceleration, clamped to physical limits
     const rawAccelG = Math.max(-MAX_ACCEL_G, Math.min(MAX_ACCEL_G,
-      (speedMpsCurr - speedMpsPrev) / dtS / GRAVITY_MPS2
+      (speedMpsCurr - speedMpsPrev) / dtS / STANDARD_GRAVITY_MPS2
     ));
 
     // EMA smoothing
@@ -198,7 +197,7 @@ export function computeBrakingGSeriesSG(
 
   // Extract speed in m/s
   const speedMps = samples.map(s => {
-    const v = s.speedMph * 0.44704;
+    const v = s.speedMph * MPH_TO_MPS;
     return (v > MAX_SPEED_MPS || v < 0) ? 0 : v;
   });
 
@@ -226,7 +225,7 @@ export function computeBrakingGSeriesSG(
   return sgResult.map((dvdt: number, i: number) => {
     const speedMs = speedMps[i];
     if (speedMs < MIN_SPEED_MPS) return 0;
-    const g = dvdt / GRAVITY_MPS2;
+    const g = dvdt / STANDARD_GRAVITY_MPS2;
     return Math.max(-MAX_ACCEL_G, Math.min(MAX_ACCEL_G, g));
   });
 }
@@ -257,8 +256,8 @@ function createZone(samples: GpsSample[], startIdx: number, endIdx: number): Bra
     path.push({ lat: samples[i].lat, lon: samples[i].lon });
   }
 
-  const startSpeedMps = startSample.speedMph * 0.44704;
-  const endSpeedMps = endSample.speedMph * 0.44704;
+  const startSpeedMps = startSample.speedMph * MPH_TO_MPS;
+  const endSpeedMps = endSample.speedMph * MPH_TO_MPS;
 
   return {
     start: {

--- a/src/lib/courseDetection.ts
+++ b/src/lib/courseDetection.ts
@@ -22,11 +22,11 @@
 
 import { GpsSample, Track, Course, Lap, CourseDirection, CourseDetectionResult } from '@/types/racing';
 import { calculateLaps, detectSectorOrder } from './lapCalculation';
-import { findNearestTrack } from './trackUtils';
-import { haversineDistance } from './parserUtils';
+import { findNearestTrack, DEFAULT_TRACK_SEARCH_RADIUS_M } from './trackUtils';
+import { haversineDistance, METERS_TO_FEET } from './parserUtils';
 
-// 5 miles in meters
-const TRACK_SEARCH_RADIUS_M = 8047;
+// 5 miles in meters — re-exported alias for clarity at the call site.
+const TRACK_SEARCH_RADIUS_M = DEFAULT_TRACK_SEARCH_RADIUS_M;
 
 // Speed threshold for waypoint drop (MPH)
 const WAYPOINT_SPEED_THRESHOLD_MPH = 30;
@@ -53,7 +53,7 @@ function calculateAverageLapDistanceFt(samples: GpsSample[], laps: Lap[]): numbe
         samples[i + 1].lat, samples[i + 1].lon
       );
     }
-    totalDistFt += lapDist * 3.28084; // meters to feet
+    totalDistFt += lapDist * METERS_TO_FEET;
   }
 
   return totalDistFt / laps.length;

--- a/src/lib/db/supabaseAdapter.ts
+++ b/src/lib/db/supabaseAdapter.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { ITrackDatabase, DbTrack, DbCourse, DbSubmission, DbBannedIp, DbCourseLayout } from './types';
 import { calculatePolylineLength } from '@/lib/trackUtils';
+import { METERS_TO_FEET } from '@/lib/parserUtils';
 
 export class SupabaseTrackDatabase implements ITrackDatabase {
   // Tracks
@@ -195,7 +196,7 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
         const lengthFt = c.length_ft_override != null
           ? c.length_ft_override
           : (layout && layout.layout_data.length >= 2
-            ? Math.round(calculatePolylineLength(layout.layout_data) * 3.28084)
+            ? Math.round(calculatePolylineLength(layout.layout_data) * METERS_TO_FEET)
             : 0);
 
         const obj: Record<string, unknown> = {

--- a/src/lib/gforceCalculation.ts
+++ b/src/lib/gforceCalculation.ts
@@ -1,5 +1,5 @@
 import { GpsSample } from '@/types/racing';
-import { clamp, normalizeHeadingDelta } from './parserUtils';
+import { clamp, normalizeHeadingDelta, STANDARD_GRAVITY_MPS2 } from './parserUtils';
 
 /**
  * G-Force calculation utilities for GPS-derived accelerations
@@ -17,7 +17,7 @@ import { clamp, normalizeHeadingDelta } from './parserUtils';
 
 // Configuration constants
 const G_FORCE_CONFIG = {
-  GRAVITY: 9.80665,        // m/s²
+  GRAVITY: STANDARD_GRAVITY_MPS2, // m/s²
   MAX_G: 3.0,              // reasonable max for karts/racing
   MIN_DT: 0.05,            // minimum time delta in seconds
   MAX_DT: 2.0,             // maximum time delta - larger gaps indicate filtered samples

--- a/src/lib/lapCalculation.ts
+++ b/src/lib/lapCalculation.ts
@@ -1,4 +1,5 @@
 import { GpsSample, Course, Lap, LapCrossing, SectorTimes, SectorLine, CourseDirection, courseHasSectors } from '@/types/racing';
+import { EARTH_RADIUS_M } from './parserUtils';
 
 interface Point {
   x: number;
@@ -7,9 +8,8 @@ interface Point {
 
 // Project lat/lon to local planar coordinates (equirectangular approximation)
 function projectToPlane(lat: number, lon: number, centerLat: number, centerLon: number): Point {
-  const R = 6371000; // Earth radius in meters
-  const x = (lon - centerLon) * Math.PI / 180 * R * Math.cos(centerLat * Math.PI / 180);
-  const y = (lat - centerLat) * Math.PI / 180 * R;
+  const x = (lon - centerLon) * Math.PI / 180 * EARTH_RADIUS_M * Math.cos(centerLat * Math.PI / 180);
+  const y = (lat - centerLat) * Math.PI / 180 * EARTH_RADIUS_M;
   return { x, y };
 }
 

--- a/src/lib/parserUtils.ts
+++ b/src/lib/parserUtils.ts
@@ -18,6 +18,14 @@ export const MAX_SPEED_MPS = 150;
 /** Standard gravity used when normalizing m/s² accelerometer readings to G. */
 export const STANDARD_GRAVITY_MPS2 = 9.80665;
 
+// ─── Geographic ────────────────────────────────────────────────────────────
+
+/** Mean Earth radius in meters (used by haversine + equirectangular projection). */
+export const EARTH_RADIUS_M = 6_371_000;
+
+/** Meters → feet (used for course-length display + database storage). */
+export const METERS_TO_FEET = 3.28084;
+
 /** Build the three-unit speed triple used on every GpsSample. */
 export function speedTriple(speedMps: number): { speedMps: number; speedMph: number; speedKph: number } {
   return {
@@ -56,7 +64,7 @@ export function normalizeHeading(heading: number): number {
 
 /** Haversine distance between two GPS coordinates, in meters. */
 export function haversineDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371000;
+  const R = EARTH_RADIUS_M;
   const dLat = (lat2 - lat1) * Math.PI / 180;
   const dLon = (lon2 - lon1) * Math.PI / 180;
   const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +

--- a/src/lib/referenceUtils.ts
+++ b/src/lib/referenceUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import { GpsSample } from '@/types/racing';
+import { EARTH_RADIUS_M } from './parserUtils';
 
 interface Point {
   x: number;
@@ -14,9 +15,8 @@ interface Point {
 
 // Project lat/lon to local planar coordinates (equirectangular approximation)
 export function projectToPlane(lat: number, lon: number, centerLat: number, centerLon: number): Point {
-  const R = 6371000; // Earth radius in meters
-  const x = (lon - centerLon) * Math.PI / 180 * R * Math.cos(centerLat * Math.PI / 180);
-  const y = (lat - centerLat) * Math.PI / 180 * R;
+  const x = (lon - centerLon) * Math.PI / 180 * EARTH_RADIUS_M * Math.cos(centerLat * Math.PI / 180);
+  const y = (lat - centerLat) * Math.PI / 180 * EARTH_RADIUS_M;
   return { x, y };
 }
 

--- a/src/lib/trackUtils.ts
+++ b/src/lib/trackUtils.ts
@@ -1,5 +1,11 @@
 import { SectorLine } from '@/types/racing';
-import { haversineDistance as haversineDist } from '@/lib/parserUtils';
+import { haversineDistance, METERS_TO_FEET } from '@/lib/parserUtils';
+
+/**
+ * Default radius (meters) within which a GPS sample is considered to belong
+ * to a given track. ~5 miles — matches the documented course-detection range.
+ */
+export const DEFAULT_TRACK_SEARCH_RADIUS_M = 8047;
 
 /** Parse sector line coordinates from string form fields. Returns undefined if any value is NaN. */
 export function parseSectorLine(sector: { aLat: string; aLon: string; bLat: string; bLon: string }): SectorLine | undefined {
@@ -45,19 +51,6 @@ export function getTrackDisplayName(track: { name: string; shortName?: string })
   return track.shortName || abbreviateTrackName(track.name);
 }
 
-/**
- * Haversine distance in meters between two lat/lon points.
- */
-function haversineDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371000;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lon2 - lon1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) *
-    Math.sin(dLon / 2) * Math.sin(dLon / 2);
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
 
 /**
  * Find the nearest track to a GPS point. Returns the track if within threshold (default 2km).
@@ -65,7 +58,7 @@ function haversineDistance(lat1: number, lon1: number, lat2: number, lon2: numbe
 export function findNearestTrack(
   lat: number, lon: number,
   tracks: { name: string; courses: { startFinishA: { lat: number; lon: number } }[] }[],
-  thresholdMeters = 8047 // 5 miles
+  thresholdMeters = DEFAULT_TRACK_SEARCH_RADIUS_M,
 ): typeof tracks[number] | null {
   let best: typeof tracks[number] | null = null;
   let bestDist = Infinity;
@@ -87,7 +80,7 @@ export function findNearestTrack(
 export function calculatePolylineLength(points: Array<{ lat: number; lon: number }>): number {
   let total = 0;
   for (let i = 1; i < points.length; i++) {
-    total += haversineDist(points[i - 1].lat, points[i - 1].lon, points[i].lat, points[i].lon);
+    total += haversineDistance(points[i - 1].lat, points[i - 1].lon, points[i].lat, points[i].lon);
   }
   return total;
 }
@@ -96,7 +89,7 @@ export function calculatePolylineLength(points: Array<{ lat: number; lon: number
  * Format a distance in meters to a compact ft / m string.
  */
 export function formatTrackLength(meters: number): string {
-  const feet = meters * 3.28084;
+  const feet = meters * METERS_TO_FEET;
   return `${Math.round(feet).toLocaleString()} ft / ${Math.round(meters).toLocaleString()} m`;
 }
 
@@ -117,7 +110,7 @@ export function resamplePolyline(
   for (let i = 1; i < points.length; i++) {
     const prev = points[i - 1];
     const curr = points[i];
-    const segDist = haversineDist(prev.lat, prev.lon, curr.lat, curr.lon);
+    const segDist = haversineDistance(prev.lat, prev.lon, curr.lat, curr.lon);
     if (segDist === 0) continue;
 
     let walked = carry;


### PR DESCRIPTION
Audit of "magic numbers" across the codebase found that most are already named module-local consts (kept that way — locality wins for single-use values). Only the actually-duplicated ones graduate to shared exports.

New shared exports in src/lib/parserUtils.ts:
  - EARTH_RADIUS_M = 6_371_000   (mean Earth radius, m)
  - METERS_TO_FEET = 3.28084     (length-display conversion)

New shared export in src/lib/trackUtils.ts:
  - DEFAULT_TRACK_SEARCH_RADIUS_M = 8047  (5 mi — default "nearest track" radius)

Already-shared constants now reused everywhere:
  - MAX_SPEED_MPS, STANDARD_GRAVITY_MPS2, MPH_TO_MPS (all from parserUtils)

Duplicates resolved (6 total):
  1. MAX_SPEED_MPS = 150 was in parserUtils (exported) + brakingZones (local copy). brakingZones now imports.
  2. 9.80665 standard gravity was in parserUtils (STANDARD_GRAVITY_MPS2) + brakingZones (GRAVITY_MPS2) + gforceCalculation (G_FORCE_CONFIG.GRAVITY). All now reference the parserUtils export.
  3. 0.44704 mph→mps  (seven inline literals in brakingZones) replaced with imported MPH_TO_MPS.
  4. 6371000 Earth radius inlined in parserUtils' haversine, lapCalculation's projectToPlane, referenceUtils' projectToPlane, AND a local haversine in trackUtils. All now use EARTH_RADIUS_M. trackUtils also had a dead local haversineDistance() copy — deleted, callers now use the alias-free import that was already in scope (haversineDist → haversineDistance).
  5. 3.28084 meters→feet was inlined in 5 places: courseDetection, trackUtils.formatTrackLength, supabaseAdapter, admin/CoursesTab, LapTable. All now import METERS_TO_FEET.
  6. 8047 (5-mile radius) was named TRACK_SEARCH_RADIUS_M in courseDetection AND a magic default param in trackUtils.findNearestTrack. trackUtils now exports DEFAULT_TRACK_SEARCH_RADIUS_M; both sites reference it.

Deliberately NOT centralized (single-use, already well-named in-module):
  - MIN_CROSSING_INTERVAL_MS, MIN_SECTOR_CROSSING_INTERVAL_MS (lapCalculation)
  - WAYPOINT_SPEED_THRESHOLD_MPH, WAYPOINT_RETURN_RADIUS_M, WAYPOINT_MIN_TRAVEL_M, LENGTH_MATCH_TOLERANCE (courseDetection)
  - LEGACY_HEADER_SIZE (dovexParser)
  - COORD_EPSILON (deviceTrackSync)
  - All BLE timeout values + UUIDs (per-protocol)
  - DEFAULT_BRAKING_CONFIG, MIN_SPEED_MPS, MAX_ACCEL_G, etc. (brakingZones)

These are each used in exactly one file. Pulling them into a shared constants.ts would have hurt readability — you'd need a round-trip to a distant file to discover that "5000" means "5-second start/finish debounce".

No behavior change. All values are numerically identical to before.

Verified:
  - npm run lint clean
  - npm run typecheck clean
  - npm run test:run: 269 passed (no test changes needed — values unchanged)
  - npm run build clean

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf