### PR TITLE
Sync user tracks & courses (documents storage type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Regular accounts have no admin privileges (admin role remains driven by
   `user_roles`).
 
+### Added
+- Your custom **tracks & courses now sync to the cloud** too (documents storage),
+  the same way setups do — auto-sync, delete propagation, and the offline-aware
+  timestamp merge. Only your user-created tracks/courses sync; built-in tracks
+  stay local.
+
 ### Changed
 - Cloud document sync is now **offline-aware and conflict-safe**. Garage records
   (vehicles, setups, templates, notes) carry an edit timestamp, and sync uses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ src/
 │   ├── chartUtils.ts          # Canvas chart rendering helpers
 │   ├── chartColors.ts         # Color palette for multi-series charts
 │   ├── trackUtils.ts          # Track geometry utilities (findNearestTrack: 5mi radius)
-│   ├── trackStorage.ts        # localStorage: tracks + courses (merged with public/tracks.json) + course drawings loader
+│   ├── trackStorage.ts        # localStorage: tracks + courses (merged with public/tracks.json) + course drawings loader. User tracks emit garageEvents + carry updatedAt → cloud-synced via a store accessor (TRACKS_SYNC_STORE)
 │   ├── referenceUtils.ts      # Reference lap comparison (legacy distance-based pace)
 │   ├── lapDelta.ts            # ★ Position-based lap delta: arc-length resample + segment-projected gap (issue #29 port)
 │   ├── dbUtils.ts             # ★ Shared IndexedDB: DB_NAME, DB_VERSION, openDB(), transaction helpers
@@ -192,7 +192,8 @@ src/
 │   │   ├── FileSyncToggle.tsx    # Per-file sync toggle, mounted on each file row (off/pending/synced)
 │   │   ├── CloudFilesSection.tsx # FileManagerSection mount: lists all cloud files (on-device marked, others pullable)
 │   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames (pure, tested)
-│   │   ├── syncStores.ts         # Pure config: which IDB stores sync + how they're keyed (testable)
+│   │   ├── syncStores.ts         # Pure config: which stores sync + how they're keyed (testable)
+│   │   ├── storeAccessors.ts     # Per-store read/get/put: default IndexedDB accessor + a localStorage accessor for tracks (the non-IDB seam)
 │   │   ├── merge.ts              # ★ Pure conflict resolution: decideSync (pending-wins + updatedAt LWW), pendingId (tested)
 │   │   ├── pendingSync.ts        # Persistent offline "pending changes" set (plugin KV); flushed priority-1 on reconnect
 │   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
@@ -441,9 +442,14 @@ Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
 | `handle_new_user` | trigger | On `auth.users` insert: creates a profile, using the sign-up `display_name` or a generated silly name (`SpeedyRac3r-546`). `unique_display_name()` auto-suffixes a taken name at creation; user edits get an explicit "taken" error instead. |
 
 Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
-`setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates` (jsonb
-docs) + `files` (blobs). Video stores are intentionally excluded (size).
+`setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates`, `tracks`
+(jsonb docs) + `files` (blobs). Video stores are intentionally excluded (size).
 `vehicle-types`/`setup-templates` ride along because setups are template-driven.
+Most stores are IndexedDB; **`tracks` is localStorage** (only *user* tracks/courses,
+never the built-in public ones), reached through `storeAccessors.ts` — a per-store
+read/get/put seam so the engine isn't hard-wired to IndexedDB. Track edits stamp
+`updatedAt` + emit `garageEvents`, so they ride the same auto-sync + delete
+propagation + pending-wins/LWW merge as setups.
 
 Cloud **log deletion** is managed on the Profile tab (`CloudLogsPanel`):
 `listCloudFiles` (now with `uploadedAt`) lists the user's cloud log files;

--- a/src/lib/trackStorage.ts
+++ b/src/lib/trackStorage.ts
@@ -1,7 +1,15 @@
 import { Track, Course, LegacyTrack, SectorLine } from '@/types/racing';
+import { emitGarageChange } from '@/lib/garageEvents';
 
 const STORAGE_KEY = 'racing-datalog-tracks-v2';
 const LEGACY_STORAGE_KEY = 'racing-datalog-tracks';
+
+/**
+ * Sync "store" name for user tracks (cloud-sync documents type). Tracks live in
+ * localStorage, not IndexedDB, so cloud-sync reaches them through a dedicated
+ * store accessor — this constant is the agreed store key on both sides.
+ */
+export const TRACKS_SYNC_STORE = 'tracks';
 
 interface DefaultCourseJson {
   name: string;
@@ -252,6 +260,47 @@ export async function loadTracks(): Promise<Track[]> {
   return merged;
 }
 
+// ── Cloud-sync accessor helpers (user tracks only) ───────────────────────────
+
+/** All user-defined tracks (the syncable overlay; excludes built-in tracks). */
+export function listUserTracks(): Track[] {
+  return loadUserTracks();
+}
+
+/** One user track by name, or undefined. */
+export function getUserTrack(name: string): Track | undefined {
+  return loadUserTracks().find((t) => t.name === name);
+}
+
+/**
+ * Upsert a user track straight into storage — NO timestamp stamp, NO garage
+ * event. This is the cloud-sync *pull* write path (preserving the cloud copy's
+ * updatedAt and avoiding a re-sync echo). User edits go through the CRUD below.
+ */
+export function putUserTrackRaw(track: Track): void {
+  const list = loadUserTracks();
+  const i = list.findIndex((t) => t.name === track.name);
+  if (i >= 0) list[i] = track;
+  else list.push(track);
+  saveUserTracks(list);
+}
+
+/** Stamp a track's edit time so cloud-sync can merge by last-write-wins. */
+function stampTrack(tracks: Track[], name: string): void {
+  const t = tracks.find((x) => x.name === name);
+  if (t) t.updatedAt = Date.now();
+}
+
+/** After a user edit, emit the right garage event so cloud-sync mirrors it. */
+function emitTrackChange(trackName: string): void {
+  const stillUser = loadUserTracks().some((t) => t.name === trackName);
+  emitGarageChange({
+    store: TRACKS_SYNC_STORE,
+    key: trackName,
+    type: stillUser ? "put" : "delete",
+  });
+}
+
 /**
  * Add a new track with an optional initial course.
  */
@@ -276,7 +325,9 @@ export async function addTrack(trackName: string, course?: Course): Promise<Trac
     });
   }
   
