### PR TITLE
Add plugin UI panel framework, surfaced in the Labs tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Plugin UI panel framework: plugins can contribute self-contained panels to a
+  named slot, starting with the Labs tab. The tab now appears automatically when
+  a plugin contributes a panel, and each panel is isolated by an error boundary.
+
 ### Changed
 - The optional AI coach plugin now ships from the public npm registry as
   `@perchwerks/eye-in-the-sky` and loads by default — no build token or `.npmrc`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,8 @@ src/
 │   ├── types.ts               # DataViewerPlugin / PluginContext / PluginRegistry contracts
 │   ├── registry.ts            # Singleton registry + generic extension points
 │   ├── index.ts               # initPlugins() — discovery + setup (called in main.tsx)
+│   ├── panels.ts              # UI panel framework: PluginPanel/Props, PANELS_POINT, PanelSlot, getPanelsForSlot
+│   ├── PluginPanelHost.tsx    # Mounts plugin panels for a slot (error-boundaried, with fallback)
 │   └── coaching/              # Gitignored private slot (AI coaching submodule)
 ├── types/
 │   └── racing.ts              # ★ Core types: GpsSample, ParsedData, Lap, Course, Track, etc.
@@ -227,12 +229,21 @@ A plugin absent at build time simply never loads — the app builds/runs without
 | `registry.ts` | Singleton registry: `register`/`get`/`list` + generic `contribute`/`getContributions`. Same-`id` plugins resolve by highest `priority` |
 | `index.ts` | `initPlugins()` — glob + external discovery, runs each plugin's `setup(ctx)`. Called once in `main.tsx` before render |
 | `external-plugins.d.ts` | Ambient type for the `virtual:external-plugins` module |
+| `panels.ts` | **UI panel framework**: `PluginPanel` / `PluginPanelProps` contract, `PANELS_POINT`, `PanelSlot`, `getPanelsForSlot(slot)`. The curated session snapshot is the entire surface a panel can rely on |
+| `PluginPanelHost.tsx` | Consumer: mounts every panel for a slot in a titled card, each wrapped in a per-panel error boundary; renders a `fallback` when none |
 | `coaching/` | **Gitignored** local-dev slot for the coach plugin (production loads it as an npm package) |
 
 A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 `setup`, it contributes to named extension points
 (`ctx.registry.contribute(point, value)`); consumers read via
 `getContributions(point)`. New extension points need no registry changes.
