### PR TITLE
Per-file cloud sync + plugin framework primitives (storage + inline mounts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   toggle, so you choose exactly which sessions sync (opt-in, off by default).
   Pushing now uploads only your selected files (plus garage data). Selecting a
   file while offline records the intent and uploads once you're back online.
+  Files that live in your cloud but not on this device are listed under the file
+  manager with a one-click pull.
 - Public user accounts (gated by `VITE_ENABLE_CLOUD`, default off): email +
   password sign up / sign in, Google sign-in via Lovable Cloud managed OAuth,
   forgot-password and reset-password flows. New routes: `/register`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the cloud and pull them onto another device. Manual push/pull; data is private
   per account. Requires a backend (Supabase) and a connection — fully optional
   and offline-first otherwise.
+- Cloud Sync — per-file selection: each file in the file manager has a sync
+  toggle, so you choose exactly which sessions sync (opt-in, off by default).
+  Pushing now uploads only your selected files (plus garage data). Selecting a
+  file while offline records the intent and uploads once you're back online.
 - Public user accounts (gated by `VITE_ENABLE_CLOUD`, default off): email +
   password sign up / sign in, Google sign-in via Lovable Cloud managed OAuth,
   forgot-password and reset-password flows. New routes: `/register`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,8 @@ src/
 │   │   ├── index.ts             # Plugin def — contributes the Labs panel + a FileRow mount (both lazy, cloud-gated)
 │   │   ├── CloudSyncPanel.tsx    # Sign-in + push/pull UI (lazy-loaded)
 │   │   ├── FileSyncToggle.tsx    # Per-file sync toggle, mounted on each file row (off/pending/synced)
-│   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus (pure, tested)
+│   │   ├── CloudFilesSection.tsx # FileManagerSection mount: cloud-only files with per-file pull
+│   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames (pure, tested)
 │   │   ├── syncStores.ts         # Pure config: which IDB stores sync + how they're keyed (testable)
 │   │   ├── syncEngine.ts         # pushAll (garage + selected files) / pushFile / pullAll: IDB ↔ sync_records + bucket
 │   │   └── cloudClient.ts        # Typed access to sync_records + bucket (escape hatch until types regen)
@@ -402,7 +403,10 @@ Files are **opt-in per file** (`fileSync.ts`): a `FileRow` mount adds a toggle t
 each file-manager row (`off` → `pending` → `synced`), and the selection set lives
 in the plugin's own KV store (`getPluginStore("cloud-sync")`). `pushAll` uploads
 all garage docs but only the *selected* files; `pushFile` handles a single
-toggle. Cloud-only files (pull-per-file) + a section mount are a follow-up.
+toggle. Cloud-only files (in the cloud, not on this device) are listed by a
+`FileManagerSection` mount (`CloudFilesSection`) with a per-file pull; pulling
+persists via `ctx.onSaveFile` (which refreshes the list). `modified` detection +
+a "sync all" affordance remain follow-ups.
 
 After a migration, Lovable regenerates `integrations/supabase/types.ts`. Until
 then `cloudClient.ts` accesses the new table/bucket through a narrowly-typed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,9 @@ src/
 │   ├── index.ts               # initPlugins() — discovery + setup (called in main.tsx)
 │   ├── panels.ts              # UI panel framework: PluginPanel/Props, PANELS_POINT, PanelSlot, getPanelsForSlot
 │   ├── PluginPanelHost.tsx    # Mounts plugin panels for a slot (error-boundaried, Suspense-wrapped, with fallback)
+│   ├── mounts.ts              # Inline mounts: MOUNTS_POINT, MountSlot (FileRow/FileManagerSection), contexts, getMounts
+│   ├── PluginMount.tsx        # Renders inline mounts for a slot (error-boundaried, Suspense; renders null when none)
+│   ├── storage.ts             # getPluginStore(id): per-plugin KV in its own IndexedDB DB (dove-plugin-<id>)
 │   ├── cloud-sync/            # ★ First-party plugin: Supabase file + garage sync (Labs panel)
 │   │   ├── index.ts             # Plugin def — contributes a lazy CloudSyncPanel to the Labs slot
 │   │   ├── CloudSyncPanel.tsx    # Sign-in + push/pull UI (lazy-loaded)
@@ -238,12 +241,16 @@ A plugin absent at build time simply never loads — the app builds/runs without
 | `external-plugins.d.ts` | Ambient type for the `virtual:external-plugins` module |
 | `panels.ts` | **UI panel framework**: `PluginPanel` / `PluginPanelProps` contract, `PANELS_POINT`, `PanelSlot`, `getPanelsForSlot(slot)`. The curated session snapshot is the entire surface a panel can rely on |
 | `PluginPanelHost.tsx` | Consumer: mounts every panel for a slot in a titled card, each wrapped in a per-panel error boundary; renders a `fallback` when none |
+| `mounts.ts` | **Inline mount framework**: `PluginMountDef`, `MOUNTS_POINT`, `MountSlot` (`FileRow`, `FileManagerSection`), per-slot context types, `getMounts(slot)`. For injecting raw components into fixed spots in core UI |
+| `PluginMount.tsx` | Consumer: `<PluginMount slot ctx>` renders every mount for a slot (error-boundaried + Suspense), or nothing when none — safe to drop into core UI unconditionally |
+| `storage.ts` | `getPluginStore(id)`: schema-less KV scoped to one plugin, in its own IndexedDB DB (`dove-plugin-<id>`). Decoupled from core `dbUtils`. Also exposed as `ctx.storage` |
 | `coaching/` | **Gitignored** local-dev slot for the coach plugin (production loads it as an npm package) |
 
 A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 `setup`, it contributes to named extension points
 (`ctx.registry.contribute(point, value)`); consumers read via
 `getContributions(point)`. New extension points need no registry changes.
+`ctx.storage` is a `PluginStore` (per-plugin KV) for persisting plugin state.
 
 **UI panels:** the first concrete extension point. A plugin contributes
 `PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
@@ -253,6 +260,14 @@ automatically even when the experimental `enableLabs` setting is off (`Index.tsx
 computes `hasLabsPanels`). New slots are just new strings — no framework change.
 `PluginPanelHost` wraps each panel in an error boundary **and** a `Suspense`
 boundary, so panel components can be `React.lazy` (as `cloud-sync` is).
