### PR TITLE
Add unique, editable user display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Propagation deletes**: deleting a vehicle or setup while signed in removes it
   from **every device and the cloud**, with a clear warning before you confirm.
 - New **Profile** tab (far right) showing your cloud storage usage against the
-  document and log limits (account display name/avatar are placeholders for now).
+  document and log limits.
+- **User display names**: choose a unique display name when you register, or get a
+  fun auto-generated one (e.g. `SpeedyRac3r-546`) if you leave it blank — editable
+  any time from the Profile tab, with a clear "that name's taken" message. Existing
+  accounts are given a generated name automatically.
 - Plugin UI panel framework: plugins can contribute self-contained panels to a
   named slot, starting with the Labs tab. The tab now appears automatically when
   a plugin contributes a panel, and each panel is isolated by an error boundary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,8 @@ src/
 │   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
 │   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord/pushDocs/pullDocs + getStorageUsage
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
-│   │   ├── StoragePanel.tsx      # Profile-tab panel: storage usage meters + account scratch pad (lazy)
+│   │   ├── StoragePanel.tsx      # Profile-tab panel: display-name editor + storage usage meters (lazy)
+│   │   ├── profile.ts            # getMyProfile / updateDisplayName (unique display names; taken-name handling)
 │   │   └── cloudClient.ts        # Typed access to sync_records + bucket + sync_storage_usage RPC (escape hatch until types regen)
 │   └── coaching/              # Gitignored private slot (AI coaching submodule)
 ├── types/
@@ -423,6 +424,8 @@ Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
 | `quota_limits` | table | `(storage_type, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Read by client + trigger. |
 | `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a storage type over its limit (`quota_exceeded`). |
 | `sync_storage_usage()` | RPC | Per-type `(used_bytes, limit_bytes)` for the caller. |
+| `profiles` | table | `(user_id PK→auth.users, display_name unique, …)`. RLS: authenticated read-all, update/insert own. Display name is unique but **not** a key — user-editable. |
+| `handle_new_user` | trigger | On `auth.users` insert: creates a profile, using the sign-up `display_name` or a generated silly name (`SpeedyRac3r-546`). `unique_display_name()` auto-suffixes a taken name at creation; user edits get an explicit "taken" error instead. |
 
 Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
 `setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates` (jsonb

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ interface AuthContextValue {
   isAdmin: boolean;
   loading: boolean;
   login: (email: string, password: string) => Promise<{ error: Error | null }>;
-  signUp: (email: string, password: string) => Promise<{ error: Error | null }>;
+  signUp: (email: string, password: string, displayName?: string) => Promise<{ error: Error | null }>;
   signInWithGoogle: () => Promise<{ error: Error | null }>;
   logout: () => Promise<void>;
   resetPassword: (email: string) => Promise<{ error: Error | null }>;
@@ -101,11 +101,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { error };
   }, []);
 