+
+**UI panels:** the first concrete extension point. A plugin contributes
+`PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
+The only slot today is `PanelSlot.Labs` — `LabsTab.tsx` renders contributed
+panels via `PluginPanelHost`, and a labs-slot panel makes the Labs tab appear
+automatically even when the experimental `enableLabs` setting is off (`Index.tsx`
+computes `hasLabsPanels`). New slots are just new strings — no framework change.
 
 **AI coach (npm package):** published to the public npm registry as
 `@perchwerks/eye-in-the-sky` and listed in `optionalDependencies`. The loader in

--- a/src/components/tabs/LabsTab.tsx
+++ b/src/components/tabs/LabsTab.tsx
@@ -1,7 +1,28 @@
 import { memo } from "react";
 import { FlaskConical } from "lucide-react";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { useSettingsContext } from "@/contexts/SettingsContext";
+import { PluginPanelHost } from "@/plugins/PluginPanelHost";
+import { PanelSlot } from "@/plugins/panels";
 
 export const LabsTab = memo(function LabsTab() {
+  const { data, laps, selectedLapNumber, course } = useSessionContext();
+  const { useKph } = useSettingsContext();
+
+  return (
+    <PluginPanelHost
+      slot={PanelSlot.Labs}
+      data={data}
+      laps={laps}
+      selectedLapNumber={selectedLapNumber}
+      course={course}
+      useKph={useKph}
+      fallback={<LabsEmpty />}
+    />
+  );
+});
+
+function LabsEmpty() {
   return (
     <div className="h-full flex items-center justify-center">
       <div className="max-w-sm space-y-5 text-center px-4">
@@ -13,4 +34,4 @@ export const LabsTab = memo(function LabsTab() {
       </div>
     </div>
   );
-});
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -26,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ParsedData } from "@/types/racing";
+import { getPanelsForSlot, PanelSlot } from "@/plugins/panels";
 import { TrackPromptDialog } from "@/components/TrackPromptDialog";
 import { useSettings } from "@/hooks/useSettings";
 import { usePlayback } from "@/hooks/usePlayback";
@@ -109,6 +110,10 @@ export default function Index() {
 
   const [topPanelView, setTopPanelView] = useState<TopPanelView>("raceline");
   const [showOverlays, setShowOverlays] = useState(true);
+  // Plugins are registered at startup, so a labs-slot panel means the Labs tab
+  // has real content — surface it even when the experimental setting is off.
+  const hasLabsPanels = useMemo(() => getPanelsForSlot(PanelSlot.Labs).length > 0, []);
+  const showLabs = settings.enableLabs || hasLabsPanels;
 
   // Video sync for Labs tab
   const videoSync = useVideoSync({
@@ -379,7 +384,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} enableLabs={settings.enableLabs} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -387,7 +392,7 @@ export default function Index() {
           {topPanelView === "laptable" && <LapTimesTab />}
           <Suspense fallback={null}>
             {topPanelView === "graphview" && <GraphViewTab />}
-            {topPanelView === "labs" && settings.enableLabs && <LabsTab />}
+            {topPanelView === "labs" && showLabs && <LabsTab />}
           </Suspense>
         </div>
       </main>
@@ -412,13 +417,13 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, enableLabs }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
   showOverlays: boolean;
   onToggleOverlays: () => void;
-  enableLabs: boolean;
+  showLabs: boolean;
 }) {
   const tabClass = (view: TopPanelView) =>
     `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
@@ -441,7 +446,7 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
           <span className="ml-1 px-1.5 py-0.5 text-xs bg-primary/20 text-primary rounded">{laps.length}</span>
         )}
       </button>
