### PR TITLE
Add dedicated AI Coach tab (PanelSlot.Coach)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin UI panel framework: plugins can contribute self-contained panels to a
   named slot, starting with the Labs tab. The tab now appears automatically when
   a plugin contributes a panel, and each panel is isolated by an error boundary.
+- Dedicated AI Coach tab: a new top-level view (`PanelSlot.Coach`) that hosts the
+  coaching plugin's session-debrief panels. Like Labs, it is self-gating — the
+  tab only appears when the coach plugin is installed and contributes a panel.
 - Cloud Sync (first-party plugin, in the Labs tab): sign in to back up and sync
   your session files and garage data (vehicles, setups, notes, graph prefs) to
   the cloud and pull them onto another device. Manual push/pull; data is private

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ src/
 ├── components/
 │   ├── ui/                # shadcn/ui primitives (button, dialog, tabs, etc.)
 │   ├── admin/             # Admin tabs: TracksTab, CoursesTab, SubmissionsTab, BannedIpsTab, ToolsTab, MessagesTab
-│   ├── tabs/              # Main view tabs: GraphViewTab, RaceLineTab, LapTimesTab, LabsTab
+│   ├── tabs/              # Main view tabs: GraphViewTab, RaceLineTab, LapTimesTab, LabsTab, CoachTab
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, InfoBox
 │   ├── drawer/            # File manager drawer tabs: FilesTab, KartsTab, NotesTab, SetupsTab, DeviceSettingsTab, DeviceTracksTab
 │   ├── track-editor/      # Track editor sub-components
@@ -257,10 +257,13 @@ A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 
 **UI panels:** the first concrete extension point. A plugin contributes
 `PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
-The only slot today is `PanelSlot.Labs` — `LabsTab.tsx` renders contributed
-panels via `PluginPanelHost`, and a labs-slot panel makes the Labs tab appear
-automatically even when the experimental `enableLabs` setting is off (`Index.tsx`
-computes `hasLabsPanels`). New slots are just new strings — no framework change.
+Two slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`) and
+`PanelSlot.Coach` (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home
+for the `@perchwerks/eye-in-the-sky` coaching plugin). Both render contributed
+panels via `PluginPanelHost` and are **self-gating**: `Index.tsx` computes
+`hasLabsPanels`/`showCoach` from `getPanelsForSlot`, so a tab appears only when a
+plugin contributes a panel to it (Labs additionally shows when the experimental
+`enableLabs` setting is on). New slots are just new strings — no framework change.
 `PluginPanelHost` wraps each panel in an error boundary **and** a `Suspense`
 boundary, so panel components can be `React.lazy` (as `cloud-sync` is).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "^0.0.4"
+        "@perchwerks/eye-in-the-sky": "^0.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.0.4.tgz",
-      "integrity": "sha512-YefiNWXJ/syA1ADI38VUWtFqpGAxBigJMsKT0nuO8NNQN1AbvHZ9Oy9BBorl+4l+QWWO8pCir0OGG2Mi2HMsDA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.1.0.tgz",
+      "integrity": "sha512-HFsl3BEhCQXuf9WUTJVRPEr50HIMNNj4+CJ16OwAAdXjDG/Wntz4aEYP8sxKvScozzswA6MZrAsvIrjMHMcAVg==",
       "license": "GPL-3.0-or-later",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "^0.0.4"
+    "@perchwerks/eye-in-the-sky": "^0.1.0"
   }
 }