+
+**Inline mounts:** where panels are standalone cards, *mounts* inject a raw
+component into a fixed spot in core UI. A plugin contributes a `PluginMountDef`
+to `MOUNTS_POINT`, targeting a `MountSlot`; the host renders `<PluginMount slot
+ctx={…}>` at that spot, passing a typed context as a single `ctx` prop.
+`FilesTab` exposes two: `MountSlot.FileRow` (per file row, ctx = that file) and
+`MountSlot.FileManagerSection` (once under the list, ctx = the whole list). New
+mount locations are just new slot strings.
 
 **Cloud Sync (first-party plugin, `src/plugins/cloud-sync/`):** the first
 in-repo plugin built on the panel framework. Contributes a lazy Labs panel that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,11 +184,13 @@ src/
 │   ├── mounts.ts              # Inline mounts: MOUNTS_POINT, MountSlot (FileRow/FileManagerSection), contexts, getMounts
 │   ├── PluginMount.tsx        # Renders inline mounts for a slot (error-boundaried, Suspense; renders null when none)
 │   ├── storage.ts             # getPluginStore(id): per-plugin KV in its own IndexedDB DB (dove-plugin-<id>)
-│   ├── cloud-sync/            # ★ First-party plugin: Supabase file + garage sync (Labs panel)
-│   │   ├── index.ts             # Plugin def — contributes a lazy CloudSyncPanel to the Labs slot
+│   ├── cloud-sync/            # ★ First-party plugin: Supabase file + garage sync (Labs panel + per-file toggle)
+│   │   ├── index.ts             # Plugin def — contributes the Labs panel + a FileRow mount (both lazy, cloud-gated)
 │   │   ├── CloudSyncPanel.tsx    # Sign-in + push/pull UI (lazy-loaded)
+│   │   ├── FileSyncToggle.tsx    # Per-file sync toggle, mounted on each file row (off/pending/synced)
+│   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus (pure, tested)
 │   │   ├── syncStores.ts         # Pure config: which IDB stores sync + how they're keyed (testable)
-│   │   ├── syncEngine.ts         # pushAll/pullAll: IDB ↔ sync_records (jsonb) + user-files bucket (blobs)
+│   │   ├── syncEngine.ts         # pushAll (garage + selected files) / pushFile / pullAll: IDB ↔ sync_records + bucket
 │   │   └── cloudClient.ts        # Typed access to sync_records + bucket (escape hatch until types regen)
 │   └── coaching/              # Gitignored private slot (AI coaching submodule)
 ├── types/
@@ -395,6 +397,12 @@ Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
 `setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates` (jsonb
 docs) + `files` (blobs). Video stores are intentionally excluded (size).
 `vehicle-types`/`setup-templates` ride along because setups are template-driven.
+
+Files are **opt-in per file** (`fileSync.ts`): a `FileRow` mount adds a toggle to
+each file-manager row (`off` → `pending` → `synced`), and the selection set lives
+in the plugin's own KV store (`getPluginStore("cloud-sync")`). `pushAll` uploads
+all garage docs but only the *selected* files; `pushFile` handles a single
+toggle. Cloud-only files (pull-per-file) + a section mount are a follow-up.
 
 After a migration, Lovable regenerates `integrations/supabase/types.ts`. Until
 then `cloudClient.ts` accesses the new table/bucket through a narrowly-typed

--- a/src/components/drawer/FilesTab.tsx
+++ b/src/components/drawer/FilesTab.tsx
@@ -9,6 +9,8 @@ const DataloggerDownload = lazy(() =>
   import("@/components/DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
 );
 import { listSessionVideos, deleteSessionVideo, StoredVideoMeta } from "@/lib/videoFileStorage";
+import { PluginMount } from "@/plugins/PluginMount";
+import { MountSlot } from "@/plugins/mounts";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -206,6 +208,10 @@ export function FilesTab({
                   )}
                 </div>
               </button>
+              <PluginMount
+                slot={MountSlot.FileRow}
+                ctx={{ file, metadata: fileMetadataMap.get(file.name) }}
+              />
               <Button
                 variant="ghost"
                 size="icon"
@@ -227,6 +233,11 @@ export function FilesTab({
             </div>
           ))
         )}
+        {/* Plugin-contributed file-manager section (e.g. cloud-only files). */}
+        <PluginMount
+          slot={MountSlot.FileManagerSection}
+          ctx={{ files, onSaveFile }}
+        />
       </div>
 
       {/* Storage Usage */}

