### PR TITLE
Propagate log deletes to the cloud + prevent orphaned blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,13 +65,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `user_roles`).
 
 ### Added
+- Deleting a **synced log locally** now offers an opt-in *"also delete the cloud
+  copy"* toggle in the delete confirm (off by default — the cloud copy is a
+  backup). When offline, the cloud delete queues and propagates on reconnect.
 - Your custom **tracks & courses now sync to the cloud** too (documents storage),
   the same way setups do — auto-sync, delete propagation, and the offline-aware
   timestamp merge. Only your user-created tracks/courses sync; built-in tracks
   stay local.
 
 ### Changed
-- Cloud document sync is now **offline-aware and conflict-safe**. Garage records
+- Cloud document sync is now **offline-aware and conflict-safe**.
+
+### Fixed
+- Cloud log uploads no longer **orphan a blob** when the server quota rejects the
+  index write — the just-uploaded blob is rolled back. Any pre-existing orphans
+  are reclaimed when the Cloud logs panel is opened. Garage records
   (vehicles, setups, templates, notes) carry an edit timestamp, and sync uses
   last-write-wins, so a newer change is never overwritten by an older copy.
   Changes made **offline** are saved as pending and, on reconnect, take

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,14 +190,15 @@ src/
 │   │   ├── index.ts             # Plugin def — contributes the Labs panel + a FileRow mount (both lazy, cloud-gated)
 │   │   ├── CloudSyncPanel.tsx    # Sign-in + push/pull UI (lazy-loaded)
 │   │   ├── FileSyncToggle.tsx    # Per-file sync toggle, mounted on each file row (off/pending/synced)
+│   │   ├── FileDeleteToggle.tsx  # FileDeleteConfirm mount: opt-in "also delete the cloud copy" on local log delete (offline → pending)
 │   │   ├── CloudFilesSection.tsx # FileManagerSection mount: lists all cloud files (on-device marked, others pullable)
-│   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames (pure, tested)
+│   │   ├── fileSync.ts           # Per-file selection state in the plugin store + fileSyncStatus/cloudOnlyNames/orphanedObjectNames (pure, tested)
 │   │   ├── syncStores.ts         # Pure config: which stores sync + how they're keyed (testable)
 │   │   ├── storeAccessors.ts     # Per-store read/get/put: default IndexedDB accessor + a localStorage accessor for tracks (the non-IDB seam)
 │   │   ├── merge.ts              # ★ Pure conflict resolution: decideSync (pending-wins + updatedAt LWW), pendingId (tested)
 │   │   ├── pendingSync.ts        # Persistent offline "pending changes" set (plugin KV); flushed priority-1 on reconnect
 │   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
-│   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord/pushDocs/pullDocs + getStorageUsage
+│   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord + getStorageUsage + deleteCloudFile (rolls back orphan blob on index failure) + cleanupOrphanBlobs
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
 │   │   ├── StoragePanel.tsx      # Profile-tab panel: display-name editor + storage usage meters (lazy)
 │   │   ├── CloudLogsPanel.tsx    # Profile-tab panel: list + delete cloud log files (cloud-only; opt-in local delete) (lazy)
@@ -288,9 +289,12 @@ are all chromeless (`isBareSlot`) also drops the host's outer padding.
 component into a fixed spot in core UI. A plugin contributes a `PluginMountDef`
 to `MOUNTS_POINT`, targeting a `MountSlot`; the host renders `<PluginMount slot
 ctx={…}>` at that spot, passing a typed context as a single `ctx` prop.
-`FilesTab` exposes two: `MountSlot.FileRow` (per file row, ctx = that file) and
-`MountSlot.FileManagerSection` (once under the list, ctx = the whole list). New
-mount locations are just new slot strings.
+`FilesTab` exposes three: `MountSlot.FileRow` (per file row, ctx = that file),
+`MountSlot.FileManagerSection` (once under the list, ctx = the whole list), and
+`MountSlot.FileDeleteConfirm` (inside the delete-confirm banner, ctx = the target
+file + a `registerOnConfirm` hook so a plugin can run an extra action — e.g.
+cloud-sync's "also delete the cloud copy" — without the host knowing about
+cloud). New mount locations are just new slot strings.
 
 **Cloud Sync (first-party plugin, `src/plugins/cloud-sync/`):** the first
 in-repo plugin built on the panel framework. Contributes a lazy Labs panel that