-      {enableLabs && (
+      {showLabs && (
         <button onClick={() => setTopPanelView("labs")} className={tabClass("labs")}>
           <FlaskConical className="w-4 h-4" /> <span className="hidden sm:inline">Labs</span>
         </button>

--- a/src/plugins/PluginPanelHost.tsx
+++ b/src/plugins/PluginPanelHost.tsx
@@ -1,0 +1,65 @@
+import { Component, useMemo, type ReactNode } from "react";
+import { getPanelsForSlot, type PluginPanelProps } from "./panels";
+
+/**
+ * Isolates a single plugin panel: a throw in one panel renders a local notice
+ * instead of taking down the tab (or the app). Plugin UI is untrusted-ish —
+ * first-party today, potentially user-installed later — so each gets a boundary.
+ */
+class PanelErrorBoundary extends Component<
+  { title: string; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs text-muted-foreground">
+          The “{this.props.title}” panel hit an error and was unloaded.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Mounts every plugin panel registered for `slot`, passing each the live
+ * session snapshot. Renders `fallback` when no panels target the slot.
+ */
+export function PluginPanelHost({
+  slot,
+  fallback,
+  ...props
+}: { slot: string; fallback?: ReactNode } & PluginPanelProps) {
+  const panels = useMemo(() => getPanelsForSlot(slot), [slot]);
+
+  if (panels.length === 0) return <>{fallback ?? null}</>;
+
+  return (
+    <div className="h-full overflow-auto p-4 space-y-4">
+      {panels.map((panel) => {
+        const Icon = panel.icon;
+        const Body = panel.component;
+        return (
+          <section key={panel.id} className="rounded-lg border border-border bg-card">
+            <header className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+              {Icon && <Icon className="w-4 h-4 text-primary" />}
+              <h3 className="text-sm font-medium text-foreground">{panel.title}</h3>
+            </header>
+            <div className="p-4">
+              <PanelErrorBoundary title={panel.title}>
+                <Body {...props} />
+              </PanelErrorBoundary>
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -32,6 +32,60 @@ const plugin: DataViewerPlugin = {
 export default plugin;
 ```
 
+## Contributing UI panels (`panels.ts`)
+
+The first concrete extension point is the **panel framework**: a plugin
+contributes self-contained React panels to a named *slot* (a host surface), and
+the host mounts them. Today the only slot is the **Labs tab** (`PanelSlot.Labs`);
+new slots are just new strings — no registry or framework changes needed.
+
+A panel is a `PluginPanel` contributed to the `PANELS_POINT` extension point:
+
+```tsx
+import { FlaskConical } from "lucide-react";
+import type { DataViewerPlugin } from "@/plugins/types";
+import { PANELS_POINT, PanelSlot, type PluginPanel, type PluginPanelProps } from "@/plugins/panels";
+
+function CoachPanel({ data, laps, selectedLapNumber, useKph }: PluginPanelProps) {
+  if (!data) return <p className="text-sm text-muted-foreground">Load a session to start coaching.</p>;
+  return <p className="text-sm text-foreground">{laps.length} laps ready to analyze.</p>;
+}
+
+const plugin: DataViewerPlugin = {
+  id: "ai-coaching",
+  name: "AI Coaching",
+  priority: 100,
+  setup(ctx) {
+    const panel: PluginPanel = {
+      id: "ai-coaching",
+      title: "AI Coaching",
+      slot: PanelSlot.Labs,
+      order: 0,
+      icon: FlaskConical,
+      component: CoachPanel,
+    };
+    ctx.registry.contribute(PANELS_POINT, panel);
+  },
+};
+
+export default plugin;
+```
+
+Contract notes:
+
+- **`PluginPanelProps` is the entire surface a panel can rely on** — a curated,
+  read-only snapshot of the active session (`data`, `laps`, `selectedLapNumber`,
+  `course`, `useKph`). Panels never touch the host's internal session context, so
+  the host can refactor internals without breaking plugins.
+- The host (`PluginPanelHost`) renders each panel inside a titled card and wraps
+  it in an **error boundary** — a throwing panel shows a local notice instead of
+  crashing the tab.
+- A labs-slot panel makes the **Labs tab appear automatically**, even when the
+  experimental Labs setting is off (`Index.tsx`).
+- Panels resolve `react` from the host bundle (plugins are compiled as source by
+  the host's Vite), so an external package adds `react` to its `devDependencies`
+  for its own typecheck but does **not** bundle a second copy.
+
 ## The AI coach as a public npm package
 
 The coach lives in its own repo and is published to the **public npm registry**

--- a/src/plugins/panels.test.ts
+++ b/src/plugins/panels.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { pluginRegistry } from "./registry";
+import { PANELS_POINT, getPanelsForSlot, type PluginPanel } from "./panels";
+
+const noopComponent: PluginPanel["component"] = () => null;
+
+function panel(id: string, slot: string, order?: number): PluginPanel {
+  return { id, title: id, slot, order, component: noopComponent };
+}
+
+describe("getPanelsForSlot", () => {
+  it("returns only panels contributed to the requested slot", () => {
+    pluginRegistry.contribute(PANELS_POINT, panel("a", "slot-filter"));
+    pluginRegistry.contribute(PANELS_POINT, panel("b", "slot-other"));
+
+    expect(getPanelsForSlot("slot-filter").map((p) => p.id)).toEqual(["a"]);
+  });
+
+  it("sorts by order ascending, treating missing order as 0", () => {
+    pluginRegistry.contribute(PANELS_POINT, panel("late", "slot-order", 10));
+    pluginRegistry.contribute(PANELS_POINT, panel("default", "slot-order"));
+    pluginRegistry.contribute(PANELS_POINT, panel("early", "slot-order", -5));
+
+    expect(getPanelsForSlot("slot-order").map((p) => p.id)).toEqual([
+      "early",
+      "default",
+      "late",
+    ]);
+  });
+
+  it("returns an empty array for a slot with no contributions", () => {
+    expect(getPanelsForSlot("slot-empty")).toEqual([]);
+  });
+});

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -1,0 +1,62 @@
+// UI panel framework for plugins.
+//
+// A plugin contributes self-contained React panels to a named *slot* (a host
+// surface, e.g. the Labs tab). The host mounts every panel registered for a
+// slot and hands each one a curated, stable `PluginPanelProps` snapshot of the
+// active session — plugins never see the host's internal session context, so
+// the contract here is the entire surface a plugin can rely on.
+//
+// New slots need no changes here: a host surface picks a slot string, plugins
+// target it, and `getPanelsForSlot` wires them together.
+
+import type { ComponentType } from "react";
+import type { ParsedData, Lap, Course } from "@/types/racing";
+import { pluginRegistry } from "./registry";
+
+/** Registry extension point that all UI panels are contributed to. */
+export const PANELS_POINT = "ui:panels";
+
+/** Known host surfaces a panel can mount into. */
+export const PanelSlot = {
+  /** The Labs tab in the main view. */
+  Labs: "labs",
+} as const;
+export type PanelSlot = (typeof PanelSlot)[keyof typeof PanelSlot];
+
+/** Live, read-only session snapshot handed to every panel on each render. */
+export interface PluginPanelProps {
+  /** Parsed telemetry for the active session, or null when none is loaded. */
+  data: ParsedData | null;
+  /** Detected laps for the active session. */
+  laps: Lap[];
+  /** Currently selected lap number, or null for "all laps". */
+  selectedLapNumber: number | null;
+  /** Selected course (start/finish + sectors), or null when undetected. */
+  course: Course | null;
+  /** Unit preference: true = km/h, false = mph. */
+  useKph: boolean;
+}
+
+/** Descriptor a plugin contributes to `PANELS_POINT` to render a panel. */
+export interface PluginPanel {
+  /** Unique id (within its slot). */
+  id: string;
+  /** Title shown in the panel header. */
+  title: string;
+  /** Host surface to mount into — a `PanelSlot` value. */
+  slot: string;
+  /** Sort order within the slot; lower renders first. Defaults to 0. */
+  order?: number;
+  /** Optional lucide-style icon for the panel header. */
+  icon?: ComponentType<{ className?: string }>;
+  /** The panel body. Re-renders with a fresh `PluginPanelProps` snapshot. */
+  component: ComponentType<PluginPanelProps>;
+}
+
+/** All panels contributed to `slot`, sorted by `order` then registration. */
+export function getPanelsForSlot(slot: string): PluginPanel[] {
+  return pluginRegistry
+    .getContributions<PluginPanel>(PANELS_POINT)
+    .filter((panel) => panel.slot === slot)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}


### PR DESCRIPTION
## Summary

First concrete extension point for the plugin system: plugins contribute self-contained React panels to a named slot, and the host mounts them. Built so future personal/third-party plugins plug in the same way.

- panels.ts: PluginPanel/PluginPanelProps contract, PANELS_POINT, PanelSlot, getPanelsForSlot. PluginPanelProps is a curated, read-only session snapshot so plugins never depend on the host's internal session context.
- PluginPanelHost: mounts every panel for a slot in a titled card, each behind a per-panel error boundary so a buggy plugin can't crash the tab.
- LabsTab renders the "labs" slot; Index shows the Labs tab automatically when a plugin contributes a labs panel, even with the experimental setting off.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run test:run` passes
- [ ] `npm run build` succeeds
- [ ] Feature works **offline** (no new required network calls, except weather / map tiles / admin)
- [ ] Docs updated where relevant (`README.md`, `CLAUDE.md`, Credits, `CHANGELOG.md`)
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table
