### PR TITLE
Document storage + auto-sync, propagation deletes, quotas + Profile tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Document storage tier + **auto-sync**: when you're signed in, your garage
+  (vehicles, setups, setup templates, notes) now backs up to the cloud
+  automatically as you change it — no manual push. This "documents" tier is free
+  with a **5 MB** limit; raw session **logs** are a separate **20 MB** tier.
+  Limits are enforced server-side.
+- **Propagation deletes**: deleting a vehicle or setup while signed in removes it
+  from **every device and the cloud**, with a clear warning before you confirm.
+- New **Profile** tab (far right) showing your cloud storage usage against the
+  document and log limits (account display name/avatar are placeholders for now).
 - Plugin UI panel framework: plugins can contribute self-contained panels to a
   named slot, starting with the Labs tab. The tab now appears automatically when
   a plugin contributes a panel, and each panel is isolated by an error boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Document storage tier + **auto-sync**: when you're signed in, your garage
+- Document storage + **auto-sync**: when you're signed in, your garage
   (vehicles, setups, setup templates, notes) now backs up to the cloud
-  automatically as you change it — no manual push. This "documents" tier is free
-  with a **5 MB** limit; raw session **logs** are a separate **20 MB** tier.
-  Limits are enforced server-side.
+  automatically as you change it — no manual push. The "documents" storage type
+  is free with a **5 MB** limit; raw session **logs** are a separate **20 MB**
+  storage type. Limits are enforced server-side.
 - **Propagation deletes**: deleting a vehicle or setup while signed in removes it
   from **every device and the cloud**, with a clear warning before you confirm.
 - New **Profile** tab (far right) showing your cloud storage usage against the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ src/
 ├── components/
 │   ├── ui/                # shadcn/ui primitives (button, dialog, tabs, etc.)
 │   ├── admin/             # Admin tabs: TracksTab, CoursesTab, SubmissionsTab, BannedIpsTab, ToolsTab, MessagesTab
-│   ├── tabs/              # Main view tabs: GraphViewTab, RaceLineTab, LapTimesTab, LabsTab, CoachTab
+│   ├── tabs/              # Main view tabs: GraphViewTab, RaceLineTab, LapTimesTab, LabsTab, CoachTab, ProfileTab
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, InfoBox
 │   ├── drawer/            # File manager drawer tabs: FilesTab, KartsTab, NotesTab, SetupsTab, DeviceSettingsTab, DeviceTracksTab
 │   ├── track-editor/      # Track editor sub-components
@@ -146,6 +146,7 @@ src/
 │   ├── referenceUtils.ts      # Reference lap comparison (legacy distance-based pace)
 │   ├── lapDelta.ts            # ★ Position-based lap delta: arc-length resample + segment-projected gap (issue #29 port)
 │   ├── dbUtils.ts             # ★ Shared IndexedDB: DB_NAME, DB_VERSION, openDB(), transaction helpers
+│   ├── garageEvents.ts        # ★ Host pub/sub: storage modules emit {store,key,put|delete}; cloud-sync auto-syncs off it
 │   ├── fileStorage.ts         # IndexedDB: raw file blobs
 │   ├── kartStorage.ts         # Old kart storage (kept for compat)
 │   ├── vehicleStorage.ts     # ★ Vehicle profiles CRUD (replaces kartStorage)
@@ -192,8 +193,11 @@ src/
 │   │   ├── CloudFilesSection.tsx # FileManagerSection mount: lists all cloud files (on-device marked, others pullable)
 │   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames (pure, tested)
 │   │   ├── syncStores.ts         # Pure config: which IDB stores sync + how they're keyed (testable)
-│   │   ├── syncEngine.ts         # pushAll (garage + selected files) / pushFile / pullAll: IDB ↔ sync_records + bucket
-│   │   └── cloudClient.ts        # Typed access to sync_records + bucket (escape hatch until types regen)
+│   │   ├── tiers.ts              # Pure: storage tiers (documents 5MB / logs 20MB) + usage math (tested)
+│   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord/pushDocs/pullDocs + getStorageUsage
+│   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
+│   │   ├── StoragePanel.tsx      # Profile-tab panel: storage usage meters + account scratch pad (lazy)
+│   │   └── cloudClient.ts        # Typed access to sync_records + bucket + sync_storage_usage RPC (escape hatch until types regen)
 │   └── coaching/              # Gitignored private slot (AI coaching submodule)
 ├── types/
 │   └── racing.ts              # ★ Core types: GpsSample, ParsedData, Lap, Course, Track, etc.