+  stampTrack(tracks, trackName);
   saveUserTracks(tracks);
+  emitTrackChange(trackName);
   return tracks;
 }
 
@@ -304,8 +355,10 @@ export async function addCourse(trackName: string, course: Course): Promise<Trac
   } else {
     track.courses.push({ ...course, isUserDefined: true });
   }
-  
+
+  stampTrack(tracks, trackName);
   saveUserTracks(tracks);
+  emitTrackChange(trackName);
   return tracks;
 }
 
@@ -319,9 +372,13 @@ export async function updateTrackName(oldName: string, newName: string): Promise
   if (track) {
     track.name = newName;
     track.isUserDefined = true;
+    track.updatedAt = Date.now();
     saveUserTracks(tracks);
+    // A rename is a delete of the old key + a put of the new one.
+    emitGarageChange({ store: TRACKS_SYNC_STORE, key: oldName, type: "delete" });
+    emitGarageChange({ store: TRACKS_SYNC_STORE, key: newName, type: "put" });
   }
-  
+
   return tracks;
 }
 
@@ -340,10 +397,12 @@ export async function updateCourse(
     const course = track.courses.find(c => c.name === courseName);
     if (course) {
       Object.assign(course, updates, { isUserDefined: true });
+      stampTrack(tracks, trackName);
       saveUserTracks(tracks);
+      emitTrackChange(trackName);
     }
   }
-  
+
   return tracks;
 }
 
@@ -356,9 +415,12 @@ export async function deleteCourse(trackName: string, courseName: string): Promi
   const track = tracks.find(t => t.name === trackName);
   if (track) {
     track.courses = track.courses.filter(c => c.name !== courseName);
+    track.updatedAt = Date.now();
     saveUserTracks(tracks);
+    // The track may now be gone from user storage (no user courses left).
+    emitTrackChange(trackName);
   }
-  
+
   return tracks;
 }
 
@@ -377,8 +439,9 @@ export async function deleteTrack(trackName: string): Promise<Track[]> {
       tracks = tracks.filter(t => t.name !== trackName);
     }
     saveUserTracks(tracks);
+    emitTrackChange(trackName);
   }
-  
+
   return tracks;
 }
 