--- a/src/components/tabs/CoachTab.tsx
+++ b/src/components/tabs/CoachTab.tsx
@@ -1,0 +1,37 @@
+import { memo } from "react";
+import { Gauge } from "lucide-react";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { useSettingsContext } from "@/contexts/SettingsContext";
+import { PluginPanelHost } from "@/plugins/PluginPanelHost";
+import { PanelSlot } from "@/plugins/panels";
+
+export const CoachTab = memo(function CoachTab() {
+  const { data, laps, selectedLapNumber, course } = useSessionContext();
+  const { useKph } = useSettingsContext();
+
+  return (
+    <PluginPanelHost
+      slot={PanelSlot.Coach}
+      data={data}
+      laps={laps}
+      selectedLapNumber={selectedLapNumber}
+      course={course}
+      useKph={useKph}
+      fallback={<CoachEmpty />}
+    />
+  );
+});
+
+function CoachEmpty() {
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="max-w-sm space-y-5 text-center px-4">
+        <Gauge className="w-10 h-10 text-muted-foreground/40 mx-auto" />
+        <p className="text-sm font-medium text-foreground">AI Coach</p>
+        <p className="text-xs text-muted-foreground">
+          The coaching plugin isn’t loaded in this build.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,9 @@ const GraphViewTab = lazy(() =>
 const LabsTab = lazy(() =>
   import("@/components/tabs/LabsTab").then((m) => ({ default: m.LabsTab })),
 );
+const CoachTab = lazy(() =>
+  import("@/components/tabs/CoachTab").then((m) => ({ default: m.CoachTab })),
+);
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SettingsModal } from "@/components/SettingsModal";
 // FileManagerDrawer is a slide-out that only opens on user click. Lazy-loading
@@ -46,7 +49,7 @@ import { DeviceProvider } from "@/contexts/DeviceContext";
 import { SessionProvider, type SessionContextValue } from "@/contexts/SessionContext";
 
 
-type TopPanelView = "raceline" | "laptable" | "graphview" | "labs";
+type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
@@ -116,6 +119,9 @@ export default function Index() {
   // has real content — surface it even when the experimental setting is off.
   const hasLabsPanels = useMemo(() => getPanelsForSlot(PanelSlot.Labs).length > 0, []);
   const showLabs = settings.enableLabs || hasLabsPanels;
+  // The Coach tab is self-gating: it appears only when a plugin contributes a
+  // panel to the Coach slot (i.e. the coach package is installed).
+  const showCoach = useMemo(() => getPanelsForSlot(PanelSlot.Coach).length > 0, []);
 
   // Video sync for Labs tab
   const videoSync = useVideoSync({
@@ -387,7 +393,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -396,6 +402,7 @@ export default function Index() {
           <Suspense fallback={null}>
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "labs" && showLabs && <LabsTab />}
+            {topPanelView === "coach" && showCoach && <CoachTab />}
           </Suspense>
         </div>
       </main>
@@ -420,13 +427,14 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
   showOverlays: boolean;
   onToggleOverlays: () => void;
   showLabs: boolean;
+  showCoach: boolean;
 }) {
   const tabClass = (view: TopPanelView) =>
     `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
@@ -452,6 +460,11 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
       {showLabs && (
         <button onClick={() => setTopPanelView("labs")} className={tabClass("labs")}>
           <FlaskConical className="w-4 h-4" /> <span className="hidden sm:inline">Labs</span>
+        </button>
+      )}
+      {showCoach && (
+        <button onClick={() => setTopPanelView("coach")} className={tabClass("coach")}>
+          <Gauge className="w-4 h-4" /> <span className="hidden sm:inline">Coach</span>
         </button>
       )}
       {topPanelView === "raceline" && (

--- a/src/plugins/panels.test.ts
+++ b/src/plugins/panels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { pluginRegistry } from "./registry";
-import { PANELS_POINT, getPanelsForSlot, type PluginPanel } from "./panels";
+import { PANELS_POINT, PanelSlot, getPanelsForSlot, type PluginPanel } from "./panels";
 
 const noopComponent: PluginPanel["component"] = () => null;
 
@@ -30,5 +30,13 @@ describe("getPanelsForSlot", () => {
 
   it("returns an empty array for a slot with no contributions", () => {
     expect(getPanelsForSlot("slot-empty")).toEqual([]);
+  });
+
+  it("keeps the Coach and Labs slots separate", () => {
+    pluginRegistry.contribute(PANELS_POINT, panel("coach-panel", PanelSlot.Coach));
+    pluginRegistry.contribute(PANELS_POINT, panel("labs-panel", PanelSlot.Labs));
+
+    expect(getPanelsForSlot(PanelSlot.Coach).map((p) => p.id)).toEqual(["coach-panel"]);
+    expect(getPanelsForSlot(PanelSlot.Labs).map((p) => p.id)).toEqual(["labs-panel"]);
   });
 });

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -20,6 +20,8 @@ export const PANELS_POINT = "ui:panels";
 export const PanelSlot = {
   /** The Labs tab in the main view. */
   Labs: "labs",
+  /** The dedicated AI Coach tab in the main view. */
+  Coach: "coach",
 } as const;
 export type PanelSlot = (typeof PanelSlot)[keyof typeof PanelSlot];
 


### PR DESCRIPTION
## Summary

Adds the host-side home for the **Eye in the Sky** AI coach: a dedicated **Coach
tab**. This is the base PR for the coaching work — we'll keep adding to it until a
working base is done.

- New `PanelSlot.Coach` + lazy-loaded `CoachTab`, rendered via the existing
  `PluginPanelHost` (titled cards, per-panel error boundary, Suspense).
- **Self-gating** like the Labs tab: the tab only appears when a plugin
  contributes a `Coach`-slot panel (`Index.tsx` computes `showCoach` from
  `getPanelsForSlot`). Builds without the coach are unaffected.
- The coach plugin (`@perchwerks/eye-in-the-sky`) currently targets
  `PanelSlot.Labs` and keeps working there until it migrates to `PanelSlot.Coach`
  and republishes — at which point we bump the `optionalDependencies` pin
  (`^0.0.2` → `^0.1.0`). No app-side "interpreter" needed: panels already receive
  the curated parsed session (`{ data, laps, selectedLapNumber, course, useKph }`),
  so the coach gets every format DataViewer supports for free.

## Why a dedicated tab (not Labs)

The coach is a first-class destination, not an experiment. Decision recorded with
the architecture docs (deterministic Stage-1 analysis, model-on-top later).

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` (304 passed; added a Coach/Labs slot-separation test)
- [x] `npm run build` (CoachTab emitted as its own lazy chunk)
- [ ] Visible Coach tab — pending the coach plugin migrating to `PanelSlot.Coach`

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_