--- a/src/plugins/PluginMount.tsx
+++ b/src/plugins/PluginMount.tsx
@@ -1,0 +1,38 @@
+import { Component, Suspense, useMemo, type ReactNode } from "react";
+import { getMounts } from "./mounts";
+
+/** Isolates a single mounted component so a plugin throw can't break core UI. */
+class MountErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+/**
+ * Renders every plugin component mounted at `slot`, passing each the given
+ * context. Renders nothing when no plugin targets the slot, so it's safe to
+ * drop into core UI unconditionally. Each component is error-boundaried and
+ * Suspense-wrapped, so mounts may be `React.lazy`.
+ */
+export function PluginMount<C>({ slot, ctx }: { slot: string; ctx: C }) {
+  const mounts = useMemo(() => getMounts<C>(slot), [slot]);
+  if (mounts.length === 0) return null;
+  return (
+    <>
+      {mounts.map((m) => {
+        const Body = m.component;
+        return (
+          <MountErrorBoundary key={m.id}>
+            <Suspense fallback={null}>
+              <Body ctx={ctx} />
+            </Suspense>
+          </MountErrorBoundary>
+        );
+      })}
+    </>
+  );
+}

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -87,6 +87,48 @@ Contract notes:
   the host's Vite), so an external package adds `react` to its `devDependencies`
   for its own typecheck but does **not** bundle a second copy.
 
+## Inline mounts (`mounts.ts`)
+
+Where a panel is a standalone card, a **mount** injects a raw component into a
+fixed spot in core UI. A plugin contributes a `PluginMountDef` to `MOUNTS_POINT`,
+targeting a `MountSlot`; the host renders it via `<PluginMount slot ctx={…}>`,
+passing a typed context as a single `ctx` prop. The component is error-boundaried
+and `Suspense`-wrapped, so it can be `React.lazy`.
+
+```tsx
+import { lazy } from "react";
+import { MOUNTS_POINT, MountSlot, type PluginMountDef, type FileRowContext } from "@/plugins/mounts";
+
+const FileBadge = lazy(() => import("./FileBadge")); // ({ ctx }: { ctx: FileRowContext }) => …
+
+ctx.registry.contribute(MOUNTS_POINT, {
+  id: "my-file-badge",
+  slot: MountSlot.FileRow,            // rendered once per file row
+  component: FileBadge,
+} satisfies PluginMountDef<FileRowContext>);
+```
+
+Today's slots: `MountSlot.FileRow` (ctx = a file + its metadata) and
+`MountSlot.FileManagerSection` (ctx = the whole file list). `cloud-sync`'s
+per-file toggle is a `FileRow` mount. A slot with no contributions renders
+nothing, so hosts add `<PluginMount>` unconditionally. New slots are just new
+strings — no framework change.
+
+## Plugin storage (`storage.ts`)
+
+Each plugin gets a private key-value store in its **own** IndexedDB database
+(`dove-plugin-<id>`) — decoupled from the core schema, so persisting plugin
+state never touches `dbUtils`/`DB_VERSION`. Available as `ctx.storage` in
+`setup`, or `getPluginStore(id)` from anywhere (e.g. a panel/mount component):
+
+```ts
+const store = getPluginStore("my-plugin");
+await store.set("prefs", { theme: "neon" });
+const prefs = await store.get<{ theme: string }>("prefs");
+```
+
+`cloud-sync` uses it to hold the opt-in set of files selected for sync.
+
 ## The AI coach as a public npm package
 
 The coach lives in its own repo and is published to the **public npm registry**

