### PR TITLE
Partial document push when over the cloud quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Cloud document sync is now **offline-aware and conflict-safe**.
+- When local garage data exceeds the cloud **documents** limit, sync now does a
+  **partial push** — it saves everything that fits and tells you how many items
+  didn't — instead of rejecting the whole batch and syncing nothing.
 
 ### Fixed
 - Cloud log uploads no longer **orphan a blob** when the server quota rejects the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ src/
 │   │   ├── merge.ts              # ★ Pure conflict resolution: decideSync (pending-wins + updatedAt LWW), pendingId (tested)
 │   │   ├── pendingSync.ts        # Persistent offline "pending changes" set (plugin KV); flushed priority-1 on reconnect
 │   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
-│   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord + getStorageUsage + deleteCloudFile (rolls back orphan blob on index failure) + cleanupOrphanBlobs
+│   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord + getStorageUsage + deleteCloudFile (rolls back orphan blob on index failure) + cleanupOrphanBlobs. Doc pushes chunk to a per-record fallback on quota (partial push + skipped count)
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
 │   │   ├── StoragePanel.tsx      # Profile-tab panel: display-name editor + storage usage meters (lazy)
 │   │   ├── CloudLogsPanel.tsx    # Profile-tab panel: list + delete cloud log files (cloud-only; opt-in local delete) (lazy)
