### PR TITLE
Bump coach plugin to v0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "^0.2.0"
+        "@perchwerks/eye-in-the-sky": "0.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.3.tgz",
-      "integrity": "sha512-9qc5fMtbrS9ELiCB2RAw+O2bTh/3hmQ1C83VPwCKcT/VpyIDB+R0OoXhuChrtrrnJJzOF+vQdOQDK0TA9dSmxg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.4.tgz",
+      "integrity": "sha512-KLITvw1kwA/kR5kJbn7Vhz2UxAxqDYoPi6vD4SXtsyuPUpAr4L4N1fSRea7CyiQoorhlsGGCs9pN6Bg8RG12Cg==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.2.3"
+    "@perchwerks/eye-in-the-sky": "0.2.4"
   }
 }


### PR DESCRIPTION
## Summary

Refreshes the AI coach plugin pin + lockfile **0.2.3 → 0.2.4**.

- Peer ranges unchanged (`react ^18.3 || ^19`, `react-dom ^18.3 || ^19`,
  `leaflet ^1.9.4`); resolves cleanly against the host's React 18.
- Lockfile updated to the 0.2.4 tarball + integrity.

## Test plan
- [x] `npm run typecheck` / `npm run test:run` (328) / `npm run build`
- [x] uPlot/Leaflet confirmed off the initial bundle (coach chunks stay lazy)

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_