### PR TITLE
Refresh coach plugin to v0.2.2 (React 18 peer fix + Leaflet map)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,13 +2473,18 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.0.tgz",
-      "integrity": "sha512-yzaAz04EE3VSd4G+hdqvdfHTyod25Qr/O1PLUVqKG6pyhun2HajD0bl8q5Ke6YGcexQ0lMaHnZUoMtaaJJmr6w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.2.tgz",
+      "integrity": "sha512-oZe/Pp/loFLyknibRTroxSZGp3PVjCSDaWSigLMYck+yKYIrMgfvHbZlKRrgANzoeRbOpWICy58KYdnGzVZmig==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {
         "uplot": "^1.6.32"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.4",
+        "react": "^18.3 || ^19.0.0",
+        "react-dom": "^18.3 || ^19.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {


### PR DESCRIPTION
0.2.2 widens its React peer range to ^18.3 || ^19 (0.2.1 required ^19 and wouldn't resolve against the host's React 18.3.1) and adds a Leaflet race-line map panel. Lockfile-only refresh; the ^0.2.0 pin already covers it. Verified: typecheck/tests/build green, uPlot stays off the initial bundle, and the map reuses the host's shared vendor-leaflet chunk (leaflet is a plugin peer dep).

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