--- a/src/plugins/cloud-sync/CloudFilesSection.tsx
+++ b/src/plugins/cloud-sync/CloudFilesSection.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { CloudDownload, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import type { FileManagerSectionContext } from "@/plugins/mounts";
+import { cloudOnlyNames, markPushed } from "./fileSync";
+import { listCloudFiles, downloadCloudFile, type CloudFile } from "./syncEngine";
+
+/**
+ * Lists files that exist in the user's cloud but not on this device, each with a
+ * per-file pull. Pulled files persist via `ctx.onSaveFile` (which refreshes the
+ * file list), so they move out of this section and into the list automatically.
+ */
+export default function CloudFilesSection({ ctx }: { ctx: FileManagerSectionContext }) {
+  const { user } = useAuth();
+  const online = useOnlineStatus();
+  const [cloud, setCloud] = useState<CloudFile[] | null>(null);
+  const [pulling, setPulling] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user || !online) {
+      setCloud(null);
+      return;
+    }
+    let active = true;
+    listCloudFiles(user.id)
+      .then((c) => active && setCloud(c))
+      .catch(() => active && setCloud([]));
+    return () => {
+      active = false;
+    };
+  }, [user, online]);
+
+  const localNames = useMemo(() => ctx.files.map((f) => f.name), [ctx.files]);
+  const onlyInCloud = useMemo(
+    () => cloudOnlyNames((cloud ?? []).map((c) => c.name), localNames),
+    [cloud, localNames],
+  );
+
+  if (!user || onlyInCloud.length === 0) return null;
+
+  const pull = async (name: string) => {
+    if (pulling) return;
+    setPulling(name);
+    try {
+      const blob = await downloadCloudFile(user.id, name);
+      if (!blob) throw new Error("Download returned no data");
+      await ctx.onSaveFile(name, blob);
+      await markPushed(name);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : `Failed to pull ${name}`);
+    } finally {
+      setPulling(null);
+    }
+  };
+
+  return (
+    <div className="mt-2 pt-2 border-t border-border space-y-1">
+      <p className="px-1 text-xs text-muted-foreground">Available in cloud</p>
+      {onlyInCloud.map((name) => (
+        <div key={name} className="flex items-center gap-2 p-2 rounded-md text-muted-foreground">
+          <span className="flex-1 min-w-0 text-sm font-mono truncate">{name}</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 opacity-70 hover:opacity-100"
+            onClick={() => pull(name)}
+            disabled={pulling !== null}
+            title="Download from cloud"
+          >
+            {pulling === name ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <CloudDownload className="w-3.5 h-3.5" />}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/CloudSyncPanel.tsx
+++ b/src/plugins/cloud-sync/CloudSyncPanel.tsx
@@ -104,7 +104,7 @@ export default function CloudSyncPanel() {
       </div>
 
       <p className="text-xs text-muted-foreground">
-        Push uploads this device's files and garage data. Pull brings your cloud copy down. Conflicts resolve in the direction you choose; nothing is deleted.
+        Push uploads your selected files (toggle them in the file manager) and your garage data. Pull brings your cloud copy down. Conflicts resolve in the direction you choose; nothing is deleted.
       </p>
     </div>
   );

--- a/src/plugins/cloud-sync/FileSyncToggle.tsx
+++ b/src/plugins/cloud-sync/FileSyncToggle.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { Cloud, CloudOff, CloudUpload, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import type { FileRowContext } from "@/plugins/mounts";
+import { fileSyncStatus, getFileRecord, selectFile, unselectFile, type FileSyncState } from "./fileSync";
+import { pushFile } from "./syncEngine";
+
+const TITLES: Record<FileSyncState, string> = {
+  off: "Sync this file to the cloud",
+  pending: "Selected — uploads once you're signed in and online",
+  synced: "Synced — click to stop syncing (cloud copy is kept)",
+};
+
+export default function FileSyncToggle({ ctx }: { ctx: FileRowContext }) {
+  const { user } = useAuth();
+  const online = useOnlineStatus();
+  const name = ctx.file.name;
+  const [state, setState] = useState<FileSyncState>("off");
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    getFileRecord(name).then((r) => active && setState(fileSyncStatus(r)));
+    return () => {
+      active = false;
+    };
+  }, [name]);
+
+  const toggle = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      if (state === "off") {
+        await selectFile(name);
+        if (user && online) {
+          await pushFile(user.id, name);
+          setState("synced");
+        } else {
+          setState("pending"); // intent recorded; uploads later
+        }
+      } else {
+        await unselectFile(name);
+        setState("off");
+      }
+    } catch {
+      setState("pending"); // selected, but the upload failed — retry later
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const Icon = busy ? Loader2 : state === "synced" ? Cloud : state === "pending" ? CloudUpload : CloudOff;
+  const color = state === "synced" ? "text-primary" : "text-muted-foreground";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`h-7 w-7 shrink-0 opacity-70 hover:opacity-100 ${color}`}
+      onClick={toggle}
+      disabled={busy}
+      title={TITLES[state]}
+      aria-pressed={state !== "off"}
+    >
+      <Icon className={`w-3.5 h-3.5 ${busy ? "animate-spin" : ""}`} />
+    </Button>
+  );
+}

--- a/src/plugins/cloud-sync/fileSync.test.ts
+++ b/src/plugins/cloud-sync/fileSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fileSyncStatus } from "./fileSync";
+import { fileSyncStatus, cloudOnlyNames } from "./fileSync";
 
 describe("fileSyncStatus", () => {
   it("is 'off' when there is no record (not selected)", () => {
@@ -12,5 +12,15 @@ describe("fileSyncStatus", () => {
 
   it("is 'synced' once a push timestamp is recorded", () => {
     expect(fileSyncStatus({ pushedAt: Date.now() })).toBe("synced");
+  });
+});
+
+describe("cloudOnlyNames", () => {
+  it("returns cloud files not present locally", () => {
+    expect(cloudOnlyNames(["a", "b", "c"], ["b"])).toEqual(["a", "c"]);
+  });
+
+  it("returns nothing when every cloud file is already local", () => {
+    expect(cloudOnlyNames(["a", "b"], ["a", "b", "x"])).toEqual([]);
   });
 });

--- a/src/plugins/cloud-sync/fileSync.test.ts
+++ b/src/plugins/cloud-sync/fileSync.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { fileSyncStatus } from "./fileSync";
+
+describe("fileSyncStatus", () => {
+  it("is 'off' when there is no record (not selected)", () => {
+    expect(fileSyncStatus(undefined)).toBe("off");
+  });
+
+  it("is 'pending' when selected but not yet uploaded", () => {
+    expect(fileSyncStatus({})).toBe("pending");
+  });
+
+  it("is 'synced' once a push timestamp is recorded", () => {
+    expect(fileSyncStatus({ pushedAt: Date.now() })).toBe("synced");
+  });
+});

--- a/src/plugins/cloud-sync/fileSync.ts
+++ b/src/plugins/cloud-sync/fileSync.ts
@@ -48,3 +48,9 @@ export async function listSelectedFiles(): Promise<string[]> {
   const keys = await store.keys();
   return keys.filter((k) => k.startsWith(PREFIX)).map((k) => k.slice(PREFIX.length));
 }
+
+/** Cloud file names that aren't present locally (i.e. pullable). Pure. */
+export function cloudOnlyNames(cloudNames: string[], localNames: Iterable<string>): string[] {
+  const local = new Set(localNames);
+  return cloudNames.filter((n) => !local.has(n));
+}

--- a/src/plugins/cloud-sync/fileSync.ts
+++ b/src/plugins/cloud-sync/fileSync.ts
@@ -1,0 +1,50 @@
+// Per-file sync selection state (opt-in, default off).
+//
+// Which files the user has chosen to sync lives in this plugin's own KV store
+// (getPluginStore), keyed `file:<name>`. A record's presence means "selected";
+// `pushedAt` means it has been uploaded at least once. Absence means "not
+// synced". File blobs are immutable (same name = same bytes), so once pushed a
+// file stays synced — no "modified" state needed for the blob itself.
+
+import { getPluginStore } from "@/plugins/storage";
+
+export type FileSyncState = "off" | "pending" | "synced";
+
+export interface FileSyncRecord {
+  pushedAt?: number;
+}
+
+const store = getPluginStore("cloud-sync");
+const PREFIX = "file:";
+const recordKey = (name: string) => `${PREFIX}${name}`;
+
+/** Derive the UI state from a stored record. Pure — unit-tested. */
+export function fileSyncStatus(rec: FileSyncRecord | undefined): FileSyncState {
+  if (!rec) return "off";
+  return rec.pushedAt ? "synced" : "pending";
+}
+
+export function getFileRecord(name: string): Promise<FileSyncRecord | undefined> {
+  return store.get<FileSyncRecord>(recordKey(name));
+}
+
+/** Mark a file as selected for sync (not yet uploaded). */
+export function selectFile(name: string): Promise<void> {
+  return store.set<FileSyncRecord>(recordKey(name), {});
+}
+
+/** Record that a file has been uploaded to the cloud. */
+export function markPushed(name: string): Promise<void> {
+  return store.set<FileSyncRecord>(recordKey(name), { pushedAt: Date.now() });
+}
+
+/** Stop syncing a file. Additive: the cloud copy is left in place. */
+export function unselectFile(name: string): Promise<void> {
+  return store.delete(recordKey(name));
+}
+
+/** File names currently selected for sync. */
+export async function listSelectedFiles(): Promise<string[]> {
+  const keys = await store.keys();
+  return keys.filter((k) => k.startsWith(PREFIX)).map((k) => k.slice(PREFIX.length));
+}

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -2,15 +2,19 @@ import { lazy } from "react";
 import { Cloud } from "lucide-react";
 import type { DataViewerPlugin } from "@/plugins/types";
 import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
-import { MOUNTS_POINT, MountSlot, type PluginMountDef, type FileRowContext } from "@/plugins/mounts";
+import {
+  MOUNTS_POINT, MountSlot,
+  type PluginMountDef, type FileRowContext, type FileManagerSectionContext,
+} from "@/plugins/mounts";
 
 // The panel pulls in the Supabase sync engine + storage modules, so it's lazy:
 // the chunk loads only when the Labs tab is opened, keeping the initial bundle
 // lean (see Bundle Splitting in CLAUDE.md).
 const CloudSyncPanel = lazy(() => import("./CloudSyncPanel"));
-// Likewise the per-file toggle: lazy so the file-manager drawer doesn't pull the
-// sync engine onto its chunk until a row actually renders the control.
+// Likewise the per-file toggle + cloud-only list: lazy so the file-manager
+// drawer doesn't pull the sync engine onto its chunk until they render.
 const FileSyncToggle = lazy(() => import("./FileSyncToggle"));
+const CloudFilesSection = lazy(() => import("./CloudFilesSection"));
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 
@@ -40,6 +44,15 @@ const plugin: DataViewerPlugin = {
       order: 0,
       component: FileSyncToggle,
     } satisfies PluginMountDef<FileRowContext>);
+
+    // Cloud-only files (in the cloud, not on this device) listed under the file
+    // list, each with a per-file pull.
+    ctx.registry.contribute(MOUNTS_POINT, {
+      id: "cloud-sync-cloud-files",
+      slot: MountSlot.FileManagerSection,
+      order: 0,
+      component: CloudFilesSection,
+    } satisfies PluginMountDef<FileManagerSectionContext>);
   },
 };
 

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -2,11 +2,15 @@ import { lazy } from "react";
 import { Cloud } from "lucide-react";
 import type { DataViewerPlugin } from "@/plugins/types";
 import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
+import { MOUNTS_POINT, MountSlot, type PluginMountDef, type FileRowContext } from "@/plugins/mounts";
 
 // The panel pulls in the Supabase sync engine + storage modules, so it's lazy:
 // the chunk loads only when the Labs tab is opened, keeping the initial bundle
 // lean (see Bundle Splitting in CLAUDE.md).
 const CloudSyncPanel = lazy(() => import("./CloudSyncPanel"));
+// Likewise the per-file toggle: lazy so the file-manager drawer doesn't pull the
+// sync engine onto its chunk until a row actually renders the control.
+const FileSyncToggle = lazy(() => import("./FileSyncToggle"));
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 
@@ -28,6 +32,14 @@ const plugin: DataViewerPlugin = {
       component: CloudSyncPanel,
     };
     ctx.registry.contribute(PANELS_POINT, panel);
+
+    // Per-file sync toggle injected into each file-manager row.
+    ctx.registry.contribute(MOUNTS_POINT, {
+      id: "cloud-sync-file-toggle",
+      slot: MountSlot.FileRow,
+      order: 0,
+      component: FileSyncToggle,
+    } satisfies PluginMountDef<FileRowContext>);
   },
 };
 

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -55,6 +55,31 @@ export async function pushFile(userId: string, name: string): Promise<void> {
   await markPushed(name);
 }
 