-  const signUp = useCallback(async (email: string, password: string) => {
+  const signUp = useCallback(async (email: string, password: string, displayName?: string) => {
+    const trimmed = displayName?.trim();
     const { error } = await supabase.auth.signUp({
       email,
       password,
-      options: { emailRedirectTo: window.location.origin + '/auth/callback' },
+      options: {
+        emailRedirectTo: window.location.origin + '/auth/callback',
+        // Picked up by the handle_new_user trigger; blank → a random name is
+        // generated server-side. A taken name is auto-suffixed there too.
+        data: trimmed ? { display_name: trimmed } : {},
+      },
     });
     return { error };
   }, []);

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -15,6 +15,7 @@ export default function Register() {
     canonical: 'https://hackthetrack.net/register',
   });
   const [email, setEmail] = useState('');
+  const [displayName, setDisplayName] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -32,7 +33,7 @@ export default function Register() {
       return;
     }
     setIsLoading(true);
-    const { error } = await signUp(email, password);
+    const { error } = await signUp(email, password, displayName);
     setIsLoading(false);
     if (error) {
       toast({ title: 'Registration failed', description: error.message, variant: 'destructive' });
@@ -75,6 +76,10 @@ export default function Register() {
             <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
               <Input id="email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="displayName">Display name <span className="text-muted-foreground font-normal">(optional)</span></Label>
+              <Input id="displayName" type="text" maxLength={40} placeholder="Leave blank for a random name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="password">Password</Label>

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
-import { User as UserIcon } from "lucide-react";
+import { Check, Pencil, User as UserIcon, X } from "lucide-react";
+import { toast } from "sonner";
 import type { PluginPanelProps } from "@/plugins/panels";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { getStorageUsage } from "./syncEngine";
+import { getMyProfile, updateDisplayName } from "./profile";
 import { formatBytes, usageFraction, type StorageTypeUsage } from "./storageTypes";
 
 const TYPE_LABEL: Record<string, string> = { documents: "Documents", logs: "Logs" };
@@ -11,9 +15,8 @@ const TYPE_HINT: Record<string, string> = {
   logs: "Session log files you've chosen to sync.",
 };
 
-// Scratch-pad profile panel: who you're signed in as + your cloud storage usage
-// against the document/log storage limits. (Display name / avatar are placeholders
-// until profiles land.)
+// Scratch-pad profile panel: your (editable, unique) display name + cloud storage
+// usage against the document/log storage limits.
 export default function StoragePanel(_props: PluginPanelProps) {
   const { user, loading } = useAuth();
   const [usage, setUsage] = useState<StorageTypeUsage[] | null>(null);
@@ -46,20 +49,9 @@ export default function StoragePanel(_props: PluginPanelProps) {
     );
   }
 
-  const displayName =
-    (user.user_metadata?.display_name as string | undefined) || user.email || "Driver";
-
   return (
     <div className="space-y-5">
-      <div className="flex items-center gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
-          <UserIcon className="h-6 w-6" />
-        </div>
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-foreground">{displayName}</p>
-          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-        </div>
-      </div>
+      <DisplayName userId={user.id} email={user.email ?? ""} />
 
       <div className="space-y-3">
         <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Storage</p>
@@ -68,6 +60,89 @@ export default function StoragePanel(_props: PluginPanelProps) {
         {usage?.map((u) => (
           <Meter key={u.storageType} usage={u} />
         ))}
+      </div>
+    </div>
+  );
+}
+
+function DisplayName({ userId, email }: { userId: string; email: string }) {
+  const [name, setName] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getMyProfile(userId)
+      .then((p) => {
+        if (!cancelled) setName(p?.display_name ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setName(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const startEdit = () => {
+    setDraft(name ?? "");
+    setEditing(true);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    const result = await updateDisplayName(userId, draft);
+    setSaving(false);
+    if (result.ok) {
+      setName(draft.trim());
+      setEditing(false);
+      toast.success("Display name updated.");
+    } else if (result.reason === "taken") {
+      toast.error("That name's taken — try another.");
+    } else if (result.reason === "empty") {
+      toast.error("Display name can't be empty.");
+    } else {
+      toast.error(result.message ?? "Couldn't update display name.");
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <UserIcon className="h-6 w-6" />
+      </div>
+      <div className="min-w-0 flex-1">
+        {editing ? (
+          <div className="flex items-center gap-1.5">
+            <Input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              maxLength={40}
+              autoFocus
+              disabled={saving}
+              className="h-8"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void save();
+                if (e.key === "Escape") setEditing(false);
+              }}
+            />
+            <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0" disabled={saving} onClick={() => void save()}>
+              <Check className="h-4 w-4" />
+            </Button>
+            <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0" disabled={saving} onClick={() => setEditing(false)}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-sm font-medium text-foreground">{name ?? "…"}</p>
+            <Button size="icon" variant="ghost" className="h-6 w-6 shrink-0 text-muted-foreground" onClick={startEdit}>
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )}
+        <p className="truncate text-xs text-muted-foreground">{email}</p>
       </div>
     </div>
   );

--- a/src/plugins/cloud-sync/cloudClient.ts
+++ b/src/plugins/cloud-sync/cloudClient.ts
@@ -53,3 +53,21 @@ export async function fetchStorageUsage(): Promise<StorageUsageRow[]> {
 export function isQuotaError(err: unknown): boolean {
   return err instanceof Error && /quota_exceeded/i.test(err.message);
 }
+
+/** A row in public.profiles — the user's unique, editable display name. */
+export interface ProfileRow {
+  user_id: string;
+  display_name: string;
+}
+
+/** Query builder for the profiles table. */
+export function profiles() {
+  return untyped.from("profiles");
+}
+
+/** True when a Postgres error is a unique-constraint violation (e.g. taken name). */
+export function isUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { code?: string; message?: string };
+  return e.code === "23505" || /duplicate key|unique constraint/i.test(e.message ?? "");
+}

--- a/src/plugins/cloud-sync/profile.ts
+++ b/src/plugins/cloud-sync/profile.ts
@@ -1,0 +1,35 @@
+// Display-name profile access. The name is unique (DB constraint) but not a key
+// and is user-editable: account creation auto-resolves a free name server-side,
+// while an explicit edit surfaces a "taken" result so the user can pick another.
+
+import { isUniqueViolation, profiles, type ProfileRow } from "./cloudClient";
+
+/** The signed-in user's profile, or null if it doesn't exist yet. */
+export async function getMyProfile(userId: string): Promise<ProfileRow | null> {
+  const { data, error } = await profiles()
+    .select("user_id,display_name")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data as ProfileRow | null) ?? null;
+}
+
+export type UpdateNameResult =
+  | { ok: true }
+  | { ok: false; reason: "taken" | "empty" | "error"; message?: string };
+
+/** Change the display name, reporting a taken name distinctly so the UI can prompt. */
+export async function updateDisplayName(userId: string, name: string): Promise<UpdateNameResult> {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, reason: "empty" };
+
+  const { error } = await profiles()
+    .update({ display_name: trimmed, updated_at: new Date().toISOString() })
+    .eq("user_id", userId);
+
+  if (error) {
+    if (isUniqueViolation(error)) return { ok: false, reason: "taken" };
+    return { ok: false, reason: "error", message: error.message };
+  }
+  return { ok: true };
+}

--- a/supabase/migrations/20260525030000_user_profiles.sql
+++ b/supabase/migrations/20260525030000_user_profiles.sql
@@ -1,0 +1,112 @@
+-- User profiles: a unique, user-editable display name per account.
+--
+-- Display name is NOT a key (the user id is) — it's a human label that must be
+-- unique and can be changed any time. If none is provided at sign-up (or for
+-- existing users when this migration runs), a silly random name is generated,
+-- e.g. "SpeedyRac3r-546". Avatars / richer profiles are intentionally deferred.
+
+-- ── Table ────────────────────────────────────────────────────────────────────
+create table if not exists public.profiles (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  display_name text not null unique,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+-- Display names aren't sensitive (and are needed for future social/team
+-- features + name-availability), so any authenticated user may read them.
+drop policy if exists "Profiles readable by authenticated" on public.profiles;
+create policy "Profiles readable by authenticated"
+  on public.profiles for select to authenticated using (true);
+
+drop policy if exists "Users insert own profile" on public.profiles;
+create policy "Users insert own profile"
+  on public.profiles for insert to authenticated with check (auth.uid() = user_id);
+
+drop policy if exists "Users update own profile" on public.profiles;
+create policy "Users update own profile"
+  on public.profiles for update to authenticated
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- ── Random silly name generation ─────────────────────────────────────────────
+-- Adjective + (lightly leetified) noun + "-" + 3 digits, e.g. "SpeedyRac3r-546".
+-- Retries until the generated name is free.
+create or replace function public.random_display_name()
+returns text language plpgsql as $$
+declare
+  adjs text[] := array[
+    'Speedy','Turbo','Drifty','Nitro','Reckless','Smooth','Apex','Sideways',
+    'Greasy','Loose','Sketchy','Mighty','Sneaky','Wobbly','Blazing','Rowdy',
+    'Janky','Cosmic','Feral','Zippy'];
+  nouns text[] := array[
+    'Racer','Driver','Pilot','Hooligan','Throttle','Slider','Charger','Rocket',
+    'Gremlin','Goblin','Wrench','Piston','Sender','Drifter','Maniac','Comet',
+    'Bandit','Cheetah','Noodle','Menace'];
+  candidate text;
+begin
+  loop
+    candidate :=
+      adjs[1 + floor(random() * array_length(adjs, 1))::int]
+      || replace(nouns[1 + floor(random() * array_length(nouns, 1))::int], 'e', '3')
+      || '-' || (100 + floor(random() * 900))::int::text;
+    exit when not exists (select 1 from public.profiles where display_name = candidate);
+  end loop;
+  return candidate;
+end;
+$$;
+
+-- Resolve a desired name to a free one: blank → a random silly name; a taken
+-- name → suffixed with digits until free. Used at account creation only (user
+-- edits get an explicit "taken" error instead — see the client).
+create or replace function public.unique_display_name(desired text)
+returns text language plpgsql as $$
+declare
+  d text := nullif(btrim(coalesce(desired, '')), '');
+  candidate text;
+  tries int := 0;
+begin
+  if d is null then
+    return public.random_display_name();
+  end if;
+  candidate := d;
+  while exists (select 1 from public.profiles where display_name = candidate) loop
+    tries := tries + 1;
+    candidate := d || '-' || (100 + floor(random() * 9900))::int::text;
+    if tries > 50 then
+      candidate := d || '-' || replace(gen_random_uuid()::text, '-', '');
+      exit;
+    end if;
+  end loop;
+  return candidate;
+end;
+$$;
+
+-- ── Auto-create a profile on sign-up ─────────────────────────────────────────
+create or replace function public.handle_new_user()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.profiles (user_id, display_name)
+  values (new.id, public.unique_display_name(new.raw_user_meta_data->>'display_name'));
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ── Backfill existing users (one at a time so names stay unique) ──────────────
+do $$
+declare u record;
+begin
+  for u in
+    select id, raw_user_meta_data from auth.users
+    where id not in (select user_id from public.profiles)
+  loop
+    insert into public.profiles (user_id, display_name)
+    values (u.id, public.unique_display_name(u.raw_user_meta_data->>'display_name'));
+  end loop;
+end $$;


### PR DESCRIPTION
## Summary

Gives every account a **unique, user-editable display name** — the groundwork for
later social/team features, but scoped to just the name for now (no avatars).

- **Unique, but not a key.** The user id remains the key; `display_name` is a
  human label with a `UNIQUE` constraint, changeable any time.
- **Auto-generated when blank.** Leave the field empty at sign-up and you get a
  silly name like **`SpeedyRac3r-546`** (adjective + leetified noun + 3 digits).
- **Two deliberate duplicate behaviors:**
  - *At account creation* (sign-up + the migration backfill): a blank/taken name
    is resolved to a free one server-side, so account creation never fails on a name.
  - *On user edit*: an explicit **"that name's taken — try another"** message
    (rather than a raw DB error), since renaming is an intentional action.

## What's included

**Migration `..._user_profiles.sql`**
- `profiles` table — `(user_id PK → auth.users, display_name UNIQUE, timestamps)`.
  RLS: authenticated users read all names (for future social + availability),
  insert/update only their own.
- `random_display_name()` — silly name generator, retries until free.
- `unique_display_name(desired)` — blank → random; taken → digit-suffixed.
- `handle_new_user` trigger on `auth.users` insert → creates the profile
  (`SECURITY DEFINER`), using the sign-up name or a generated one.
- **Backfill** of existing users without a profile (one-at-a-time so names stay
  unique).

**Client**
- `signUp(email, password, displayName?)` threads the name into user metadata;
  the Register form gains an optional **Display name** field.
- Profile tab `StoragePanel` shows the name with an inline pencil-edit
  (Enter/Esc, Save/Cancel). `profile.ts` (`getMyProfile` / `updateDisplayName`)
  + `cloudClient` (`profiles()`, `isUniqueViolation`) back it, surfacing a taken
  name distinctly.

## Type of Change
- [x] New feature

## Checklist
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (328)
- [x] `npm run build` succeeds
- [x] Feature works **offline** — display names are a cloud-only concern, gated by `VITE_ENABLE_CLOUD`; the core app is unaffected
- [x] Docs updated (`CHANGELOG.md`, `CLAUDE.md`)

## Notes for reviewers
- Builds on the document-storage / Profile-tab work; the display-name editor lives
  in that Profile tab's `StoragePanel`.
- After this migration deploys, Lovable regenerates `integrations/supabase/types.ts`;
  until then `profiles` is reached through `cloudClient`'s narrowly-typed escape
  hatch (same pattern as `sync_records`).
- Not yet done (intentional): avatars/images, and a pre-submit name-availability
  check on the Register form (sign-up auto-resolves instead).

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3