### PR TITLE
Refresh coach plugin to v0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.2.tgz",
-      "integrity": "sha512-oZe/Pp/loFLyknibRTroxSZGp3PVjCSDaWSigLMYck+yKYIrMgfvHbZlKRrgANzoeRbOpWICy58KYdnGzVZmig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.3.tgz",
+      "integrity": "sha512-9qc5fMtbrS9ELiCB2RAw+O2bTh/3hmQ1C83VPwCKcT/VpyIDB+R0OoXhuChrtrrnJJzOF+vQdOQDK0TA9dSmxg==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
Lockfile-only refresh within the existing ^0.2.0 pin. Peer ranges unchanged (React ^18.3 || ^19). Verified green: typecheck, 322 tests, build; uPlot stays off the initial bundle.

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

