### PR TITLE
Cloud cleanup: sign-in on Profile, download-all in Files, pricing cards, register captcha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same way setups do — auto-sync, delete propagation, and the offline-aware
   timestamp merge. Only your user-created tracks/courses sync; built-in tracks
   stay local.
+- **Plans & pricing** cards on the landing page (below the sample) and on the
+  registration page — Free offline, Free online, and paid tiers (marked
+  "Coming soon" until billing is wired up).
+- Registration now supports a **Cloudflare Turnstile captcha** when
+  `VITE_TURNSTILE_SITE_KEY` is set (gracefully skipped when it isn't), and
+  rejects **disposable / temporary email** addresses.
 
 ### Changed
+- **Cloud Sync moved out of the Labs tab**: sign-in and manual push/pull now live
+  at the bottom of the file manager's **Files** tab, next to the files they back
+  up. The Labs tab no longer appears unless the experimental setting is on or a
+  plugin contributes to it.
+- Landing-page and About copy now reflect **optional cloud storage** (instead of
+  "files never leave your device"), since cloud sync is available when signed in.
 - Cloud document sync is now **offline-aware and conflict-safe**. Garage records
   (vehicles, setups, templates, notes) carry an edit timestamp, and sync uses
   last-write-wins, so a newer change is never overwritten by an older copy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,17 +70,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timestamp merge. Only your user-created tracks/courses sync; built-in tracks
   stay local.
 - **Plans & pricing** cards on the landing page (below the sample) and on the
-  registration page — Free offline, Free online, and paid tiers (marked
-  "Coming soon" until billing is wired up).
+  registration page — Free offline, Free online (20 MB cloud logs), and paid
+  tiers (marked "Coming soon" until billing is wired up).
+- **"Download all cloud logs"** button at the bottom of the file manager:
+  one-click bulk pull of every cloud log not already on this device.
 - Registration now supports a **Cloudflare Turnstile captcha** when
   `VITE_TURNSTILE_SITE_KEY` is set (gracefully skipped when it isn't), and
   rejects **disposable / temporary email** addresses.
 
 ### Changed
 - **Cloud Sync moved out of the Labs tab**: sign-in and manual push/pull now live
-  at the bottom of the file manager's **Files** tab, next to the files they back
-  up. The Labs tab no longer appears unless the experimental setting is on or a
-  plugin contributes to it.
+  on the **Profile** tab as an "Account" panel. The Labs tab no longer appears
+  unless the experimental setting is on or a plugin contributes to it.
 - Landing-page and About copy now reflect **optional cloud storage** (instead of
   "files never leave your device"), since cloud sync is available when signed in.
 - Cloud document sync is now **offline-aware and conflict-safe**. Garage records

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,9 +268,11 @@ A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 
 **UI panels:** the first concrete extension point. A plugin contributes
 `PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
-Three slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`),
-`PanelSlot.Coach` (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home
-for the `@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
+Three slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`; no
+first-party panel targets it now — it shows only when the experimental
+`enableLabs` setting is on or another plugin contributes), `PanelSlot.Coach`
+(rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home for the
+`@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
 (rendered by `ProfileTab.tsx`, far-right — cloud-sync contributes the storage
 meters). All render contributed panels via `PluginPanelHost` and are
 **self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showProfile`
@@ -288,15 +290,19 @@ are all chromeless (`isBareSlot`) also drops the host's outer padding.
 component into a fixed spot in core UI. A plugin contributes a `PluginMountDef`
 to `MOUNTS_POINT`, targeting a `MountSlot`; the host renders `<PluginMount slot
 ctx={…}>` at that spot, passing a typed context as a single `ctx` prop.
-`FilesTab` exposes two: `MountSlot.FileRow` (per file row, ctx = that file) and
-`MountSlot.FileManagerSection` (once under the list, ctx = the whole list). New
-mount locations are just new slot strings.
+`FilesTab` exposes three: `MountSlot.FileRow` (per file row, ctx = that file),
+`MountSlot.FileManagerSection` (once under the list, ctx = the whole list), and
+`MountSlot.FileManagerFooter` (near the bottom, above storage usage, ctx = the
+whole list — home for the Cloud Sync panel). New mount locations are just new
+slot strings.
 
 **Cloud Sync (first-party plugin, `src/plugins/cloud-sync/`):** the first
-in-repo plugin built on the panel framework. Contributes a lazy Labs panel that
-signs the user in (`useAuth`) and does manual push/pull of local IndexedDB data
-to Supabase. Structured stores go to the `sync_records` table as jsonb
-documents; raw session blobs go to the private `user-files` Storage bucket. See
+in-repo plugin built on the panel framework. Contributes `CloudSyncPanel` (lazy)
+as a `MountSlot.FileManagerFooter` mount — sign-in (`useAuth`) + manual push/pull
+of local IndexedDB data to Supabase, sitting at the bottom of the file manager
+(it used to be a Labs panel; no first-party panel targets Labs now). Structured
+stores go to the `sync_records` table as jsonb documents; raw session blobs go to
+the private `user-files` Storage bucket. See
 the Cloud Sync section below for the data model.
 
 **AI coach (npm package):** published to the public npm registry as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,8 +273,9 @@ first-party panel targets it now — it shows only when the experimental
 `enableLabs` setting is on or another plugin contributes), `PanelSlot.Coach`
 (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home for the
 `@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
-(rendered by `ProfileTab.tsx`, far-right — cloud-sync contributes the storage
-meters). All render contributed panels via `PluginPanelHost` and are
+(rendered by `ProfileTab.tsx`, far-right — cloud-sync contributes the Account
+sign-in panel, storage meters, and cloud-log management). All render contributed
+panels via `PluginPanelHost` and are
 **self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showProfile`
 from `getPanelsForSlot`, so a tab appears only when a
 plugin contributes a panel to it (Labs additionally shows when the experimental
@@ -293,16 +294,18 @@ ctx={…}>` at that spot, passing a typed context as a single `ctx` prop.
 `FilesTab` exposes three: `MountSlot.FileRow` (per file row, ctx = that file),
 `MountSlot.FileManagerSection` (once under the list, ctx = the whole list), and
 `MountSlot.FileManagerFooter` (near the bottom, above storage usage, ctx = the
-whole list — home for the Cloud Sync panel). New mount locations are just new
-slot strings.
+whole list — home for the "Download all cloud logs" bulk action). New mount
+locations are just new slot strings.
 
 **Cloud Sync (first-party plugin, `src/plugins/cloud-sync/`):** the first
-in-repo plugin built on the panel framework. Contributes `CloudSyncPanel` (lazy)
-as a `MountSlot.FileManagerFooter` mount — sign-in (`useAuth`) + manual push/pull
-of local IndexedDB data to Supabase, sitting at the bottom of the file manager
-(it used to be a Labs panel; no first-party panel targets Labs now). Structured
-stores go to the `sync_records` table as jsonb documents; raw session blobs go to
-the private `user-files` Storage bucket. See
+in-repo plugin built on the panel framework. Sign-in + manual push/pull live in
+`CloudSyncPanel` (lazy), contributed as the **Account** panel on the Profile tab
+(`PanelSlot.Profile`, ordered first). The file manager's footer
+(`MountSlot.FileManagerFooter`) gets a separate lazy `DownloadAllCloudLogs` mount
+— a one-click bulk pull of every cloud log not yet on this device (self-hides
+when signed out). (Cloud Sync used to be a Labs panel; no first-party panel
+targets Labs now.) Structured stores go to the `sync_records` table as jsonb
+documents; raw session blobs go to the private `user-files` Storage bucket. See
 the Cloud Sync section below for the data model.
 
 **AI coach (npm package):** published to the public npm registry as

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -15,7 +15,7 @@ const SECTIONS: Array<{ heading: string; body: React.ReactNode }> = [
   },
   {
     heading: "Your Data Stays on Your Device",
-    body: <>All data processing happens entirely in your browser. Your log files, session notes, kart setups, and video sync data are saved locally on your device — nothing is uploaded to any server.</>,
+    body: <>All data processing happens entirely in your browser, and everything is saved locally on your device by default. Cloud storage is entirely optional — nothing leaves your device unless you create an account and turn on sync.</>,
   },
   {
     heading: "Community Track Database",
@@ -23,7 +23,7 @@ const SECTIONS: Array<{ heading: string; body: React.ReactNode }> = [
   },
   {
     heading: "Free & Open Source",
-    body: <>Every feature in HackTheTrack is completely free. The source code is open and available on GitHub. If cloud-saving is added in the future, that may carry a small cost to cover server fees — but all local features will always remain free.</>,
+    body: <>Every local feature in HackTheTrack is completely free, and the source code is open and available on GitHub. Optional cloud storage has a free tier; larger storage and AI coaching are paid add-ons that cover server and model costs — but all local features will always remain free.</>,
   },
 ];
 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -8,6 +8,7 @@ import { ContactDialog } from "@/components/ContactDialog";
 import { SupportedFilesDialog } from "@/components/SupportedFilesDialog";
 import { AboutDialog } from "@/components/AboutDialog";
 import { CreditsDialog } from "@/components/CreditsDialog";
+import { PricingCards } from "@/components/PricingCards";
 import { useAuth } from "@/contexts/AuthContext";
 import type { ParsedData } from "@/types/racing";
 
@@ -92,8 +93,8 @@ export function LandingPage({
         </div>
       </header>
 
-      <main className="flex-1 flex items-center justify-center p-8">
-        <div className="w-full max-w-xl space-y-6">
+      <main className="flex-1 p-8 space-y-12">
+        <div className="mx-auto w-full max-w-xl space-y-6">
           <div className="flex justify-end items-center gap-2">
             <LocalWeatherDialog />
           </div>
@@ -103,7 +104,7 @@ export function LandingPage({
               Free Online VBO, MoTeC, AiM &amp; NMEA Telemetry Viewer
             </h1>
             <p className="text-sm text-muted-foreground">
-              Open any Racelogic VBO, MoTeC i2 (LD/CSV), AiM MyChron, Alfano, u-blox UBX, NMEA or Dove datalog right in your browser. 100% offline — your files never leave your device.
+              Open any Racelogic VBO, MoTeC i2 (LD/CSV), AiM MyChron, Alfano, u-blox UBX, NMEA or Dove datalog right in your browser. Offline-first — with optional cloud storage to sync across your devices.
             </p>
           </div>
 
@@ -128,12 +129,16 @@ export function LandingPage({
               </Button>
             </div>
           </div>
+        </div>
 
-          <div className="flex justify-center mt-3">
+        <PricingCards className="mx-auto w-full max-w-5xl" />
+
+        <div className="mx-auto w-full max-w-xl space-y-4">
+          <div className="flex justify-center">
             <BrowserCompatDialog />
           </div>
 
-          <div className="flex items-center justify-center gap-8 mt-4">
+          <div className="flex items-center justify-center gap-8">
             {GITHUB_LINKS.map((link) => (
               <a
                 key={link.href}
@@ -148,7 +153,7 @@ export function LandingPage({
             ))}
           </div>
 
-          <div className="flex items-center justify-center gap-6 mt-3 flex-wrap">
+          <div className="flex items-center justify-center gap-6 flex-wrap">
             <Link to="/privacy" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
               <Shield className="w-3 h-3" />
               Privacy Policy

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -1,0 +1,120 @@
+import { Check } from "lucide-react";
+
+interface Tier {
+  name: string;
+  blurb: string;
+  price: string;
+  cadence?: string;
+  inherits?: string;
+  features: string[];
+  highlight?: boolean;
+  comingSoon?: boolean;
+}
+
+const TIERS: Tier[] = [
+  {
+    name: "Free",
+    blurb: "Offline",
+    price: "$0",
+    features: [
+      "Full data viewer",
+      "Bluetooth (BLE) device connectivity",
+      "Save logs to your device",
+      "Add overlays & export videos",
+      "Offline mathematical session debrief",
+    ],
+  },
+  {
+    name: "Free",
+    blurb: "Online account",
+    price: "$0",
+    highlight: true,
+    inherits: "Everything in Free, plus",
+    features: [
+      "Setup info synced across all your devices",
+      "Sync your personal tracks",
+      "10 MB cloud log storage",
+    ],
+  },
+  {
+    name: "Plus",
+    blurb: "For bigger garages",
+    price: "$1",
+    cadence: "/mo",
+    comingSoon: true,
+    inherits: "Everything in Free online, plus",
+    features: ["500 MB cloud log storage"],
+  },
+  {
+    name: "Pro",
+    blurb: "With AI coaching",
+    price: "$10",
+    cadence: "/mo",
+    comingSoon: true,
+    inherits: "Everything in Plus, plus",
+    features: ["1 GB cloud log storage", "100 AI coaching credits / month"],
+  },
+];
+
+function TierCard({ tier }: { tier: Tier }) {
+  return (
+    <div
+      className={`relative flex flex-col rounded-xl border bg-card p-5 text-left ${
+        tier.highlight ? "border-primary ring-1 ring-primary/40" : "border-border"
+      }`}
+    >
+      {tier.highlight && (
+        <span className="absolute -top-2.5 left-4 rounded-full bg-primary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-foreground">
+          Recommended
+        </span>
+      )}
+      {tier.comingSoon && (
+        <span className="absolute -top-2.5 right-4 rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Coming soon
+        </span>
+      )}
+      <div className="space-y-0.5">
+        <h3 className="text-base font-semibold text-foreground">{tier.name}</h3>
+        <p className="text-xs text-muted-foreground">{tier.blurb}</p>
+      </div>
+      <div className="mt-3 flex items-baseline gap-1">
+        <span className="text-2xl font-bold text-foreground">{tier.price}</span>
+        {tier.cadence && <span className="text-sm text-muted-foreground">{tier.cadence}</span>}
+      </div>
+      {tier.inherits && (
+        <p className="mt-3 text-xs font-medium text-muted-foreground">{tier.inherits}</p>
+      )}
+      <ul className="mt-2 space-y-2">
+        {tier.features.map((f) => (
+          <li key={f} className="flex items-start gap-2 text-sm text-foreground">
+            <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <span>{f}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Plans / pricing grid. Shown on the landing page (below the sample box) and on
+ * the registration page. Informational only — paid tiers are marked "Coming
+ * soon" until billing is wired up.
+ */
+export function PricingCards({ className }: { className?: string }) {
+  return (
+    <section className={className}>
+      <div className="text-center space-y-1">
+        <h2 className="text-xl font-bold text-foreground">Plans &amp; pricing</h2>
+        <p className="text-sm text-muted-foreground">
+          Start free and fully offline. Add an account for cross-device sync — upgrade only if you need more.
+        </p>
+      </div>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {TIERS.map((tier) => (
+          <TierCard key={`${tier.name}-${tier.blurb}`} tier={tier} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -33,7 +33,7 @@ const TIERS: Tier[] = [
     features: [
       "Setup info synced across all your devices",
       "Sync your personal tracks",
-      "10 MB cloud log storage",
+      "20 MB cloud log storage",
     ],
   },
   {
@@ -52,7 +52,7 @@ const TIERS: Tier[] = [
     cadence: "/mo",
     comingSoon: true,
     inherits: "Everything in Plus, plus",
-    features: ["1 GB cloud log storage", "100 AI coaching credits / month"],
+    features: ["1 GB cloud log storage", "AI coaching (coming soon)"],
   },
 ];
 

--- a/src/components/Turnstile.tsx
+++ b/src/components/Turnstile.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
+
+/** True when a Turnstile site key is configured. When false, callers should
+ *  treat the captcha as satisfied (graceful fallback for self-hosters). */
+export const turnstileEnabled = !!SITE_KEY;
+
+interface TurnstileWidget {
+  render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+  remove: (id: string) => void;
+}
+
+interface TurnstileProps {
+  /** Receives the token on success, or null when reset/expired/errored. */
+  onToken: (token: string | null) => void;
+  theme?: "auto" | "light" | "dark";
+  className?: string;
+}
+
+/**
+ * Cloudflare Turnstile widget. Renders nothing (and never blocks) when no
+ * `VITE_TURNSTILE_SITE_KEY` is set, so the app works without a captcha key.
+ */
+export function Turnstile({ onToken, theme = "auto", className }: TurnstileProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!SITE_KEY || document.getElementById("cf-turnstile-script")) return;
+    const script = document.createElement("script");
+    script.id = "cf-turnstile-script";
+    script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+    script.async = true;
+    document.head.appendChild(script);
+  }, []);
+
+  const tryRender = useCallback((): boolean => {
+    if (!SITE_KEY || !containerRef.current) return false;
+    const ts = (window as unknown as { turnstile?: TurnstileWidget }).turnstile;
+    if (!ts) return false;
+    if (widgetId.current) {
+      try { ts.remove(widgetId.current); } catch { /* already gone */ }
+      widgetId.current = null;
+    }
+    onToken(null);
+    widgetId.current = ts.render(containerRef.current, {
+      sitekey: SITE_KEY,
+      callback: (t: string) => onToken(t),
+      "expired-callback": () => onToken(null),
+      "error-callback": () => onToken(null),
+      theme,
+    });
+    return true;
+  }, [onToken, theme]);
+
+  useEffect(() => {
+    if (!SITE_KEY) return;
+    // The script loads async; poll briefly until the global is ready.
+    let tries = 0;
+    const id = setInterval(() => {
+      if (tryRender() || ++tries > 50) clearInterval(id);
+    }, 100);
+    return () => {
+      clearInterval(id);
+      const ts = (window as unknown as { turnstile?: TurnstileWidget }).turnstile;
+      if (widgetId.current && ts) {
+        try { ts.remove(widgetId.current); } catch { /* already gone */ }
+        widgetId.current = null;
+      }
+    };
+  }, [tryRender]);
+
+  if (!SITE_KEY) return null;
+  return <div ref={containerRef} className={className} />;
+}

--- a/src/components/drawer/FilesTab.tsx
+++ b/src/components/drawer/FilesTab.tsx
@@ -10,7 +10,7 @@ const DataloggerDownload = lazy(() =>
 );
 import { listSessionVideos, deleteSessionVideo, StoredVideoMeta } from "@/lib/videoFileStorage";
 import { PluginMount } from "@/plugins/PluginMount";
-import { MountSlot } from "@/plugins/mounts";
+import { MountSlot, getMounts } from "@/plugins/mounts";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -239,6 +239,13 @@ export function FilesTab({
           ))
         )}
       </div>
+
+      {/* Plugin-contributed footer (e.g. Cloud Sync sign-in / push-pull). */}
+      {getMounts(MountSlot.FileManagerFooter).length > 0 && (
+        <div className="px-4 py-3 border-t border-border shrink-0">
+          <PluginMount slot={MountSlot.FileManagerFooter} ctx={{ files, onSaveFile }} />
+        </div>
+      )}
 
       {/* Storage Usage */}
       <div className="px-4 py-2 border-t border-border shrink-0">

--- a/src/components/drawer/FilesTab.tsx
+++ b/src/components/drawer/FilesTab.tsx
@@ -10,7 +10,7 @@ const DataloggerDownload = lazy(() =>
 );
 import { listSessionVideos, deleteSessionVideo, StoredVideoMeta } from "@/lib/videoFileStorage";
 import { PluginMount } from "@/plugins/PluginMount";
-import { MountSlot, getMounts } from "@/plugins/mounts";
+import { MountSlot } from "@/plugins/mounts";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -240,12 +240,9 @@ export function FilesTab({
         )}
       </div>
 
-      {/* Plugin-contributed footer (e.g. Cloud Sync sign-in / push-pull). */}
-      {getMounts(MountSlot.FileManagerFooter).length > 0 && (
-        <div className="px-4 py-3 border-t border-border shrink-0">
-          <PluginMount slot={MountSlot.FileManagerFooter} ctx={{ files, onSaveFile }} />
-        </div>
-      )}
+      {/* Plugin-contributed footer (e.g. "Download all cloud logs").
+          The mount owns its own chrome and self-hides when not applicable. */}
+      <PluginMount slot={MountSlot.FileManagerFooter} ctx={{ files, onSaveFile }} />
 
       {/* Storage Usage */}
       <div className="px-4 py-2 border-t border-border shrink-0">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ interface AuthContextValue {
   isAdmin: boolean;
   loading: boolean;
   login: (email: string, password: string) => Promise<{ error: Error | null }>;
-  signUp: (email: string, password: string, displayName?: string) => Promise<{ error: Error | null }>;
+  signUp: (email: string, password: string, displayName?: string, captchaToken?: string) => Promise<{ error: Error | null }>;
   signInWithGoogle: () => Promise<{ error: Error | null }>;
   logout: () => Promise<void>;
   resetPassword: (email: string) => Promise<{ error: Error | null }>;
@@ -101,7 +101,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { error };
   }, []);
 
-  const signUp = useCallback(async (email: string, password: string, displayName?: string) => {
+  const signUp = useCallback(async (email: string, password: string, displayName?: string, captchaToken?: string) => {
     const trimmed = displayName?.trim();
     const { error } = await supabase.auth.signUp({
       email,
@@ -111,6 +111,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Picked up by the handle_new_user trigger; blank → a random name is
         // generated server-side. A taken name is auto-suffixed there too.
         data: trimmed ? { display_name: trimmed } : {},
+        // Verified server-side when Turnstile is enabled in the Supabase Auth
+        // settings; ignored otherwise (graceful fallback when no key is set).
+        ...(captchaToken ? { captchaToken } : {}),
       },
     });
     return { error };

--- a/src/lib/emailValidation.test.ts
+++ b/src/lib/emailValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { emailDomain, isDisposableEmail, looksLikeEmail } from "./emailValidation";
+
+describe("emailDomain", () => {
+  it("returns the lower-cased domain", () => {
+    expect(emailDomain("Driver@Gmail.COM")).toBe("gmail.com");
+  });
+  it("returns null without a usable domain", () => {
+    expect(emailDomain("no-at-sign")).toBeNull();
+    expect(emailDomain("trailing@")).toBeNull();
+  });
+});
+
+describe("isDisposableEmail", () => {
+  it("flags known disposable providers (case-insensitive)", () => {
+    expect(isDisposableEmail("a@mailinator.com")).toBe(true);
+    expect(isDisposableEmail("a@Guerrillamail.com")).toBe(true);
+    expect(isDisposableEmail("a@yopmail.com")).toBe(true);
+  });
+  it("allows normal providers", () => {
+    expect(isDisposableEmail("a@gmail.com")).toBe(false);
+    expect(isDisposableEmail("racer@hackthetrack.net")).toBe(false);
+  });
+  it("is false for malformed input", () => {
+    expect(isDisposableEmail("not-an-email")).toBe(false);
+  });
+});
+
+describe("looksLikeEmail", () => {
+  it("accepts a basic address and rejects obvious junk", () => {
+    expect(looksLikeEmail("a@b.co")).toBe(true);
+    expect(looksLikeEmail("a@b")).toBe(false);
+    expect(looksLikeEmail("a b@c.com")).toBe(false);
+  });
+});

--- a/src/lib/emailValidation.ts
+++ b/src/lib/emailValidation.ts
@@ -1,0 +1,63 @@
+// Lightweight, offline disposable-email guard for account sign-up. Not meant to
+// be exhaustive (an online list would break offline-first and go stale) — just a
+// curated set of the common "5-minute mailbox" providers, plus basic shape
+// checks. The server (Supabase auth) remains the real gate.
+
+const DISPOSABLE_DOMAINS = new Set<string>([
+  "10minutemail.com",
+  "10minutemail.net",
+  "20minutemail.com",
+  "33mail.com",
+  "burnermail.io",
+  "dispostable.com",
+  "emailondeck.com",
+  "fakeinbox.com",
+  "fexbox.org",
+  "getairmail.com",
+  "getnada.com",
+  "grr.la",
+  "guerrillamail.com",
+  "guerrillamail.info",
+  "guerrillamail.net",
+  "guerrillamail.org",
+  "inboxkitten.com",
+  "mailcatch.com",
+  "maildrop.cc",
+  "mailinator.com",
+  "mailnesia.com",
+  "mailsac.com",
+  "mailto.plus",
+  "minuteinbox.com",
+  "mintemail.com",
+  "mohmal.com",
+  "moakt.com",
+  "sharklasers.com",
+  "spam4.me",
+  "spamgourmet.com",
+  "temp-mail.org",
+  "tempmail.com",
+  "tempmailo.com",
+  "throwawaymail.com",
+  "tmpmail.org",
+  "trashmail.com",
+  "yopmail.com",
+  "yopmail.net",
+]);
+
+/** The lower-cased domain part of an email, or null if it has no `@`. */
+export function emailDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0 || at === email.length - 1) return null;
+  return email.slice(at + 1).trim().toLowerCase();
+}
+
+/** True if the email's domain is a known disposable / temporary-mail provider. */
+export function isDisposableEmail(email: string): boolean {
+  const domain = emailDomain(email);
+  return domain != null && DISPOSABLE_DOMAINS.has(domain);
+}
+
+/** Very small structural sanity check (a real validator lives server-side). */
+export function looksLikeEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -7,6 +7,9 @@ import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 import { Gauge, ArrowLeft } from 'lucide-react';
 import { useDocumentHead } from '@/hooks/useDocumentHead';
+import { Turnstile, turnstileEnabled } from '@/components/Turnstile';
+import { PricingCards } from '@/components/PricingCards';
+import { isDisposableEmail, looksLikeEmail } from '@/lib/emailValidation';
 
 export default function Register() {
   useDocumentHead({
@@ -19,11 +22,20 @@ export default function Register() {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
   const { signUp, signInWithGoogle } = useAuth();
   const navigate = useNavigate();
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!looksLikeEmail(email)) {
+      toast({ title: 'Enter a valid email address', variant: 'destructive' });
+      return;
+    }
+    if (isDisposableEmail(email)) {
+      toast({ title: 'Please use a permanent email address', description: 'Disposable / temporary mailboxes are not allowed.', variant: 'destructive' });
+      return;
+    }
     if (password !== confirmPassword) {
       toast({ title: 'Passwords do not match', variant: 'destructive' });
       return;
@@ -32,8 +44,12 @@ export default function Register() {
       toast({ title: 'Password must be at least 6 characters', variant: 'destructive' });
       return;
     }
+    if (turnstileEnabled && !captchaToken) {
+      toast({ title: 'Please complete the captcha', variant: 'destructive' });
+      return;
+    }
     setIsLoading(true);
-    const { error } = await signUp(email, password, displayName);
+    const { error } = await signUp(email, password, displayName, captchaToken ?? undefined);
     setIsLoading(false);
     if (error) {
       toast({ title: 'Registration failed', description: error.message, variant: 'destructive' });
@@ -53,8 +69,8 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8">
-      <div className="w-full max-w-sm space-y-6">
+    <div className="min-h-screen bg-background flex flex-col items-center p-8 gap-12">
+      <div className="w-full max-w-sm space-y-6 mt-4">
         <div className="flex items-center gap-3 justify-center">
           <Gauge className="w-8 h-8 text-primary" />
           <h1 className="text-xl font-semibold text-foreground">HackTheTrack.net</h1>
@@ -89,6 +105,7 @@ export default function Register() {
               <Label htmlFor="confirmPassword">Confirm Password</Label>
               <Input id="confirmPassword" type="password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} required />
             </div>
+            <Turnstile onToken={setCaptchaToken} className="flex justify-center" />
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading ? 'Please wait...' : 'Create Account'}
             </Button>
@@ -104,6 +121,8 @@ export default function Register() {
           <ArrowLeft className="w-4 h-4" /> Back to Home
         </Button>
       </div>
+
+      <PricingCards className="w-full max-w-5xl" />
     </div>
   );
 }

--- a/src/plugins/cloud-sync/CloudSyncPanel.tsx
+++ b/src/plugins/cloud-sync/CloudSyncPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
-import { CloudUpload, CloudDownload, LogOut, WifiOff, Loader2 } from "lucide-react";
+import { Cloud, CloudUpload, CloudDownload, LogOut, WifiOff, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
@@ -32,7 +32,10 @@ export default function CloudSyncPanel() {
       }
     };
     return (
-      <div className="space-y-3 max-w-sm">
+      <div className="space-y-3 w-full">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+          <Cloud className="w-4 h-4 text-primary" /> Cloud Sync
+        </h3>
         <p className="text-xs text-muted-foreground">
           Sign in to back up and sync your files, garage and notes across devices. Cloud Sync is optional — the app works fully offline without it.
         </p>
@@ -80,9 +83,12 @@ export default function CloudSyncPanel() {
   };
 
   return (
-    <div className="space-y-4 max-w-sm">
+    <div className="space-y-4 w-full">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm text-foreground truncate">{user.email}</span>
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-foreground min-w-0">
+          <Cloud className="w-4 h-4 text-primary shrink-0" />
+          <span className="truncate">{user.email}</span>
+        </h3>
         <Button variant="ghost" size="sm" onClick={logout} disabled={busy !== null}>
           <LogOut className="w-4 h-4 mr-1.5" /> Sign out
         </Button>

--- a/src/plugins/cloud-sync/CloudSyncPanel.tsx
+++ b/src/plugins/cloud-sync/CloudSyncPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
-import { Cloud, CloudUpload, CloudDownload, LogOut, WifiOff, Loader2 } from "lucide-react";
+import { CloudUpload, CloudDownload, LogOut, WifiOff, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
@@ -33,9 +33,6 @@ export default function CloudSyncPanel() {
     };
     return (
       <div className="space-y-3 w-full">
-        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
-          <Cloud className="w-4 h-4 text-primary" /> Cloud Sync
-        </h3>
         <p className="text-xs text-muted-foreground">
           Sign in to back up and sync your files, garage and notes across devices. Cloud Sync is optional — the app works fully offline without it.
         </p>
@@ -85,10 +82,7 @@ export default function CloudSyncPanel() {
   return (
     <div className="space-y-4 w-full">
       <div className="flex items-center justify-between gap-2">
-        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-foreground min-w-0">
-          <Cloud className="w-4 h-4 text-primary shrink-0" />
-          <span className="truncate">{user.email}</span>
-        </h3>
+        <span className="text-sm text-foreground truncate">{user.email}</span>
         <Button variant="ghost" size="sm" onClick={logout} disabled={busy !== null}>
           <LogOut className="w-4 h-4 mr-1.5" /> Sign out
         </Button>

--- a/src/plugins/cloud-sync/DownloadAllCloudLogs.tsx
+++ b/src/plugins/cloud-sync/DownloadAllCloudLogs.tsx
@@ -1,0 +1,74 @@
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { CloudDownload, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import type { FileManagerSectionContext } from "@/plugins/mounts";
+import { cloudOnlyNames, markPushed } from "./fileSync";
+import { listCloudFiles, downloadCloudFile } from "./syncEngine";
+
+/**
+ * Bottom-of-file-list bulk action: pull every cloud log file that isn't already
+ * on this device. Sign-in lives on the Profile tab; this only shows when signed
+ * in. Pulled files persist via `ctx.onSaveFile` (which refreshes the list).
+ */
+export default function DownloadAllCloudLogs({ ctx }: { ctx: FileManagerSectionContext }) {
+  const { user } = useAuth();
+  const online = useOnlineStatus();
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+
+  const localNames = useMemo(() => ctx.files.map((f) => f.name), [ctx.files]);
+
+  if (!user) return null;
+
+  const busy = progress !== null;
+
+  const downloadAll = async () => {
+    if (busy) return;
+    setProgress({ done: 0, total: 0 });
+    try {
+      const cloud = await listCloudFiles(user.id);
+      const pending = cloudOnlyNames(cloud.map((c) => c.name), localNames);
+      if (pending.length === 0) {
+        toast("All cloud logs are already on this device.");
+        return;
+      }
+      let ok = 0;
+      let failed = 0;
+      setProgress({ done: 0, total: pending.length });
+      for (const name of pending) {
+        try {
+          const blob = await downloadCloudFile(user.id, name);
+          if (!blob) throw new Error("no data");
+          await ctx.onSaveFile(name, blob);
+          await markPushed(name);
+          ok++;
+        } catch {
+          failed++;
+        }
+        setProgress({ done: ok + failed, total: pending.length });
+      }
+      if (failed) toast.error(`Downloaded ${ok} log${ok === 1 ? "" : "s"}; ${failed} failed.`);
+      else toast.success(`Downloaded ${ok} cloud log${ok === 1 ? "" : "s"} to this device.`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to download cloud logs");
+    } finally {
+      setProgress(null);
+    }
+  };
+
+  return (
+    <div className="px-4 py-3 border-t border-border shrink-0">
+      <Button variant="outline" className="w-full" onClick={downloadAll} disabled={busy || !online}>
+        {busy ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <CloudDownload className="w-4 h-4 mr-2" />}
+        {busy && progress && progress.total > 0
+          ? `Downloading ${progress.done}/${progress.total}…`
+          : "Download all cloud logs"}
+      </Button>
+      {!online && (
+        <p className="mt-1.5 text-xs text-muted-foreground text-center">You're offline.</p>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -50,7 +50,7 @@ export default function StoragePanel(_props: PluginPanelProps) {
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">Not signed in</p>
         <p className="text-xs text-muted-foreground">
-          Sign in under Labs → Cloud Sync to back up your garage and see your storage usage.
+          Sign in under Account (above) to back up your garage and see your storage usage.
         </p>
       </div>
     );

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -28,18 +28,19 @@ const plugin: DataViewerPlugin = {
   version: "0.1.0",
   setup(ctx) {
     // Offline-first guard: when the cloud flag is off, contribute nothing.
-    // The Labs panel never registers, the panel chunk never loads, and the
-    // Labs tab stays hidden unless another plugin contributes there.
+    // No panels/mounts register, their chunks never load, and the Labs tab
+    // stays hidden unless another plugin contributes there.
     if (!enableCloud) return;
-    const panel: PluginPanel = {
-      id: "cloud-sync",
-      title: "Cloud Sync",
-      slot: PanelSlot.Labs,
-      order: 10,
-      icon: Cloud,
+
+    // Sign-in + manual push/pull, mounted at the bottom of the file manager
+    // (it used to live in the Labs tab — moved here so cloud sign-in/sync sits
+    // next to the files it backs up, and Labs stays empty unless a plugin uses it).
+    ctx.registry.contribute(MOUNTS_POINT, {
+      id: "cloud-sync-footer",
+      slot: MountSlot.FileManagerFooter,
+      order: 0,
       component: CloudSyncPanel,
-    };
-    ctx.registry.contribute(PANELS_POINT, panel);
+    } satisfies PluginMountDef<FileManagerSectionContext>);
 
     // Per-file sync toggle injected into each file-manager row.
     ctx.registry.contribute(MOUNTS_POINT, {

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -9,13 +9,15 @@ import {
 } from "@/plugins/mounts";
 
 // The panel pulls in the Supabase sync engine + storage modules, so it's lazy:
-// the chunk loads only when the Labs tab is opened, keeping the initial bundle
-// lean (see Bundle Splitting in CLAUDE.md).
+// the chunk loads only when the Profile tab is opened, keeping the initial
+// bundle lean (see Bundle Splitting in CLAUDE.md).
 const CloudSyncPanel = lazy(() => import("./CloudSyncPanel"));
-// Likewise the per-file toggle + cloud-only list: lazy so the file-manager
-// drawer doesn't pull the sync engine onto its chunk until they render.
+// Likewise the per-file toggle, cloud-only list, and bulk-download button: lazy
+// so the file-manager drawer doesn't pull the sync engine onto its chunk until
+// they render.
 const FileSyncToggle = lazy(() => import("./FileSyncToggle"));
 const CloudFilesSection = lazy(() => import("./CloudFilesSection"));
+const DownloadAllCloudLogs = lazy(() => import("./DownloadAllCloudLogs"));
 // Profile tab panels: storage usage meters + account, and cloud-log management.
 const StoragePanel = lazy(() => import("./StoragePanel"));
 const CloudLogsPanel = lazy(() => import("./CloudLogsPanel"));
@@ -32,14 +34,13 @@ const plugin: DataViewerPlugin = {
     // stays hidden unless another plugin contributes there.
     if (!enableCloud) return;
 
-    // Sign-in + manual push/pull, mounted at the bottom of the file manager
-    // (it used to live in the Labs tab — moved here so cloud sign-in/sync sits
-    // next to the files it backs up, and Labs stays empty unless a plugin uses it).
+    // "Download all cloud logs" bulk action at the bottom of the file list.
+    // (Sign-in itself lives on the Profile tab — see CloudSyncPanel below.)
     ctx.registry.contribute(MOUNTS_POINT, {
-      id: "cloud-sync-footer",
+      id: "cloud-sync-download-all",
       slot: MountSlot.FileManagerFooter,
       order: 0,
-      component: CloudSyncPanel,
+      component: DownloadAllCloudLogs,
     } satisfies PluginMountDef<FileManagerSectionContext>);
 
     // Per-file sync toggle injected into each file-manager row.
@@ -59,7 +60,18 @@ const plugin: DataViewerPlugin = {
       component: CloudFilesSection,
     } satisfies PluginMountDef<FileManagerSectionContext>);
 
-    // Profile tab: storage usage meters (document + log storage types) + account.
+    // Profile tab: account / sign-in + manual push/pull (the login moved here
+    // from the file manager). Ordered first so it's the top of the Profile tab.
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "cloud-sync-account",
+      title: "Account",
+      slot: PanelSlot.Profile,
+      order: -10,
+      icon: User,
+      component: CloudSyncPanel,
+    } satisfies PluginPanel);
+
+    // Profile tab: storage usage meters (document + log storage types).
     ctx.registry.contribute(PANELS_POINT, {
       id: "cloud-sync-storage",
       title: "Profile",

--- a/src/plugins/mounts.ts
+++ b/src/plugins/mounts.ts
@@ -20,6 +20,9 @@ export const MountSlot = {
   FileRow: "file-row",
   /** Rendered once below the file list. Context: the whole list. */
   FileManagerSection: "file-manager-section",
+  /** Rendered near the bottom of the file manager (above storage usage).
+   *  Context: the whole list. Home for the Cloud Sync sign-in / push-pull panel. */
+  FileManagerFooter: "file-manager-footer",
 } as const;
 export type MountSlot = (typeof MountSlot)[keyof typeof MountSlot];
 

--- a/src/plugins/mounts.ts
+++ b/src/plugins/mounts.ts
@@ -21,7 +21,7 @@ export const MountSlot = {
   /** Rendered once below the file list. Context: the whole list. */
   FileManagerSection: "file-manager-section",
   /** Rendered near the bottom of the file manager (above storage usage).
-   *  Context: the whole list. Home for the Cloud Sync sign-in / push-pull panel. */
+   *  Context: the whole list. Home for the "Download all cloud logs" action. */
   FileManagerFooter: "file-manager-footer",
 } as const;
 export type MountSlot = (typeof MountSlot)[keyof typeof MountSlot];


### PR DESCRIPTION
## Summary

A cleanup pass now that cloud features exist. Merged up to date with BETA (#59/#60). Pieces:

### 1. Cloud Sync sign-in moved to the Profile tab
`CloudSyncPanel` (sign-in + manual push/pull) is now an **"Account"** panel at the
top of the Profile tab — it no longer lives in Labs. The Labs tab self-gates away
(shows only with the experimental setting on or another plugin's panel).

### 2. "Download all cloud logs" button in the file manager
New `MountSlot.FileManagerFooter` hosts a lazy `DownloadAllCloudLogs` button at the
bottom of the file list — one-click bulk pull of every cloud log not already on this
device (with progress count). Self-hides when signed out. Host stays cloud-agnostic.

### 3. Landing + About copy — "optional cloud storage"
Hero no longer claims *"your files never leave your device"* (untrue with cloud
sync) → *"Offline-first — with optional cloud storage…"*. About dialog's
"nothing is uploaded" / "free if cloud is added" claims updated to match reality.

### 4. Plans & pricing cards (landing + register)
New reusable `PricingCards` (4 tiers), below the sample box on the landing page and
on the registration page:
- **Free — Offline**: data viewer, BLE connectivity, save logs to device, video overlays, offline session debrief
- **Free — Online** *(Recommended)*: + setup sync across devices, personal-track sync, 20 MB cloud logs
- **$1/mo** *(Coming soon)*: + 500 MB cloud logs
- **$10/mo** *(Coming soon)*: + 1 GB cloud logs, AI coaching (coming soon)

Informational only — paid tiers badged **Coming soon** (no billing wired up).

### 5. Turnstile captcha on registration (safe fallback)
New reusable `Turnstile` component: loads the CF script + renders the widget, and
**renders nothing / never blocks when `VITE_TURNSTILE_SITE_KEY` is unset**. Token
threads into `supabase.auth.signUp({ options: { captchaToken } })` (verified
server-side only if Turnstile is enabled in Supabase Auth settings).

### 6. Disposable-email guard
`emailValidation.ts` (pure + unit-tested): rejects ~40 known temporary-mail domains
and does a basic shape check on the register form, with friendly errors.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test:run` (**345**) / `npm run build` — all green after the BETA merge
- [x] Sync engine + CloudSyncPanel stay lazy / off the initial bundle
- [ ] **Visual pass (couldn't run a browser here):** Profile tab shows the Account/sign-in card; Files footer shows "Download all cloud logs" (signed-in only); Labs tab hidden; pricing grid responsive on landing + register; Turnstile renders with a key and is cleanly absent without one; disposable email rejected.

## Notes
- Free-online card says 20 MB to match the server-enforced log quota.
- Paid tiers + AI coaching are display-only pending the billing/credits system.
- Profile tab is a known scratchpad (the middle card titled "Profile" is pre-existing) — left as-is per your call.

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3