### PR TITLE
Offline-aware, conflict-safe document sync (timestamp merge + pending set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `user_roles`).
 
 ### Changed
+- Cloud document sync is now **offline-aware and conflict-safe**. Garage records
+  (vehicles, setups, templates, notes) carry an edit timestamp, and sync uses
+  last-write-wins, so a newer change is never overwritten by an older copy.
+  Changes made **offline** are saved as pending and, on reconnect, take
+  **priority** — replacing the cloud copy. The Profile tab flags when you're
+  offline and how many changes are waiting to sync.
 - Telemetry channels are now normalized to a canonical identity at import time,
   so the Settings "default fields" show/hide and your saved graph and video-
   overlay selections apply **consistently across every logger format** (e.g.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,8 @@ src/
 │   │   ├── CloudFilesSection.tsx # FileManagerSection mount: lists all cloud files (on-device marked, others pullable)
 │   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames (pure, tested)
 │   │   ├── syncStores.ts         # Pure config: which IDB stores sync + how they're keyed (testable)
+│   │   ├── merge.ts              # ★ Pure conflict resolution: decideSync (pending-wins + updatedAt LWW), pendingId (tested)
+│   │   ├── pendingSync.ts        # Persistent offline "pending changes" set (plugin KV); flushed priority-1 on reconnect
 │   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
 │   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord/pushDocs/pullDocs + getStorageUsage
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
@@ -400,14 +402,24 @@ To add a new store: increment `DB_VERSION`, add store name to `STORE_NAMES`, add
 Optional per-user backup/sync of the IndexedDB data above to Supabase. Built as
 a first-party plugin (Labs + Profile panels), online-only (accepted offline-first
 exception). Manual push/pull remains (`CloudSyncPanel`), but the **document tier
-now auto-syncs**: storage modules emit `garageEvents` on write/delete, and
-`autoSync.ts` (started in `setup`, dynamically imported to stay off the initial
-bundle) debounces and incrementally **upserts (put) / deletes (delete)** the one
-changed record while signed in, and **reconciles** (pull docs → push docs) on
-sign-in. So edits back up automatically and **deletes propagate everywhere** —
-the Karts/Setups delete UI shows a loud "deletes from every device + the cloud"
-warning when signed in. (Log-blob deletion propagation + timestamp merge are
-still follow-ups.)
+now auto-syncs**, and is **offline-aware + conflict-safe**: storage modules emit
+`garageEvents` on write/delete, and `autoSync.ts` (started in `setup`, dynamically
+imported to stay off the initial bundle) debounces and incrementally **upserts /
+deletes** the one changed record while signed in. So edits back up automatically
+and **deletes propagate everywhere** — the Karts/Setups delete UI shows a loud
+"deletes from every device + the cloud" warning when signed in.
+
+**Conflict resolution** (`merge.ts`, pure + tested): every garage record carries an
+`updatedAt` (stamped in each storage `save*`; the sync write path `writeOne` keeps
+the cloud value). `decideSync` is **pending-wins + last-write-wins**: a change made
+offline or whose push failed is recorded in a persistent **pending set**
+(`pendingSync.ts`, in the plugin KV) and, on reconnect/sign-in, flushed first as
+**priority-1** (replacing the cloud copy); everything else merges by newest
+`updatedAt` (the record's logical edit time — never the server row time).
+`reconcileDocs` does the two-way merge (pull cloud-newer, push local-newer/-only),
+skipping pending keys. `autoSync` tracks `navigator.onLine` + window online/offline
+events; the Profile-tab `StoragePanel` flags offline state + the pending count.
+(Log-blob deletion propagation remains a follow-up.)
 
 **Storage types** (`storageTypes.ts`, enforced server-side) — distinct from
 future *subscription tiers*: **documents** = all structured stores (5 MB, free,

--- a/src/lib/noteStorage.ts
+++ b/src/lib/noteStorage.ts
@@ -29,9 +29,10 @@ export async function listNotes(fileName: string): Promise<Note[]> {
 }
 
 export async function saveNote(note: Note): Promise<void> {
+  const stamped: Note = { ...note, updatedAt: Date.now() };
   const db = await openDB();
   const tx = db.transaction(NOTES_STORE, "readwrite");
-  tx.objectStore(NOTES_STORE).put(note);
+  tx.objectStore(NOTES_STORE).put(stamped);
   await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);

--- a/src/lib/setupStorage.ts
+++ b/src/lib/setupStorage.ts
@@ -56,9 +56,10 @@ export async function listSetups(): Promise<VehicleSetup[]> {
 }
 
 export async function saveSetup(setup: VehicleSetup): Promise<void> {
+  const stamped: VehicleSetup = { ...setup, updatedAt: Date.now() };
   const db = await openDB();
   const tx = db.transaction(SETUPS_STORE, "readwrite");
-  tx.objectStore(SETUPS_STORE).put(setup);
+  tx.objectStore(SETUPS_STORE).put(stamped);
   await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);

--- a/src/lib/templateStorage.ts
+++ b/src/lib/templateStorage.ts
@@ -43,6 +43,8 @@ export interface VehicleType {
   wheelCount: 2 | 4;
   isDefault: boolean;
   createdAt: number;
+  /** Last local edit time (ms) — set by saveVehicleType; used for sync merge. */
+  updatedAt?: number;
 }
 
 // ── Default Kart Template ──
@@ -162,9 +164,10 @@ export async function getVehicleType(id: string): Promise<VehicleType | null> {
 }
 
 export async function saveVehicleType(vt: VehicleType): Promise<void> {
+  const stamped: VehicleType = { ...vt, updatedAt: Date.now() };
   const db = await openDB();
   const tx = db.transaction(STORE_NAMES.VEHICLE_TYPES, "readwrite");
-  tx.objectStore(STORE_NAMES.VEHICLE_TYPES).put(vt);
+  tx.objectStore(STORE_NAMES.VEHICLE_TYPES).put(stamped);
   await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
@@ -212,9 +215,10 @@ export async function getTemplate(id: string): Promise<SetupTemplate | null> {
 }
 
 export async function saveTemplate(template: SetupTemplate): Promise<void> {
+  const stamped: SetupTemplate = { ...template, updatedAt: Date.now() };
   const db = await openDB();
   const tx = db.transaction(STORE_NAMES.SETUP_TEMPLATES, "readwrite");
-  tx.objectStore(STORE_NAMES.SETUP_TEMPLATES).put(template);
+  tx.objectStore(STORE_NAMES.SETUP_TEMPLATES).put(stamped);
   await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
@@ -256,6 +260,7 @@ export async function createVehicleTypeWithTemplate(
     wheelCount,
     isDefault: false,
     createdAt: now,
+    updatedAt: now,
   };
 
   const template: SetupTemplate = {

--- a/src/lib/vehicleStorage.ts
+++ b/src/lib/vehicleStorage.ts
@@ -14,14 +14,17 @@ export interface Vehicle {
   number: number;
   weight: number;
   weightUnit: "lb" | "kg";
+  /** Last local edit time (ms) — set by saveVehicle; used for sync merge. */
+  updatedAt?: number;
 }
 
 const VEHICLES_STORE = STORE_NAMES.KARTS; // store name unchanged in IDB
 
 export async function saveVehicle(vehicle: Vehicle): Promise<void> {
+  const stamped: Vehicle = { ...vehicle, updatedAt: Date.now() };
   const db = await openDB();
   const tx = db.transaction(VEHICLES_STORE, "readwrite");
-  tx.objectStore(VEHICLES_STORE).put(vehicle);
+  tx.objectStore(VEHICLES_STORE).put(stamped);
   await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Pencil, User as UserIcon, X } from "lucide-react";
+import { Check, CloudOff, Pencil, User as UserIcon, X } from "lucide-react";
 import { toast } from "sonner";
 import type { PluginPanelProps } from "@/plugins/panels";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { getStorageUsage } from "./syncEngine";
 import { getMyProfile, updateDisplayName } from "./profile";
+import { pendingCount } from "./pendingSync";
 import { formatBytes, usageFraction, type StorageTypeUsage } from "./storageTypes";
 
 const TYPE_LABEL: Record<string, string> = { documents: "Documents", logs: "Logs" };
@@ -19,11 +21,14 @@ const TYPE_HINT: Record<string, string> = {
 // usage against the document/log storage limits.
 export default function StoragePanel(_props: PluginPanelProps) {
   const { user, loading } = useAuth();
+  const online = useOnlineStatus();
   const [usage, setUsage] = useState<StorageTypeUsage[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(0);
 
   const refresh = useCallback(async () => {
     if (!user) return;
+    setPending(await pendingCount());
     try {
       setUsage(await getStorageUsage());
       setError(null);
@@ -32,9 +37,11 @@ export default function StoragePanel(_props: PluginPanelProps) {
     }
   }, [user]);
 
+  // Re-read on mount and whenever connectivity flips (pending changes flush on
+  // reconnect, so the count + usage should refresh then).
   useEffect(() => {
     void refresh();
-  }, [refresh]);
+  }, [refresh, online]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
 
@@ -52,6 +59,23 @@ export default function StoragePanel(_props: PluginPanelProps) {
   return (
     <div className="space-y-5">
       <DisplayName userId={user.id} email={user.email ?? ""} />
+
+      {!online && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+          <CloudOff className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            You're offline.{" "}
+            {pending > 0
+              ? `${pending} change${pending === 1 ? "" : "s"} saved locally — they'll sync when you reconnect.`
+              : "Changes are saved locally and will sync when you reconnect."}
+          </span>
+        </div>
+      )}
+      {online && pending > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Syncing {pending} pending change{pending === 1 ? "" : "s"}…
+        </p>
+      )}
 
       <div className="space-y-3">
         <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Storage</p>

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -1,23 +1,27 @@
-// Background document auto-sync.
+// Background, offline-aware document auto-sync.
 //
-// Runs outside React: tracks the signed-in user via the Supabase auth session
-// and listens to host garage-change events (vehicles/setups/templates/types/
-// notes). On a change it debounces, then upserts (put) or deletes (delete) the
-// single cloud record — so edits propagate up and deletes propagate everywhere.
-// On sign-in it reconciles (pull cloud docs down, push local docs up). Only the
-// free "documents" storage type auto-syncs here; log blobs stay manual/opt-in.
+// Runs outside React: tracks the signed-in user via the Supabase session and
+// listens to host garage-change events (vehicles/setups/templates/types/notes).
+//   • Online: debounce, then upsert (put) or delete the single changed record.
+//   • Offline (or a failed push): the change is recorded as *pending* so it isn't
+//     lost; on reconnect the pending set flushes first as priority-1 (replacing
+//     the cloud state), then a timestamp-aware reconcile merges the rest.
+// On sign-in it reconciles too. Only the free "documents" storage type syncs
+// here; log blobs stay manual/opt-in.
 
 import { supabase } from "@/integrations/supabase/client";
 import { onGarageChange, type GarageChange } from "@/lib/garageEvents";
 import { isQuotaError } from "./cloudClient";
-import { deleteRecord, pullDocs, pushDocs, pushRecord } from "./syncEngine";
+import { deleteRecord, pushRecord, reconcileDocs } from "./syncEngine";
+import { clearPending, listPending, markPending, pendingKeySet } from "./pendingSync";
+import { pendingId } from "./merge";
 import { storageTypeForStore } from "./storageTypes";
 
 const DEBOUNCE_MS = 800;
 
 let currentUserId: string | null = null;
 let started = false;
-const pending = new Map<string, ReturnType<typeof setTimeout>>();
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /** Injected so this module stays free of any toast/UI dependency. */
 type Notifier = (message: string, kind: "error" | "info") => void;
@@ -26,19 +30,25 @@ export function setAutoSyncNotifier(fn: Notifier): void {
   notify = fn;
 }
 
-function recordKey(change: GarageChange): string {
-  return `${change.store}:${change.key}`;
+function isOnline(): boolean {
+  return typeof navigator === "undefined" ? true : navigator.onLine;
+}
+
+async function pushOne(userId: string, change: GarageChange): Promise<void> {
+  if (change.type === "delete") await deleteRecord(userId, change.store, change.key);
+  else await pushRecord(userId, change.store, change.key);
 }
 
 async function flush(change: GarageChange): Promise<void> {
   const userId = currentUserId;
   if (!userId) return;
+  if (!isOnline()) {
+    await markPending(change);
+    return;
+  }
   try {
-    if (change.type === "delete") {
-      await deleteRecord(userId, change.store, change.key);
-    } else {
-      await pushRecord(userId, change.store, change.key);
-    }
+    await pushOne(userId, change);
+    await clearPending(change.store, change.key);
   } catch (err) {
     if (isQuotaError(err)) {
       notify(
@@ -46,29 +56,52 @@ async function flush(change: GarageChange): Promise<void> {
         "error",
       );
     } else {
-      console.error("auto-sync failed", err);
+      // Network/other failure → keep it as a pending change to retry on reconnect.
+      await markPending(change);
     }
   }
 }
 
 function schedule(change: GarageChange): void {
   if (!currentUserId) return; // only sync while signed in
-  const key = recordKey(change);
-  const existing = pending.get(key);
+  if (!isOnline()) {
+    void markPending(change);
+    return;
+  }
+  const key = pendingId(change.store, change.key);
+  const existing = timers.get(key);
   if (existing) clearTimeout(existing);
-  pending.set(
+  timers.set(
     key,
     setTimeout(() => {
-      pending.delete(key);
+      timers.delete(key);
       void flush(change);
     }, DEBOUNCE_MS),
   );
 }
 
-async function reconcile(userId: string): Promise<void> {
+/** Push every pending change (priority-1); drop each that confirms. */
+async function flushPending(userId: string): Promise<void> {
+  for (const change of await listPending()) {
+    try {
+      await pushOne(userId, change);
+      await clearPending(change.store, change.key);
+    } catch (err) {
+      if (isQuotaError(err)) {
+        notify(
+          `Cloud ${storageTypeForStore(change.store)} storage is full — some changes didn't sync.`,
+          "error",
+        );
+      }
+      // otherwise leave it pending for the next reconnect
+    }
+  }
+}
+
+async function runReconcile(userId: string): Promise<void> {
   try {
-    await pullDocs(userId); // cloud → local
-    await pushDocs(userId); // local-only → cloud (additive)
+    await flushPending(userId);
+    await reconcileDocs(userId, await pendingKeySet());
   } catch (err) {
     if (isQuotaError(err)) {
       notify("Cloud document storage is full — some items didn't sync.", "error");
@@ -78,6 +111,14 @@ async function reconcile(userId: string): Promise<void> {
   }
 }
 
+function handleOnline(): void {
+  if (currentUserId) void runReconcile(currentUserId);
+}
+
+function handleOffline(): void {
+  notify("You're offline — changes are saved locally and will sync when you reconnect.", "info");
+}
+
 /** Start the background document auto-sync. Idempotent. */
 export function startAutoSync(): void {
   if (started) return;
@@ -85,15 +126,20 @@ export function startAutoSync(): void {
 
   void supabase.auth.getSession().then(({ data }) => {
     currentUserId = data.session?.user?.id ?? null;
-    if (currentUserId) void reconcile(currentUserId);
+    if (currentUserId) void runReconcile(currentUserId);
   });
 
   supabase.auth.onAuthStateChange((_event, session) => {
     const next = session?.user?.id ?? null;
     const newlySignedIn = next !== null && next !== currentUserId;
     currentUserId = next;
-    if (newlySignedIn) void reconcile(next);
+    if (newlySignedIn) void runReconcile(next);
   });
 
   onGarageChange(schedule);
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+  }
 }

--- a/src/plugins/cloud-sync/merge.test.ts
+++ b/src/plugins/cloud-sync/merge.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { decideSync, recordUpdatedAt } from "./merge";
+
+const base = { hasLocal: true, hasCloud: true, localT: 0, cloudT: 0, pending: false };
+
+describe("decideSync", () => {
+  it("pushes a pending local change regardless of timestamps (priority-1)", () => {
+    expect(decideSync({ ...base, pending: true, localT: 1, cloudT: 999 })).toBe("push");
+  });
+
+  it("skips a pending change with no local record (a pending delete)", () => {
+    // The delete is flushed separately; we must not resurrect it from the cloud.
+    expect(decideSync({ ...base, pending: true, hasLocal: false, hasCloud: true })).toBe("skip");
+  });
+
+  it("pushes a local-only record (e.g. anon → new account migration)", () => {
+    expect(decideSync({ ...base, hasCloud: false })).toBe("push");
+  });
+
+  it("pulls a cloud-only record", () => {
+    expect(decideSync({ ...base, hasLocal: false })).toBe("pull");
+  });
+
+  it("last-write-wins when both exist", () => {
+    expect(decideSync({ ...base, localT: 200, cloudT: 100 })).toBe("push");
+    expect(decideSync({ ...base, localT: 100, cloudT: 200 })).toBe("pull");
+    expect(decideSync({ ...base, localT: 100, cloudT: 100 })).toBe("skip");
+  });
+
+  it("skips when neither side has the record", () => {
+    expect(decideSync({ ...base, hasLocal: false, hasCloud: false })).toBe("skip");
+  });
+});
+
+describe("recordUpdatedAt", () => {
+  it("reads a numeric updatedAt, else 0", () => {
+    expect(recordUpdatedAt({ updatedAt: 42 })).toBe(42);
+    expect(recordUpdatedAt({})).toBe(0);
+    expect(recordUpdatedAt(null)).toBe(0);
+    expect(recordUpdatedAt({ updatedAt: "nope" })).toBe(0);
+  });
+});

--- a/src/plugins/cloud-sync/merge.ts
+++ b/src/plugins/cloud-sync/merge.ts
@@ -1,0 +1,48 @@
+// Pure conflict-resolution decision for the document auto-sync reconcile.
+//
+// Rules (see the cloud-sync section in CLAUDE.md):
+//   1. A *pending* local change (edited offline or whose push failed) is
+//      priority-1: a pending put pushes up (replacing the cloud copy); a pending
+//      delete is skipped here (the delete is flushed separately, so we must not
+//      resurrect it from the cloud).
+//   2. Otherwise last-write-wins by the record's own `updatedAt` (the logical
+//      edit time, NOT the server row time — a late-uploaded stale edit must not win).
+//   3. Local-only → push (covers anon→account migration); cloud-only → pull.
+
+export type SyncAction = "push" | "pull" | "skip";
+
+export interface MergeInput {
+  hasLocal: boolean;
+  hasCloud: boolean;
+  /** Record `updatedAt` (ms); 0 when unknown/absent. */
+  localT: number;
+  cloudT: number;
+  /** A local change tracked as pending (offline or failed push). */
+  pending: boolean;
+}
+
+export function decideSync(i: MergeInput): SyncAction {
+  if (i.pending) return i.hasLocal ? "push" : "skip";
+  if (i.hasLocal && !i.hasCloud) return "push";
+  if (i.hasCloud && !i.hasLocal) return "pull";
+  if (!i.hasLocal && !i.hasCloud) return "skip";
+  if (i.localT > i.cloudT) return "push";
+  if (i.cloudT > i.localT) return "pull";
+  return "skip";
+}
+
+// Store names are fixed, space-free ids (e.g. "setup-templates"), and this
+// composite is only ever compared for equality (never split), so a space
+// separator is collision-safe even when record keys contain spaces.
+const SEP = " ";
+
+/** Stable id for a (store, record key) pair — the reconcile/pending set key. */
+export function pendingId(store: string, key: string): string {
+  return store + SEP + key;
+}
+
+/** Extract a record's logical edit time; 0 when absent. */
+export function recordUpdatedAt(data: unknown): number {
+  const u = (data as { updatedAt?: unknown } | null | undefined)?.updatedAt;
+  return typeof u === "number" ? u : 0;
+}

--- a/src/plugins/cloud-sync/pendingSync.ts
+++ b/src/plugins/cloud-sync/pendingSync.ts
@@ -1,0 +1,54 @@
+// Persistent "pending changes" set for offline-aware document sync.
+//
+// A pending entry is a local doc change (put or delete) not yet confirmed in the
+// cloud — because we were offline or a push failed. On reconnect these flush
+// first as priority-1 (replacing the cloud state). Stored in the plugin's own KV
+// so they survive a reload while offline.
+
+import { getPluginStore } from "@/plugins/storage";
+import type { GarageChangeType } from "@/lib/garageEvents";
+import { pendingId } from "./merge";
+
+export interface PendingChange {
+  store: string;
+  key: string;
+  type: GarageChangeType;
+}
+
+const store = getPluginStore("cloud-sync");
+const KEY = "pending-changes";
+
+async function read(): Promise<PendingChange[]> {
+  return (await store.get<PendingChange[]>(KEY)) ?? [];
+}
+
+/** Record (or update) a pending change; the latest op for a key wins. */
+export async function markPending(change: PendingChange): Promise<void> {
+  const list = await read();
+  const i = list.findIndex((c) => c.store === change.store && c.key === change.key);
+  if (i >= 0) list[i] = change;
+  else list.push(change);
+  await store.set(KEY, list);
+}
+
+/** Drop a pending entry once it's been confirmed in the cloud. */
+export async function clearPending(store_: string, key: string): Promise<void> {
+  const list = await read();
+  await store.set(
+    KEY,
+    list.filter((c) => !(c.store === store_ && c.key === key)),
+  );
+}
+
+export async function listPending(): Promise<PendingChange[]> {
+  return read();
+}
+
+export async function pendingCount(): Promise<number> {
+  return (await read()).length;
+}
+
+/** Set of `pendingId`s currently pending — passed to the reconcile merge. */
+export async function pendingKeySet(): Promise<Set<string>> {
+  return new Set((await read()).map((c) => pendingId(c.store, c.key)));
+}

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -17,6 +17,7 @@ import { fetchStorageUsage, syncRecords, userFiles, type SyncRecordRow } from ".
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
 import { listSelectedFiles, markPushed } from "./fileSync";
 import { DEFAULT_LIMITS, type StorageType, type StorageTypeUsage } from "./storageTypes";
+import { decideSync, pendingId, recordUpdatedAt } from "./merge";
 
 export type { SyncSummary };
 
@@ -184,37 +185,94 @@ export async function deleteRecord(userId: string, store: string, key: string): 
   if (error) throw new Error(error.message);
 }
 
-/** Mirror only the structured (free documents storage type) stores up — no file blobs. */
-export async function pushDocs(userId: string): Promise<number> {
-  const rows: SyncRecordRow[] = [];
-  for (const store of DOC_STORES) {
-    for (const record of await readAll(store)) {
-      rows.push({ user_id: userId, store, record_key: extractKey(store, record), data: record });
-    }
-  }
-  if (rows.length) {
-    const { error } = await syncRecords().upsert(rows, { onConflict: "user_id,store,record_key" });
-    if (error) throw new Error(`Failed to push documents: ${error.message}`);
-  }
-  return rows.length;
+export interface DocReconcileResult {
+  pulled: number;
+  pushed: number;
 }
 
-/** Bring only the documents-type records down into local IndexedDB (no files). */
-export async function pullDocs(userId: string): Promise<number> {
+/**
+ * Timestamp-aware two-way merge of the document stores (no file blobs):
+ *  - newer side wins by the record's own `updatedAt` (last-write-wins);
+ *  - local-only records push up (anon→account migration);
+ *  - cloud-only records pull down;
+ *  - anything in `pendingKeys` is treated as priority-1 local and pushed,
+ *    overriding the timestamp comparison.
+ * Local writes go through `writeOne` (no garage event), so a pull doesn't echo
+ * back as a change. Run this AFTER flushing pending deletes.
+ */
+export async function reconcileDocs(
+  userId: string,
+  pendingKeys: Set<string>,
+): Promise<DocReconcileResult> {
   const { data, error } = await syncRecords()
     .select("store,record_key,data")
     .eq("user_id", userId);
   if (error) throw new Error(`Failed to read cloud documents: ${error.message}`);
 
-  const rows = (data ?? []) as Pick<SyncRecordRow, "store" | "record_key" | "data">[];
-  let records = 0;
-  for (const row of rows) {
+  const cloud = new Map<string, { store: string; key: string; data: unknown; t: number }>();
+  for (const row of (data ?? []) as Pick<SyncRecordRow, "store" | "record_key" | "data">[]) {
     if ((DOC_STORES as readonly string[]).includes(row.store)) {
-      await writeOne(row.store, row.data);
-      records++;
+      cloud.set(pendingId(row.store, row.record_key), {
+        store: row.store,
+        key: row.record_key,
+        data: row.data,
+        t: recordUpdatedAt(row.data),
+      });
     }
   }
-  return records;
+
+  let pulled = 0;
+  let pushed = 0;
+  const toPush: SyncRecordRow[] = [];
+  const seen = new Set<string>();
+
+  for (const store of DOC_STORES) {
+    for (const record of await readAll(store)) {
+      const key = extractKey(store, record);
+      const id = pendingId(store, key);
+      seen.add(id);
+      const c = cloud.get(id);
+      const action = decideSync({
+        hasLocal: true,
+        hasCloud: !!c,
+        localT: recordUpdatedAt(record),
+        cloudT: c?.t ?? 0,
+        pending: pendingKeys.has(id),
+      });
+      if (action === "push") {
+        toPush.push({ user_id: userId, store, record_key: key, data: record });
+        pushed++;
+      } else if (action === "pull" && c) {
+        await writeOne(store, c.data);
+        pulled++;
+      }
+    }
+  }
+
+  // Cloud-only records (not present locally) → pull down.
+  for (const [id, c] of cloud) {
+    if (seen.has(id)) continue;
+    const action = decideSync({
+      hasLocal: false,
+      hasCloud: true,
+      localT: 0,
+      cloudT: c.t,
+      pending: pendingKeys.has(id),
+    });
+    if (action === "pull") {
+      await writeOne(c.store, c.data);
+      pulled++;
+    }
+  }
+
+  if (toPush.length) {
+    const { error: upErr } = await syncRecords().upsert(toPush, {
+      onConflict: "user_id,store,record_key",
+    });
+    if (upErr) throw new Error(`Failed to push documents: ${upErr.message}`);
+  }
+
+  return { pulled, pushed };
 }
 
 /** Per-type storage usage from the server, with the advisory limits as fallback. */


### PR DESCRIPTION
## Summary

Makes the document auto-sync **conflict-safe and offline-aware** so it stops
"stomping" edits — directly addressing the timestamp-merge follow-up.

### The merge model (you chose: pending-wins + timestamp LWW)
- **Every garage record carries `updatedAt`** — added to `Vehicle` / `VehicleType`,
  and stamped in each storage `save*` (the sync write path `writeOne` keeps the
  cloud value, so a pull never re-stamps).
- **`merge.ts`** (pure, unit-tested) — `decideSync`:
  - a **pending** local change (made offline / failed push) is **priority-1** →
    pushed up, replacing the cloud copy, regardless of clocks;
  - otherwise **last-write-wins** by the record's own `updatedAt` (its logical edit
    time — never the server row time, so a late-uploaded stale edit can't win);
  - local-only → push (anon→account migration); cloud-only → pull.

### Offline handling
- **`pendingSync.ts`** — a persistent "pending changes" set in the plugin KV, so
  offline edits survive a reload.
- **`autoSync`** tracks `navigator.onLine` + window `online`/`offline`. While
  offline (or on a failed push) a change is recorded pending; on **reconnect /
  sign-in** it **flushes pending first (priority-1)**, then `reconcileDocs` does a
  timestamp-aware two-way merge of the rest (skipping pending keys).
- **`StoragePanel`** flags offline state and shows the pending-change count.

### Engine
- `reconcileDocs(userId, pendingKeys)` replaces the old `pushDocs`/`pullDocs`
  (unconditional cloud-wins) with the merge above.

Logs are untouched (no auto-sync there yet, per scope). Manual push/pull in the
Cloud Sync panel is unchanged.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (335; +7 merge cases) / `npm run build`
- [x] `decideSync` covered: pending-put push, pending-delete skip, local-only push, cloud-only pull, LWW both directions, equal/none skip
- [ ] Live pass: edit a setup offline → "pending" flag; reconnect → it wins over a cloud copy; edit the same record on two devices → newer wins; anon local garage still migrates up on first sign-in

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_