### PR TITLE
Add Stripe subscription backend (tiers, webhook, quota wiring)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Paid subscription tiers (backend)**: Stripe-backed `Plus` ($1/mo, 500 MB
+  logs) and `Pro` ($10/mo, 1 GB logs) plans on top of the free 20 MB tier. Plan
+  limits are data-driven (`subscription_tiers` table) and the cloud-sync storage
+  quota is now enforced per the user's tier. New `create-checkout-session`,
+  `stripe-webhook`, and `create-portal-session` edge functions; entitlements are
+  granted solely by the verified Stripe webhook. (Upgrade buttons in the UI land
+  in a follow-up.)
 - Document storage + **auto-sync**: when you're signed in, your garage
   (vehicles, setups, setup templates, notes) now backs up to the cloud
   automatically as you change it — no manual push. The "documents" storage type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,9 +451,9 @@ Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
 |--------|------|-------|
 | `sync_records` | table | One jsonb document per record: `(user_id, store, record_key, data, updated_at)`, unique on `(user_id, store, record_key)`. RLS: `auth.uid() = user_id`. `store`/`record_key` mirror the IndexedDB store name + key path. |
 | `user-files` | Storage bucket | Private. Raw session blobs at `{user_id}/{encodeURIComponent(name)}`. RLS scopes objects to the owner's folder. |
-| `quota_limits` | table | `(storage_type, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Read by client + trigger. |
-| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a storage type over its limit (`quota_exceeded`). |
-| `sync_storage_usage()` | RPC | Per-type `(used_bytes, limit_bytes)` for the caller. |
+| `quota_limits` | table | `(storage_type, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Legacy baseline/fallback once tiers exist (see below). |
+| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a storage type over the **caller's tier** limit (`tier_limit()`), falling back to `quota_limits` (`quota_exceeded`). |
+| `sync_storage_usage()` | RPC | Per-type `(used_bytes, limit_bytes)` for the caller — `limit_bytes` reflects the caller's tier. |
 | `profiles` | table | `(user_id PK→auth.users, display_name unique, …)`. RLS: authenticated read-all, update/insert own. Display name is unique but **not** a key — user-editable. |
 | `handle_new_user` | trigger | On `auth.users` insert: creates a profile, using the sign-up `display_name` or a generated silly name (`SpeedyRac3r-546`). `unique_display_name()` auto-suffixes a taken name at creation; user edits get an explicit "taken" error instead. |
 
@@ -497,6 +497,34 @@ dedicated Cloud *tab* (a new garage-tab mount slot), `modified` detection, and a
 After a migration, Lovable regenerates `integrations/supabase/types.ts`. Until
 then `cloudClient.ts` accesses the new table/bucket through a narrowly-typed
 escape hatch confined to that one module.
+
+### Subscriptions / Stripe (`..._stripe_subscriptions.sql` + 3 edge functions)
+
+Paid tiers scale the cloud-sync **logs** quota (`free` 20 MB → `plus` $1 500 MB
+→ `pro` $10 1 GB; docs stay 5 MB). Tiers are **data**, not code:
+
+| Object | Type | Notes |
+|--------|------|-------|
+| `subscription_tiers` | table | One row per plan: `(tier PK, label, price_cents, logs_bytes, doc_bytes, ai_credits, stripe_price_id, sort_order)`. Authenticated read-all. Change a limit/price = UPDATE here. `stripe_price_id` is set after creating the Stripe Price. |
+| `user_subscriptions` | table | `(user_id PK→auth.users, tier→subscription_tiers, status, stripe_customer_id, stripe_subscription_id, current_period_end, updated_at)`. RLS: owner **read-only** — only the service role (webhook) writes, so no one can self-grant a tier. |
+| `user_tier(uuid)` | fn (SECURITY DEFINER) | Effective tier: the subscription tier when `status in (active, trialing, past_due)`, else `free`. |
+| `tier_limit(uuid, type)` | fn (SECURITY DEFINER) | Byte limit for a user + storage type from their tier; falls back to `free`, then `quota_limits`. Used by the quota trigger + usage RPC. |
+
+Edge functions (all `verify_jwt = false`; checkout/portal verify the JWT
+manually like the rest of the repo, the webhook verifies the Stripe signature):
+
+- `create-checkout-session` — auth user → ensure Stripe customer (persisted on
+  `user_subscriptions`) → Checkout Session (subscription mode) for the tier's
+  `stripe_price_id` → returns the hosted URL.
+- `stripe-webhook` — **the only writer of entitlements**. Verifies the signature
+  (`STRIPE_WEBHOOK_SECRET`), then on `checkout.session.completed` /
+  `customer.subscription.created|updated|deleted` upserts `user_subscriptions`
+  (tier resolved from the Price id; `deleted` → `free`) via the service role.
+- `create-portal-session` — returns a Stripe Billing Portal URL for
+  manage/cancel (no in-app billing UI).
+
+Secrets: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`. **Client upgrade/manage
+buttons (PricingCards + Profile StoragePanel) are a follow-up.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,19 @@ The app includes an optional admin system for managing a community track databas
 | `VITE_ENABLE_CLOUD` | No | Set to `true` to enable public user accounts: Cloud Sync Labs panel, Google sign-in, `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`. Default `false` — flag-off builds ship zero cloud auth code (offline-first invariant). |
 | `VITE_TURNSTILE_SITE_KEY` | No | Cloudflare Turnstile site key for track submission CAPTCHA |
 | `TURNSTILE_SECRET_KEY` | No | Cloudflare Turnstile secret key (edge function secret — `???`) |
+| `STRIPE_SECRET_KEY` | No (required for paid tiers) | Stripe secret key used by the `create-checkout-session`, `stripe-webhook`, and `create-portal-session` edge functions (edge function secret — `???`) |
+| `STRIPE_WEBHOOK_SECRET` | No (required for paid tiers) | Signing secret for the `stripe-webhook` endpoint, from the Stripe dashboard webhook config (edge function secret — `???`) |
 | `DOVE_PLUGIN_PACKAGES` | No | Build-time: comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`, the public AI coach) when set |
 
 > **Note:** `TURNSTILE_SECRET_KEY` is a server-side secret stored in Lovable Cloud, not a `VITE_` client variable. If not set, Turnstile verification is skipped.
