### PR TITLE
Chore/safer env fallbacks and toast

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug Report
+description: Report something that isn't working as expected.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill out the details
+        below so we can reproduce and fix it.
+
+        **Security issue?** Do not file it here — see `SECURITY.md` instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I import a .vbo file, the lap times are all zero...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the app
+        2. Import file X
+        3. Switch to Pro view
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: file-format
+    attributes:
+      label: File format involved
+      description: Parsers are format-specific — this helps narrow it down.
+      options:
+        - "Not file-related"
+        - "UBX (.ubx)"
+        - "VBO (.vbo)"
+        - "Dove (.dove)"
+        - "Dovex (.dovex)"
+        - "Alfano (.csv)"
+        - "AiM MyChron (.csv)"
+        - "MoTeC CSV (.csv)"
+        - "MoTeC LD (.ld)"
+        - "NMEA (.nmea/.txt/.csv)"
+        - "Other / unsure"
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser & OS
+      placeholder: "Chrome 125 on Windows 11 / Safari 17 on iOS"
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample file or screenshots
+      description: If possible, attach a sample file (or a snippet) and any screenshots. Telemetry stays local, so a sample helps enormously.
+    validations:
+      required: false
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors
+      description: Anything in the browser dev console (F12 → Console)?
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Live App — HackTheTrack.net
+    url: https://hackthetrack.net
+    about: Try the app directly in your browser.
+  - name: DovesDataLogger (Hardware)
+    url: https://github.com/TheAngryRaven/DovesDataLogger
+    about: Issues with the ESP32 GPS logger hardware belong in its own repo.
+  - name: Security Vulnerability
+    url: https://github.com/TheAngryRaven/DovesDataViewer/security/advisories/new
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest a new feature, parser, or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Remember the #1 rule: features should work
+        **offline** wherever possible (weather, map tiles, and admin are the
+        only allowed exceptions).
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point, not just the solution.
+      placeholder: I log with device X, and there's no parser for its format...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Mockups or examples welcome.
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - "New file-format parser"
+        - "Visualization / charts"
+        - "Video / overlays"
+        - "BLE / device integration"
+        - "Track / course editor"
+        - "Data management (vehicles, setups, notes)"
+        - "PWA / offline / performance"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thanks for contributing to Dove's DataViewer! -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related Issues
+
+<!-- e.g. Closes #123 -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] New file-format parser
+- [ ] Refactor / reusability improvement
+- [ ] Documentation
+- [ ] Other:
+
+## Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test:run` passes
+- [ ] `npm run build` succeeds
+- [ ] Feature works **offline** (no new required network calls, except weather / map tiles / admin)
+- [ ] Docs updated where relevant (`README.md`, `CLAUDE.md`, Credits, `CHANGELOG.md`)
+- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table
+
+## Notes for Reviewers
+
+<!-- Anything that needs special attention, screenshots, sample files, etc. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> This changelog was introduced at the `1.0.0` release. Entries before `1.0.0`
+> are reconstructed from git history and grouped by theme rather than exhaustive
+> per-commit detail.
+
+## [Unreleased]
+
+### Added
+- Open-source project hygiene: `CONTRIBUTING.md`, `SECURITY.md`, this
+  `CHANGELOG.md`, GitHub issue/PR templates, and Dependabot configuration.
+- README **Credits** and **License** sections; populated `package.json`
+  metadata (name, version, license, repository, author).
+
+### Changed
+- Code-split the bundle with `React.lazy` boundaries and `manualChunks` vendor
+  splitting, shrinking the initial gzip payload (~403 KB → ~294 KB) by deferring
+  admin, pro view, file-manager drawer, BLE download, and the Leaflet editor off
+  the first-load path.
+
+## [1.0.0] - 2026-05-22
+
+First tagged release. Dove's DataViewer is a feature-complete, offline-first,
+installable PWA for viewing and analyzing motorsport telemetry — live at
+[hackthetrack.net](https://hackthetrack.net).
+
+### Added — File Formats
+- Auto-detecting import for UBX (u-blox), VBO (Racelogic/RaceBox), Dove &
+  Dovex (DovesDataLogger), Alfano, AiM MyChron, MoTeC (CSV + native LD binary),
+  and NMEA 0183.
+- `.dovex` extended format with an 8 KB metadata header (driver, course, lap
+  times) that degrades gracefully to raw GPS if metadata is corrupt.
+
+### Added — Analysis & Visualization
+- Automatic track & course detection within a 5-mile radius, with
+  forward/reverse direction detection.
+- Waypoint mode fallback for lap timing with no known track.
+- Automatic lap detection via start/finish line crossing, with 3-sector split
+  timing and optimal-lap calculation.
+- Interactive Leaflet race-line map with speed heatmap and braking-zone
+  detection/visualization.
+- Pro graph view with multi-series Canvas telemetry charts, reference-lap
+  overlay, and pace-delta comparison.
+- G-force derivation from GPS with configurable smoothing.
+
+### Added — Video & Overlays
+- Video sync with telemetry playback.
+- Nine overlay gauge types (digital, analog, graph, bar, bubble, map, pace,
+  sector, lap time) with Classic and Neon themes.
+- MP4 export via WebCodecs (H.264 + AAC), with a MediaRecorder fallback.
+
+### Added — Data Management
+- Vehicle profiles, template-driven setup sheets, and per-session notes.
+- IndexedDB-backed storage for files, metadata, karts, notes, setups,
+  video-sync points, and graph preferences.
+- Custom track & course editor with map drawing and community submissions.
+
+### Added — Devices & Connectivity
+- BLE integration with the DovesDataLogger (file download, device settings,
+  battery, and full track sync over Web Bluetooth).
+- Local weather lookup (IEM ASOS / NWS).
+- Optional, fully gated admin backend (Supabase) for the community track
+  database — the core app makes zero database calls on normal loads.
+
+### Added — Platform
+- Installable PWA with full offline support via service worker + IndexedDB.
+- Dark & light mode.
+
+### Changed — Quality Pass (May 2026)
+- Enabled TypeScript strict mode and fixed resulting type issues.
+- Split CI into parallel lint / typecheck / test / build workflows with README
+  badges.
+- Refactored `Index.tsx` into composable hooks/contexts; split the BLE module
+  into per-concern files under `src/lib/ble/` and added protocol tests.
+- Hardened PWA cache recovery (NetworkFirst HTML, legacy `/sw.js` kill-switch),
+  added safer production env fallbacks, and added SEO metadata
+  (sitemap, robots, per-route head tags, `llms.txt`).
+
+[Unreleased]: https://github.com/TheAngryRaven/DovesDataViewer/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/TheAngryRaven/DovesDataViewer/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to Dove's DataViewer
+
+Thanks for your interest in improving Dove's DataViewer! This is an
+offline-first, open-source motorsport telemetry viewer, and contributions of
+all kinds are welcome — new file-format parsers, bug fixes, overlays, docs, and
+reusability rewrites especially.
+
+By participating, you agree to abide by our Code of Conduct (`CODE_OF_CONDUCT.md`).
+
+---
+
+## Guiding Principles
+
+These are the rules the project lives by — please keep them in mind:
+
+1. **Offline-first.** 99% of features must work with no network. Only weather,
+   satellite map tiles, and the optional admin backend are allowed to require
+   connectivity.
+2. **Never do on the server what you can do on the client.** Telemetry parsing,
+   lap detection, and visualization all happen in the browser. Data never
+   leaves the user's device.
+3. **Modular & reusable.** Prefer small, composable modules over monoliths.
+   Rewrites that make code more reusable are always welcome — line count is not
+   a concern.
+4. **Keep docs in sync.** Update `README.md` when you add a parser, change an
+   env var, or modify build params. Update the Credits list when you add a FOSS
+   dependency. Update `CLAUDE.md` with new files/architecture notes.
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+- Node.js 18+ (or [Bun](https://bun.sh))
+
+### Getting started
+
+```bash
+git clone https://github.com/TheAngryRaven/DovesDataViewer.git
+cd DovesDataViewer
+npm install
+npm run dev      # dev server on http://localhost:8080
+```
+
+The core app needs **no environment variables** — it runs fully offline. Env
+vars are only required for the optional admin backend (see the README).
+
+### Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Dev server on port 8080 |
+| `npm run build` | Production build to `dist/` |
+| `npm run preview` | Preview the production build |
+| `npm run lint` | ESLint |
+| `npm run typecheck` | Type-check via `tsc -b` |
+| `npm test` | Vitest (watch) |
+| `npm run test:run` | Vitest (single pass, CI-style) |
+
+> **Note on typechecking:** always use `npm run typecheck` (`tsc -b`), not a
+> bare `tsc --noEmit`. The root `tsconfig.json` uses project references; plain
+> `tsc` from the root silently checks nothing and exits 0.
+
+---
+
+## Before You Open a PR
+
+Run the same four checks CI runs, and make sure they pass:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+npm run build
+```
+
+CI runs these as four separate workflows on every PR. A PR won't be merged
+until all four are green.
+
+---
+
+## Adding a New Parser
+
+The parser system is the most common contribution. Each parser is
+self-contained and auto-detected on import.
+
+1. Create `src/lib/xxxParser.ts` exporting two functions:
+   - `isXxxFormat(input: string | ArrayBuffer): boolean` — format detection
+   - `parseXxxFile(input: string | ArrayBuffer): ParsedData` — full parse
+2. Register it in `src/lib/datalogParser.ts` — add the import and a detection
+   check in **both** `parseDatalogFile()` and `parseDatalogContent()`.
+3. Respect detection order: binary formats first (MoTeC LD → UBX), then text
+   formats from most-specific to least (VBO → MoTeC CSV → Dovex → Dove →
+   Alfano → AiM → NMEA fallback).
+4. Add tests with a representative sample.
+5. Update the **Supported File Formats** table in `README.md` and the parser
+   list in `CLAUDE.md`.
+
+See `src/types/racing.ts` for the `ParsedData` / `GpsSample` shapes your parser
+must produce, and `src/lib/parserUtils.ts` for shared helpers (haversine, speed
+calculation, etc.).
+
+---
+
+## Coding Conventions
+
+- **TypeScript + React 18.** Function components and hooks only.
+- **Hooks are composable** — each hook does one thing; `Index.tsx` orchestrates.
+- **Styling:** Tailwind semantic tokens from `index.css`. Never hardcode colors
+  in components.
+- **Comments:** write them only when the *why* is non-obvious. Well-named code
+  documents the *what*.
+- **Admin code** is fully optional and gated behind env vars — the core app
+  must have zero admin dependencies.
+- Keep the initial bundle small: respect the `React.lazy` boundaries and
+  `manualChunks` vendor splits described in `CLAUDE.md`.
+
+`CLAUDE.md` at the repo root is the detailed architecture map — it's the best
+single reference for how everything fits together.
+
+---
+
+## Pull Request Process
+
+1. Fork the repo and create a topic branch (`feat/...`, `fix/...`, `chore/...`).
+2. Make focused commits with clear messages.
+3. Ensure lint, typecheck, tests, and build all pass locally.
+4. Update relevant docs (`README.md`, `CLAUDE.md`, Credits) as noted above.
+5. Open a PR against `main` and fill out the PR template.
+
+---
+
+## Reporting Bugs & Requesting Features
+
+Use the GitHub issue templates. For bugs, include the file format involved
+(parsers are format-specific) and, where possible, a sample file or the steps
+to reproduce.
+
+**Security issues:** please do **not** open a public issue — follow the
+disclosure process in `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Open [http://localhost:8080](http://localhost:8080) in your browser.
 | `npm run build` | Production build to `dist/` |
 | `npm run preview` | Preview production build locally |
 | `npm run lint` | Run ESLint |
+| `npm run typecheck` | Type-check via `tsc -b` (build mode — follows project references) |
+| `npm test` | Run Vitest in watch mode |
+| `npm run test:run` | Run Vitest once (CI-style) |
 
 ---
 
@@ -233,3 +236,42 @@ src/
 ├── pages/           # Route pages
 └── types/           # TypeScript definitions
 ```
+
+---
+
+## Contributing
+
+Contributions are welcome — new parsers, bug fixes, overlays, and reusability
+rewrites especially. See **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup,
+coding conventions, how to add a new parser, and the PR checklist.
+
+By participating you agree to abide by our Code of Conduct (`CODE_OF_CONDUCT.md`).
+
+Found a security issue? Please follow the disclosure process in
+**[SECURITY.md](SECURITY.md)** rather than opening a public issue.
+
+Release history is tracked in **[CHANGELOG.md](CHANGELOG.md)**.
+
+---
+
+## Credits
+
+Built on the shoulders of these incredible open-source projects and free services:
+
+- [React](https://react.dev) · [Vite](https://vite.dev) · [TypeScript](https://www.typescriptlang.org)
+- [Tailwind CSS](https://tailwindcss.com) · [shadcn/ui](https://ui.shadcn.com) · [Radix UI](https://www.radix-ui.com) · [Lucide Icons](https://lucide.dev)
+- [Leaflet](https://leafletjs.com) · [OpenStreetMap](https://www.openstreetmap.org)
+- [TanStack Query](https://tanstack.com/query) · [Sonner](https://sonner.emilkowal.dev) · [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels)
+- [mp4-muxer](https://github.com/Vanilagy/mp4-muxer) · [Savitzky-Golay (ml.js)](https://github.com/mljs/savitzky-golay) · [JSZip](https://stuk.github.io/jszip) · [fix-webm-duration](https://github.com/yusitnikov/fix-webm-duration)
+- [IEM ASOS (Iowa State)](https://mesonet.agron.iastate.edu) · [NWS API](https://www.weather.gov/documentation/services-web-api)
+- [MoTeC i2](https://www.motec.com.au) (file format reference)
+
+Optional admin backend powered by [Supabase](https://supabase.com) via Lovable Cloud.
+
+---
+
+## License
+
+Licensed under the **GNU General Public License v3.0 (or later)** — see
+**[LICENSE](LICENSE)**. You are free to use, modify, and self-host; derivative
+works that you distribute must also be released under the GPL.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+Dove's DataViewer is a continuously deployed web app. Security fixes are applied
+to the latest release on the `main` branch, which is what powers
+[hackthetrack.net](https://hackthetrack.net). Older tagged releases are not
+separately patched.
+
+| Version | Supported |
+|---------|-----------|
+| Latest `main` / newest tag | ✅ |
+| Older tags | ❌ |
+
+## Reporting a Vulnerability
+
+Please **do not open a public GitHub issue** for security vulnerabilities.
+
+Instead, report privately through one of:
+
+- GitHub's [private vulnerability reporting](https://github.com/TheAngryRaven/DovesDataViewer/security/advisories/new)
+  (**Security → Report a vulnerability**), or
+- a direct message to the maintainer ([@TheAngryRaven](https://github.com/TheAngryRaven)).
+
+Please include:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce (a proof of concept if possible).
+- Affected area (e.g. a specific parser, the BLE flow, the admin backend).
+
+## What to Expect
+
+- An acknowledgement of your report, typically within a few days.
+- An assessment and, if confirmed, a fix on `main` as quickly as is practical.
+- Credit for the discovery if you'd like it (let us know your preference).
+
+## Scope Notes
+
+The core app is **offline-first and client-side**: telemetry files are parsed
+entirely in the browser and never uploaded. The most relevant areas for
+security review are therefore:
+
+- **File parsers** (`src/lib/*Parser.ts`) — these handle untrusted user files.
+- **The optional admin backend** (Supabase edge functions in
+  `supabase/functions/`) — the only server-side surface, and only active when
+  admin is enabled.
+- **The BLE device flow** (`src/lib/ble/`) — data exchanged with the
+  DovesDataLogger hardware.
+
+Thank you for helping keep the project and its users safe.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,18 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "doves-dataviewer",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
+  "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
+  "license": "GPL-3.0-or-later",
+  "author": "TheAngryRaven",
+  "homepage": "https://hackthetrack.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TheAngryRaven/DovesDataViewer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TheAngryRaven/DovesDataViewer/issues"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -19,6 +19,9 @@ const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
   ["Savitzky-Golay (ml.js)", "https://github.com/mljs/savitzky-golay"],
   ["Sonner", "https://sonner.emilkowal.dev"],
   ["react-resizable-panels", "https://github.com/bvaughn/react-resizable-panels"],
+  ["mp4-muxer", "https://github.com/Vanilagy/mp4-muxer"],
+  ["fix-webm-duration", "https://github.com/yusitnikov/fix-webm-duration"],
+  ["JSZip", "https://stuk.github.io/jszip"],
   ["MoTeC i2", "https://www.motec.com.au"],
 ];
 


### PR DESCRIPTION
Add OSS community-health files and project metadata 

Populate package.json metadata (name, version 1.0.0, license, repository,
author, homepage, bugs) — previously the Lovable boilerplate defaults.

Add CONTRIBUTING.md (dev setup, the tsc -b gotcha, how to add a parser, PR
checklist), SECURITY.md (private disclosure process), CHANGELOG.md (Keep a
Changelog format, 1.0.0 baseline reconstructed from history), Dependabot
config (npm + actions), a PR template, and bug/feature issue templates.

README: add Credits (mirrored from the in-app CreditsDialog), License, and
Contributing sections, and document the missing typecheck/test scripts. Code
of Conduct is referenced but intentionally not added yet.


Sync in-app Credits with shipped dependencies 

Add mp4-muxer, fix-webm-duration, and JSZip to the CreditsDialog so the in-app
list matches the README credits and the actual dependency tree.