@@ -451,12 +455,22 @@ read/get/put seam so the engine isn't hard-wired to IndexedDB. Track edits stamp
 `updatedAt` + emit `garageEvents`, so they ride the same auto-sync + delete
 propagation + pending-wins/LWW merge as setups.
 
-Cloud **log deletion** is managed on the Profile tab (`CloudLogsPanel`):
-`listCloudFiles` (now with `uploadedAt`) lists the user's cloud log files;
+Cloud **log deletion** happens two ways. (1) On the Profile tab (`CloudLogsPanel`):
+`listCloudFiles` (with `uploadedAt`) lists the user's cloud log files;
 `deleteCloudFile(userId, name)` removes the blob + its `sync_records` index row
-(cloud-only — other devices keep their downloaded copy), clears the per-file
-selection, and optionally deletes the local copy on this device. (Auto-propagation
-of log deletes on local delete is still a separate follow-up.)
+(cloud-only — other devices keep their downloaded copy), and the panel clears the
+per-file selection + optionally deletes the local copy on this device. (2) On
+**local delete** of a synced log: the `FileDeleteConfirm` mount (`FileDeleteToggle`)
+adds an opt-in *"also delete the cloud copy"* switch (off by default — the cloud
+copy is a backup). When ticked it calls `deleteCloudFile` (online) or queues a
+`{store:"files", type:"delete"}` **pending change** (offline / on failure) that
+`autoSync.pushOne` flushes via `deleteCloudFile` on reconnect.
+
+**Orphan-safety:** `uploadBlob` writes the blob then the index row; if the index
+write is rejected (e.g. the server quota trigger), it **rolls the blob back** so
+it can't orphan in the bucket. `cleanupOrphanBlobs(userId)` (run once per user when
+`CloudLogsPanel` opens) reclaims any pre-existing orphans — bucket objects whose
+decoded name has no index row (`orphanedObjectNames`, pure + tested).
 
 Files are **opt-in per file** (`fileSync.ts`): a `FileRow` mount adds a toggle to
 each file-manager row (`off` → `pending` → `synced`), and the selection set lives

--- a/src/components/drawer/FilesTab.tsx
+++ b/src/components/drawer/FilesTab.tsx
@@ -96,10 +96,22 @@ export function FilesTab({
     }
   }, [confirmLoad, onLoadFile, onDataLoaded, onClose]);
 
