### PR TITLE
Canonical channel registry + parse-time field normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `user_roles`).
 
 ### Changed
+- Telemetry channels are now normalized to a canonical identity at import time,
+  so the Settings "default fields" show/hide and your saved graph and video-
+  overlay selections apply **consistently across every logger format** (e.g.
+  lateral G is one channel whether the file came from a Dove, AiM, Alfano, or
+  VBO log). Existing files keep their saved graph/overlay choices — legacy field
+  names are migrated transparently on load.
 - Lap delta / pace is now **position-based** by default: your line is projected
   onto a reference lap resampled to a uniform arc-length grid, so the gap is
   robust to racing-line and GPS-rate differences and no longer drifts over a lap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,8 @@ src/
 │   ├── aimParser.ts           # AiM MyChron CSV parser
 │   ├── motecParser.ts         # MoTeC LD binary + CSV parser
 │   ├── parserUtils.ts         # Shared parser helpers (haversine, speed calc, etc.)
-│   ├── fieldResolver.ts       # Canonical field name mapping across parsers
+│   ├── channels.ts            # ★ Canonical channel registry (single source of truth: ids/labels/units/aliases) + normalizeChannels()
+│   ├── fieldResolver.ts       # Settings-facing adapter over channels.ts (canonical id resolution + field categories)
 │   ├── courseDetection.ts     # ★ Auto course detection, direction detection, waypoint mode
 │   ├── lapCalculation.ts      # Start/finish line crossing detection → Lap[]
 │   ├── brakingZones.ts        # Braking zone detection from G-force data
@@ -215,6 +216,7 @@ File Import (drag-drop / BLE download / file manager)
   → fileStorage.ts (save raw blob to IndexedDB)
   → useSessionData.ts (read blob, call parseDatalogFile)
     → datalogParser.ts (auto-detect format, route to specific parser)
+      → normalizeChannels() (channels.ts): rewrites every fieldMapping name + extraFields key to a canonical ChannelId (or `custom:` slug), sets display label/unit. Runs once for all formats — parsers keep emitting human names internally.
       → returns ParsedData { samples: GpsSample[], fieldMappings, bounds, duration, startDate, dovexMetadata?, parserStats? }
   → courseDetection.ts (auto-detect track, course, direction; waypoint fallback)
     → returns CourseDetectionResult { track, course, direction, laps, isWaypointMode }
@@ -321,7 +323,7 @@ Detection order matters: binary formats first (MoTeC LD → UBX), then text form
 | `Track` | `name`, `shortName?` (max 8 chars), `courses[]` |
 | `CourseDetectionResult` | `track`, `course`, `direction?`, `laps[]`, `isWaypointMode`, `waypointNotice?` |
 | `CourseDirection` | `'forward' \| 'reverse'` |
-| `FieldMapping` | `index`, `name`, `unit?`, `enabled` — maps extraFields to UI toggles |
+| `FieldMapping` | `index`, `name` (canonical ChannelId or `custom:` slug — the extraFields key), `label?` (display), `unit?`, `enabled` |
 | `FileMetadata` | `fileName`, `trackName`, `courseName`, `weatherStation*?`, `sessionKartId?`, `sessionSetupId?`, `fastestLapMs?`, `fastestLapNumber?` |
 
 ---
