### PR TITLE
Safer env fallbacks + named constant for persistent toast duration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,16 @@ import "./index.css";
 import { toast } from "@/components/ui/sonner";
 import { registerSW } from "virtual:pwa-register";
 
+/**
+ * "Never auto-dismiss" duration for sonner toasts. Sonner doesn't export a
+ * persist constant, and passing `Infinity` hands the value to `setTimeout`
+ * which different browsers handle differently (some clamp to ~24 days, some
+ * fire immediately). A long finite value is unambiguous; 24h is more than
+ * enough — the toast is dismissed by the user clicking Refresh or Later
+ * long before this expires.
+ */
+const PERSISTENT_TOAST_DURATION_MS = 24 * 60 * 60 * 1000;
+
 createRoot(document.getElementById("root")!).render(<App />);
 
 const isInIframe = (() => {
@@ -31,7 +41,7 @@ if (isInIframe || isPreviewHost) {
     onNeedRefresh() {
       toast("Update ready", {
         description: "Refresh to clear stale cached files and load the latest app version.",
-        duration: Infinity,
+        duration: PERSISTENT_TOAST_DURATION_MS,
         action: {
           label: "Refresh",
           onClick: async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,12 @@ const PUBLIC_BACKEND_FALLBACKS = {
   VITE_SUPABASE_PUBLISHABLE_KEY:
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN2amxpZW92cHlpZmZicXdodGdrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEwMDQ1MzcsImV4cCI6MjA4NjU4MDUzN30.-LnwDsiT1vmWxfoLiHlK9hHqCzN9ToHeB6qkH5-A2I4",
   VITE_SUPABASE_URL: "https://svjlieovpyiffbqwhtgk.supabase.co",
-  VITE_ENABLE_ADMIN: "true",
-  VITE_ENABLE_REGISTRATION: "true",
+  // Admin + registration default OFF in fallbacks. The production deploy
+  // enables them via Lovable Cloud env injection ("true"). A new contributor
+  // cloning the repo without a .env should see the public app, not admin UI
+  // pointing at a backend they don't control.
+  VITE_ENABLE_ADMIN: "false",
+  VITE_ENABLE_REGISTRATION: "false",
 } as const;
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
Two small follow-ups to the post-incident hardening:

1. vite.config.ts — default ADMIN + REGISTRATION fallbacks to "false"
   Previously these were hardcoded "true" in PUBLIC_BACKEND_FALLBACKS, so
   any build without explicit env vars (a fresh clone, `npm run build`
   with no .env) would have admin UI + /register enabled by default —
   pointing at the project's Supabase backend that the cloner doesn't
   control. The production deploy continues to enable them via Lovable
   Cloud env injection.

   Net effect: "no .env" now degrades gracefully (public app only,
   admin features hidden) instead of showing admin links that lead to
   auth errors.

2. src/main.tsx — replace `duration: Infinity` with a named constant
   Sonner doesn't expose a persist constant. Passing Infinity to
   setTimeout is implementation-defined: most browsers clamp to ~24
   days, but some fire immediately. Replaced with
   PERSISTENT_TOAST_DURATION_MS = 24h — explicit, unambiguous,
   well past any plausible "update ready" notification lifetime
   (toast is dismissed by user clicking Refresh or Later long
   before this expires).

Verified:
  - npm run lint clean
  - npm run typecheck clean
  - npm run test:run (269 passed)
  - npm run build clean

https://claude.ai/code/session_01YaYnpBkkvPsiQP4CtV7mVf