@@ -259,11 +263,13 @@ A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 
 **UI panels:** the first concrete extension point. A plugin contributes
 `PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
-Two slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`) and
+Three slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`),
 `PanelSlot.Coach` (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home
-for the `@perchwerks/eye-in-the-sky` coaching plugin). Both render contributed
-panels via `PluginPanelHost` and are **self-gating**: `Index.tsx` computes
-`hasLabsPanels`/`showCoach` from `getPanelsForSlot`, so a tab appears only when a
+for the `@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
+(rendered by `ProfileTab.tsx`, far-right — cloud-sync contributes the storage
+meters). All render contributed panels via `PluginPanelHost` and are
+**self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showProfile`
+from `getPanelsForSlot`, so a tab appears only when a
 plugin contributes a panel to it (Labs additionally shows when the experimental
 `enableLabs` setting is on). New slots are just new strings — no framework change.
 `PluginPanelHost` wraps each panel in an error boundary **and** a `Suspense`
@@ -390,18 +396,33 @@ To add a new store: increment `DB_VERSION`, add store name to `STORE_NAMES`, add
 ## Cloud Sync (`src/plugins/cloud-sync/`)
 
 Optional per-user backup/sync of the IndexedDB data above to Supabase. Built as
-a first-party plugin (Labs panel), online-only (accepted offline-first
-exception). **Manual & directional**: "push" mirrors local → cloud, "pull"
-brings cloud → local; on a key collision the chosen direction wins. Sync is
-**additive** — neither side deletes the other's extra records (deletion
-propagation + timestamp merge are deliberate follow-ups).
+a first-party plugin (Labs + Profile panels), online-only (accepted offline-first
+exception). Manual push/pull remains (`CloudSyncPanel`), but the **document tier
+now auto-syncs**: storage modules emit `garageEvents` on write/delete, and
+`autoSync.ts` (started in `setup`, dynamically imported to stay off the initial
+bundle) debounces and incrementally **upserts (put) / deletes (delete)** the one
+changed record while signed in, and **reconciles** (pull docs → push docs) on
+sign-in. So edits back up automatically and **deletes propagate everywhere** —
+the Karts/Setups delete UI shows a loud "deletes from every device + the cloud"
+warning when signed in. (Log-blob deletion propagation + timestamp merge are
+still follow-ups.)
 
-Backend (migration `..._cloud_sync.sql`):
+**Storage tiers** (`tiers.ts`, enforced server-side): **documents** = all
+structured stores (5 MB, free, auto-synced) and **logs** = file blobs (20 MB,
+opt-in). Limits live in the `quota_limits` table (one source of truth for the
+enforcing trigger + the client meter); `sync_storage_usage()` returns per-tier
+usage for the Profile-tab meters. Client checks are advisory — the DB trigger is
+the real gate.
+
+Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
 
 | Object | Type | Notes |
 |--------|------|-------|
 | `sync_records` | table | One jsonb document per record: `(user_id, store, record_key, data, updated_at)`, unique on `(user_id, store, record_key)`. RLS: `auth.uid() = user_id`. `store`/`record_key` mirror the IndexedDB store name + key path. |
 | `user-files` | Storage bucket | Private. Raw session blobs at `{user_id}/{encodeURIComponent(name)}`. RLS scopes objects to the owner's folder. |
+| `quota_limits` | table | `(tier, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Read by client + trigger. |
+| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a tier over its limit (`quota_exceeded`). |
+| `sync_storage_usage()` | RPC | Per-tier `(used_bytes, limit_bytes)` for the caller. |
 
 Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
 `setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates` (jsonb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ src/
 │   │   ├── CloudFilesSection.tsx # FileManagerSection mount: lists all cloud files (on-device marked, others pullable)
 │   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames (pure, tested)
 │   │   ├── syncStores.ts         # Pure config: which IDB stores sync + how they're keyed (testable)
-│   │   ├── tiers.ts              # Pure: storage tiers (documents 5MB / logs 20MB) + usage math (tested)
+│   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
 │   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord/pushDocs/pullDocs + getStorageUsage
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
 │   │   ├── StoragePanel.tsx      # Profile-tab panel: storage usage meters + account scratch pad (lazy)
@@ -407,12 +407,12 @@ the Karts/Setups delete UI shows a loud "deletes from every device + the cloud"
 warning when signed in. (Log-blob deletion propagation + timestamp merge are
 still follow-ups.)
 
-**Storage tiers** (`tiers.ts`, enforced server-side): **documents** = all
-structured stores (5 MB, free, auto-synced) and **logs** = file blobs (20 MB,
-opt-in). Limits live in the `quota_limits` table (one source of truth for the
-enforcing trigger + the client meter); `sync_storage_usage()` returns per-tier
-usage for the Profile-tab meters. Client checks are advisory — the DB trigger is
-the real gate.
+**Storage types** (`storageTypes.ts`, enforced server-side) — distinct from
+future *subscription tiers*: **documents** = all structured stores (5 MB, free,
+auto-synced) and **logs** = file blobs (20 MB, opt-in). Limits live in the
+`quota_limits` table (one source of truth for the enforcing trigger + the client
+meter); `sync_storage_usage()` returns per-type usage for the Profile-tab meters.
+Client checks are advisory — the DB trigger is the real gate.
 
 Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
 
@@ -420,9 +420,9 @@ Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
 |--------|------|-------|
 | `sync_records` | table | One jsonb document per record: `(user_id, store, record_key, data, updated_at)`, unique on `(user_id, store, record_key)`. RLS: `auth.uid() = user_id`. `store`/`record_key` mirror the IndexedDB store name + key path. |
 | `user-files` | Storage bucket | Private. Raw session blobs at `{user_id}/{encodeURIComponent(name)}`. RLS scopes objects to the owner's folder. |
-| `quota_limits` | table | `(tier, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Read by client + trigger. |
-| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a tier over its limit (`quota_exceeded`). |
-| `sync_storage_usage()` | RPC | Per-tier `(used_bytes, limit_bytes)` for the caller. |
+| `quota_limits` | table | `(storage_type, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Read by client + trigger. |
+| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a storage type over its limit (`quota_exceeded`). |
+| `sync_storage_usage()` | RPC | Per-type `(used_bytes, limit_bytes)` for the caller. |
 
 Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
 `setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates` (jsonb

--- a/src/components/drawer/KartsTab.tsx
+++ b/src/components/drawer/KartsTab.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Kart } from "@/lib/kartStorage";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface KartsTabProps {
   karts: Kart[];
@@ -16,6 +17,7 @@ interface KartsTabProps {
 const emptyForm: Omit<Kart, "id"> = { name: "", engine: "", number: 0, weight: 0, weightUnit: "lb" };
 
 export function KartsTab({ karts, onAdd, onUpdate, onRemove }: KartsTabProps) {
+  const { user } = useAuth();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState(emptyForm);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
@@ -57,10 +59,16 @@ export function KartsTab({ karts, onAdd, onUpdate, onRemove }: KartsTabProps) {
     <div className="flex flex-col flex-1 min-h-0">
       {/* Delete Confirmation */}
       {confirmDelete && (
-        <div className="mx-3 mt-3 mb-1 p-3 rounded-md border border-border bg-muted/60 space-y-2 shrink-0">
-          <p className="text-sm text-foreground">
-            Delete this kart? This cannot be undone.
-          </p>
+        <div className={`mx-3 mt-3 mb-1 p-3 rounded-md border space-y-2 shrink-0 ${user ? "border-destructive/50 bg-destructive/10" : "border-border bg-muted/60"}`}>
+          {user ? (
+            <p className="text-sm font-medium text-destructive">
+              Delete this kart everywhere? This removes it from <strong>every device and the cloud</strong> — it can't be undone.
+            </p>
+          ) : (
+            <p className="text-sm text-foreground">
+              Delete this kart? This cannot be undone.
+            </p>
+          )}
           <div className="flex justify-end gap-2">
             <Button variant="outline" size="sm" onClick={() => setConfirmDelete(null)}>Cancel</Button>
             <Button variant="destructive" size="sm" onClick={handleDeleteConfirm}>Delete</Button>

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -10,6 +10,7 @@ import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
 import { VehicleType, SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
 import { TemplateCreator } from "@/components/drawer/TemplateCreator";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface SetupsTabProps {
   vehicles: Vehicle[];
@@ -62,6 +63,7 @@ export function SetupsTab({
   const [preloaded, setPreloaded] = useState(false);
   const preloadSnapshot = useRef<Record<string, unknown> | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const { user } = useAuth();
 
   // PSI display helpers
   const [psiSingle, setPsiSingle] = useState<number | null>(null);
@@ -293,7 +295,9 @@ export function SetupsTab({
                     </div>
                     {isDeleting && (
                       <div className="mx-3 mb-1 p-2 rounded-md bg-destructive/10 border border-destructive/30 flex items-center gap-2">
-                        <span className="text-xs text-destructive flex-1">Delete this setup?</span>
+                        <span className="text-xs text-destructive flex-1">
+                          {user ? "Delete everywhere — removes this setup from every device and the cloud." : "Delete this setup?"}
+                        </span>
                         <Button size="sm" variant="destructive" className="h-6 text-xs px-2" onClick={async () => { await onRemove(setup.id); setDeleteConfirmId(null); }}>Confirm</Button>
                         <Button size="sm" variant="ghost" className="h-6 text-xs px-2" onClick={() => setDeleteConfirmId(null)}>Cancel</Button>
                       </div>

--- a/src/components/tabs/ProfileTab.tsx
+++ b/src/components/tabs/ProfileTab.tsx
@@ -1,0 +1,37 @@
+import { memo } from "react";
+import { User } from "lucide-react";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { useSettingsContext } from "@/contexts/SettingsContext";
+import { PluginPanelHost } from "@/plugins/PluginPanelHost";
+import { PanelSlot } from "@/plugins/panels";
+
+export const ProfileTab = memo(function ProfileTab() {
+  const { data, laps, selectedLapNumber, course } = useSessionContext();
+  const { useKph } = useSettingsContext();
+
+  return (
+    <PluginPanelHost
+      slot={PanelSlot.Profile}
+      data={data}
+      laps={laps}
+      selectedLapNumber={selectedLapNumber}
+      course={course}
+      useKph={useKph}
+      fallback={<ProfileEmpty />}
+    />
+  );
+});
+
+function ProfileEmpty() {
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="max-w-sm space-y-5 text-center px-4">
+        <User className="w-10 h-10 text-muted-foreground/40 mx-auto" />
+        <p className="text-sm font-medium text-foreground">Profile</p>
+        <p className="text-xs text-muted-foreground">
+          Profile &amp; storage are unavailable in this build.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/garageEvents.ts
+++ b/src/lib/garageEvents.ts
@@ -1,0 +1,38 @@
+// Lightweight host pub/sub for garage mutations (vehicles, setups, templates,
+// vehicle types, notes). Storage modules emit a change after each write/delete;
+// the cloud-sync plugin subscribes to drive incremental auto-sync (upsert on
+// put, delete on delete). Host-owned and generic — no plugin or network deps —
+// so the core works the same whether or not a sync plugin is listening.
+
+export type GarageChangeType = "put" | "delete";
+
+export interface GarageChange {
+  /** IndexedDB store name (matches STORE_NAMES + the cloud record `store`). */
+  store: string;
+  /** Record key (the store's key path value). */
+  key: string;
+  type: GarageChangeType;
+}
+
+type Listener = (change: GarageChange) => void;
+
+const listeners = new Set<Listener>();
+
+/** Subscribe to garage changes. Returns an unsubscribe function. */
+export function onGarageChange(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Notify subscribers of a garage mutation. Listener errors are isolated. */
+export function emitGarageChange(change: GarageChange): void {
+  for (const listener of listeners) {
+    try {
+      listener(change);
+    } catch (err) {
+      console.error("garage change listener failed", err);
+    }
+  }
+}

--- a/src/lib/noteStorage.ts
+++ b/src/lib/noteStorage.ts
@@ -3,6 +3,7 @@
  */
 
 import { openDB, STORE_NAMES } from './dbUtils';
+import { emitGarageChange } from './garageEvents';
 
 export interface Note {
   id: string;
@@ -36,6 +37,7 @@ export async function saveNote(note: Note): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: NOTES_STORE, key: note.id, type: "put" });
 }
 
 export async function deleteNote(id: string): Promise<void> {
@@ -47,4 +49,5 @@ export async function deleteNote(id: string): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: NOTES_STORE, key: id, type: "delete" });
 }

--- a/src/lib/setupStorage.ts
+++ b/src/lib/setupStorage.ts
@@ -4,6 +4,7 @@
  */
 
 import { openDB, STORE_NAMES } from './dbUtils';
+import { emitGarageChange } from './garageEvents';
 
 export interface VehicleSetup {
   id: string;
@@ -63,6 +64,7 @@ export async function saveSetup(setup: VehicleSetup): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: SETUPS_STORE, key: setup.id, type: "put" });
 }
 
 export async function deleteSetup(id: string): Promise<void> {
@@ -74,6 +76,7 @@ export async function deleteSetup(id: string): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: SETUPS_STORE, key: id, type: "delete" });
 }
 
 export async function getLatestSetupForVehicle(vehicleId: string): Promise<VehicleSetup | null> {

--- a/src/lib/templateStorage.ts
+++ b/src/lib/templateStorage.ts
@@ -4,6 +4,7 @@
  */
 
 import { openDB, STORE_NAMES } from './dbUtils';
+import { emitGarageChange } from './garageEvents';
 
 // ── Types ──
 
@@ -169,6 +170,7 @@ export async function saveVehicleType(vt: VehicleType): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: STORE_NAMES.VEHICLE_TYPES, key: vt.id, type: "put" });
 }
 
 export async function deleteVehicleType(id: string): Promise<void> {
@@ -180,6 +182,7 @@ export async function deleteVehicleType(id: string): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: STORE_NAMES.VEHICLE_TYPES, key: id, type: "delete" });
 }
 
 // ── Setup Template CRUD ──
@@ -217,6 +220,7 @@ export async function saveTemplate(template: SetupTemplate): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: STORE_NAMES.SETUP_TEMPLATES, key: template.id, type: "put" });
 }
 
 export async function deleteTemplate(id: string): Promise<void> {
@@ -228,6 +232,7 @@ export async function deleteTemplate(id: string): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: STORE_NAMES.SETUP_TEMPLATES, key: id, type: "delete" });
 }
 
 /**
@@ -274,6 +279,8 @@ export async function createVehicleTypeWithTemplate(
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: STORE_NAMES.VEHICLE_TYPES, key: vehicleType.id, type: "put" });
+  emitGarageChange({ store: STORE_NAMES.SETUP_TEMPLATES, key: template.id, type: "put" });
 
   return { vehicleType, template };
 }
@@ -291,4 +298,6 @@ export async function deleteVehicleTypeWithTemplate(vehicleTypeId: string, templ
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: STORE_NAMES.VEHICLE_TYPES, key: vehicleTypeId, type: "delete" });
+  emitGarageChange({ store: STORE_NAMES.SETUP_TEMPLATES, key: templateId, type: "delete" });
 }

--- a/src/lib/vehicleStorage.ts
+++ b/src/lib/vehicleStorage.ts
@@ -4,6 +4,7 @@
  */
 
 import { openDB, STORE_NAMES } from './dbUtils';
+import { emitGarageChange } from './garageEvents';
 
 export interface Vehicle {
   id: string;
@@ -26,6 +27,7 @@ export async function saveVehicle(vehicle: Vehicle): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: VEHICLES_STORE, key: vehicle.id, type: "put" });
 }
 
 export async function listVehicles(): Promise<Vehicle[]> {
@@ -61,4 +63,5 @@ export async function deleteVehicle(id: string): Promise<void> {
     tx.onerror = () => reject(tx.error);
   });
   db.close();