--- a/src/plugins/cloud-sync/storeAccessors.ts
+++ b/src/plugins/cloud-sync/storeAccessors.ts
@@ -1,0 +1,57 @@
+// Per-store read/get/put accessors for the document sync engine.
+//
+// Most syncable stores live in IndexedDB and share one accessor. Tracks live in
+// localStorage (trackStorage), so they get their own accessor backed by the
+// user-track helpers. This is the seam that lets non-IDB data sync through the
+// same engine — `reconcileDocs` / `pushRecord` / `writeOne` go through here
+// instead of assuming IndexedDB.
+
+import { withReadTransaction, withWriteTransaction } from "@/lib/dbUtils";
+import type { Track } from "@/types/racing";
+import {
+  TRACKS_SYNC_STORE,
+  getUserTrack,
+  listUserTracks,
+  putUserTrackRaw,
+} from "@/lib/trackStorage";
+
+type Record_ = Record<string, unknown>;
+
+export interface StoreAccessor {
+  readAll(): Promise<Record_[]>;
+  getOne(key: string): Promise<Record_ | undefined>;
+  /** Raw write — must NOT emit a garage event or re-stamp (it's the pull path). */
+  putOne(record: Record_): Promise<void>;
+}
+
+function idbAccessor(store: string): StoreAccessor {
+  return {
+    readAll: () => withReadTransaction<Record_[]>(store, (s) => s.getAll()),
+    getOne: (key) => withReadTransaction<Record_ | undefined>(store, (s) => s.get(key)),
+    putOne: (record) => withWriteTransaction(store, (s) => s.put(record)),
+  };
+}
+
+const tracksAccessor: StoreAccessor = {
+  readAll: async () => listUserTracks() as unknown as Record_[],
+  getOne: async (key) => getUserTrack(key) as unknown as Record_ | undefined,
+  putOne: async (record) => putUserTrackRaw(record as unknown as Track),
+};
+
+const overrides: Record<string, StoreAccessor> = {
+  [TRACKS_SYNC_STORE]: tracksAccessor,
+};
+
+const idbCache = new Map<string, StoreAccessor>();
+
+/** The accessor for a sync store (localStorage-backed for tracks, else IndexedDB). */
+export function getAccessor(store: string): StoreAccessor {
+  const override = overrides[store];
+  if (override) return override;
+  let accessor = idbCache.get(store);
+  if (!accessor) {
+    accessor = idbAccessor(store);
+    idbCache.set(store, accessor);
+  }
+  return accessor;
+}

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -11,8 +11,8 @@
 // adding a new syncable store is a single entry in syncStores.ts. File blobs
 // can't live in jsonb, so they round-trip through the Storage bucket instead.
 
-import { withReadTransaction, withWriteTransaction } from "@/lib/dbUtils";
 import { getFile, saveFile } from "@/lib/fileStorage";
