### PR TITLE
Chromeless plugin panels + coach dashboard (v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ A plugin absent at build time simply never loads — the app builds/runs without
 | `index.ts` | `initPlugins()` — glob + external discovery, runs each plugin's `setup(ctx)`. Called once in `main.tsx` before render |
 | `external-plugins.d.ts` | Ambient type for the `virtual:external-plugins` module |
 | `panels.ts` | **UI panel framework**: `PluginPanel` / `PluginPanelProps` contract, `PANELS_POINT`, `PanelSlot`, `getPanelsForSlot(slot)`. The curated session snapshot is the entire surface a panel can rely on |
-| `PluginPanelHost.tsx` | Consumer: mounts every panel for a slot in a titled card, each wrapped in a per-panel error boundary; renders a `fallback` when none |
+| `PluginPanelHost.tsx` | Consumer: mounts every panel for a slot in a titled card, each wrapped in a per-panel error boundary; renders a `fallback` when none. A `chromeless` panel skips the card chrome (full-bleed); an all-chromeless slot (`isBareSlot`) drops the host's outer padding so one panel fills the tab |
 | `mounts.ts` | **Inline mount framework**: `PluginMountDef`, `MOUNTS_POINT`, `MountSlot` (`FileRow`, `FileManagerSection`), per-slot context types, `getMounts(slot)`. For injecting raw components into fixed spots in core UI |
 | `PluginMount.tsx` | Consumer: `<PluginMount slot ctx>` renders every mount for a slot (error-boundaried + Suspense), or nothing when none — safe to drop into core UI unconditionally |
 | `storage.ts` | `getPluginStore(id)`: schema-less KV scoped to one plugin, in its own IndexedDB DB (`dove-plugin-<id>`). Decoupled from core `dbUtils`. Also exposed as `ctx.storage` |
@@ -267,7 +267,11 @@ panels via `PluginPanelHost` and are **self-gating**: `Index.tsx` computes
 plugin contributes a panel to it (Labs additionally shows when the experimental
 `enableLabs` setting is on). New slots are just new strings — no framework change.
 `PluginPanelHost` wraps each panel in an error boundary **and** a `Suspense`
-boundary, so panel components can be `React.lazy` (as `cloud-sync` is).
+boundary, so panel components can be `React.lazy` (as `cloud-sync` is). A panel
+may set `chromeless: true` to render its body without the host's card/header/
+padding — for panels that own their full layout (e.g. a full-bleed coach
+dashboard); the error boundary + Suspense still apply, and a slot whose panels
+are all chromeless (`isBareSlot`) also drops the host's outer padding.
 
 **Inline mounts:** where panels are standalone cards, *mounts* inject a raw
 component into a fixed spot in core UI. A plugin contributes a `PluginMountDef`

--- a/src/plugins/PluginPanelHost.tsx
+++ b/src/plugins/PluginPanelHost.tsx
@@ -1,5 +1,5 @@
 import { Component, Suspense, useMemo, type ReactNode } from "react";
-import { getPanelsForSlot, type PluginPanelProps } from "./panels";
+import { getPanelsForSlot, isBareSlot, type PluginPanelProps } from "./panels";
 
 /**
  * Isolates a single plugin panel: a throw in one panel renders a local notice
@@ -41,24 +41,34 @@ export function PluginPanelHost({
 
   if (panels.length === 0) return <>{fallback ?? null}</>;
 
+  // A fully-chromeless slot drops the host's outer padding/spacing so the panel
+  // can fill the tab; a mixed/chromed slot keeps the padded, stacked layout.
+  const bare = isBareSlot(panels);
+
   return (
-    <div className="h-full overflow-auto p-4 space-y-4">
+    <div className={bare ? "h-full overflow-auto" : "h-full overflow-auto p-4 space-y-4"}>
       {panels.map((panel) => {
         const Icon = panel.icon;
         const Body = panel.component;
+
+        const body = (
+          <PanelErrorBoundary title={panel.title}>
+            <Suspense fallback={<p className="text-xs text-muted-foreground">Loading…</p>}>
+              <Body {...props} />
+            </Suspense>
+          </PanelErrorBoundary>
+        );
+
+        // Chromeless: render the body directly, letting the panel own its layout.
+        if (panel.chromeless) return <div key={panel.id} className="h-full">{body}</div>;
+
         return (
           <section key={panel.id} className="rounded-lg border border-border bg-card">
             <header className="flex items-center gap-2 border-b border-border px-4 py-2.5">
               {Icon && <Icon className="w-4 h-4 text-primary" />}
               <h3 className="text-sm font-medium text-foreground">{panel.title}</h3>
             </header>
-            <div className="p-4">
-              <PanelErrorBoundary title={panel.title}>
-                <Suspense fallback={<p className="text-xs text-muted-foreground">Loading…</p>}>
-                  <Body {...props} />
-                </Suspense>
-              </PanelErrorBoundary>
-            </div>
+            <div className="p-4">{body}</div>
           </section>
         );
       })}

--- a/src/plugins/panels.test.ts
+++ b/src/plugins/panels.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { pluginRegistry } from "./registry";
-import { PANELS_POINT, PanelSlot, getPanelsForSlot, type PluginPanel } from "./panels";
+import { PANELS_POINT, PanelSlot, getPanelsForSlot, isBareSlot, type PluginPanel } from "./panels";
 
 const noopComponent: PluginPanel["component"] = () => null;
 
 function panel(id: string, slot: string, order?: number): PluginPanel {
   return { id, title: id, slot, order, component: noopComponent };
+}
+
+function chromelessPanel(id: string, slot: string): PluginPanel {
+  return { id, title: id, slot, chromeless: true, component: noopComponent };
 }
 
 describe("getPanelsForSlot", () => {
@@ -38,5 +42,19 @@ describe("getPanelsForSlot", () => {
 
     expect(getPanelsForSlot(PanelSlot.Coach).map((p) => p.id)).toEqual(["coach-panel"]);
     expect(getPanelsForSlot(PanelSlot.Labs).map((p) => p.id)).toEqual(["labs-panel"]);
+  });
+});
+
+describe("isBareSlot", () => {
+  it("is true only when there are panels and all are chromeless", () => {
+    expect(isBareSlot([chromelessPanel("a", "s"), chromelessPanel("b", "s")])).toBe(true);
+  });
+
+  it("is false for an empty slot", () => {
+    expect(isBareSlot([])).toBe(false);
+  });
+
+  it("is false when any panel keeps its chrome", () => {
+    expect(isBareSlot([chromelessPanel("a", "s"), panel("b", "s")])).toBe(false);
   });
 });

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -53,6 +53,14 @@ export interface PluginPanel {
   icon?: ComponentType<{ className?: string }>;
   /** The panel body. Re-renders with a fresh `PluginPanelProps` snapshot. */
   component: ComponentType<PluginPanelProps>;
+  /**
+   * Render the body without the host's card chrome (no bordered section,
+   * header, or padding) — for panels that own their full layout, e.g. a
+   * full-bleed dashboard. The error boundary and Suspense still apply. When a
+   * slot's panels are all chromeless, the host also drops its outer padding so
+   * the panel can fill the tab.
+   */
+  chromeless?: boolean;
 }
 
 /** All panels contributed to `slot`, sorted by `order` then registration. */