@@ -509,7 +511,16 @@ Key settings: `useKph`, `gForceSmoothing`, `gForceSmoothingStrength`, `brakingZo
 switches on `deltaMethod`. The position method is the issue #29 port; `distance`
 falls back to the legacy `calculatePace` in `referenceUtils.ts`.
 
-`fieldResolver.ts` maps parser-specific field names (e.g., "Lat G", "Lateral G", "LatG") to canonical IDs (`lat_g`) so settings apply uniformly.
+Channels are normalized to canonical ids at parse time (`channels.ts` →
+`normalizeChannels()`), so `extraFields` keys and `FieldMapping.name` are uniform
+across formats (e.g. every parser's lateral-g lands on `lat_g`, with display
+`label` "Lat G"). G-force is modelled as distinct ids per source — `lat_g`/`lon_g`
+(primary/GPS-derived), `lat_g_native`/`lon_g_native` (logger-native), `accel_x/y/z`
+(raw IMU) — which coexist on a sample and must never collapse. `fieldResolver.ts`
+is the settings-facing adapter (resolves names→ids for the field-default
+show/hide). `toChannelKey()` is the idempotent shim that migrates legacy
+display-name keys persisted in graph-prefs / saved overlay configs on load, so
+existing user data keeps resolving without a destructive migration.
 
 ---
 

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -426,7 +426,7 @@ export function TelemetryChart({
           const mappingIndex = fieldMappings.findIndex(f => f.name === field.name);
           const colorIndex = ((mappingIndex === -1 ? 0 : mappingIndex) + 1) % COLORS.length;
           ctx.fillStyle = COLORS[colorIndex];
-          ctx.fillText(`${field.name}: ${val.toFixed(1)}`, boxX + 8, boxY + 14 + fieldOffset * 16);
+          ctx.fillText(`${field.label ?? field.name}: ${val.toFixed(1)}`, boxX + 8, boxY + 14 + fieldOffset * 16);
           fieldOffset++;
         }
       });
@@ -521,7 +521,7 @@ export function TelemetryChart({
               className="w-3 h-3 rounded-full" 
               style={{ backgroundColor: COLORS[(idx + 1) % COLORS.length] }} 
             />
-            <span className="text-xs font-mono">{field.name}</span>
+            <span className="text-xs font-mono">{field.label ?? field.name}</span>
           </button>
         ))}
       </div>

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -129,11 +129,11 @@ export function GraphPanel({
 
   // Check if both GPS and HW G-force data are available
   const hasHwAccel = useMemo(() => {
-    return filteredSamples.some(s => s.extraFields['Accel X'] !== undefined);
+    return filteredSamples.some(s => s.extraFields['accel_x'] !== undefined);
   }, [filteredSamples]);
 
   const hasGpsG = useMemo(() => {
-    return filteredSamples.some(s => s.extraFields['Lat G'] !== undefined);
+    return filteredSamples.some(s => s.extraFields['lat_g'] !== undefined);
   }, [filteredSamples]);
 
   const hasBothSources = hasHwAccel && hasGpsG;
@@ -148,14 +148,15 @@ export function GraphPanel({
     }
     sources.push({ key: '__braking_g__', label: hasBothSources ? 'Brake % (GPS)' : 'Brake % (computed)' });
     fieldMappings.forEach(f => {
-      let label = f.name + (f.unit ? ` (${f.unit})` : '');
+      const display = f.label ?? f.name;
+      let label = display + (f.unit ? ` (${f.unit})` : '');
       // Add source indicator when both GPS and HW G-force data exist
       if (hasBothSources) {
-        if (f.name === 'Lat G') label = 'Lat G (GPS)';
-        else if (f.name === 'Lon G') label = 'Lon G (GPS)';
-        else if (f.name === 'Accel X') label = 'Accel X (HW)';
-        else if (f.name === 'Accel Y') label = 'Accel Y (HW)';
-        else if (f.name === 'Accel Z') label = 'Accel Z (HW)';
+        if (f.name === 'lat_g') label = 'Lat G (GPS)';
+        else if (f.name === 'lon_g') label = 'Lon G (GPS)';
+        else if (f.name === 'accel_x') label = 'Accel X (HW)';
+        else if (f.name === 'accel_y') label = 'Accel Y (HW)';
+        else if (f.name === 'accel_z') label = 'Accel Z (HW)';
       }
       sources.push({ key: f.name, label });
     });

--- a/src/components/video-overlays/dataSourceResolver.ts
+++ b/src/components/video-overlays/dataSourceResolver.ts
@@ -1,4 +1,18 @@
 import type { GpsSample, FieldMapping } from "@/types/racing";
+import { toChannelKey } from "@/lib/channels";
+
+/**
+ * Find a data source by id, falling back to the canonical key for legacy
+ * sourceIds saved before channel normalization (e.g. a stored "Lat G" now lives
+ * under "lat_g"). Special ids ("speed", "__pace__"…) match exactly on the first
+ * lookup.
+ */
+function findSource(dataSources: DataSourceDef[], sourceId: string): DataSourceDef | undefined {
+  return (
+    dataSources.find((d) => d.id === sourceId) ??
+    dataSources.find((d) => d.id === toChannelKey(sourceId))
+  );
+}
 import type { DataSourceDef } from "./types";
 
 /**
@@ -65,7 +79,7 @@ export function buildDataSources(
   for (const f of fieldMappings) {
     sources.push({
       id: f.name,
-      label: f.name + (f.unit ? ` (${f.unit})` : ""),
+      label: (f.label ?? f.name) + (f.unit ? ` (${f.unit})` : ""),
       unit: f.unit ?? "",
       getValue: (s) => s.extraFields[f.name] ?? null,
       getMin: (samples) => {
@@ -108,7 +122,7 @@ export function resolveValue(
   if (sourceId === "__braking_g__") {
     return brakingGData?.[currentIndex] ?? null;
   }
-  const src = dataSources.find((d) => d.id === sourceId);
+  const src = findSource(dataSources, sourceId);
   if (!src) return null;
   return src.getValue(sample);
 }
@@ -135,19 +149,19 @@ export function resolveRange(
     const absMax = Math.max(Math.abs(min), Math.abs(max), 0.5);
     return { min: -absMax, max: absMax };
   }
-  const src = dataSources.find((d) => d.id === sourceId);
+  const src = findSource(dataSources, sourceId);
   if (!src) return { min: 0, max: 100 };
   return { min: src.getMin(samples), max: src.getMax(samples) };
 }
 
 /** Get the unit string for a source */
 export function resolveUnit(sourceId: string, dataSources: DataSourceDef[]): string {
-  const src = dataSources.find((d) => d.id === sourceId);
+  const src = findSource(dataSources, sourceId);
   return src?.unit ?? "";
 }
 
 /** Get the label for a source */
 export function resolveLabel(sourceId: string, dataSources: DataSourceDef[]): string {
-  const src = dataSources.find((d) => d.id === sourceId);
+  const src = findSource(dataSources, sourceId);
   return src?.label ?? sourceId;
 }

--- a/src/lib/channels.test.ts
+++ b/src/lib/channels.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  CHANNELS,
+  channelKeyFor,
+  channelLabel,
+  channelUnit,
+  customChannelId,
+  isKnownChannel,
+  resolveChannelId,
+} from "./channels";
+
+describe("channel registry", () => {
+  it("has unique ids", () => {
+    const ids = CHANNELS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("resolves a canonical label to its id (case-insensitive, trimmed)", () => {
+    expect(resolveChannelId("RPM")).toBe("rpm");
+    expect(resolveChannelId("  rpm  ")).toBe("rpm");
+    expect(resolveChannelId("Water Temp")).toBe("water_temp");
+  });
+
+  it("resolves known aliases to the canonical id", () => {
+    expect(resolveChannelId("Lateral G")).toBe("lat_g");
+    expect(resolveChannelId("Engine RPM")).toBe("rpm");
+    expect(resolveChannelId("Altitude (m)")).toBe("altitude");
+    expect(resolveChannelId("H Acc M")).toBe("h_acc");
+  });
+
+  it("keeps measured, native, and raw-IMU g as distinct ids (never collapses)", () => {
+    expect(resolveChannelId("Lat G")).toBe("lat_g");
+    expect(resolveChannelId("Lat G (Native)")).toBe("lat_g_native");
+    expect(resolveChannelId("Accel X")).toBe("accel_x");
+    // The three are genuinely different channels that can coexist on one sample.
+    const ids = new Set(["lat_g", "lat_g_native", "accel_x"]);
+    expect(ids.size).toBe(3);
+  });
+
+  it("returns undefined for an unknown name", () => {
+    expect(resolveChannelId("Brake Bias Wizardry")).toBeUndefined();
+  });
+
+  it("exposes labels and units", () => {
+    expect(channelLabel("lat_g")).toBe("Lat G");
+    expect(channelUnit("altitude")).toBe("m");
+    expect(channelUnit("satellites")).toBeUndefined();
+  });
+
+  it("recognises known ids", () => {
+    expect(isKnownChannel("rpm")).toBe(true);
+    expect(isKnownChannel("custom:foo")).toBe(false);
+  });
+
+  it("slugs unknown columns into a collision-proof custom key", () => {
+    expect(customChannelId("My Weird Sensor!")).toBe("custom:my_weird_sensor");
+    expect(customChannelId("  --  ")).toBe("custom:field");
+    // A custom slug can never look like a canonical id.
+    expect(isKnownChannel(customChannelId("RPM-ish"))).toBe(false);
+  });
+
+  it("channelKeyFor yields the canonical id when known, else a custom slug", () => {
+    expect(channelKeyFor("Lon G")).toBe("lon_g");
+    expect(channelKeyFor("Gizmo Voltage")).toBe("custom:gizmo_voltage");
+  });
+});

--- a/src/lib/channels.test.ts
+++ b/src/lib/channels.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { ParsedData, FieldMapping, GpsSample } from "@/types/racing";
 import {
   CHANNELS,
   channelKeyFor,
@@ -6,7 +7,9 @@ import {
   channelUnit,
   customChannelId,
   isKnownChannel,
+  normalizeChannels,
   resolveChannelId,
+  toChannelKey,
 } from "./channels";
 
 describe("channel registry", () => {
@@ -62,5 +65,101 @@ describe("channel registry", () => {
   it("channelKeyFor yields the canonical id when known, else a custom slug", () => {
     expect(channelKeyFor("Lon G")).toBe("lon_g");
     expect(channelKeyFor("Gizmo Voltage")).toBe("custom:gizmo_voltage");
+  });
+});
+
+describe("toChannelKey (idempotent migration)", () => {
+  it("resolves a legacy display name to its canonical id", () => {
+    expect(toChannelKey("Lat G")).toBe("lat_g");
+    expect(toChannelKey("Gizmo Voltage")).toBe("custom:gizmo_voltage");
+  });
+
+  it("leaves already-migrated keys untouched (idempotent)", () => {
+    expect(toChannelKey("lat_g")).toBe("lat_g");
+    expect(toChannelKey("custom:gizmo_voltage")).toBe("custom:gizmo_voltage");
+    expect(toChannelKey(toChannelKey("Lat G"))).toBe("lat_g");
+    expect(toChannelKey(toChannelKey("Gizmo Voltage"))).toBe("custom:gizmo_voltage");
+  });
+});
+
+describe("normalizeChannels", () => {
+  function sample(extra: Record<string, number>): GpsSample {
+    return {
+      t: 0,
+      lat: 0,
+      lon: 0,
+      speedMps: 0,
+      speedMph: 0,
+      speedKph: 0,
+      extraFields: extra,
+    };
+  }
+
+  function data(mappings: FieldMapping[], samples: GpsSample[]): ParsedData {
+    return {
+      samples,
+      fieldMappings: mappings,
+      bounds: { minLat: 0, maxLat: 0, minLon: 0, maxLon: 0 },
+      duration: 0,
+    };
+  }
+
+  it("renames mappings and sample keys to canonical ids and sets labels", () => {
+    const out = normalizeChannels(
+      data(
+        [
+          { index: -10, name: "Lat G", enabled: true },
+          { index: -20, name: "RPM", enabled: true },
+        ],
+        [sample({ "Lat G": 0.5, RPM: 9000 })],
+      ),
+    );
+    expect(out.fieldMappings.map((m) => m.name)).toEqual(["lat_g", "rpm"]);
+    expect(out.fieldMappings[0].label).toBe("Lat G");
+    expect(out.samples[0].extraFields).toEqual({ lat_g: 0.5, rpm: 9000 });
+  });
+
+  it("keeps native, derived, and raw-IMU g as separate keys on one sample", () => {
+    const out = normalizeChannels(
+      data(
+        [
+          { index: -10, name: "Lat G", enabled: true },
+          { index: -12, name: "Lat G (Native)", enabled: true },
+          { index: -30, name: "Accel X", unit: "G", enabled: true },
+        ],
+        [sample({ "Lat G": 0.5, "Lat G (Native)": 0.48, "Accel X": 0.51 })],
+      ),
+    );
+    expect(out.samples[0].extraFields).toEqual({
+      lat_g: 0.5,
+      lat_g_native: 0.48,
+      accel_x: 0.51,
+    });
+    // A pre-set unit is preserved over the registry default.
+    expect(out.fieldMappings.find((m) => m.name === "accel_x")!.unit).toBe("G");
+  });
+
+  it("preserves unmapped custom columns under a stable custom key", () => {
+    const out = normalizeChannels(
+      data(
+        [{ index: 5, name: "Gizmo Voltage", enabled: true }],
+        [sample({ "Gizmo Voltage": 12.6 })],
+      ),
+    );
+    expect(out.fieldMappings[0].name).toBe("custom:gizmo_voltage");
+    expect(out.fieldMappings[0].label).toBe("Gizmo Voltage");
+    expect(out.samples[0].extraFields).toEqual({ "custom:gizmo_voltage": 12.6 });
+  });
+
+  it("is idempotent — re-normalizing already-canonical data is a no-op", () => {
+    const once = normalizeChannels(
+      data(
+        [{ index: -10, name: "Lat G", enabled: true }],
+        [sample({ "Lat G": 0.5 })],
+      ),
+    );
+    const twice = normalizeChannels(once);
+    expect(twice.fieldMappings.map((m) => m.name)).toEqual(["lat_g"]);
+    expect(twice.samples[0].extraFields).toEqual({ lat_g: 0.5 });
   });
 });

--- a/src/lib/channels.ts
+++ b/src/lib/channels.ts
@@ -1,0 +1,149 @@
+// Canonical telemetry channel registry — the single source of truth for channel
+// identity across every parser and consumer.
+//
+// Problem this solves: each parser used to emit its own display-name keys into
+// `GpsSample.extraFields` ("Lat G", "RPM", "Accel X", "Water Temp"…). Those keys
+// doubled as the field's identity everywhere — chart toggles, settings
+// field-default hide/show, stored graph-prefs, saved video-overlay configs — so
+// "hide RPM by default" only matched the one parser whose spelling you'd seen.
+//
+// Here we define a stable `ChannelId` per physical quantity. Parsers resolve the
+// raw log/column name to a `ChannelId` and key `extraFields` by it; the UI reads
+// `label`/`unit` for display. A default like "hide RPM" then applies regardless
+// of which logger produced the file.
+//
+// G-force note: lateral/longitudinal g is modelled as DISTINCT ids per source —
+// `lat_g`/`lon_g` (primary; GPS-derived when computed), `lat_g_native`/
+// `lon_g_native` (logger-reported native g), and `accel_x/y/z` (raw body-frame
+// IMU). These legitimately coexist on one sample (e.g. Alfano reports native g
+// while we also derive g from GPS), so they must never collapse to one key.
+
+export type ChannelId =
+  // GPS / quality
+  | "altitude"
+  | "satellites"
+  | "hdop"
+  | "h_acc"
+  // G-force / IMU
+  | "lat_g"
+  | "lon_g"
+  | "lat_g_native"
+  | "lon_g_native"
+  | "accel_x"
+  | "accel_y"
+  | "accel_z"
+  | "yaw_rate"
+  // Engine / sensors
+  | "rpm"
+  | "water_temp"
+  | "oil_temp"
+  | "egt"
+  | "temp_1"
+  | "temp_2"
+  | "throttle"
+  | "brake"
+  // Derived
+  | "distance";
+
+export interface ChannelDef {
+  id: ChannelId;
+  /** Human-readable label for UI display. */
+  label: string;
+  /** Display unit, when one is well-defined. */
+  unit?: string;
+  /**
+   * Raw field/column names (across loggers and older parsers) that resolve to
+   * this id. Matched case-insensitively. The canonical `label` need not be
+   * repeated here — it is matched implicitly (see `resolveChannelId`).
+   */
+  aliases: string[];
+}
+
+// Order is the canonical display/registration order.
+export const CHANNELS: readonly ChannelDef[] = [
+  { id: "altitude", label: "Altitude", unit: "m", aliases: ["Altitude (m)", "Alt", "Altitude M"] },
+  { id: "satellites", label: "Satellites", aliases: ["Sats", "NumSats"] },
+  { id: "hdop", label: "HDOP", aliases: ["Hdop"] },
+  { id: "h_acc", label: "H Accuracy", unit: "m", aliases: ["H Acc M", "Horizontal Accuracy"] },
+
+  { id: "lat_g", label: "Lat G", unit: "g", aliases: ["Lateral G", "LatG"] },
+  { id: "lon_g", label: "Lon G", unit: "g", aliases: ["Longitudinal G", "LonG"] },
+  { id: "lat_g_native", label: "Lat G (Native)", unit: "g", aliases: [] },
+  { id: "lon_g_native", label: "Lon G (Native)", unit: "g", aliases: [] },
+  { id: "accel_x", label: "Accel X", aliases: [] },
+  { id: "accel_y", label: "Accel Y", aliases: [] },
+  { id: "accel_z", label: "Accel Z", aliases: [] },
+  { id: "yaw_rate", label: "Yaw Rate", unit: "°/s", aliases: [] },
+
+  { id: "rpm", label: "RPM", aliases: ["Rpm", "Engine RPM", "Engine_RPM"] },
+  { id: "water_temp", label: "Water Temp", unit: "°C", aliases: ["Water Temperature", "Coolant Temp"] },
+  { id: "oil_temp", label: "Oil Temp", unit: "°C", aliases: ["Oil Temperature"] },
+  { id: "egt", label: "EGT", unit: "°C", aliases: ["Exhaust Temp", "Exhaust Gas Temp"] },
+  { id: "temp_1", label: "Temp 1", unit: "°C", aliases: [] },
+  { id: "temp_2", label: "Temp 2", unit: "°C", aliases: [] },
+  { id: "throttle", label: "Throttle", unit: "%", aliases: ["TPS", "Throttle Position"] },
+  { id: "brake", label: "Brake", aliases: ["Brake Pressure"] },
+
+  { id: "distance", label: "Distance", unit: "m", aliases: [] },
+] as const;
+
+const byId = new Map<ChannelId, ChannelDef>(CHANNELS.map((c) => [c.id, c]));
+
+// Reverse lookup: lowercased raw name -> id. Both the canonical `label` and every
+// alias resolve. A later registration never overwrites an earlier one, so the
+// table is deterministic regardless of insertion quirks.
+const nameToId = new Map<string, ChannelId>();
+for (const def of CHANNELS) {
+  for (const name of [def.label, ...def.aliases]) {
+    const key = name.toLowerCase();
+    if (!nameToId.has(key)) nameToId.set(key, def.id);
+  }
+}
+
+/** Resolve a raw log/column/display name to a `ChannelId`, or undefined if unknown. */
+export function resolveChannelId(rawName: string): ChannelId | undefined {
+  return nameToId.get(rawName.trim().toLowerCase());
+}
+
+/** The definition for a known id. */
+export function getChannelDef(id: ChannelId): ChannelDef | undefined {
+  return byId.get(id);
+}
+
+/** Display label for an id (falls back to the id itself if somehow unknown). */
+export function channelLabel(id: ChannelId): string {
+  return byId.get(id)?.label ?? id;
+}
+
+/** Display unit for an id, or undefined when none is well-defined. */
+export function channelUnit(id: ChannelId): string | undefined {
+  return byId.get(id)?.unit;
+}
+
+export function isKnownChannel(id: string): id is ChannelId {
+  return byId.has(id as ChannelId);
+}
+
+/**
+ * Stable key for a channel with no canonical mapping (a custom logger column).
+ * Slugged so the same raw column always yields the same key — `custom:` prefixed
+ * so it can never collide with a canonical id. Consumers display the original
+ * name via the field's label, not this key.
+ */
+export function customChannelId(rawName: string): string {
+  const slug = rawName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return `custom:${slug || "field"}`;
+}
+
+/**
+ * Resolve a raw name to its stable storage key: a `ChannelId` when known, else a
+ * `custom:`-prefixed slug. This is the identity parsers write into `extraFields`
+ * and that settings/graph-prefs/overlays key off.
+ */
+export function channelKeyFor(rawName: string): string {
+  return resolveChannelId(rawName) ?? customChannelId(rawName);
+}

--- a/src/lib/channels.ts
+++ b/src/lib/channels.ts
@@ -18,12 +18,16 @@
 // IMU). These legitimately coexist on one sample (e.g. Alfano reports native g
 // while we also derive g from GPS), so they must never collapse to one key.
 
+import type { ParsedData } from "@/types/racing";
+
 export type ChannelId =
   // GPS / quality
   | "altitude"
   | "satellites"
   | "hdop"
   | "h_acc"
+  | "v_acc"
+  | "speed_acc"
   // G-force / IMU
   | "lat_g"
   | "lon_g"
@@ -64,7 +68,9 @@ export const CHANNELS: readonly ChannelDef[] = [
   { id: "altitude", label: "Altitude", unit: "m", aliases: ["Altitude (m)", "Alt", "Altitude M"] },
   { id: "satellites", label: "Satellites", aliases: ["Sats", "NumSats"] },
   { id: "hdop", label: "HDOP", aliases: ["Hdop"] },
-  { id: "h_acc", label: "H Accuracy", unit: "m", aliases: ["H Acc M", "Horizontal Accuracy"] },
+  { id: "h_acc", label: "H Accuracy", unit: "m", aliases: ["H Accuracy (m)", "H Acc M", "Horizontal Accuracy"] },
+  { id: "v_acc", label: "V Accuracy", unit: "m", aliases: ["V Accuracy (m)", "V Acc M", "Vertical Accuracy"] },
+  { id: "speed_acc", label: "Speed Accuracy", unit: "m/s", aliases: ["Speed Acc (m/s)", "Speed Acc"] },
 
   { id: "lat_g", label: "Lat G", unit: "g", aliases: ["Lateral G", "LatG"] },
   { id: "lon_g", label: "Lon G", unit: "g", aliases: ["Longitudinal G", "LonG"] },
@@ -146,4 +152,59 @@ export function customChannelId(rawName: string): string {
  */
 export function channelKeyFor(rawName: string): string {
   return resolveChannelId(rawName) ?? customChannelId(rawName);
+}
+
+/**
+ * Idempotent migration of any field identity to its canonical storage key.
+ * Handles three inputs: an already-canonical id (kept), an already-migrated
+ * `custom:` slug (kept), or a legacy display name (resolved). Use this for
+ * persisted identities (stored graph-prefs, saved overlay sourceIds) so old data
+ * keeps resolving without a destructive migration.
+ */
+export function toChannelKey(name: string): string {
+  if (isKnownChannel(name) || name.startsWith("custom:")) return name;
+  return channelKeyFor(name);
+}
+
+/**
+ * Rewrite a freshly-parsed `ParsedData` so every channel identity is canonical:
+ * `fieldMappings` get a stable `name` (id/slug) plus a display `label` and unit,
+ * and every sample's `extraFields` keys are renamed to match. Run once per parse
+ * (at the format router) so all parsers can keep emitting human display names
+ * internally while the rest of the app sees uniform keys regardless of format.
+ *
+ * Mutates the passed samples' `extraFields` in place (they're owned by the
+ * just-parsed result) and returns `data` with rebuilt `fieldMappings`.
+ */
+export function normalizeChannels(data: ParsedData): ParsedData {
+  const rename = new Map<string, string>();
+  const usedKeys = new Set<string>();
+
+  const fieldMappings = data.fieldMappings.map((m) => {
+    const known = resolveChannelId(m.name);
+    let key = toChannelKey(m.name);
+    // Two source columns must never collapse onto one channel id — that would
+    // clobber a column's samples. Keep the later duplicate under a custom key.
+    if (usedKeys.has(key)) key = customChannelId(m.name);
+    usedKeys.add(key);
+    rename.set(m.name, key);
+    return {
+      ...m,
+      name: key,
+      label: m.label ?? (known ? channelLabel(known) : m.name),
+      unit: m.unit ?? (known ? channelUnit(known) : undefined),
+    };
+  });
+
+  for (const s of data.samples) {
+    const next: Record<string, number> = {};
+    for (const k in s.extraFields) {
+      const v = s.extraFields[k];
+      if (v === undefined) continue;
+      next[rename.get(k) ?? toChannelKey(k)] = v;
+    }
+    s.extraFields = next;
+  }
+
+  return { ...data, fieldMappings };
 }

--- a/src/lib/chartUtils.ts
+++ b/src/lib/chartUtils.ts
@@ -2,11 +2,11 @@
  * Shared chart utilities used by TelemetryChart and SingleSeriesChart.
  */
 
-/** Field names that should have optional smoothing applied in charts (GPS-derived). */
-export const G_FORCE_FIELDS_GPS = ['Lat G', 'Lon G'];
+/** Canonical channel ids for GPS-derived G-force (optional smoothing applied). */
+export const G_FORCE_FIELDS_GPS = ['lat_g', 'lon_g'];
 
-/** Field names for hardware accelerometer G-force fields. */
-export const G_FORCE_FIELDS_HW = ['Accel X', 'Accel Y'];
+/** Canonical channel ids for hardware accelerometer G-force fields. */
+export const G_FORCE_FIELDS_HW = ['accel_x', 'accel_y'];
 
 /** All G-force field names (for smoothing detection). */
 export const G_FORCE_FIELDS = [...G_FORCE_FIELDS_GPS, ...G_FORCE_FIELDS_HW];

--- a/src/lib/datalogParser.test.ts
+++ b/src/lib/datalogParser.test.ts
@@ -108,10 +108,12 @@ describe("regression: okc-tillotson-data.dovex", () => {
     expect(parsed.dovexMetadata!.bestLapMs).toBe(minLap);
   });
 
-  it("fieldMappings includes the GPS-derived G-forces", () => {
+  it("fieldMappings includes the GPS-derived G-forces (canonical ids + labels)", () => {
     const names = parsed.fieldMappings.map((m) => m.name);
-    expect(names).toContain("Lat G");
-    expect(names).toContain("Lon G");
+    expect(names).toContain("lat_g");
+    expect(names).toContain("lon_g");
+    const latG = parsed.fieldMappings.find((m) => m.name === "lat_g");
+    expect(latG!.label).toBe("Lat G");
   });
 
   it("parserStats reports the row breakdown", () => {
@@ -195,18 +197,19 @@ describe("regression: okc-tillotson-plain.nmea", () => {
 
   it("fieldMappings includes GPS-derived G-forces (added by parser)", () => {
     const names = parsed.fieldMappings.map((m) => m.name);
-    expect(names).toContain("Lat G");
-    expect(names).toContain("Lon G");
+    expect(names).toContain("lat_g");
+    expect(names).toContain("lon_g");
   });
 
   it("populates Satellites/HDOP/Altitude from GGA sentences in extraFields", () => {
-    // The NMEA fixture has interleaved $GPGGA sentences which provide these
-    const anyWithSats = parsed.samples.find((s) => s.extraFields["Satellites"] !== undefined);
+    // The NMEA fixture has interleaved $GPGGA sentences which provide these;
+    // extraFields are keyed by canonical channel id after normalization.
+    const anyWithSats = parsed.samples.find((s) => s.extraFields["satellites"] !== undefined);
     expect(anyWithSats).toBeDefined();
-    expect(anyWithSats!.extraFields["Satellites"]).toBeGreaterThan(0);
-    expect(anyWithSats!.extraFields["Satellites"]).toBeLessThan(50);
+    expect(anyWithSats!.extraFields["satellites"]).toBeGreaterThan(0);
+    expect(anyWithSats!.extraFields["satellites"]).toBeLessThan(50);
 
-    const anyWithAlt = parsed.samples.find((s) => s.extraFields["Altitude (m)"] !== undefined);
+    const anyWithAlt = parsed.samples.find((s) => s.extraFields["altitude"] !== undefined);
     expect(anyWithAlt).toBeDefined();
   });
 

--- a/src/lib/datalogParser.ts
+++ b/src/lib/datalogParser.ts
@@ -1,4 +1,5 @@
 import { ParsedData } from '@/types/racing';
+import { normalizeChannels } from './channels';
 import { parseDatalog } from './nmeaParser';
 import { parseUbxFile, isUbxFormat } from './ubxParser';
 import { parseVboFile, isVboFormat } from './vboParser';
@@ -22,6 +23,17 @@ import { isMotecLdFormat, parseMotecLdFile, isMotecCsvFormat, parseMotecCsvFile 
  * - NMEA text format (CSV with NMEA sentences, .nmea files)
  */
 export async function parseDatalogFile(file: File): Promise<ParsedData> {
+  return normalizeChannels(await routeDatalogFile(file));
+}
+
+/**
+ * Parse from raw content (for when you already have the data loaded).
+ */
+export function parseDatalogContent(content: string | ArrayBuffer): ParsedData {
+  return normalizeChannels(routeDatalogContent(content));
+}
+
+async function routeDatalogFile(file: File): Promise<ParsedData> {
   const buffer = await file.arrayBuffer();
   
   // Check MoTeC LD binary format first (different magic bytes from UBX)
@@ -71,10 +83,7 @@ export async function parseDatalogFile(file: File): Promise<ParsedData> {
   return parseDatalog(text);
 }
 
-/**
- * Parse from raw content (for when you already have the data loaded)
- */
-export function parseDatalogContent(content: string | ArrayBuffer): ParsedData {
+function routeDatalogContent(content: string | ArrayBuffer): ParsedData {
   if (content instanceof ArrayBuffer) {
     if (isMotecLdFormat(content)) {
       return parseMotecLdFile(content);

--- a/src/lib/fieldResolver.ts
+++ b/src/lib/fieldResolver.ts
@@ -6,7 +6,7 @@
 // (`getCanonicalFieldId`, `isFieldHiddenByCanonical`, `FIELD_CATEGORIES`) stay
 // stable.
 
-import { type ChannelId, getChannelDef, resolveChannelId } from "./channels";
+import { type ChannelId, getChannelDef, isKnownChannel, resolveChannelId } from "./channels";
 
 /** A canonical field id is a registry channel id. */
 export type CanonicalFieldId = ChannelId;
@@ -16,6 +16,9 @@ export type CanonicalFieldId = ChannelId;
  * known alias). Returns undefined if the field has no canonical mapping.
  */
 export function getCanonicalFieldId(fieldName: string): CanonicalFieldId | undefined {
+  // Accept an already-canonical id (post-normalization field name) or a raw
+  // display name / alias (legacy callers, settings UI).
+  if (isKnownChannel(fieldName)) return fieldName;
   return resolveChannelId(fieldName);
 }
 

--- a/src/lib/fieldResolver.ts
+++ b/src/lib/fieldResolver.ts
@@ -1,52 +1,29 @@
-// Canonical field name resolver for consistent settings across different parsers
+// Canonical field name resolver for consistent settings across different parsers.
+//
+// Channel identity now lives in the single registry (`channels.ts`); this module
+// is the settings-facing adapter over it (canonical-id resolution + the
+// settings-UI field categories). Kept as a separate module so existing imports
+// (`getCanonicalFieldId`, `isFieldHiddenByCanonical`, `FIELD_CATEGORIES`) stay
+// stable.
 
-export type CanonicalFieldId = 
-  | 'altitude'
-  | 'satellites'
-  | 'hdop'
-  | 'lat_g'
-  | 'lon_g'
-  | 'rpm'
-  | 'water_temp'
-  | 'egt'
-  | 'throttle'
-  | 'brake';
+import { type ChannelId, getChannelDef, resolveChannelId } from "./channels";
 
-// Maps all possible field name variations to their canonical ID
-const FIELD_ALIASES: Record<CanonicalFieldId, string[]> = {
-  altitude: ['Altitude (m)', 'Altitude', 'Alt'],
-  satellites: ['Satellites', 'Sats', 'NumSats'],
-  hdop: ['HDOP', 'Hdop'],
-  lat_g: ['Lat G', 'Lat G (Native)', 'Lateral G', 'LatG'],
-  lon_g: ['Lon G', 'Lon G (Native)', 'Longitudinal G', 'LonG'],
-  rpm: ['RPM', 'Rpm'],
-  water_temp: ['Water Temp', 'Water Temperature', 'Coolant Temp'],
-  egt: ['EGT', 'Exhaust Temp'],
-  throttle: ['Throttle', 'TPS', 'Throttle Position'],
-  brake: ['Brake', 'Brake Pressure'],
-};
-
-// Reverse lookup: field name -> canonical ID
-const nameToCanonical: Map<string, CanonicalFieldId> = new Map();
-for (const [canonical, aliases] of Object.entries(FIELD_ALIASES)) {
-  for (const alias of aliases) {
-    nameToCanonical.set(alias.toLowerCase(), canonical as CanonicalFieldId);
-  }
-}
+/** A canonical field id is a registry channel id. */
+export type CanonicalFieldId = ChannelId;
 
 /**
- * Get the canonical field ID for a given field name.
- * Returns undefined if the field doesn't have a canonical mapping.
+ * Get the canonical field ID for a given field name (canonical label or any
+ * known alias). Returns undefined if the field has no canonical mapping.
  */
 export function getCanonicalFieldId(fieldName: string): CanonicalFieldId | undefined {
-  return nameToCanonical.get(fieldName.toLowerCase());
+  return resolveChannelId(fieldName);
 }
 
 /**
  * Check if a field name is hidden based on the canonical hidden list.
  */
 export function isFieldHiddenByCanonical(
-  fieldName: string, 
+  fieldName: string,
   hiddenCanonicalIds: string[]
 ): boolean {
   const canonicalId = getCanonicalFieldId(fieldName);
@@ -55,10 +32,11 @@ export function isFieldHiddenByCanonical(
 }
 
 /**
- * Get all aliases for a canonical field ID
+ * Get all aliases for a canonical field ID (its label plus registered aliases).
  */
 export function getFieldAliases(canonicalId: CanonicalFieldId): string[] {
-  return FIELD_ALIASES[canonicalId] || [];
+  const def = getChannelDef(canonicalId);
+  return def ? [def.label, ...def.aliases] : [];
 }
 
 // Field configuration for the settings UI

--- a/src/lib/graphPrefsStorage.ts
+++ b/src/lib/graphPrefsStorage.ts
@@ -2,6 +2,7 @@
  * Persist active graph selections per session file in IndexedDB.
  */
 import { STORE_NAMES, withReadTransaction, withWriteTransaction } from './dbUtils';
+import { toChannelKey } from './channels';
 
 interface GraphPrefsRecord {
   sessionFileName: string;
@@ -9,6 +10,13 @@ interface GraphPrefsRecord {
 }
 
 const STORE = STORE_NAMES.GRAPH_PREFS;
+
+// Synthetic graph keys that are not telemetry channels and must pass through
+// channel migration untouched.
+function migrateGraphKey(key: string): string {
+  if (key === 'speed' || key.startsWith('__')) return key;
+  return toChannelKey(key);
+}
 
 export async function saveGraphPrefs(sessionFileName: string, activeGraphs: string[]): Promise<void> {
   await withWriteTransaction(STORE, (store) => {
@@ -21,7 +29,7 @@ export async function loadGraphPrefs(sessionFileName: string): Promise<string[]>
     STORE,
     (store) => store.get(sessionFileName),
   );
-  return record?.activeGraphs ?? [];
+  return (record?.activeGraphs ?? []).map(migrateGraphKey);
 }
 
 export async function deleteGraphPrefs(sessionFileName: string): Promise<void> {

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -77,7 +77,10 @@ export interface Lap {
 
 export interface FieldMapping {
   index: number;
+  /** Stable channel identity (canonical ChannelId or a `custom:` slug). */
   name: string;
+  /** Human-readable display name; falls back to `name` when absent. */
+  label?: string;
   unit?: string;
   enabled: boolean;
 }


### PR DESCRIPTION
## Summary

Gives the app **one canonical identity per telemetry channel**, so a field-default
like "hide RPM" applies regardless of which logger produced the file. Previously
each parser emitted its own display-name keys into `extraFields` ("Lat G",
"Accel X", "Water Temp"…), and that string doubled as the field's identity across
chart toggles, settings hide/show, stored graph-prefs, and saved overlay configs.

Decision (with @mikeachampagne): **normalize at parse time** — chosen over a
read-only resolver layer because uniform keys make cross-format settings coherent
at the data level. G-force is modelled as **distinct ids per source** (`lat_g`/
`lon_g`, `lat_g_native`/`lon_g_native`, `accel_x/y/z`) so measured, native, and
raw-IMU g never collapse — preserving the measured-vs-derived distinction the
coach plugin needs and the existing `gForceSource` GPS/HW toggle.

Implementation note: a single `normalizeChannels()` pass at the format router
rewrites keys/labels for **all** formats, so parsers keep emitting human names
internally — no per-parser churn.

### Landed
- [x] `src/lib/channels.ts` — registry (stable `ChannelId` + labels/units/aliases),
      `resolveChannelId`, collision-proof `custom:` slug, the idempotent
      `toChannelKey` migration shim, and `normalizeChannels(ParsedData)`.
- [x] `fieldResolver` delegates to the registry; `getCanonicalFieldId` also
      accepts already-canonical ids. Settings API unchanged.
- [x] `datalogParser` router wraps both entry points with `normalizeChannels`.
- [x] `FieldMapping.label` added; `name` is now the stable id.
- [x] Consumers on canonical ids: `chartUtils` G-force constants, `GraphPanel`,
      `TelemetryChart` (display via `label`), video `dataSourceResolver`.
- [x] **Back-compat**: `toChannelKey` migrates legacy display-name keys in stored
      graph-prefs (`graphPrefsStorage`) and saved overlay `sourceId`s
      (`dataSourceResolver`) on load — no destructive migration.
- [x] Tests for `normalizeChannels`/`toChannelKey`; parser regression assertions
      updated to canonical ids.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (318) / `npm run build`
- [x] Per-format manual check that channels, chart toggles, and settings defaults still resolve, and that an existing file's saved graph/overlay selections survive

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3