+import { getAccessor } from "./storeAccessors";
 import { fetchStorageUsage, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
 import { listSelectedFiles, markPushed } from "./fileSync";
@@ -26,12 +26,14 @@ function blobPath(userId: string, name: string): string {
   return `${userId}/${encodeURIComponent(name)}`;
 }
 
+// Route through the per-store accessor (IndexedDB for most stores, localStorage
+// for tracks) instead of assuming IndexedDB.
 async function readAll(store: string): Promise<Record<string, unknown>[]> {
-  return withReadTransaction<Record<string, unknown>[]>(store, (s) => s.getAll());
+  return getAccessor(store).readAll();
 }
 
 async function writeOne(store: string, record: unknown): Promise<void> {
-  await withWriteTransaction(store, (s) => s.put(record as Record<string, unknown>));
+  await getAccessor(store).putOne(record as Record<string, unknown>);
 }
 
 /** Upload one local file blob + its index row. Returns false if not stored locally. */
@@ -163,10 +165,7 @@ export async function pullAll(userId: string): Promise<SyncSummary> {
  * (including the server quota rejection — see `isQuotaError`).
  */
 export async function pushRecord(userId: string, store: string, key: string): Promise<void> {
-  const record = await withReadTransaction<Record<string, unknown> | undefined>(
-    store,
-    (s) => s.get(key),
-  );
+  const record = await getAccessor(store).getOne(key);
   if (record == null) return;
   const { error } = await syncRecords().upsert(
     [{ user_id: userId, store, record_key: key, data: record }],

--- a/src/plugins/cloud-sync/syncStores.test.ts
+++ b/src/plugins/cloud-sync/syncStores.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { STORE_NAMES } from "@/lib/dbUtils";
+import { TRACKS_SYNC_STORE } from "@/lib/trackStorage";
 import { extractKey, DOC_STORES, FILE_STORE } from "./syncStores";
 
 describe("extractKey", () => {
@@ -12,6 +13,10 @@ describe("extractKey", () => {
 
   it("coerces non-string keys to string", () => {
     expect(extractKey(STORE_NAMES.NOTES, { id: 42 })).toBe("42");
+  });
+
+  it("keys user tracks by name", () => {
+    expect(extractKey(TRACKS_SYNC_STORE, { name: "Local Kart Track" })).toBe("Local Kart Track");
   });
 });
 
@@ -35,6 +40,7 @@ describe("synced store coverage", () => {
       STORE_NAMES.VEHICLE_TYPES,
       STORE_NAMES.SETUP_TEMPLATES,
       STORE_NAMES.METADATA,
+      TRACKS_SYNC_STORE,
     ]) {
       expect(DOC_STORES).toContain(store);
     }

--- a/src/plugins/cloud-sync/syncStores.ts
+++ b/src/plugins/cloud-sync/syncStores.ts
@@ -3,8 +3,9 @@
 // stays unit-testable in a node environment.
 
 import { STORE_NAMES } from "@/lib/dbUtils";
+import { TRACKS_SYNC_STORE } from "@/lib/trackStorage";
 
-/** IndexedDB key path for each syncable store. */
+/** Key path for each syncable store (IndexedDB stores + the localStorage tracks). */
 const KEY_FIELD: Record<string, string> = {
   [STORE_NAMES.METADATA]: "fileName",
   [STORE_NAMES.KARTS]: "id",
@@ -15,6 +16,7 @@ const KEY_FIELD: Record<string, string> = {
   // with them or pulled setups can't render.
   [STORE_NAMES.VEHICLE_TYPES]: "id",
   [STORE_NAMES.SETUP_TEMPLATES]: "id",
+  [TRACKS_SYNC_STORE]: "name", // user tracks (localStorage, via a store accessor)
   [STORE_NAMES.FILES]: "name",
 };
 
@@ -27,6 +29,7 @@ export const DOC_STORES = [
   STORE_NAMES.GRAPH_PREFS,
   STORE_NAMES.VEHICLE_TYPES,
   STORE_NAMES.SETUP_TEMPLATES,
+  TRACKS_SYNC_STORE,
 ] as const;
 
 /** Store whose payload is a Blob, synced through the Storage bucket. */

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -37,6 +37,7 @@ export interface Track {
   shortName?: string; // max 8 chars, used for zip filenames and compact display
   courses: Course[];
   isUserDefined?: boolean; // true if entire track is user-added
+  updatedAt?: number; // last local edit time (ms) — set on save; used for cloud-sync merge
 }
 
 // Legacy interface for backward compatibility during migration


### PR DESCRIPTION
## Summary

Brings **tracks & courses** into cloud sync, behaving exactly like setups —
auto-sync, delete propagation, and the offline-aware pending-wins/LWW merge,
under the free **documents** storage type. Implemented via **Option A** (the
store-accessor layer), so tracks stay in localStorage and no data is migrated.

### The accessor seam (`storeAccessors.ts`)
The sync engine was hard-wired to IndexedDB. It now goes through a per-store
`{ readAll, getOne, putOne }` accessor:
- existing stores share one **IndexedDB accessor** (identical behavior);
- **tracks** get a **localStorage accessor** backed by `trackStorage`.

`reconcileDocs` / `pushRecord` / `writeOne` route through `getAccessor(store)`.

### Tracks become a synced doc store
- `Track` gains `updatedAt`, stamped on every `trackStorage` CRUD op.
- User edits emit `garageEvents` so the existing auto-sync mirrors them:
  add/update → `put`; delete (or removing the last user course) → `delete`;
  **rename = delete(old) + put(new)**.
- `listUserTracks` / `getUserTrack` / `putUserTrackRaw` back the accessor.
  `putUserTrackRaw` is the **pull** path — no stamp, no event (preserves the
  cloud `updatedAt`, no re-sync echo).
- `"tracks"` added to `DOC_STORES`, keyed by `name`.

### Scope guards
- **Only user tracks/courses sync** — `trackStorage` already persists just the
  user overlay; built-in `public/tracks.json` tracks never leave the device.
- Logs untouched. Manual push/pull unchanged.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (336; +track keying cases) / `npm run build`
- [x] Sync engine still off the initial bundle
- [x] Existing sync behavior unchanged (IDB accessor mirrors prior `withReadTransaction`/`withWriteTransaction` calls)
- [ ] Live pass: add/edit/delete a track & course while signed in → mirrors to cloud; offline edits go pending → priority-1 on reconnect; rename propagates as delete+add; built-in tracks never sync

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_