### PR TITLE
Cloud log deletion (Profile tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from **every device and the cloud**, with a clear warning before you confirm.
 - New **Profile** tab (far right) showing your cloud storage usage against the
   document and log limits.
+- **Cloud log management** (Profile tab): see the session log files stored in your
+  cloud — with upload date and size — and delete them. Deleting removes the
+  **cloud copy only** (other devices keep what they've already downloaded), with
+  an optional toggle to **also delete the local copy from this device**. Clear
+  "this can't be undone" warning.
 - **User display names**: choose a unique display name when you register, or get a
   fun auto-generated one (e.g. `SpeedyRac3r-546`) if you leave it blank — editable
   any time from the Profile tab, with a clear "that name's taken" message. Existing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ src/
 │   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord/pushDocs/pullDocs + getStorageUsage
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
 │   │   ├── StoragePanel.tsx      # Profile-tab panel: display-name editor + storage usage meters (lazy)
+│   │   ├── CloudLogsPanel.tsx    # Profile-tab panel: list + delete cloud log files (cloud-only; opt-in local delete) (lazy)
 │   │   ├── profile.ts            # getMyProfile / updateDisplayName (unique display names; taken-name handling)
 │   │   └── cloudClient.ts        # Typed access to sync_records + bucket + sync_storage_usage RPC (escape hatch until types regen)
 │   └── coaching/              # Gitignored private slot (AI coaching submodule)
@@ -431,6 +432,13 @@ Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
 `setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates` (jsonb
 docs) + `files` (blobs). Video stores are intentionally excluded (size).
 `vehicle-types`/`setup-templates` ride along because setups are template-driven.
+
+Cloud **log deletion** is managed on the Profile tab (`CloudLogsPanel`):
+`listCloudFiles` (now with `uploadedAt`) lists the user's cloud log files;
+`deleteCloudFile(userId, name)` removes the blob + its `sync_records` index row
+(cloud-only — other devices keep their downloaded copy), clears the per-file
+selection, and optionally deletes the local copy on this device. (Auto-propagation
+of log deletes on local delete is still a separate follow-up.)
 
 Files are **opt-in per file** (`fileSync.ts`): a `FileRow` mount adds a toggle to
 each file-manager row (`off` → `pending` → `synced`), and the selection set lives

--- a/src/plugins/cloud-sync/CloudLogsPanel.tsx
+++ b/src/plugins/cloud-sync/CloudLogsPanel.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useState } from "react";
+import { FileText, Trash2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/contexts/AuthContext";
+import { deleteFile, listFiles } from "@/lib/fileStorage";
+import { deleteCloudFile, listCloudFiles, type CloudFile } from "./syncEngine";
+import { unselectFile } from "./fileSync";
+import { formatBytes } from "./storageTypes";
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return isNaN(d.getTime())
+    ? "—"
+    : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+// Profile-tab panel: manage the log files stored in YOUR cloud. Deleting removes
+// the cloud copy only (other devices keep what they've downloaded); an opt-in
+// toggle also removes the local copy from this device.
+export default function CloudLogsPanel(_props: PluginPanelProps) {
+  const { user, loading } = useAuth();
+  const [files, setFiles] = useState<CloudFile[] | null>(null);
+  const [localNames, setLocalNames] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+  const [alsoLocal, setAlsoLocal] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    try {
+      const [cloud, local] = await Promise.all([listCloudFiles(user.id), listFiles()]);
+      cloud.sort((a, b) => (b.uploadedAt ?? "").localeCompare(a.uploadedAt ?? ""));
+      setFiles(cloud);
+      setLocalNames(new Set(local.map((f) => f.name)));
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load cloud files");
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (!user) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Sign in to manage the log files stored in your cloud.
+      </p>
+    );
+  }
+
+  const startConfirm = (name: string) => {
+    setConfirming(name);
+    setAlsoLocal(false);
+  };
+
+  const handleDelete = async (file: CloudFile) => {
+    const removeLocal = alsoLocal && localNames.has(file.name);
+    setBusy(file.name);
+    try {
+      await deleteCloudFile(user.id, file.name);
+      await unselectFile(file.name);
+      if (removeLocal) await deleteFile(file.name);
+      toast.success(
+        removeLocal
+          ? `Deleted "${file.name}" from the cloud and this device.`
+          : `Deleted "${file.name}" from the cloud.`,
+      );
+      setConfirming(null);
+      setAlsoLocal(false);
+      await refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (error) return <p className="text-xs text-destructive">{error}</p>;
+  if (!files) return <p className="text-xs text-muted-foreground">Loading cloud files…</p>;
+  if (files.length === 0) {
+    return <p className="text-xs text-muted-foreground">No log files in your cloud yet.</p>;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {files.map((file) => {
+        const isConfirming = confirming === file.name;
+        const onDevice = localNames.has(file.name);
+        return (
+          <div key={file.name} className="rounded-md border border-border">
+            <div className="flex items-center gap-2 px-3 py-2">
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm text-foreground">{file.name}</p>
+                <p className="text-[11px] text-muted-foreground">
+                  {formatDate(file.uploadedAt)}
+                  {file.size != null && ` · ${formatBytes(file.size)}`}
+                  {onDevice && " · on this device"}
+                </p>
+              </div>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                disabled={busy === file.name}
+                onClick={() => startConfirm(file.name)}
+                aria-label={`Delete ${file.name} from cloud`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+
+            {isConfirming && (
+              <div className="space-y-2 border-t border-destructive/30 bg-destructive/5 px-3 py-2.5">
+                <p className="flex items-start gap-1.5 text-xs text-destructive">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>Permanently delete the <strong>cloud copy</strong>? This can't be undone.</span>
+                </p>
+                {onDevice && (
+                  <div className="flex items-center gap-2">
+                    <Switch id={`local-${file.name}`} checked={alsoLocal} onCheckedChange={setAlsoLocal} disabled={busy === file.name} />
+                    <Label htmlFor={`local-${file.name}`} className="text-xs text-muted-foreground">
+                      Also delete the local file from this device (other devices keep their copy)
+                    </Label>
+                  </div>
+                )}
+                <div className="flex justify-end gap-2">
+                  <Button size="sm" variant="ghost" className="h-7 text-xs" disabled={busy === file.name} onClick={() => setConfirming(null)}>
+                    Cancel
+                  </Button>
+                  <Button size="sm" variant="destructive" className="h-7 text-xs" disabled={busy === file.name} onClick={() => void handleDelete(file)}>
+                    {busy === file.name ? "Deleting…" : "Delete"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -16,8 +16,9 @@ const CloudSyncPanel = lazy(() => import("./CloudSyncPanel"));
 // drawer doesn't pull the sync engine onto its chunk until they render.
 const FileSyncToggle = lazy(() => import("./FileSyncToggle"));
 const CloudFilesSection = lazy(() => import("./CloudFilesSection"));
-// Profile tab panel: storage usage meters + account scratch pad.
+// Profile tab panels: storage usage meters + account, and cloud-log management.
 const StoragePanel = lazy(() => import("./StoragePanel"));
+const CloudLogsPanel = lazy(() => import("./CloudLogsPanel"));
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 
@@ -65,6 +66,16 @@ const plugin: DataViewerPlugin = {
       order: 0,
       icon: User,
       component: StoragePanel,
+    } satisfies PluginPanel);
+
+    // Profile tab: manage (delete) the log files stored in the cloud.
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "cloud-sync-logs",
+      title: "Cloud logs",
+      slot: PanelSlot.Profile,
+      order: 10,
+      icon: Cloud,
+      component: CloudLogsPanel,
     } satisfies PluginPanel);
 
     // Background document auto-sync. Dynamically imported so the sync engine

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -59,19 +59,40 @@ export async function pushFile(userId: string, name: string): Promise<void> {
 export interface CloudFile {
   name: string;
   size?: number;
+  /** When the file was last uploaded (ISO string from the index row). */
+  uploadedAt?: string;
 }
 
 /** List the files this user has in the cloud (the file index rows). */
 export async function listCloudFiles(userId: string): Promise<CloudFile[]> {
   const { data, error } = await syncRecords()
-    .select("record_key,data")
+    .select("record_key,data,updated_at")
     .eq("user_id", userId)
     .eq("store", FILE_STORE);
   if (error) throw new Error(`Failed to list cloud files: ${error.message}`);
-  return ((data ?? []) as { record_key: string; data: { size?: number } | null }[]).map((r) => ({
+  return (
+    (data ?? []) as { record_key: string; data: { size?: number } | null; updated_at?: string }[]
+  ).map((r) => ({
     name: r.record_key,
     size: r.data?.size,
+    uploadedAt: r.updated_at,
   }));
+}
+
+/**
+ * Delete one log file from the cloud: the blob in the bucket + its index row.
+ * Does NOT touch any device's local copy — callers handle local deletion
+ * separately (and only for the current device).
+ */
+export async function deleteCloudFile(userId: string, name: string): Promise<void> {
+  const { error: rmErr } = await userFiles().remove([blobPath(userId, name)]);
+  if (rmErr) throw new Error(`Failed to delete cloud file: ${rmErr.message}`);
+  const { error } = await syncRecords()
+    .delete()
+    .eq("user_id", userId)
+    .eq("store", FILE_STORE)
+    .eq("record_key", name);
+  if (error) throw new Error(`Failed to remove cloud file index: ${error.message}`);
 }
 
 /** Download a single file blob from the cloud (does not persist it locally). */


### PR DESCRIPTION
## Summary

Lets users manage the **log files stored in their cloud** from the Profile tab —
view and delete them. Built on the existing per-file sync plumbing.

- New **`CloudLogsPanel`** (Profile-tab panel): lists each cloud log with its
  **name, upload date, size**, and an "on this device" marker.
- **Delete = cloud-only by default.** `deleteCloudFile(userId, name)` removes the
  blob from the `user-files` bucket + its `sync_records` index row, and clears the
  per-file sync selection. **Other devices keep what they've already downloaded** —
  nothing local is touched unless the user opts in.
- Per-file confirm with a **"this can't be undone"** warning. When the file is
  also present **on this device**, an opt-in toggle: *"Also delete the local file
  from this device (other devices keep their copy)"* → additionally `deleteFile`
  locally (same as the file manager's local delete).
- `listCloudFiles` now returns `uploadedAt` (from the index row's `updated_at`).

This is the manual half of the **log-blob delete** follow-up (auto-propagation of
log deletes on a *local* delete remains a separate follow-up, tracked on #41).

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (328) / `npm run build`
- [x] Feature is cloud-gated (`VITE_ENABLE_CLOUD`); offline core unaffected
- [x] Docs updated (`CHANGELOG.md`, `CLAUDE.md`)
- [ ] Live pass: delete a cloud log (cloud-only) → gone from cloud, local kept; with toggle → also removed locally; cloud-only file (not on device) hides the toggle

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_