+
+> **Stripe / paid tiers:** `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are
+> edge-function secrets (not `VITE_` client vars). After creating the Plus/Pro
+> Products + recurring Prices in Stripe, store each Price id in the matching
+> `subscription_tiers.stripe_price_id` row, and point a Stripe webhook (events:
+> `checkout.session.completed`, `customer.subscription.created/updated/deleted`)
+> at the `stripe-webhook` function URL. Use Stripe **test mode** first. Tier
+> entitlements are granted only by the webhook, never the client.
 
 > **Note:** `DOVE_PLUGIN_PACKAGES` is build-time only (read by `vite.config.ts`), not a client `VITE_` variable. It overrides which external plugin packages the build loads; by default the build pulls in the public AI coach (`@perchwerks/eye-in-the-sky`) from npm as an optional dependency — see `src/plugins/README.md`.
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -11,3 +11,12 @@ verify_jwt = false
 
 [functions.submit-message]
 verify_jwt = false
+
+[functions.create-checkout-session]
+verify_jwt = false
+
+[functions.stripe-webhook]
+verify_jwt = false
+
+[functions.create-portal-session]
+verify_jwt = false

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,0 +1,103 @@
+// Creates a Stripe Checkout Session for a subscription tier and returns its URL.
+// The caller's Supabase JWT (Authorization: Bearer …) identifies the user; the
+// tier's Price id lives in the subscription_tiers table (set after you create
+// the Price in Stripe). The actual entitlement is granted by stripe-webhook on
+// completion — never by the client.
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import Stripe from "https://esm.sh/stripe@17.7.0?target=deno";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  apiVersion: '2025-03-31.basil',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    // Identify the user from their JWT.
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: userErr } = await authClient.auth.getUser();
+    if (userErr || !user) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const { tier, returnUrl } = await req.json().catch(() => ({}));
+    if (!tier || typeof tier !== 'string' || tier === 'free') {
+      return json({ error: 'Invalid tier' }, 400);
+    }
+
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    // Resolve the tier's Stripe Price.
+    const { data: tierRow } = await admin
+      .from('subscription_tiers')
+      .select('stripe_price_id')
+      .eq('tier', tier)
+      .maybeSingle();
+    if (!tierRow?.stripe_price_id) {
+      return json({ error: 'Tier is not purchasable' }, 400);
+    }
+
+    // Reuse the user's Stripe customer if we have one, else create + persist it.
+    const { data: sub } = await admin
+      .from('user_subscriptions')
+      .select('stripe_customer_id')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    let customerId = sub?.stripe_customer_id ?? undefined;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email ?? undefined,
+        metadata: { user_id: user.id },
+      });
+      customerId = customer.id;
+      await admin.from('user_subscriptions').upsert(
+        { user_id: user.id, stripe_customer_id: customerId },
+        { onConflict: 'user_id' },
+      );
+    }
+
+    const base = (typeof returnUrl === 'string' && returnUrl) || req.headers.get('origin') || '';
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [{ price: tierRow.stripe_price_id, quantity: 1 }],
+      client_reference_id: user.id,
+      subscription_data: { metadata: { user_id: user.id, tier } },
+      allow_promotion_codes: true,
+      success_url: `${base}?checkout=success`,
+      cancel_url: `${base}?checkout=cancel`,
+    });
+
+    return json({ url: session.url });
+  } catch (e) {
+    console.error('create-checkout-session error', e);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/functions/create-portal-session/index.ts
+++ b/supabase/functions/create-portal-session/index.ts
@@ -1,0 +1,69 @@
+// Returns a Stripe Billing Portal URL so the user can manage / cancel their
+// subscription on Stripe-hosted pages (no billing UI to build or maintain).
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import Stripe from "https://esm.sh/stripe@17.7.0?target=deno";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  apiVersion: '2025-03-31.basil',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: userErr } = await authClient.auth.getUser();
+    if (userErr || !user) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const { returnUrl } = await req.json().catch(() => ({}));
+
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+    const { data: sub } = await admin
+      .from('user_subscriptions')
+      .select('stripe_customer_id')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (!sub?.stripe_customer_id) {
+      return json({ error: 'No billing account' }, 400);
+    }
+
+    const base = (typeof returnUrl === 'string' && returnUrl) || req.headers.get('origin') || undefined;
+    const session = await stripe.billingPortal.sessions.create({
+      customer: sub.stripe_customer_id,
+      return_url: base,
+    });
+
+    return json({ url: session.url });
+  } catch (e) {
+    console.error('create-portal-session error', e);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,130 @@
+// Stripe webhook — the ONLY thing that grants/revokes a tier. Verifies the
+// Stripe signature, then mirrors the subscription state into user_subscriptions
+// using the service role. Must be deployed with verify_jwt = false (Stripe does
+// not send a Supabase JWT) — auth is the signature check instead.
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import Stripe from "https://esm.sh/stripe@17.7.0?target=deno";
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  apiVersion: '2025-03-31.basil',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+const cryptoProvider = Stripe.createSubtleCryptoProvider();
+
+const admin = (): SupabaseClient => createClient(
+  Deno.env.get('SUPABASE_URL')!,
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+);
+
+// Map a Stripe Price id → our tier slug (falls back to 'free' if unknown).
+async function tierForPrice(db: SupabaseClient, priceId: string | undefined): Promise<string> {
+  if (!priceId) return 'free';
+  const { data } = await db
+    .from('subscription_tiers')
+    .select('tier')
+    .eq('stripe_price_id', priceId)
+    .maybeSingle();
+  return data?.tier ?? 'free';
+}
+
+// Resolve our user_id for a subscription: prefer the metadata we stamped at
+// checkout, else look up by Stripe customer id.
+async function resolveUserId(
+  db: SupabaseClient,
+  sub: Stripe.Subscription,
+): Promise<string | null> {
+  const metaId = sub.metadata?.user_id;
+  if (metaId) return metaId;
+  const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer?.id;
+  if (!customerId) return null;
+  const { data } = await db
+    .from('user_subscriptions')
+    .select('user_id')
+    .eq('stripe_customer_id', customerId)
+    .maybeSingle();
+  return data?.user_id ?? null;
+}
+
+// current_period_end moved onto subscription items in recent API versions;
+// fall back across both shapes.
+function periodEnd(sub: Stripe.Subscription): string | null {
+  const item = sub.items?.data?.[0] as (Stripe.SubscriptionItem & { current_period_end?: number }) | undefined;
+  const ts = item?.current_period_end
+    ?? (sub as unknown as { current_period_end?: number }).current_period_end;
+  return typeof ts === 'number' ? new Date(ts * 1000).toISOString() : null;
+}
+
+async function applySubscription(
+  db: SupabaseClient,
+  sub: Stripe.Subscription,
+  opts: { deleted?: boolean } = {},
+): Promise<void> {
+  const userId = await resolveUserId(db, sub);
+  if (!userId) {
+    console.error('stripe-webhook: no user for subscription', sub.id);
+    return;
+  }
+
+  const priceId = sub.items?.data?.[0]?.price?.id;
+  const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer?.id;
+  const tier = opts.deleted ? 'free' : await tierForPrice(db, priceId);
+  const status = opts.deleted ? 'canceled' : sub.status;
+
+  await db.from('user_subscriptions').upsert({
+    user_id: userId,
+    tier,
+    status,
+    stripe_customer_id: customerId,
+    stripe_subscription_id: sub.id,
+    current_period_end: periodEnd(sub),
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'user_id' });
+}
+
+Deno.serve(async (req) => {
+  const sig = req.headers.get('stripe-signature');
+  const secret = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+  const body = await req.text();
+  if (!sig || !secret) {
+    return new Response('Missing signature', { status: 400 });
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = await stripe.webhooks.constructEventAsync(body, sig, secret, undefined, cryptoProvider);
+  } catch (e) {
+    console.error('stripe-webhook: signature verification failed', e);
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  try {
+    const db = admin();
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const subId = typeof session.subscription === 'string'
+          ? session.subscription
+          : session.subscription?.id;
+        if (subId) {
+          const sub = await stripe.subscriptions.retrieve(subId);
+          await applySubscription(db, sub);
+        }
+        break;
+      }
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+        await applySubscription(db, event.data.object as Stripe.Subscription);
+        break;
+      case 'customer.subscription.deleted':
+        await applySubscription(db, event.data.object as Stripe.Subscription, { deleted: true });
+        break;
+    }
+  } catch (e) {
+    console.error('stripe-webhook: handler error', e);
+    return new Response('Handler error', { status: 500 });
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/migrations/20260526000000_stripe_subscriptions.sql
+++ b/supabase/migrations/20260526000000_stripe_subscriptions.sql
@@ -1,0 +1,154 @@
+-- Subscription tiers + Stripe-backed user subscriptions.
+--
+-- Builds on storage_quotas: that migration enforced two storage *types*
+-- (documents / logs) against a single global quota_limits table. This one makes
+-- the *limit* depend on the user's subscription tier:
+--
+--   • subscription_tiers  — one row per plan (free / plus / pro) with its per-type
+--     byte limits, price, and Stripe price id. Limits are now DATA: changing a
+--     plan's storage or price is an UPDATE here, not a code change.
+--   • user_subscriptions  — one row per user mapping them to a tier, plus the
+--     Stripe customer/subscription ids + status. Written ONLY by the service role
+--     (the stripe-webhook edge function) — users can read their own row but can
+--     never grant themselves a tier.
+--
+-- The enforce_sync_quota trigger + sync_storage_usage() now resolve the caller's
+-- tier limit (falling back to free, then to quota_limits) instead of reading the
+-- global table directly. quota_limits remains the ultimate baseline/fallback.
+
+-- ── Tiers (data-driven plan catalogue) ──────────────────────────────────────
+create table if not exists public.subscription_tiers (
+  tier            text primary key,
+  label           text   not null,
+  price_cents     integer not null default 0,
+  logs_bytes      bigint not null,
+  doc_bytes       bigint not null,
+  ai_credits      integer not null default 0,
+  stripe_price_id text,                      -- null for free; set after creating the Stripe Price
+  sort_order      integer not null default 0
+);
+
+insert into public.subscription_tiers
+  (tier,   label,  price_cents, logs_bytes,  doc_bytes, ai_credits, sort_order) values
+  ('free', 'Free',           0,   20971520,    5242880,          0, 0),  --  20 MB logs / 5 MB docs
+  ('plus', 'Plus',         100,  524288000,    5242880,          0, 1),  -- 500 MB logs / 5 MB docs
+  ('pro',  'Pro',         1000, 1073741824,    5242880,          0, 2)   --   1 GB logs / 5 MB docs
+on conflict (tier) do update set
+  label       = excluded.label,
+  price_cents = excluded.price_cents,
+  logs_bytes  = excluded.logs_bytes,
+  doc_bytes   = excluded.doc_bytes,
+  ai_credits  = excluded.ai_credits,
+  sort_order  = excluded.sort_order;
+
+alter table public.subscription_tiers enable row level security;
+
+drop policy if exists "Anyone authenticated reads tiers" on public.subscription_tiers;
+create policy "Anyone authenticated reads tiers"
+  on public.subscription_tiers for select to authenticated
+  using (true);
+
+-- ── Per-user subscription state (service-role-written) ──────────────────────
+create table if not exists public.user_subscriptions (
+  user_id                uuid primary key references auth.users(id) on delete cascade,
+  tier                   text not null default 'free' references public.subscription_tiers(tier),
+  status                 text not null default 'active',  -- Stripe subscription.status
+  stripe_customer_id     text,
+  stripe_subscription_id text,
+  current_period_end     timestamptz,
+  updated_at             timestamptz not null default now()
+);
+
+create index if not exists user_subscriptions_customer_idx
+  on public.user_subscriptions (stripe_customer_id);
+
+alter table public.user_subscriptions enable row level security;
+
+-- Users may read their own row. No insert/update/delete policies exist, so only
+-- the service role (which bypasses RLS) can write — i.e. the stripe-webhook fn.
+drop policy if exists "Users read own subscription" on public.user_subscriptions;
+create policy "Users read own subscription"
+  on public.user_subscriptions for select to authenticated
+  using (auth.uid() = user_id);
+
+-- ── Tier resolution helpers ─────────────────────────────────────────────────
+-- The effective tier for a user: their subscription tier when the status grants
+-- access (active / trialing / past_due grace), else 'free'. SECURITY DEFINER so
+-- the quota trigger can resolve any row's tier regardless of RLS.
+create or replace function public.user_tier(p_user uuid)
+returns text language sql stable security definer set search_path = public as $$
+  select coalesce(
+    (select s.tier
+       from public.user_subscriptions s
+      where s.user_id = p_user
+        and s.status in ('active', 'trialing', 'past_due')),
+    'free');
+$$;
+
+-- The byte limit for a given user + storage type, from their effective tier.
+-- Falls back to the free tier, then to the legacy quota_limits baseline.
+create or replace function public.tier_limit(p_user uuid, p_type text)
+returns bigint language sql stable security definer set search_path = public as $$
+  select coalesce(
+    (select case when p_type = 'logs' then t.logs_bytes else t.doc_bytes end
+       from public.subscription_tiers t
+      where t.tier = public.user_tier(p_user)),
+    (select case when p_type = 'logs' then t.logs_bytes else t.doc_bytes end
+       from public.subscription_tiers t
+      where t.tier = 'free'),
+    (select max_bytes from public.quota_limits where storage_type = p_type));
+$$;
+
+grant execute on function public.user_tier(uuid)  to authenticated;
+grant execute on function public.tier_limit(uuid, text) to authenticated;
+
+-- ── Quota enforcement: now tier-aware ───────────────────────────────────────
+create or replace function public.enforce_sync_quota()
+returns trigger language plpgsql as $$
+declare
+  v_type  text   := public.sync_storage_type(NEW.store);
+  v_limit bigint := public.tier_limit(NEW.user_id, v_type);
+  v_used  bigint;
+  v_new   bigint := public.sync_record_size(NEW.store, NEW.data);
+begin
+  if v_limit is null then
+    return NEW; -- no limit configured for this type
+  end if;
+
+  -- Current usage for this type, excluding the row being upserted.
+  select coalesce(sum(public.sync_record_size(store, data)), 0)
+    into v_used
+    from public.sync_records
+   where user_id = NEW.user_id
+     and public.sync_storage_type(store) = v_type
+     and not (store = NEW.store and record_key = NEW.record_key);
+
+  if v_used + v_new > v_limit then
+    raise exception
+      'quota_exceeded: % storage over limit (% bytes used + % new > % limit)',
+      v_type, v_used, v_new, v_limit
+      using errcode = 'check_violation';
+  end if;
+
+  return NEW;
+end;
+$$;
+
+-- (trigger sync_records_quota already bound to this function in storage_quotas)
+
+-- ── Usage readout: limits now reflect the caller's tier ─────────────────────
+create or replace function public.sync_storage_usage()
+returns table(storage_type text, used_bytes bigint, limit_bytes bigint)
+language sql stable as $$
+  select t.storage_type,
+         coalesce((
+           select sum(public.sync_record_size(r.store, r.data))
+             from public.sync_records r
+            where r.user_id = auth.uid()
+              and public.sync_storage_type(r.store) = t.storage_type
+         ), 0)::bigint,
+         public.tier_limit(auth.uid(), t.storage_type)
+    from (values ('documents'), ('logs')) as t(storage_type);
+$$;
+
+grant execute on function public.sync_storage_usage() to authenticated;


### PR DESCRIPTION
## Summary

Adds the **backend** for paid subscription tiers. Plans scale the cloud-sync **logs** quota on top of the existing free tier:

| tier | price | logs quota | docs quota | AI credits |
|------|-------|-----------|-----------|-----------|
| `free` | $0 | 20 MB | 5 MB | 0 |
| `plus` | $1/mo | 500 MB | 5 MB | 0 |
| `pro` | $10/mo | 1 GB | 5 MB | 0 |

Numbers match the shipped `PricingCards`. Plan limits are **data**, not code — change a limit or price with an `UPDATE`, no deploy.

This is backend-only. **Client upgrade/manage buttons (PricingCards + Profile StoragePanel) are a deliberate follow-up.**

## What's in it

**Migration** `supabase/migrations/20260526000000_stripe_subscriptions.sql`
- `subscription_tiers` — one row per plan: `(tier, label, price_cents, logs_bytes, doc_bytes, ai_credits, stripe_price_id, sort_order)`. Authenticated read-all. `stripe_price_id` is populated after you create the Stripe Price.
- `user_subscriptions` — `(user_id PK→auth.users, tier, status, stripe_customer_id, stripe_subscription_id, current_period_end, updated_at)`. RLS gives users **read-only** access to their own row; there are no write policies, so only the service role can write.
- `user_tier(uuid)` / `tier_limit(uuid, type)` — `SECURITY DEFINER` helpers. Effective tier = the subscription tier while `status in (active, trialing, past_due)`, else `free`. `tier_limit` resolves a user+type byte limit, falling back to `free` → the legacy `quota_limits` baseline.
- Rewires the existing `enforce_sync_quota` trigger and `sync_storage_usage()` RPC to use the caller's **tier** limit instead of the global table — so the storage meter and server-side enforcement both reflect the user's plan.

**Edge functions** (all `verify_jwt = false`, matching the repo convention; checkout/portal verify the user's JWT manually, the webhook verifies the Stripe signature)
- `create-checkout-session` — authenticates the user, ensures a Stripe customer (persisted on `user_subscriptions`), creates a subscription-mode Checkout Session for the tier's `stripe_price_id`, returns the hosted URL.
- `stripe-webhook` — **the only writer of entitlements.** Verifies the Stripe signature, then on `checkout.session.completed` / `customer.subscription.created|updated|deleted` upserts `user_subscriptions` (tier resolved from the Price id; `deleted` → `free`) via the service role.
- `create-portal-session` — returns a Stripe Billing Portal URL for manage/cancel (no in-app billing UI to maintain).

**Docs** — README env table (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` as edge-function secrets), CHANGELOG `[Unreleased]`, and CLAUDE.md (Cloud Sync → Subscriptions/Stripe subsection).