+export interface CloudFile {
+  name: string;
+  size?: number;
+}
+
+/** List the files this user has in the cloud (the file index rows). */
+export async function listCloudFiles(userId: string): Promise<CloudFile[]> {
+  const { data, error } = await syncRecords()
+    .select("record_key,data")
+    .eq("user_id", userId)
+    .eq("store", FILE_STORE);
+  if (error) throw new Error(`Failed to list cloud files: ${error.message}`);
+  return ((data ?? []) as { record_key: string; data: { size?: number } | null }[]).map((r) => ({
+    name: r.record_key,
+    size: r.data?.size,
+  }));
+}
+
+/** Download a single file blob from the cloud (does not persist it locally). */
+export async function downloadCloudFile(userId: string, name: string): Promise<Blob | null> {
+  const { data, error } = await userFiles().download(blobPath(userId, name));
+  if (error || !data) return null;
+  return data;
+}
+
 /**
  * Mirror local data up to the cloud: all structured (garage) records, plus only
  * the files the user has selected for sync.

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -12,9 +12,10 @@
 // can't live in jsonb, so they round-trip through the Storage bucket instead.
 
 import { withReadTransaction, withWriteTransaction } from "@/lib/dbUtils";
-import { getFile, listFiles, saveFile } from "@/lib/fileStorage";
+import { getFile, saveFile } from "@/lib/fileStorage";
 import { syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
+import { listSelectedFiles, markPushed } from "./fileSync";
 
 export type { SyncSummary };
 
@@ -31,7 +32,33 @@ async function writeOne(store: string, record: unknown): Promise<void> {
   await withWriteTransaction(store, (s) => s.put(record as Record<string, unknown>));
 }
 
-/** Mirror all local data (structured records + file blobs) up to the cloud. */
+/** Upload one local file blob + its index row. Returns false if not stored locally. */
+async function uploadBlob(userId: string, name: string): Promise<boolean> {
+  const blob = await getFile(name);
+  if (!blob) return false;
+  const { error: upErr } = await userFiles().upload(blobPath(userId, name), blob, {
+    upsert: true,
+    contentType: blob.type || "application/octet-stream",
+  });
+  if (upErr) throw new Error(`Failed to upload ${name}: ${upErr.message}`);
+  const { error } = await syncRecords().upsert(
+    [{ user_id: userId, store: FILE_STORE, record_key: name, data: { size: blob.size } }],
+    { onConflict: "user_id,store,record_key" },
+  );
+  if (error) throw new Error(`Failed to index ${name}: ${error.message}`);
+  return true;
+}
+
+/** Push a single selected file and mark it synced. Throws if not stored locally. */
+export async function pushFile(userId: string, name: string): Promise<void> {
+  if (!(await uploadBlob(userId, name))) throw new Error(`File not found locally: ${name}`);
+  await markPushed(name);
+}
+
+/**
+ * Mirror local data up to the cloud: all structured (garage) records, plus only
+ * the files the user has selected for sync.
+ */
 export async function pushAll(userId: string): Promise<SyncSummary> {
   const rows: SyncRecordRow[] = [];
   for (const store of DOC_STORES) {
@@ -44,28 +71,15 @@ export async function pushAll(userId: string): Promise<SyncSummary> {
     if (error) throw new Error(`Failed to push records: ${error.message}`);
   }
 
-  const fileRows: SyncRecordRow[] = [];
-  for (const file of await listFiles()) {
-    const blob = await getFile(file.name);
-    if (!blob) continue;
-    const { error } = await userFiles().upload(blobPath(userId, file.name), blob, {
-      upsert: true,
-      contentType: blob.type || "application/octet-stream",
-    });
-    if (error) throw new Error(`Failed to upload ${file.name}: ${error.message}`);
-    fileRows.push({
-      user_id: userId,
-      store: FILE_STORE,
-      record_key: file.name,
-      data: { size: file.size, savedAt: file.savedAt },
-    });
-  }
-  if (fileRows.length) {
-    const { error } = await syncRecords().upsert(fileRows, { onConflict: "user_id,store,record_key" });
-    if (error) throw new Error(`Failed to push file index: ${error.message}`);
+  let files = 0;
+  for (const name of await listSelectedFiles()) {
+    if (await uploadBlob(userId, name)) {
+      await markPushed(name);
+      files++;
+    }
   }
 
-  return { records: rows.length, files: fileRows.length };
+  return { records: rows.length, files };
 }
 
 /** Bring the cloud copy down into local IndexedDB. */
@@ -83,6 +97,7 @@ export async function pullAll(userId: string): Promise<SyncSummary> {
       const { data: blob, error: dlError } = await userFiles().download(blobPath(userId, row.record_key));
       if (dlError || !blob) continue;
       await saveFile(row.record_key, blob);
+      await markPushed(row.record_key); // pulled files are now synced locally
       files++;
     } else if ((DOC_STORES as readonly string[]).includes(row.store)) {
       await writeOne(row.store, row.data);

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,5 +1,6 @@
 import externalPlugins from "virtual:external-plugins";
 import { pluginRegistry } from "./registry";
+import { getPluginStore } from "./storage";
 import type { DataViewerPlugin } from "./types";
 
 let initialized = false;
@@ -29,7 +30,7 @@ export function initPlugins(): void {
   }
 
   for (const plugin of pluginRegistry.list()) {
-    void plugin.setup?.({ registry: pluginRegistry });
+    void plugin.setup?.({ registry: pluginRegistry, storage: getPluginStore(plugin.id) });
   }
 
   if (import.meta.env.DEV) {

--- a/src/plugins/mounts.test.ts
+++ b/src/plugins/mounts.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { pluginRegistry } from "./registry";
+import { MOUNTS_POINT, getMounts, type PluginMountDef } from "./mounts";
+
+const noop: PluginMountDef["component"] = () => null;
+
+function mount(id: string, slot: string, order?: number): PluginMountDef {
+  return { id, slot, order, component: noop };
+}
+
+describe("getMounts", () => {
+  it("returns only mounts contributed to the requested slot", () => {
+    pluginRegistry.contribute(MOUNTS_POINT, mount("a", "slot-x"));
+    pluginRegistry.contribute(MOUNTS_POINT, mount("b", "slot-y"));
+    expect(getMounts("slot-x").map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("sorts by order ascending, missing order treated as 0", () => {
+    pluginRegistry.contribute(MOUNTS_POINT, mount("late", "slot-ord", 5));
+    pluginRegistry.contribute(MOUNTS_POINT, mount("mid", "slot-ord"));
+    pluginRegistry.contribute(MOUNTS_POINT, mount("early", "slot-ord", -1));
+    expect(getMounts("slot-ord").map((m) => m.id)).toEqual(["early", "mid", "late"]);
+  });
+
+  it("returns an empty array for a slot with no mounts", () => {
+    expect(getMounts("slot-empty")).toEqual([]);
+  });
+});

--- a/src/plugins/mounts.ts
+++ b/src/plugins/mounts.ts
@@ -1,0 +1,56 @@
+// Inline UI mount points.
+//
+// Where `panels.ts` lets a plugin contribute a standalone titled card to a slot
+// (the Labs tab), a *mount* lets a plugin inject a raw component into a fixed
+// spot in core UI — e.g. a control on every file row, or a section under the
+// file list. Each mount targets a named slot and receives a typed context.
+//
+// All mounts share one registry point (`MOUNTS_POINT`), discriminated by `slot`,
+// so adding a new mount location is just a new string — no registry change.
+
+import type { ComponentType } from "react";
+import type { FileEntry, FileMetadata } from "@/lib/fileStorage";
+import { pluginRegistry } from "./registry";
+
+export const MOUNTS_POINT = "ui:mounts";
+
+/** Known inline mount locations in core UI. */
+export const MountSlot = {
+  /** Rendered once per file row in the file manager. Context: that file. */
+  FileRow: "file-row",
+  /** Rendered once below the file list. Context: the whole list. */
+  FileManagerSection: "file-manager-section",
+} as const;
+export type MountSlot = (typeof MountSlot)[keyof typeof MountSlot];
+
+/** Context handed to a `MountSlot.FileRow` component. */
+export interface FileRowContext {
+  file: FileEntry;
+  metadata?: FileMetadata;
+}
+
+/** Context handed to a `MountSlot.FileManagerSection` component. */
+export interface FileManagerSectionContext {
+  files: FileEntry[];
+  /** Persist a (e.g. cloud-pulled) blob into local storage. */
+  onSaveFile: (name: string, blob: Blob) => Promise<void>;
+}
+
+/**
+ * A mount descriptor. The component receives its slot's context as a single
+ * `ctx` prop (avoids generic prop-spreading; keeps the contract explicit).
+ */
+export interface PluginMountDef<C = unknown> {
+  id: string;
+  slot: string;
+  order?: number;
+  component: ComponentType<{ ctx: C }>;
+}
+
+/** All mounts contributed to `slot`, sorted by `order` then registration. */
+export function getMounts<C = unknown>(slot: string): PluginMountDef<C>[] {
+  return pluginRegistry
+    .getContributions<PluginMountDef<C>>(MOUNTS_POINT)
+    .filter((m) => m.slot === slot)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -52,7 +52,14 @@ describe("pluginRegistry", () => {
       received = ctx.registry;
     });
     pluginRegistry.register(p);
-    void pluginRegistry.get("with-setup")?.setup?.({ registry: pluginRegistry });
+    const storage = {
+      get: async () => undefined,
+      set: async () => undefined,
+      delete: async () => undefined,
+      getAll: async () => [],
+      keys: async () => [],
+    };
+    void pluginRegistry.get("with-setup")?.setup?.({ registry: pluginRegistry, storage });
     expect(received).toBe(pluginRegistry);
   });
 });

--- a/src/plugins/storage.ts
+++ b/src/plugins/storage.ts
@@ -1,0 +1,70 @@
+// Per-plugin persistent storage.
+//
+// Each plugin gets its own IndexedDB database (`dove-plugin-<id>`) with a single
+// key-value object store. This keeps plugin data fully decoupled from the core
+// schema in `dbUtils.ts` — plugins never bump the app's DB_VERSION or register
+// stores there, so a new plugin's storage needs is zero core changes.
+
+import type { PluginStore } from "./types";
+
+const DB_PREFIX = "dove-plugin-";
+const KV_STORE = "kv";
+
+// Plugin ids become part of an IndexedDB database name; keep them tame.
+function assertSafeId(pluginId: string): void {
+  if (!/^[a-z0-9][a-z0-9_-]*$/i.test(pluginId)) {
+    throw new Error(`Invalid plugin id for storage: "${pluginId}"`);
+  }
+}
+
+function openDb(pluginId: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(`${DB_PREFIX}${pluginId}`, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(KV_STORE)) db.createObjectStore(KV_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function withStore<T>(
+  pluginId: string,
+  mode: IDBTransactionMode,
+  op: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  const db = await openDb(pluginId);
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(KV_STORE, mode);
+      const req = op(tx.objectStore(KV_STORE));
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+const stores = new Map<string, PluginStore>();
+
+/** Get the key-value store for a plugin (memoized per id). */
+export function getPluginStore(pluginId: string): PluginStore {
+  assertSafeId(pluginId);
+  const cached = stores.get(pluginId);
+  if (cached) return cached;
+
+  const store: PluginStore = {
+    get: <T>(key: string) => withStore<T>(pluginId, "readonly", (s) => s.get(key) as IDBRequest<T>),
+    set: (key, value) =>
+      withStore<IDBValidKey>(pluginId, "readwrite", (s) => s.put(value, key)).then(() => undefined),
+    delete: (key) =>
+      withStore<undefined>(pluginId, "readwrite", (s) => s.delete(key) as IDBRequest<undefined>).then(() => undefined),
+    getAll: <T>() => withStore<T[]>(pluginId, "readonly", (s) => s.getAll() as IDBRequest<T[]>),
+    keys: () =>
+      withStore<IDBValidKey[]>(pluginId, "readonly", (s) => s.getAllKeys()).then((ks) => ks.map(String)),
+  };
+  stores.set(pluginId, store);
+  return store;
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -9,6 +9,21 @@
 export interface PluginContext {
   /** The shared registry. Plugins read/write extension points through this. */
   registry: PluginRegistry;
+  /** Persistent key-value storage private to this plugin (own IndexedDB DB). */
+  storage: PluginStore;
+}
+
+/**
+ * Schema-less key-value storage scoped to one plugin. Backed by the plugin's
+ * own IndexedDB database, so plugins never touch the core schema/version.
+ * Values must be structured-cloneable.
+ */
+export interface PluginStore {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<void>;
+  getAll<T>(): Promise<T[]>;
+  keys(): Promise<string[]>;
 }
 
 export interface DataViewerPlugin {


### PR DESCRIPTION
## Summary

Lets users **individually choose which files sync to the cloud** from the file manager (modeled on the device track/course sync UX), and adds the plugin-framework primitives that make it possible.

Per-file sync is **opt-in, off by default**; gated by `VITE_ENABLE_CLOUD` like the rest of cloud sync; fully offline-first (toggling offline records intent and uploads on reconnect).

## Phase A — framework primitives (no behavior change on their own)

- **Plugin storage hook** (`plugins/storage.ts`): `getPluginStore(id)` gives a plugin a schema-less KV store in its **own** IndexedDB DB (`dove-plugin-<id>`), fully decoupled from core `dbUtils`/`DB_VERSION`. Also surfaced as `ctx.storage`.
- **Inline mount framework** (`plugins/mounts.ts` + `PluginMount.tsx`): sibling to the panel framework. Plugins contribute a `PluginMountDef` to a `MountSlot`; `<PluginMount slot ctx>` renders them error-boundaried + `Suspense`-wrapped, or **nothing** when no plugin targets the slot. `FilesTab` exposes `MountSlot.FileRow` (per file) and `MountSlot.FileManagerSection` (under the list).

## Phase B — per-file cloud sync

- `cloud-sync/fileSync.ts`: per-file selection state in the plugin's KV store + a pure, tested `fileSyncStatus` (`off` → `pending` → `synced`).
- `cloud-sync/FileSyncToggle.tsx`: a `FileRow` mount — the per-file toggle (lazy chunk, ~1.3 kB).
- `syncEngine`: `pushAll` uploads all garage docs but only the **selected** files; new `pushFile` for a single toggle; pulled files are marked synced.

## Phase C — cloud-only files inline

- `cloud-sync/CloudFilesSection.tsx`: a `FileManagerSection` mount listing files that are in your cloud but not on this device, each with a one-click **pull**. Pulling persists via `ctx.onSaveFile` (which refreshes the list), so the file moves into the list automatically.
- `syncEngine`: `listCloudFiles` + `downloadCloudFile`; `cloudOnlyNames` pure helper (tested).
- `CloudSyncPanel` copy updated to reflect selective push.

## Deferred (follow-ups)
`modified` detection (file blobs are immutable so this is low-value for files) and a "sync all / select all" convenience.

## Docs
`plugins/README.md` (storage + inline-mount authoring sections), `CLAUDE.md`, `CHANGELOG.md`.

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (303 passing), `npm run build` all green locally
- [x] New unit tests: `getMounts` selector; `fileSyncStatus` states; `cloudOnlyNames`
- [ ] Manual (in a `VITE_ENABLE_CLOUD=true` build): toggle a file on while signed in → uploads + shows synced; toggle while offline → pending, uploads on reconnect; toggle off → stops syncing (cloud copy kept); a file synced from another device appears under "Available in cloud" and pulls into the list in one click

https://claude.ai/code/session_01QF56Xjp5ZMgXrqfTWD14Le