+  // A plugin (cloud-sync) can register an extra action to run on confirm — e.g.
+  // also removing the synced copy from the cloud. The host stays cloud-agnostic.
+  const deleteConfirmAction = useRef<(() => Promise<void>) | null>(null);
+  const registerDeleteConfirm = useCallback((fn: (() => Promise<void>) | null) => {
+    deleteConfirmAction.current = fn;
+  }, []);
+
   const handleDeleteConfirm = useCallback(async () => {
     if (!confirmDelete) return;
     await onDeleteFile(confirmDelete);
-    setConfirmDelete(null);
+    try {
+      await deleteConfirmAction.current?.();
+    } finally {
+      deleteConfirmAction.current = null;
+      setConfirmDelete(null);
+    }
   }, [confirmDelete, onDeleteFile]);
 
   const handleUpload = useCallback(
@@ -158,6 +170,11 @@ export function FilesTab({
               <p className="text-sm text-foreground">
                 Delete <span className="font-mono font-medium">{confirmDelete}</span>? This cannot be undone.
               </p>
+              <PluginMount
+                key={confirmDelete}
+                slot={MountSlot.FileDeleteConfirm}
+                ctx={{ fileName: confirmDelete, registerOnConfirm: registerDeleteConfirm }}
+              />
               <div className="flex justify-end gap-2">
                 <Button variant="outline" size="sm" onClick={() => setConfirmDelete(null)}>Cancel</Button>
                 <Button variant="destructive" size="sm" onClick={handleDeleteConfirm}>Delete</Button>

--- a/src/plugins/cloud-sync/CloudLogsPanel.tsx
+++ b/src/plugins/cloud-sync/CloudLogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FileText, Trash2, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import type { PluginPanelProps } from "@/plugins/panels";
@@ -7,7 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useAuth } from "@/contexts/AuthContext";
 import { deleteFile, listFiles } from "@/lib/fileStorage";
-import { deleteCloudFile, listCloudFiles, type CloudFile } from "./syncEngine";
+import { cleanupOrphanBlobs, deleteCloudFile, listCloudFiles, type CloudFile } from "./syncEngine";
 import { unselectFile } from "./fileSync";
 import { formatBytes } from "./storageTypes";
 
@@ -47,6 +47,17 @@ export default function CloudLogsPanel(_props: PluginPanelProps) {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // Reclaim any orphaned blobs (no index row) once per signed-in user. Orphans
+  // don't appear in the index-based list, so this just frees their storage.
+  const cleanedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!user || cleanedFor.current === user.id) return;
+    cleanedFor.current = user.id;
+    void cleanupOrphanBlobs(user.id).then((n) => {
+      if (n > 0) void refresh();
+    });
+  }, [user, refresh]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
   if (!user) {

--- a/src/plugins/cloud-sync/FileDeleteToggle.tsx
+++ b/src/plugins/cloud-sync/FileDeleteToggle.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import type { FileDeleteConfirmContext } from "@/plugins/mounts";
+import { fileSyncStatus, getFileRecord, unselectFile } from "./fileSync";
+import { deleteCloudFile } from "./syncEngine";
+import { markPending } from "./pendingSync";
+import { FILE_STORE } from "./syncStores";
+
+/**
+ * Mounted inside the file delete-confirm banner. When the file being deleted is
+ * synced, it offers an opt-in "also delete the cloud copy" checkbox and, on
+ * confirm, removes the cloud blob + index (or queues it as a pending delete when
+ * offline / on failure, so it propagates on reconnect). The cloud copy is a
+ * backup, so the box defaults off — local deletion alone never touches it.
+ */
+export default function FileDeleteToggle({ ctx }: { ctx: FileDeleteConfirmContext }) {
+  const { user } = useAuth();
+  const online = useOnlineStatus();
+  const { fileName, registerOnConfirm } = ctx;
+  const [synced, setSynced] = useState(false);
+  const [alsoDelete, setAlsoDelete] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    if (!user) {
+      setSynced(false);
+      return;
+    }
+    getFileRecord(fileName).then((r) => active && setSynced(fileSyncStatus(r) === "synced"));
+    return () => {
+      active = false;
+    };
+  }, [user, fileName]);
+
+  useEffect(() => {
+    if (!user || !synced || !alsoDelete) {
+      registerOnConfirm(null);
+      return;
+    }
+    const userId = user.id;
+    registerOnConfirm(async () => {
+      if (!online) {
+        await markPending({ store: FILE_STORE, key: fileName, type: "delete" });
+        return;
+      }
+      try {
+        await deleteCloudFile(userId, fileName);
+        await unselectFile(fileName);
+      } catch {
+        // Network/other failure — retry the cloud delete on reconnect.
+        await markPending({ store: FILE_STORE, key: fileName, type: "delete" });
+      }
+    });
+    return () => registerOnConfirm(null);
+  }, [user, synced, alsoDelete, online, fileName, registerOnConfirm]);
+
+  if (!user || !synced) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Switch
+        id={`cloud-del-${fileName}`}
+        checked={alsoDelete}
+        onCheckedChange={setAlsoDelete}
+        className="scale-90"
+      />
+      <Label htmlFor={`cloud-del-${fileName}`} className="text-xs text-muted-foreground">
+        Also delete the synced copy from the cloud backup
+      </Label>
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -12,10 +12,12 @@
 import { supabase } from "@/integrations/supabase/client";
 import { onGarageChange, type GarageChange } from "@/lib/garageEvents";
 import { isQuotaError } from "./cloudClient";
-import { deleteRecord, pushRecord, reconcileDocs } from "./syncEngine";
+import { deleteCloudFile, deleteRecord, pushRecord, reconcileDocs } from "./syncEngine";
 import { clearPending, listPending, markPending, pendingKeySet } from "./pendingSync";
+import { unselectFile } from "./fileSync";
 import { pendingId } from "./merge";
 import { storageTypeForStore } from "./storageTypes";
+import { FILE_STORE } from "./syncStores";
 
 const DEBOUNCE_MS = 800;
 
@@ -35,6 +37,15 @@ function isOnline(): boolean {
 }
 
 async function pushOne(userId: string, change: GarageChange): Promise<void> {
+  if (change.store === FILE_STORE) {
+    // Files only ever queue here as a deferred *delete* (a log removed while
+    // offline). Remove the blob + its index, and drop the stale selection.
+    if (change.type === "delete") {
+      await deleteCloudFile(userId, change.key);
+      await unselectFile(change.key);
+    }
+    return;
+  }
   if (change.type === "delete") await deleteRecord(userId, change.store, change.key);
   else await pushRecord(userId, change.store, change.key);
 }

--- a/src/plugins/cloud-sync/fileSync.test.ts
+++ b/src/plugins/cloud-sync/fileSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fileSyncStatus, cloudOnlyNames } from "./fileSync";
+import { fileSyncStatus, cloudOnlyNames, orphanedObjectNames } from "./fileSync";
 
 describe("fileSyncStatus", () => {
   it("is 'off' when there is no record (not selected)", () => {
@@ -22,5 +22,23 @@ describe("cloudOnlyNames", () => {
 
   it("returns nothing when every cloud file is already local", () => {
     expect(cloudOnlyNames(["a", "b"], ["a", "b", "x"])).toEqual([]);
+  });
+});
+
+describe("orphanedObjectNames", () => {
+  it("flags bucket objects with no matching index row", () => {
+    expect(orphanedObjectNames(["run1.dovex", "ghost.dovex"], ["run1.dovex"])).toEqual([
+      "ghost.dovex",
+    ]);
+  });
+
+  it("decodes URL-encoded object names before comparing to raw index keys", () => {
+    // Bucket path segments are encodeURIComponent(name); index keys are raw.
+    expect(orphanedObjectNames(["my%20run.dovex"], ["my run.dovex"])).toEqual([]);
+    expect(orphanedObjectNames(["my%20run.dovex"], ["other.dovex"])).toEqual(["my%20run.dovex"]);
+  });
+
+  it("returns nothing when every object is indexed", () => {
+    expect(orphanedObjectNames(["a", "b"], ["a", "b"])).toEqual([]);
   });
 });

--- a/src/plugins/cloud-sync/fileSync.ts
+++ b/src/plugins/cloud-sync/fileSync.ts
@@ -54,3 +54,24 @@ export function cloudOnlyNames(cloudNames: string[], localNames: Iterable<string
   const local = new Set(localNames);
   return cloudNames.filter((n) => !local.has(n));
 }
+
+/**
+ * Bucket object names with no matching index row — orphans to clean up. Pure.
+ * Object names are URL-encoded file names (the bucket path segment), while index
+ * keys are the raw file names, so each object name is decoded before comparing.
+ */
+export function orphanedObjectNames(
+  objectNames: string[],
+  indexedKeys: Iterable<string>,
+): string[] {
+  const indexed = new Set(indexedKeys);
+  return objectNames.filter((n) => {
+    let decoded = n;
+    try {
+      decoded = decodeURIComponent(n);
+    } catch {
+      // Malformed encoding — compare raw.
+    }
+    return !indexed.has(decoded);
+  });
+}

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -6,6 +6,7 @@ import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
 import {
   MOUNTS_POINT, MountSlot,
   type PluginMountDef, type FileRowContext, type FileManagerSectionContext,
+  type FileDeleteConfirmContext,
 } from "@/plugins/mounts";
 
 // The panel pulls in the Supabase sync engine + storage modules, so it's lazy:
@@ -15,6 +16,7 @@ const CloudSyncPanel = lazy(() => import("./CloudSyncPanel"));
 // Likewise the per-file toggle + cloud-only list: lazy so the file-manager
 // drawer doesn't pull the sync engine onto its chunk until they render.
 const FileSyncToggle = lazy(() => import("./FileSyncToggle"));
+const FileDeleteToggle = lazy(() => import("./FileDeleteToggle"));
 const CloudFilesSection = lazy(() => import("./CloudFilesSection"));
 // Profile tab panels: storage usage meters + account, and cloud-log management.
 const StoragePanel = lazy(() => import("./StoragePanel"));
@@ -48,6 +50,15 @@ const plugin: DataViewerPlugin = {
       order: 0,
       component: FileSyncToggle,
     } satisfies PluginMountDef<FileRowContext>);
+
+    // "Also delete from the cloud" opt-in, shown in the file delete-confirm
+    // banner when the file is synced.
+    ctx.registry.contribute(MOUNTS_POINT, {
+      id: "cloud-sync-file-delete",
+      slot: MountSlot.FileDeleteConfirm,
+      order: 0,
+      component: FileDeleteToggle,
+    } satisfies PluginMountDef<FileDeleteConfirmContext>);
 
     // Cloud-only files (in the cloud, not on this device) listed under the file
     // list, each with a per-file pull.

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -15,7 +15,7 @@ import { getFile, saveFile } from "@/lib/fileStorage";
 import { getAccessor } from "./storeAccessors";
 import { fetchStorageUsage, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
-import { listSelectedFiles, markPushed } from "./fileSync";
+import { listSelectedFiles, markPushed, orphanedObjectNames } from "./fileSync";
 import { DEFAULT_LIMITS, type StorageType, type StorageTypeUsage } from "./storageTypes";
 import { decideSync, pendingId, recordUpdatedAt } from "./merge";
 
@@ -40,7 +40,8 @@ async function writeOne(store: string, record: unknown): Promise<void> {
 async function uploadBlob(userId: string, name: string): Promise<boolean> {
   const blob = await getFile(name);
   if (!blob) return false;
-  const { error: upErr } = await userFiles().upload(blobPath(userId, name), blob, {
+  const path = blobPath(userId, name);
+  const { error: upErr } = await userFiles().upload(path, blob, {
     upsert: true,
     contentType: blob.type || "application/octet-stream",
   });
@@ -49,7 +50,12 @@ async function uploadBlob(userId: string, name: string): Promise<boolean> {
     [{ user_id: userId, store: FILE_STORE, record_key: name, data: { size: blob.size } }],
     { onConflict: "user_id,store,record_key" },
   );
-  if (error) throw new Error(`Failed to index ${name}: ${error.message}`);
+  if (error) {
+    // The blob is uploaded but its index row was rejected (e.g. the server
+    // quota trigger). Roll the blob back so it can't orphan in the bucket.
+    await userFiles().remove([path]).catch(() => {});
+    throw new Error(`Failed to index ${name}: ${error.message}`);
+  }
   return true;
 }
 
@@ -96,6 +102,25 @@ export async function deleteCloudFile(userId: string, name: string): Promise<voi
     .eq("store", FILE_STORE)
     .eq("record_key", name);
   if (error) throw new Error(`Failed to remove cloud file index: ${error.message}`);
+}
+
+/**
+ * Remove bucket blobs that have no `sync_records` index row (orphans — e.g. left
+ * by an interrupted upload before the rollback fix). Returns the count removed.
+ */
+export async function cleanupOrphanBlobs(userId: string): Promise<number> {
+  const { data: objects, error: listErr } = await userFiles().list(userId, { limit: 1000 });
+  if (listErr || !objects) return 0;
+  const { data: rows } = await syncRecords()
+    .select("record_key")
+    .eq("user_id", userId)
+    .eq("store", FILE_STORE);
+  const indexed = (rows ?? []).map((r) => (r as { record_key: string }).record_key);
+  const orphans = orphanedObjectNames(objects.map((o) => o.name), indexed);
+  if (!orphans.length) return 0;
+  const { error: rmErr } = await userFiles().remove(orphans.map((n) => `${userId}/${n}`));
+  if (rmErr) return 0;
+  return orphans.length;
 }
 
 /** Download a single file blob from the cloud (does not persist it locally). */

--- a/src/plugins/mounts.ts
+++ b/src/plugins/mounts.ts
@@ -20,6 +20,9 @@ export const MountSlot = {
   FileRow: "file-row",
   /** Rendered once below the file list. Context: the whole list. */
   FileManagerSection: "file-manager-section",
+  /** Rendered inside the file delete-confirm banner. Context: the target file +
+   *  a hook to run an extra action when the user confirms the delete. */
+  FileDeleteConfirm: "file-delete-confirm",
 } as const;
 export type MountSlot = (typeof MountSlot)[keyof typeof MountSlot];
 
@@ -34,6 +37,18 @@ export interface FileManagerSectionContext {
   files: FileEntry[];
   /** Persist a (e.g. cloud-pulled) blob into local storage. */
   onSaveFile: (name: string, blob: Blob) => Promise<void>;
+}
+
+/** Context handed to a `MountSlot.FileDeleteConfirm` component. */
+export interface FileDeleteConfirmContext {
+  /** The file about to be deleted locally. */
+  fileName: string;
+  /**
+   * Register an extra action the host runs (after the local delete) when the
+   * user confirms — or `null` to clear it. Lets a plugin (e.g. cloud-sync)
+   * offer "also delete from the cloud" without the host knowing about cloud.
+   */
+  registerOnConfirm: (fn: (() => Promise<void>) | null) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the "auto log-delete propagation" follow-up from the BETA tracker (#41).
Three things were tangled in that note — this handles all three.

### 1. Delete propagation — per-delete toggle (your call)
Deleting a **synced** log locally now shows an opt-in **"also delete the cloud
copy"** switch in the delete confirm (**off by default** — the cloud copy is a
backup; local deletion alone never touches it). Other devices keep their
downloaded copy, consistent with #56.

The host file manager stays **cloud-agnostic**. New generic mount seam
`MountSlot.FileDeleteConfirm`: a plugin registers an action the confirm runs
*after* the local delete (`registerOnConfirm`). cloud-sync mounts
`FileDeleteToggle` there (rendered only when the file is synced + signed in).
- **Online + ticked** → `deleteCloudFile` (blob + index), then clears the selection.
- **Offline / failure** → queues a `{store:"files", type:"delete"}` **pending
  change**; `autoSync.pushOne` now flushes file-deletes via `deleteCloudFile` on
  reconnect (reusing the existing pending machinery).

### 2. Orphan prevention (the upload-order bug)
`uploadBlob` uploads the blob *then* writes the index row; if the index write is
rejected (e.g. the server `enforce_sync_quota` trigger), the blob was left
orphaned in the bucket. It now **rolls the blob back** on index failure — atomic
regardless of cause. (This supersedes the proposed "pre-upload check": no orphan
is possible, and there's no per-file usage round-trip or false-reject on re-push.)

### 3. Orphan cleanup (historical)
`cleanupOrphanBlobs(userId)` lists the user's bucket objects and removes any with
no `sync_records` index row. Run **once per user** when the Cloud logs panel
opens. The naming logic is a pure, tested helper (`orphanedObjectNames`, decodes
the URL-encoded bucket segment before comparing to raw index keys).

## Files
- **Host:** `mounts.ts` (new slot + `FileDeleteConfirmContext`), `FilesTab.tsx`
  (renders the mount; runs the registered action after local delete).
- **Plugin:** `FileDeleteToggle.tsx` (new), `index.ts` (register mount),
  `syncEngine.ts` (rollback + `cleanupOrphanBlobs`), `autoSync.ts` (file-delete
  flush branch), `fileSync.ts` (`orphanedObjectNames`), `CloudLogsPanel.tsx`
  (cleanup on open).

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (339; +3 `orphanedObjectNames` cases) / `npm run build`
- [x] Sync engine still off the initial bundle
- [ ] Live: delete a synced log with toggle off → cloud copy stays; toggle on → cloud copy + index gone, other-device copy untouched; offline delete → pending → propagates on reconnect; unsynced log → no toggle shown; orphan reclaimed when Cloud logs panel opens

## Still open (tracker)
Over-limit batch push (chunked `reconcileDocs`) + a dedicated Cloud tab remain follow-ups.

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_