### PR TITLE
Pull in coach plugin v0.2.0 (analysis dashboard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named slot, starting with the Labs tab. The tab now appears automatically when
   a plugin contributes a panel, and each panel is isolated by an error boundary.
 - Dedicated AI Coach tab: a new top-level view (`PanelSlot.Coach`) that hosts the
-  coaching plugin's session-debrief panels. Like Labs, it is self-gating — the
-  tab only appears when the coach plugin is installed and contributes a panel.
+  coaching plugin's session-debrief dashboard. Like Labs, it is self-gating — the
+  tab only appears when the coach plugin is installed and contributes a panel. The
+  bundled coach (`@perchwerks/eye-in-the-sky` 0.2.0) ships a full-bleed analysis
+  dashboard (uPlot telemetry charts, corner/sector breakdowns) that loads lazily,
+  off the initial bundle.
+- Plugin panels can now be **chromeless** — a panel may render full-bleed without
+  the host's card/header/padding (used by the coach dashboard), while keeping its
+  error boundary and Suspense.
 - Cloud Sync (first-party plugin, in the Labs tab): sign in to back up and sync
   your session files and garage data (vehicles, setups, notes, graph prefs) to
   the cloud and pull them onto another device. Manual push/pull; data is private

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "^0.1.0"
+        "@perchwerks/eye-in-the-sky": "^0.2.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,11 +2473,14 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.1.0.tgz",
-      "integrity": "sha512-HFsl3BEhCQXuf9WUTJVRPEr50HIMNNj4+CJ16OwAAdXjDG/Wntz4aEYP8sxKvScozzswA6MZrAsvIrjMHMcAVg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.0.tgz",
+      "integrity": "sha512-yzaAz04EE3VSd4G+hdqvdfHTyod25Qr/O1PLUVqKG6pyhun2HajD0bl8q5Ke6YGcexQ0lMaHnZUoMtaaJJmr6w==",
       "license": "GPL-3.0-or-later",
-      "optional": true
+      "optional": true,
+      "dependencies": {
+        "uplot": "^1.6.32"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -10615,6 +10618,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uplot": {
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "^0.1.0"
+    "@perchwerks/eye-in-the-sky": "^0.2.0"
   }
 }


### PR DESCRIPTION
Bumps @perchwerks/eye-in-the-sky 0.1.0 → 0.2.0 and refreshes the lockfile. v0.2.0 ships a full-bleed Coach dashboard (uPlot charts + corner/sector analysis) that uses the new chromeless panel flag and lazy-loads its body, so uPlot lands in its own chunk (~70KB) off the initial bundle. Coupled with the chromeless host change in this PR — v0.2.0's `chromeless: true` requires the PluginPanel flag to typecheck.