## Security model

Tiers can only be granted by the **signature-verified Stripe webhook** running as the service role. Users can read their own subscription row but cannot write it, so the client can never self-upgrade. Quota enforcement remains server-side in the DB trigger; client checks stay advisory.

## Required setup (out of band — not done by this PR)

1. Create **Plus** and **Pro** Products + recurring Prices in Stripe (**use test mode first**).
2. Store each Price id in the matching `subscription_tiers.stripe_price_id` row.
3. Set Supabase secrets `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`.
4. Register a Stripe webhook → the `stripe-webhook` function URL, subscribing to `checkout.session.completed` and `customer.subscription.created/updated/deleted`.

## Test plan

- [ ] `npm run lint` / `npm run typecheck` / `npm run test:run` / `npm run build` green (CI). _Note: edge functions are Deno and outside the app tsconfig; they are eslint-clean._
- [ ] Apply the migration; confirm `subscription_tiers` seeds free/plus/pro and `sync_storage_usage()` returns the free limits for a new user.
- [ ] In Stripe **test mode**: complete a checkout for `plus` → webhook flips `user_subscriptions.tier` to `plus`, storage meter shows 500 MB.
- [ ] Cancel via the billing portal → `customer.subscription.deleted` reverts the user to `free`.
- [ ] Confirm a user cannot write their own `user_subscriptions` row directly (RLS).

> Live checkout/webhook flow was **not** exercised in the dev container (no Stripe keys / Supabase deploy) — it needs to be validated on the project in Stripe test mode.

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3