@@ -422,9 +422,12 @@ offline or whose push failed is recorded in a persistent **pending set**
 **priority-1** (replacing the cloud copy); everything else merges by newest
 `updatedAt` (the record's logical edit time — never the server row time).
 `reconcileDocs` does the two-way merge (pull cloud-newer, push local-newer/-only),
-skipping pending keys. `autoSync` tracks `navigator.onLine` + window online/offline
-events; the Profile-tab `StoragePanel` flags offline state + the pending count.
-(Log-blob deletion propagation remains a follow-up.)
+skipping pending keys. Its push (and `pushAll`'s) goes through `pushDocRows`: one
+optimistic batch, falling back to per-record upserts if the server quota trigger
+rejects the batch — so an over-limit local set still **partial-syncs** everything
+that fits and reports a `skipped` count (surfaced as a toast) rather than failing
+wholesale. `autoSync` tracks `navigator.onLine` + window online/offline events;
+the Profile-tab `StoragePanel` flags offline state + the pending count.
 
 **Storage types** (`storageTypes.ts`, enforced server-side) — distinct from
 future *subscription tiers*: **documents** = all structured stores (5 MB, free,

--- a/src/plugins/cloud-sync/CloudSyncPanel.tsx
+++ b/src/plugins/cloud-sync/CloudSyncPanel.tsx
@@ -58,7 +58,13 @@ export default function CloudSyncPanel() {
     setBusy("push");
     try {
       const r = await pushAll(user.id);
-      toast.success(`Pushed ${r.records} records and ${r.files} files to the cloud.`);
+      if (r.skipped > 0) {
+        toast.error(
+          `Pushed ${r.records} records and ${r.files} files, but ${r.skipped} didn't fit — cloud document storage is full.`,
+        );
+      } else {
+        toast.success(`Pushed ${r.records} records and ${r.files} files to the cloud.`);
+      }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Push failed");
     } finally {

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -112,7 +112,13 @@ async function flushPending(userId: string): Promise<void> {
 async function runReconcile(userId: string): Promise<void> {
   try {
     await flushPending(userId);
-    await reconcileDocs(userId, await pendingKeySet());
+    const { skipped } = await reconcileDocs(userId, await pendingKeySet());
+    if (skipped > 0) {
+      notify(
+        `Cloud document storage is full — ${skipped} item${skipped === 1 ? "" : "s"} didn't sync.`,
+        "error",
+      );
+    }
   } catch (err) {
     if (isQuotaError(err)) {
       notify("Cloud document storage is full — some items didn't sync.", "error");

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -13,7 +13,7 @@
 
 import { getFile, saveFile } from "@/lib/fileStorage";
 import { getAccessor } from "./storeAccessors";
-import { fetchStorageUsage, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
+import { fetchStorageUsage, isQuotaError, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
 import { listSelectedFiles, markPushed, orphanedObjectNames } from "./fileSync";
 import { DEFAULT_LIMITS, type StorageType, type StorageTypeUsage } from "./storageTypes";
@@ -131,6 +131,32 @@ export async function downloadCloudFile(userId: string, name: string): Promise<B
 }
 
 /**
+ * Push document rows in one batch (the common, under-limit case). If the server
+ * quota trigger rejects the batch, the whole statement rolls back — so fall back
+ * to per-record upserts, saving everything that still fits and reporting the rest
+ * as `skipped`, instead of failing the entire sync. Non-quota errors still throw.
+ */
+async function pushDocRows(rows: SyncRecordRow[]): Promise<{ pushed: number; skipped: number }> {
+  if (!rows.length) return { pushed: 0, skipped: 0 };
+  const { error } = await syncRecords().upsert(rows, { onConflict: "user_id,store,record_key" });
+  if (!error) return { pushed: rows.length, skipped: 0 };
+  if (!isQuotaError(new Error(error.message))) {
+    throw new Error(`Failed to push documents: ${error.message}`);
+  }
+  let pushed = 0;
+  let skipped = 0;
+  for (const row of rows) {
+    const { error: rowErr } = await syncRecords().upsert([row], {
+      onConflict: "user_id,store,record_key",
+    });
+    if (!rowErr) pushed++;
+    else if (isQuotaError(new Error(rowErr.message))) skipped++;
+    else throw new Error(`Failed to push documents: ${rowErr.message}`);
+  }
+  return { pushed, skipped };
+}
+
+/**
  * Mirror local data up to the cloud: all structured (garage) records, plus only
  * the files the user has selected for sync.
  */
@@ -141,10 +167,7 @@ export async function pushAll(userId: string): Promise<SyncSummary> {
       rows.push({ user_id: userId, store, record_key: extractKey(store, record), data: record });
     }
   }
-  if (rows.length) {
-    const { error } = await syncRecords().upsert(rows, { onConflict: "user_id,store,record_key" });
-    if (error) throw new Error(`Failed to push records: ${error.message}`);
-  }
+  const { pushed, skipped } = await pushDocRows(rows);
 
   let files = 0;
   for (const name of await listSelectedFiles()) {
@@ -154,7 +177,7 @@ export async function pushAll(userId: string): Promise<SyncSummary> {
     }
   }
 
-  return { records: rows.length, files };
+  return { records: pushed, files, skipped };
 }
 
 /** Bring the cloud copy down into local IndexedDB. */
@@ -179,7 +202,7 @@ export async function pullAll(userId: string): Promise<SyncSummary> {
       records++;
     }
   }
-  return { records, files };
+  return { records, files, skipped: 0 };
 }
 
 // ── Incremental (auto) sync ──────────────────────────────────────────────────
@@ -212,6 +235,8 @@ export async function deleteRecord(userId: string, store: string, key: string): 
 export interface DocReconcileResult {
   pulled: number;
   pushed: number;
+  /** Records that didn't fit under the documents quota (partial push). */
+  skipped: number;
 }
 
 /**
@@ -246,7 +271,6 @@ export async function reconcileDocs(
   }
 
   let pulled = 0;
-  let pushed = 0;
   const toPush: SyncRecordRow[] = [];
   const seen = new Set<string>();
 
@@ -265,7 +289,6 @@ export async function reconcileDocs(
       });
       if (action === "push") {
         toPush.push({ user_id: userId, store, record_key: key, data: record });
-        pushed++;
       } else if (action === "pull" && c) {
         await writeOne(store, c.data);
         pulled++;
@@ -289,14 +312,8 @@ export async function reconcileDocs(
     }
   }
 
-  if (toPush.length) {
-    const { error: upErr } = await syncRecords().upsert(toPush, {
-      onConflict: "user_id,store,record_key",
-    });
-    if (upErr) throw new Error(`Failed to push documents: ${upErr.message}`);
-  }
-
-  return { pulled, pushed };
+  const { pushed, skipped } = await pushDocRows(toPush);
+  return { pulled, pushed, skipped };
 }
 
 /** Per-type storage usage from the server, with the advisory limits as fallback. */

--- a/src/plugins/cloud-sync/syncStores.ts
+++ b/src/plugins/cloud-sync/syncStores.ts
@@ -38,6 +38,8 @@ export const FILE_STORE = STORE_NAMES.FILES;
 export interface SyncSummary {
   records: number;
   files: number;
+  /** Document records that didn't fit under the quota (partial push). 0 on pull. */
+  skipped: number;
 }
 
 /** Extract the cloud record_key for a store's record using its IndexedDB key path. */


### PR DESCRIPTION
## Summary

Closes the last open Cloud Sync follow-up from the BETA tracker (#41):
over-limit batch push.

`reconcileDocs` (and `pushAll`) upserted **all** document records in one batch.
The `enforce_sync_quota` trigger runs per-row, but the batch is one statement —
so a single over-limit record rolls back the whole statement and **nothing
syncs**, even the records that would have fit.

### Fix — chunk to a per-record fallback
New `pushDocRows(rows)`:
1. **Optimistic batch** — one upsert, the common under-limit path (no behavior change).
2. On a **quota rejection**, fall back to **per-record upserts**: everything that
   still fits is saved; the rest are counted as `skipped`. Non-quota errors still throw.

So an over-limit local set now **partial-syncs** instead of failing wholesale.
(Per-record only kicks in on the rare over-limit path, so the normal case stays a
single round-trip.)

### Clearer messaging
`SyncSummary` / `DocReconcileResult` gain a `skipped` count, surfaced as:
- **Manual push** (`CloudSyncPanel`): *"Pushed N records and M files, but K didn't
  fit — cloud document storage is full."*
- **Background reconcile** (`autoSync.runReconcile`): *"Cloud document storage is
  full — K item(s) didn't sync."*

## ⚠️ Stacks on #59
> This branch is built on top of `claude/log-delete-propagation` (**PR #59**), so
> the diff currently shows **both** commits. **Merge #59 first**; once it lands in
> `BETA` this reduces to just the partial-push commit. (The CLAUDE.md edit also
> retires the now-done "log-blob deletion propagation" follow-up note, since #59
> handles it.)

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (339) / `npm run build`
- [ ] Live: fill document storage past 5 MB, push → fits-portion syncs, toast reports the skipped count; under-limit push unchanged (single batch)

Note: `pushDocRows` is network/Supabase-coupled (like the rest of `syncEngine`), so it's covered by the live pass rather than a unit test — there's no pure logic to extract.

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_