@@ -61,4 +69,13 @@ export function getPanelsForSlot(slot: string): PluginPanel[] {
     .getContributions<PluginPanel>(PANELS_POINT)
     .filter((panel) => panel.slot === slot)
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+/**
+ * A slot is "bare" when it has panels and every one is chromeless — the host
+ * then renders without its outer padding/spacing so a single dashboard panel
+ * can fill the tab. A mixed slot keeps the padded, stacked layout.
+ */
+export function isBareSlot(panels: PluginPanel[]): boolean {
+  return panels.length > 0 && panels.every((p) => p.chromeless);
 }


### PR DESCRIPTION
## Summary

Enables and ships the AI coach's full-bleed analysis dashboard. Two coupled
changes — the coach `chromeless: true` panel can't typecheck without the host flag,
so they land together.

**Host: chromeless panels**
- `PluginPanel` gains `chromeless?: boolean`. When set, `PluginPanelHost` renders
  the body directly (no bordered section / header / inner padding).
- New pure helper `isBareSlot(panels)` — true when a slot has panels and **all**
  are chromeless; the host then also drops its **outer** padding so a single
  dashboard panel fills the tab.
- Safety unchanged: every panel still gets its per-panel **error boundary +
  Suspense** (so chromeless panels can be `React.lazy`).
- Mixed/chromed slots (e.g. Cloud Sync's Labs panel) are **visually unchanged**.

**Coach plugin v0.2.0**
- Bumps `@perchwerks/eye-in-the-sky` `0.1.0 → 0.2.0` + refreshed lockfile.
- v0.2.0 ships a full-bleed Coach dashboard (uPlot telemetry charts, corner/sector
  analysis) that adopts `chromeless: true` and lazy-loads its body.
- Verified chunking: `CoachDashboard` + uPlot land in their own lazy chunk
  (~70 KB js + 1.7 KB css), **not** the initial bundle. `CoachTab` stays a 0.97 KB
  chunk.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (322) / `npm run build`
- [x] Host typechecks the plugin's `chromeless` usage (confirms the coupling)
- [x] uPlot confirmed **out** of the initial `index` chunk (own lazy chunk)
- [ ] Visual pass: open the Coach tab with a session loaded and confirm the dashboard renders

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3