+  emitGarageChange({ store: VEHICLES_STORE, key: id, type: "delete" });
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical } from "lucide-react";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, User } from "lucide-react";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { RaceLineTab } from "@/components/tabs/RaceLineTab";
@@ -16,6 +16,9 @@ const LabsTab = lazy(() =>
 );
 const CoachTab = lazy(() =>
   import("@/components/tabs/CoachTab").then((m) => ({ default: m.CoachTab })),
+);
+const ProfileTab = lazy(() =>
+  import("@/components/tabs/ProfileTab").then((m) => ({ default: m.ProfileTab })),
 );
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SettingsModal } from "@/components/SettingsModal";
@@ -49,7 +52,7 @@ import { DeviceProvider } from "@/contexts/DeviceContext";
 import { SessionProvider, type SessionContextValue } from "@/contexts/SessionContext";
 
 
-type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach";
+type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach" | "profile";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
@@ -122,6 +125,9 @@ export default function Index() {
   // The Coach tab is self-gating: it appears only when a plugin contributes a
   // panel to the Coach slot (i.e. the coach package is installed).
   const showCoach = useMemo(() => getPanelsForSlot(PanelSlot.Coach).length > 0, []);
+  // Profile tab is self-gating too: appears only when a plugin (cloud-sync)
+  // contributes a Profile panel (i.e. the cloud build flag is on).
+  const showProfile = useMemo(() => getPanelsForSlot(PanelSlot.Profile).length > 0, []);
 
   // Video sync for Labs tab
   const videoSync = useVideoSync({
@@ -393,7 +399,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} showProfile={showProfile} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -403,6 +409,7 @@ export default function Index() {
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "labs" && showLabs && <LabsTab />}
             {topPanelView === "coach" && showCoach && <CoachTab />}
+            {topPanelView === "profile" && showProfile && <ProfileTab />}
           </Suspense>
         </div>
       </main>
@@ -427,7 +434,7 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, showProfile }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
@@ -435,6 +442,7 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   onToggleOverlays: () => void;
   showLabs: boolean;
   showCoach: boolean;
+  showProfile: boolean;
 }) {
   const tabClass = (view: TopPanelView) =>
     `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
@@ -474,6 +482,11 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
             <span className="text-xs">Overlay</span>
           </Button>
         </div>
+      )}
+      {showProfile && (
+        <button onClick={() => setTopPanelView("profile")} className={`${tabClass("profile")} ${topPanelView === "raceline" ? "" : "ml-auto"}`}>
+          <User className="w-4 h-4" /> <span className="hidden sm:inline">Profile</span>
+        </button>
       )}
     </div>
   );

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -3,20 +3,20 @@ import { User as UserIcon } from "lucide-react";
 import type { PluginPanelProps } from "@/plugins/panels";
 import { useAuth } from "@/contexts/AuthContext";
 import { getStorageUsage } from "./syncEngine";
-import { formatBytes, usageFraction, type TierUsage } from "./tiers";
+import { formatBytes, usageFraction, type StorageTypeUsage } from "./storageTypes";
 
-const TIER_LABEL: Record<string, string> = { documents: "Documents", logs: "Logs" };
-const TIER_HINT: Record<string, string> = {
+const TYPE_LABEL: Record<string, string> = { documents: "Documents", logs: "Logs" };
+const TYPE_HINT: Record<string, string> = {
   documents: "Vehicles, setups, templates & notes — free, auto-synced.",
   logs: "Session log files you've chosen to sync.",
 };
 
 // Scratch-pad profile panel: who you're signed in as + your cloud storage usage
-// against the document/log tier limits. (Display name / avatar are placeholders
+// against the document/log storage limits. (Display name / avatar are placeholders
 // until profiles land.)
 export default function StoragePanel(_props: PluginPanelProps) {
   const { user, loading } = useAuth();
-  const [usage, setUsage] = useState<TierUsage[] | null>(null);
+  const [usage, setUsage] = useState<StorageTypeUsage[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
@@ -66,20 +66,20 @@ export default function StoragePanel(_props: PluginPanelProps) {
         {error && <p className="text-xs text-destructive">{error}</p>}
         {!usage && !error && <p className="text-xs text-muted-foreground">Loading usage…</p>}
         {usage?.map((u) => (
-          <Meter key={u.tier} usage={u} />
+          <Meter key={u.storageType} usage={u} />
         ))}
       </div>
     </div>
   );
 }
 
-function Meter({ usage }: { usage: TierUsage }) {
+function Meter({ usage }: { usage: StorageTypeUsage }) {
   const pct = Math.round(usageFraction(usage) * 100);
   const over = usage.usedBytes > usage.limitBytes;
   return (
     <div className="space-y-1">
       <div className="flex items-baseline justify-between text-sm">
-        <span className="text-foreground">{TIER_LABEL[usage.tier] ?? usage.tier}</span>
+        <span className="text-foreground">{TYPE_LABEL[usage.storageType] ?? usage.storageType}</span>
         <span className={`text-xs tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
           {formatBytes(usage.usedBytes)} / {formatBytes(usage.limitBytes)}
         </span>
@@ -90,7 +90,7 @@ function Meter({ usage }: { usage: TierUsage }) {
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="text-[11px] text-muted-foreground">{TIER_HINT[usage.tier]}</p>
+      <p className="text-[11px] text-muted-foreground">{TYPE_HINT[usage.storageType]}</p>
     </div>
   );
 }

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from "react";
+import { User as UserIcon } from "lucide-react";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { useAuth } from "@/contexts/AuthContext";
+import { getStorageUsage } from "./syncEngine";
+import { formatBytes, usageFraction, type TierUsage } from "./tiers";
+
+const TIER_LABEL: Record<string, string> = { documents: "Documents", logs: "Logs" };
+const TIER_HINT: Record<string, string> = {
+  documents: "Vehicles, setups, templates & notes — free, auto-synced.",
+  logs: "Session log files you've chosen to sync.",
+};
+
+// Scratch-pad profile panel: who you're signed in as + your cloud storage usage
+// against the document/log tier limits. (Display name / avatar are placeholders
+// until profiles land.)
+export default function StoragePanel(_props: PluginPanelProps) {
+  const { user, loading } = useAuth();
+  const [usage, setUsage] = useState<TierUsage[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    try {
+      setUsage(await getStorageUsage());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load storage usage");
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+
+  if (!user) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">Not signed in</p>
+        <p className="text-xs text-muted-foreground">
+          Sign in under Labs → Cloud Sync to back up your garage and see your storage usage.
+        </p>
+      </div>
+    );
+  }
+
+  const displayName =
+    (user.user_metadata?.display_name as string | undefined) || user.email || "Driver";
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <UserIcon className="h-6 w-6" />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
+          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Storage</p>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        {!usage && !error && <p className="text-xs text-muted-foreground">Loading usage…</p>}
+        {usage?.map((u) => (
+          <Meter key={u.tier} usage={u} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Meter({ usage }: { usage: TierUsage }) {
+  const pct = Math.round(usageFraction(usage) * 100);
+  const over = usage.usedBytes > usage.limitBytes;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between text-sm">
+        <span className="text-foreground">{TIER_LABEL[usage.tier] ?? usage.tier}</span>
+        <span className={`text-xs tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
+          {formatBytes(usage.usedBytes)} / {formatBytes(usage.limitBytes)}
+        </span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full ${over ? "bg-destructive" : "bg-primary"}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-[11px] text-muted-foreground">{TIER_HINT[usage.tier]}</p>
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -1,0 +1,99 @@
+// Background document auto-sync.
+//
+// Runs outside React: tracks the signed-in user via the Supabase auth session
+// and listens to host garage-change events (vehicles/setups/templates/types/
+// notes). On a change it debounces, then upserts (put) or deletes (delete) the
+// single cloud record — so edits propagate up and deletes propagate everywhere.
+// On sign-in it reconciles (pull cloud docs down, push local docs up). Only the
+// free "documents" tier auto-syncs here; log blobs stay manual/opt-in.
+
+import { supabase } from "@/integrations/supabase/client";
+import { onGarageChange, type GarageChange } from "@/lib/garageEvents";
+import { isQuotaError } from "./cloudClient";
+import { deleteRecord, pullDocs, pushDocs, pushRecord } from "./syncEngine";
+import { tierForStore } from "./tiers";
+
+const DEBOUNCE_MS = 800;
+
+let currentUserId: string | null = null;
+let started = false;
+const pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Injected so this module stays free of any toast/UI dependency. */
+type Notifier = (message: string, kind: "error" | "info") => void;
+let notify: Notifier = () => {};
+export function setAutoSyncNotifier(fn: Notifier): void {
+  notify = fn;
+}
+
+function recordKey(change: GarageChange): string {
+  return `${change.store}:${change.key}`;
+}
+
+async function flush(change: GarageChange): Promise<void> {
+  const userId = currentUserId;
+  if (!userId) return;
+  try {
+    if (change.type === "delete") {
+      await deleteRecord(userId, change.store, change.key);
+    } else {
+      await pushRecord(userId, change.store, change.key);
+    }
+  } catch (err) {
+    if (isQuotaError(err)) {
+      notify(
+        `Cloud ${tierForStore(change.store)} storage is full — saved locally, not synced.`,
+        "error",
+      );
+    } else {
+      console.error("auto-sync failed", err);
+    }
+  }
+}
+
+function schedule(change: GarageChange): void {
+  if (!currentUserId) return; // only sync while signed in
+  const key = recordKey(change);
+  const existing = pending.get(key);
+  if (existing) clearTimeout(existing);
+  pending.set(
+    key,
+    setTimeout(() => {
+      pending.delete(key);
+      void flush(change);
+    }, DEBOUNCE_MS),
+  );
+}
+
+async function reconcile(userId: string): Promise<void> {
+  try {
+    await pullDocs(userId); // cloud → local
+    await pushDocs(userId); // local-only → cloud (additive)
+  } catch (err) {
+    if (isQuotaError(err)) {
+      notify("Cloud document storage is full — some items didn't sync.", "error");
+    } else {
+      console.error("auto-sync reconcile failed", err);
+    }
+  }
+}
+
+/** Start the background document auto-sync. Idempotent. */
+export function startAutoSync(): void {
+  if (started) return;
+  started = true;
+
+  void supabase.auth.getSession().then(({ data }) => {
+    currentUserId = data.session?.user?.id ?? null;
+    if (currentUserId) void reconcile(currentUserId);
+  });
+
+  supabase.auth.onAuthStateChange((_event, session) => {
+    const next = session?.user?.id ?? null;
+    const newlySignedIn = next !== null && next !== currentUserId;
+    currentUserId = next;
+    if (newlySignedIn) void reconcile(next);
+  });
+
+  onGarageChange(schedule);
+}

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -5,13 +5,13 @@
 // notes). On a change it debounces, then upserts (put) or deletes (delete) the
 // single cloud record — so edits propagate up and deletes propagate everywhere.
 // On sign-in it reconciles (pull cloud docs down, push local docs up). Only the
-// free "documents" tier auto-syncs here; log blobs stay manual/opt-in.
+// free "documents" storage type auto-syncs here; log blobs stay manual/opt-in.
 
 import { supabase } from "@/integrations/supabase/client";
 import { onGarageChange, type GarageChange } from "@/lib/garageEvents";
 import { isQuotaError } from "./cloudClient";
 import { deleteRecord, pullDocs, pushDocs, pushRecord } from "./syncEngine";
-import { tierForStore } from "./tiers";
+import { storageTypeForStore } from "./storageTypes";
 
 const DEBOUNCE_MS = 800;
 
@@ -42,7 +42,7 @@ async function flush(change: GarageChange): Promise<void> {
   } catch (err) {
     if (isQuotaError(err)) {
       notify(
-        `Cloud ${tierForStore(change.store)} storage is full — saved locally, not synced.`,
+        `Cloud ${storageTypeForStore(change.store)} storage is full — saved locally, not synced.`,
         "error",
       );
     } else {

--- a/src/plugins/cloud-sync/cloudClient.ts
+++ b/src/plugins/cloud-sync/cloudClient.ts
@@ -34,3 +34,22 @@ export function syncRecords() {
 export function userFiles() {
   return untyped.storage.from(SYNC_BUCKET);
 }
+
+/** One tier's usage as returned by the server's sync_storage_usage() RPC. */
+export interface StorageUsageRow {
+  tier: string;
+  used_bytes: number;
+  limit_bytes: number;
+}
+
+/** Per-tier storage usage for the current user (authoritative, server-computed). */
+export async function fetchStorageUsage(): Promise<StorageUsageRow[]> {
+  const { data, error } = await untyped.rpc("sync_storage_usage");
+  if (error) throw new Error(`Failed to read storage usage: ${error.message}`);
+  return (data ?? []) as StorageUsageRow[];
+}
+
+/** True when an error from a sync_records write is the server quota rejection. */
+export function isQuotaError(err: unknown): boolean {
+  return err instanceof Error && /quota_exceeded/i.test(err.message);
+}

--- a/src/plugins/cloud-sync/cloudClient.ts
+++ b/src/plugins/cloud-sync/cloudClient.ts
@@ -35,14 +35,14 @@ export function userFiles() {
   return untyped.storage.from(SYNC_BUCKET);
 }
 
-/** One tier's usage as returned by the server's sync_storage_usage() RPC. */
+/** One storage type's usage as returned by the server's sync_storage_usage() RPC. */
 export interface StorageUsageRow {
-  tier: string;
+  storage_type: string;
   used_bytes: number;
   limit_bytes: number;
 }
 
-/** Per-tier storage usage for the current user (authoritative, server-computed). */
+/** Per-type storage usage for the current user (authoritative, server-computed). */
 export async function fetchStorageUsage(): Promise<StorageUsageRow[]> {
   const { data, error } = await untyped.rpc("sync_storage_usage");
   if (error) throw new Error(`Failed to read storage usage: ${error.message}`);

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -1,5 +1,6 @@
 import { lazy } from "react";
-import { Cloud } from "lucide-react";
+import { Cloud, User } from "lucide-react";
+import { toast } from "sonner";
 import type { DataViewerPlugin } from "@/plugins/types";
 import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
 import {
@@ -15,6 +16,8 @@ const CloudSyncPanel = lazy(() => import("./CloudSyncPanel"));
 // drawer doesn't pull the sync engine onto its chunk until they render.
 const FileSyncToggle = lazy(() => import("./FileSyncToggle"));
 const CloudFilesSection = lazy(() => import("./CloudFilesSection"));
+// Profile tab panel: storage usage meters + account scratch pad.
+const StoragePanel = lazy(() => import("./StoragePanel"));
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 
@@ -53,6 +56,24 @@ const plugin: DataViewerPlugin = {
       order: 0,
       component: CloudFilesSection,
     } satisfies PluginMountDef<FileManagerSectionContext>);
+
+    // Profile tab: storage usage meters (document + log tiers) + account.
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "cloud-sync-storage",
+      title: "Profile",
+      slot: PanelSlot.Profile,
+      order: 0,
+      icon: User,
+      component: StoragePanel,
+    } satisfies PluginPanel);
+
+    // Background document auto-sync. Dynamically imported so the sync engine
+    // stays off the initial bundle; the notifier routes quota warnings to a
+    // toast (keeping autoSync itself free of any UI dependency).
+    void import("./autoSync").then((m) => {
+      m.setAutoSyncNotifier((msg, kind) => (kind === "error" ? toast.error(msg) : toast(msg)));
+      m.startAutoSync();
+    });
   },
 };
 

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -57,7 +57,7 @@ const plugin: DataViewerPlugin = {
       component: CloudFilesSection,
     } satisfies PluginMountDef<FileManagerSectionContext>);
 
-    // Profile tab: storage usage meters (document + log tiers) + account.
+    // Profile tab: storage usage meters (document + log storage types) + account.
     ctx.registry.contribute(PANELS_POINT, {
       id: "cloud-sync-storage",
       title: "Profile",

--- a/src/plugins/cloud-sync/storageTypes.test.ts
+++ b/src/plugins/cloud-sync/storageTypes.test.ts
@@ -4,17 +4,17 @@ import {
   docByteSize,
   formatBytes,
   isOverLimit,
-  tierForStore,
+  storageTypeForStore,
   usageFraction,
   wouldExceed,
-} from "./tiers";
+} from "./storageTypes";
 
-describe("storage tiers", () => {
+describe("storage types", () => {
   it("classifies the files store as logs, everything else as documents", () => {
-    expect(tierForStore("files")).toBe("logs");
-    expect(tierForStore("setups")).toBe("documents");
-    expect(tierForStore("karts")).toBe("documents");
-    expect(tierForStore("graph-prefs")).toBe("documents");
+    expect(storageTypeForStore("files")).toBe("logs");
+    expect(storageTypeForStore("setups")).toBe("documents");
+    expect(storageTypeForStore("karts")).toBe("documents");
+    expect(storageTypeForStore("graph-prefs")).toBe("documents");
   });
 
   it("has the agreed default limits (5 MB docs / 20 MB logs)", () => {

--- a/src/plugins/cloud-sync/storageTypes.ts
+++ b/src/plugins/cloud-sync/storageTypes.ts
@@ -1,24 +1,25 @@
-// Storage tiers + limits for cloud sync.
+// Storage types + limits for cloud sync.
 //
-// Two tiers: "documents" (garage data — vehicles, setups, templates, types,
-// notes, metadata, graph prefs) and "logs" (raw session file blobs). The real
-// limits + enforcement live server-side (the quota_limits table + trigger in
-// the storage-quotas migration); these client values are the offline/advisory
-// fallback for the meter and the pre-push check. sync_storage_usage() on the
-// server is the source of truth the UI reads when online.
+// Two storage *types* (not to be confused with subscription tiers, which will
+// scale these limits later): "documents" (garage data — vehicles, setups,
+// templates, types, notes, metadata, graph prefs) and "logs" (raw session file
+// blobs). The real limits + enforcement live server-side (the quota_limits
+// table + trigger in the storage-quotas migration); these client values are the
+// offline/advisory fallback for the meter and the pre-push check.
+// sync_storage_usage() on the server is the source of truth the UI reads online.
 
 import { FILE_STORE } from "./syncStores";
 
-export type Tier = "documents" | "logs";
+export type StorageType = "documents" | "logs";
 
 /** Advisory fallback limits (bytes). Mirror of the server `quota_limits` seed. */
-export const DEFAULT_LIMITS: Record<Tier, number> = {
+export const DEFAULT_LIMITS: Record<StorageType, number> = {
   documents: 5 * 1024 * 1024, // 5 MB
   logs: 20 * 1024 * 1024, // 20 MB
 };
 
-/** Which tier a sync store belongs to. */
-export function tierForStore(store: string): Tier {
+/** Which storage type a sync store belongs to. */
+export function storageTypeForStore(store: string): StorageType {
   return store === FILE_STORE ? "logs" : "documents";
 }
 
@@ -27,14 +28,14 @@ export function docByteSize(record: unknown): number {
   return new TextEncoder().encode(JSON.stringify(record ?? null)).length;
 }
 
-export interface TierUsage {
-  tier: Tier;
+export interface StorageTypeUsage {
+  storageType: StorageType;
   usedBytes: number;
   limitBytes: number;
 }
 
 /** Fraction of the limit used, clamped to [0, 1]. */
-export function usageFraction(u: Pick<TierUsage, "usedBytes" | "limitBytes">): number {
+export function usageFraction(u: Pick<StorageTypeUsage, "usedBytes" | "limitBytes">): number {
   if (u.limitBytes <= 0) return 0;
   return Math.min(1, u.usedBytes / u.limitBytes);
 }

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -16,7 +16,7 @@ import { getFile, saveFile } from "@/lib/fileStorage";
 import { fetchStorageUsage, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
 import { listSelectedFiles, markPushed } from "./fileSync";
-import { DEFAULT_LIMITS, type Tier, type TierUsage } from "./tiers";
+import { DEFAULT_LIMITS, type StorageType, type StorageTypeUsage } from "./storageTypes";
 
 export type { SyncSummary };
 
@@ -163,7 +163,7 @@ export async function deleteRecord(userId: string, store: string, key: string): 
   if (error) throw new Error(error.message);
 }
 
-/** Mirror only the structured (free document-tier) stores up — no file blobs. */
+/** Mirror only the structured (free documents storage type) stores up — no file blobs. */
 export async function pushDocs(userId: string): Promise<number> {
   const rows: SyncRecordRow[] = [];
   for (const store of DOC_STORES) {
@@ -178,7 +178,7 @@ export async function pushDocs(userId: string): Promise<number> {
   return rows.length;
 }
 
-/** Bring only the document-tier records down into local IndexedDB (no files). */
+/** Bring only the documents-type records down into local IndexedDB (no files). */
 export async function pullDocs(userId: string): Promise<number> {
   const { data, error } = await syncRecords()
     .select("store,record_key,data")
@@ -196,17 +196,17 @@ export async function pullDocs(userId: string): Promise<number> {
   return records;
 }
 
-/** Per-tier storage usage from the server, with the advisory limits as fallback. */
-export async function getStorageUsage(): Promise<TierUsage[]> {
+/** Per-type storage usage from the server, with the advisory limits as fallback. */
+export async function getStorageUsage(): Promise<StorageTypeUsage[]> {
   const rows = await fetchStorageUsage();
-  const byTier = new Map(rows.map((r) => [r.tier, r]));
-  const tiers: Tier[] = ["documents", "logs"];
-  return tiers.map((tier) => {
-    const row = byTier.get(tier);
+  const byType = new Map(rows.map((r) => [r.storage_type, r]));
+  const types: StorageType[] = ["documents", "logs"];
+  return types.map((storageType) => {
+    const row = byType.get(storageType);
     return {
-      tier,
+      storageType,
       usedBytes: row?.used_bytes ?? 0,
-      limitBytes: row?.limit_bytes ?? DEFAULT_LIMITS[tier],
+      limitBytes: row?.limit_bytes ?? DEFAULT_LIMITS[storageType],
     };
   });
 }

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -13,9 +13,10 @@
 
 import { withReadTransaction, withWriteTransaction } from "@/lib/dbUtils";
 import { getFile, saveFile } from "@/lib/fileStorage";
-import { syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
+import { fetchStorageUsage, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
 import { listSelectedFiles, markPushed } from "./fileSync";
+import { DEFAULT_LIMITS, type Tier, type TierUsage } from "./tiers";
 
 export type { SyncSummary };
 
@@ -130,4 +131,82 @@ export async function pullAll(userId: string): Promise<SyncSummary> {
     }
   }
   return { records, files };
+}
+
+// ── Incremental (auto) sync ──────────────────────────────────────────────────
+
+/**
+ * Upsert one document record to the cloud by reading it from its local store.
+ * No-op if the record is already gone locally. Throws on a backend error
+ * (including the server quota rejection — see `isQuotaError`).
+ */
+export async function pushRecord(userId: string, store: string, key: string): Promise<void> {
+  const record = await withReadTransaction<Record<string, unknown> | undefined>(
+    store,
+    (s) => s.get(key),
+  );
+  if (record == null) return;
+  const { error } = await syncRecords().upsert(
+    [{ user_id: userId, store, record_key: key, data: record }],
+    { onConflict: "user_id,store,record_key" },
+  );
+  if (error) throw new Error(error.message);
+}
+
+/** Delete one document record from the cloud (deletion propagation). */
+export async function deleteRecord(userId: string, store: string, key: string): Promise<void> {
+  const { error } = await syncRecords()
+    .delete()
+    .eq("user_id", userId)
+    .eq("store", store)
+    .eq("record_key", key);
+  if (error) throw new Error(error.message);
+}
+
+/** Mirror only the structured (free document-tier) stores up — no file blobs. */
+export async function pushDocs(userId: string): Promise<number> {
+  const rows: SyncRecordRow[] = [];
+  for (const store of DOC_STORES) {
+    for (const record of await readAll(store)) {
+      rows.push({ user_id: userId, store, record_key: extractKey(store, record), data: record });
+    }
+  }
+  if (rows.length) {
+    const { error } = await syncRecords().upsert(rows, { onConflict: "user_id,store,record_key" });
+    if (error) throw new Error(`Failed to push documents: ${error.message}`);
+  }
+  return rows.length;
+}
+
+/** Bring only the document-tier records down into local IndexedDB (no files). */
+export async function pullDocs(userId: string): Promise<number> {
+  const { data, error } = await syncRecords()
+    .select("store,record_key,data")
+    .eq("user_id", userId);
+  if (error) throw new Error(`Failed to read cloud documents: ${error.message}`);
+
+  const rows = (data ?? []) as Pick<SyncRecordRow, "store" | "record_key" | "data">[];
+  let records = 0;
+  for (const row of rows) {
+    if ((DOC_STORES as readonly string[]).includes(row.store)) {
+      await writeOne(row.store, row.data);
+      records++;
+    }
+  }
+  return records;
+}
+
+/** Per-tier storage usage from the server, with the advisory limits as fallback. */
+export async function getStorageUsage(): Promise<TierUsage[]> {
+  const rows = await fetchStorageUsage();
+  const byTier = new Map(rows.map((r) => [r.tier, r]));
+  const tiers: Tier[] = ["documents", "logs"];
+  return tiers.map((tier) => {
+    const row = byTier.get(tier);
+    return {
+      tier,
+      usedBytes: row?.used_bytes ?? 0,
+      limitBytes: row?.limit_bytes ?? DEFAULT_LIMITS[tier],
+    };
+  });
 }

--- a/src/plugins/cloud-sync/tiers.test.ts
+++ b/src/plugins/cloud-sync/tiers.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_LIMITS,
+  docByteSize,
+  formatBytes,
+  isOverLimit,
+  tierForStore,
+  usageFraction,
+  wouldExceed,
+} from "./tiers";
+
+describe("storage tiers", () => {
+  it("classifies the files store as logs, everything else as documents", () => {
+    expect(tierForStore("files")).toBe("logs");
+    expect(tierForStore("setups")).toBe("documents");
+    expect(tierForStore("karts")).toBe("documents");
+    expect(tierForStore("graph-prefs")).toBe("documents");
+  });
+
+  it("has the agreed default limits (5 MB docs / 20 MB logs)", () => {
+    expect(DEFAULT_LIMITS.documents).toBe(5 * 1024 * 1024);
+    expect(DEFAULT_LIMITS.logs).toBe(20 * 1024 * 1024);
+  });
+
+  it("measures document byte size from serialized JSON", () => {
+    expect(docByteSize({ a: 1 })).toBe(new TextEncoder().encode('{"a":1}').length);
+    expect(docByteSize(null)).toBe(4); // "null"
+  });
+
+  it("computes a clamped usage fraction", () => {
+    expect(usageFraction({ usedBytes: 0, limitBytes: 100 })).toBe(0);
+    expect(usageFraction({ usedBytes: 50, limitBytes: 100 })).toBe(0.5);
+    expect(usageFraction({ usedBytes: 200, limitBytes: 100 })).toBe(1);
+    expect(usageFraction({ usedBytes: 5, limitBytes: 0 })).toBe(0);
+  });
+
+  it("detects over-limit and projected overflow", () => {
+    expect(isOverLimit(101, 100)).toBe(true);
+    expect(isOverLimit(100, 100)).toBe(false);
+    expect(wouldExceed(90, 20, 100)).toBe(true);
+    expect(wouldExceed(90, 10, 100)).toBe(false);
+  });
+
+  it("formats byte sizes", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});

--- a/src/plugins/cloud-sync/tiers.ts
+++ b/src/plugins/cloud-sync/tiers.ts
@@ -1,0 +1,56 @@
+// Storage tiers + limits for cloud sync.
+//
+// Two tiers: "documents" (garage data — vehicles, setups, templates, types,
+// notes, metadata, graph prefs) and "logs" (raw session file blobs). The real
+// limits + enforcement live server-side (the quota_limits table + trigger in
+// the storage-quotas migration); these client values are the offline/advisory
+// fallback for the meter and the pre-push check. sync_storage_usage() on the
+// server is the source of truth the UI reads when online.
+
+import { FILE_STORE } from "./syncStores";
+
+export type Tier = "documents" | "logs";
+
+/** Advisory fallback limits (bytes). Mirror of the server `quota_limits` seed. */
+export const DEFAULT_LIMITS: Record<Tier, number> = {
+  documents: 5 * 1024 * 1024, // 5 MB
+  logs: 20 * 1024 * 1024, // 20 MB
+};
+
+/** Which tier a sync store belongs to. */
+export function tierForStore(store: string): Tier {
+  return store === FILE_STORE ? "logs" : "documents";
+}
+
+/** Approximate serialized byte size of a structured (document) record. */
+export function docByteSize(record: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(record ?? null)).length;
+}
+
+export interface TierUsage {
+  tier: Tier;
+  usedBytes: number;
+  limitBytes: number;
+}
+
+/** Fraction of the limit used, clamped to [0, 1]. */
+export function usageFraction(u: Pick<TierUsage, "usedBytes" | "limitBytes">): number {
+  if (u.limitBytes <= 0) return 0;
+  return Math.min(1, u.usedBytes / u.limitBytes);
+}
+
+export function isOverLimit(usedBytes: number, limitBytes: number): boolean {
+  return usedBytes > limitBytes;
+}
+
+/** Would adding `addBytes` to the current usage exceed the limit? */
+export function wouldExceed(usedBytes: number, addBytes: number, limitBytes: number): boolean {
+  return usedBytes + addBytes > limitBytes;
+}
+
+/** Human-readable byte size (KB/MB), 1 decimal for MB. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -22,6 +22,8 @@ export const PanelSlot = {
   Labs: "labs",
   /** The dedicated AI Coach tab in the main view. */
   Coach: "coach",
+  /** The user profile tab (storage usage, account) in the main view. */
+  Profile: "profile",
 } as const;
 export type PanelSlot = (typeof PanelSlot)[keyof typeof PanelSlot];
 

--- a/supabase/migrations/20260525020000_storage_quotas.sql
+++ b/supabase/migrations/20260525020000_storage_quotas.sql
@@ -1,0 +1,96 @@
+-- Storage quotas for cloud sync.
+--
+-- Two tiers, enforced server-side (client caps are advisory only):
+--   • documents — all structured sync_records except file blobs (vehicles,
+--     setups, templates, vehicle types, notes, metadata, graph prefs)
+--   • logs      — raw session file blobs, tracked by their index row's size
+--
+-- Limits live in a single table (quota_limits) read by both the enforcing
+-- trigger and the client meter, so there's one source of truth. A BEFORE
+-- INSERT/UPDATE trigger on sync_records rejects writes that would push a tier
+-- over its limit; sync_storage_usage() returns per-tier usage for the UI.
+
+-- ── Limits (single source of truth) ─────────────────────────────────────────
+create table if not exists public.quota_limits (
+  tier text primary key,
+  max_bytes bigint not null
+);
+
+insert into public.quota_limits (tier, max_bytes) values
+  ('documents', 5242880),    -- 5 MB
+  ('logs',     20971520)     -- 20 MB
+on conflict (tier) do update set max_bytes = excluded.max_bytes;
+
+alter table public.quota_limits enable row level security;
+
+drop policy if exists "Anyone authenticated reads limits" on public.quota_limits;
+create policy "Anyone authenticated reads limits"
+  on public.quota_limits for select to authenticated
+  using (true);
+
+-- ── Per-record byte size ────────────────────────────────────────────────────
+-- Files are counted by the size recorded on their index row; structured docs by
+-- their serialized jsonb length.
+create or replace function public.sync_record_size(p_store text, p_data jsonb)
+returns bigint language sql immutable as $$
+  select case
+    when p_store = 'files' then coalesce((p_data->>'size')::bigint, 0)
+    else octet_length(p_data::text)::bigint
+  end;
+$$;
+
+-- ── Quota enforcement trigger ───────────────────────────────────────────────
+create or replace function public.enforce_sync_quota()
+returns trigger language plpgsql as $$
+declare
+  v_is_log boolean := (NEW.store = 'files');
+  v_tier   text    := case when v_is_log then 'logs' else 'documents' end;
+  v_limit  bigint;
+  v_used   bigint;
+  v_new    bigint := public.sync_record_size(NEW.store, NEW.data);
+begin
+  select max_bytes into v_limit from public.quota_limits where tier = v_tier;
+  if v_limit is null then
+    return NEW; -- no limit configured for this tier
+  end if;
+
+  -- Current usage for this tier, excluding the row being upserted.
+  select coalesce(sum(public.sync_record_size(store, data)), 0)
+    into v_used
+    from public.sync_records
+   where user_id = NEW.user_id
+     and (store = 'files') = v_is_log
+     and not (store = NEW.store and record_key = NEW.record_key);
+
+  if v_used + v_new > v_limit then
+    raise exception
+      'quota_exceeded: % tier over limit (% bytes used + % new > % limit)',
+      v_tier, v_used, v_new, v_limit
+      using errcode = 'check_violation';
+  end if;
+
+  return NEW;
+end;
+$$;
+
+drop trigger if exists sync_records_quota on public.sync_records;
+create trigger sync_records_quota
+  before insert or update on public.sync_records
+  for each row execute function public.enforce_sync_quota();
+
+-- ── Usage readout for the client meter ──────────────────────────────────────
+-- Returns one row per tier with used + limit bytes, scoped to the caller.
+create or replace function public.sync_storage_usage()
+returns table(tier text, used_bytes bigint, limit_bytes bigint)
+language sql stable as $$
+  select q.tier,
+         coalesce(sum(public.sync_record_size(r.store, r.data)), 0)::bigint,
+         q.max_bytes
+    from public.quota_limits q
+    left join public.sync_records r
+      on r.user_id = auth.uid()
+     and (case when r.store = 'files' then 'logs' else 'documents' end) = q.tier
+   group by q.tier, q.max_bytes;
+$$;
+
+grant execute on function public.sync_storage_usage() to authenticated;

--- a/supabase/migrations/20260525020000_storage_quotas.sql
+++ b/supabase/migrations/20260525020000_storage_quotas.sql
@@ -1,25 +1,26 @@
 -- Storage quotas for cloud sync.
 --
--- Two tiers, enforced server-side (client caps are advisory only):
+-- Two storage *types*, enforced server-side (client caps are advisory only):
 --   • documents — all structured sync_records except file blobs (vehicles,
 --     setups, templates, vehicle types, notes, metadata, graph prefs)
 --   • logs      — raw session file blobs, tracked by their index row's size
 --
+-- ("type", not "tier" — subscription tiers will scale these limits later.)
 -- Limits live in a single table (quota_limits) read by both the enforcing
 -- trigger and the client meter, so there's one source of truth. A BEFORE
--- INSERT/UPDATE trigger on sync_records rejects writes that would push a tier
--- over its limit; sync_storage_usage() returns per-tier usage for the UI.
+-- INSERT/UPDATE trigger on sync_records rejects writes that would push a type
+-- over its limit; sync_storage_usage() returns per-type usage for the UI.
 
 -- ── Limits (single source of truth) ─────────────────────────────────────────
 create table if not exists public.quota_limits (
-  tier text primary key,
+  storage_type text primary key,
   max_bytes bigint not null
 );
 
-insert into public.quota_limits (tier, max_bytes) values
+insert into public.quota_limits (storage_type, max_bytes) values
   ('documents', 5242880),    -- 5 MB
   ('logs',     20971520)     -- 20 MB
-on conflict (tier) do update set max_bytes = excluded.max_bytes;
+on conflict (storage_type) do update set max_bytes = excluded.max_bytes;
 
 alter table public.quota_limits enable row level security;
 
@@ -39,33 +40,38 @@ returns bigint language sql immutable as $$
   end;
 $$;
 
+-- Which storage type a sync store belongs to.
+create or replace function public.sync_storage_type(p_store text)
+returns text language sql immutable as $$
+  select case when p_store = 'files' then 'logs' else 'documents' end;
+$$;
+
 -- ── Quota enforcement trigger ───────────────────────────────────────────────
 create or replace function public.enforce_sync_quota()
 returns trigger language plpgsql as $$
 declare
-  v_is_log boolean := (NEW.store = 'files');
-  v_tier   text    := case when v_is_log then 'logs' else 'documents' end;
-  v_limit  bigint;
-  v_used   bigint;
-  v_new    bigint := public.sync_record_size(NEW.store, NEW.data);
+  v_type  text   := public.sync_storage_type(NEW.store);
+  v_limit bigint;
+  v_used  bigint;
+  v_new   bigint := public.sync_record_size(NEW.store, NEW.data);
 begin
-  select max_bytes into v_limit from public.quota_limits where tier = v_tier;
+  select max_bytes into v_limit from public.quota_limits where storage_type = v_type;
   if v_limit is null then
-    return NEW; -- no limit configured for this tier
+    return NEW; -- no limit configured for this type
   end if;
 
-  -- Current usage for this tier, excluding the row being upserted.
+  -- Current usage for this type, excluding the row being upserted.
   select coalesce(sum(public.sync_record_size(store, data)), 0)
     into v_used
     from public.sync_records
    where user_id = NEW.user_id
-     and (store = 'files') = v_is_log
+     and public.sync_storage_type(store) = v_type
      and not (store = NEW.store and record_key = NEW.record_key);
 
   if v_used + v_new > v_limit then
     raise exception
-      'quota_exceeded: % tier over limit (% bytes used + % new > % limit)',
-      v_tier, v_used, v_new, v_limit
+      'quota_exceeded: % storage over limit (% bytes used + % new > % limit)',
+      v_type, v_used, v_new, v_limit
       using errcode = 'check_violation';
   end if;
 
@@ -79,18 +85,18 @@ create trigger sync_records_quota
   for each row execute function public.enforce_sync_quota();
 
 -- ── Usage readout for the client meter ──────────────────────────────────────
--- Returns one row per tier with used + limit bytes, scoped to the caller.
+-- Returns one row per storage type with used + limit bytes, scoped to the caller.
 create or replace function public.sync_storage_usage()
-returns table(tier text, used_bytes bigint, limit_bytes bigint)
+returns table(storage_type text, used_bytes bigint, limit_bytes bigint)
 language sql stable as $$
-  select q.tier,
+  select q.storage_type,
          coalesce(sum(public.sync_record_size(r.store, r.data)), 0)::bigint,
          q.max_bytes
     from public.quota_limits q
     left join public.sync_records r
       on r.user_id = auth.uid()
-     and (case when r.store = 'files' then 'logs' else 'documents' end) = q.tier
-   group by q.tier, q.max_bytes;
+     and public.sync_storage_type(r.store) = q.storage_type
+   group by q.storage_type, q.max_bytes;
 $$;
 
 grant execute on function public.sync_storage_usage() to authenticated;


### PR DESCRIPTION
## Summary

Turns garage data into a free, auto-synced **"documents"** storage type — separate
from log blobs — with server-enforced limits and a new Profile tab to see usage.

> **Naming:** these are storage **types** (documents / logs), *not* "tiers" —
> "tier" is reserved for future subscription levels that will scale these limits.

### Auto-sync (documents storage type)
- New host pub/sub `src/lib/garageEvents.ts`: the doc-store modules
  (`vehicleStorage`, `setupStorage`, `templateStorage`, `noteStorage`) emit
  `{ store, key, put|delete }` after each write.
- `cloud-sync/autoSync.ts` subscribes (when signed in), debounces, and
  incrementally **upserts (put) / deletes (delete)** the single changed cloud
  record; **reconciles** (pull docs → push docs) on sign-in. Started in the
  plugin `setup` via a dynamic import, so the sync engine stays **off the initial
  bundle** (verified).

### Anonymous → cloud account migration
- Handled by the sign-in reconcile: `pullDocs` (cloud → local) then `pushDocs`
  (local → cloud). For a **new** account the cloud is empty, so the pull is a
  no-op and the push **uploads all the anon user's local setups/vehicles/templates
  into their new account** — automatic, no extra step. (Runs on every signed-in
  load, so it self-heals.)
- Caveat: signing into an **existing** account that already has a record with the
  same id → cloud wins on the pull (local edit could be overwritten). No
  collisions on a fresh account. Timestamp-merge is the follow-up (tracked on #41).

### Propagation deletes
- Deleting a vehicle/setup while signed in removes the cloud record too. The
  Karts/Setups delete confirm shows a loud **"deletes from every device and the
  cloud"** warning when signed in (normal copy when signed out).

### Storage types + **server-side** enforcement
- `documents` = all structured stores (**5 MB**, free, auto-synced); `logs` = file
  blobs (**20 MB**, opt-in). Migration `..._storage_quotas.sql` adds:
  - `quota_limits` table (`storage_type`, `max_bytes`) — single source of truth
    (client meter + trigger read it).
  - `enforce_sync_quota` BEFORE INSERT/UPDATE trigger on `sync_records` — rejects
    over-limit writes (`quota_exceeded`); `sync_storage_type()` helper.
  - `sync_storage_usage()` RPC — per-type `(used, limit)` for the meter.
- `storageTypes.ts` holds the advisory client mirror + usage math (unit-tested).
  Client checks are advisory; the DB trigger is the real gate.

### Profile tab
- New far-right **Profile** tab (`PanelSlot.Profile`, self-gating like Coach).
  cloud-sync contributes `StoragePanel` — per-type usage meters + an account
  scratch pad (display name/avatar are placeholders for now).

## Notes / follow-ups (tracked on #41)
- **Log-blob delete propagation** is still not handled (additive).
- **Existing-account id collisions** overwrite local on pull (timestamp merge TODO).
- **Over-limit batch push**: `pushDocs` is a single batch upsert, so if local docs
  exceed the limit the whole batch is rejected (saved locally, not synced) —
  could be chunked/partial later.
- Display name / avatar editing is a placeholder (roadmap).

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (328; +6 storage-type tests) / `npm run build`
- [x] Sync engine confirmed **off** the initial `index` chunk
- [x] Vehicle/setup delete routes through the emitting storage path (propagation fires)
- [ ] Live pass: sign in → edit auto-syncs; delete → warning + gone from cloud; anon local garage migrates up on first sign-in; Profile meters update; over-limit write rejected server-side

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3