### PR TITLE
Add plugin UI panel framework, surfaced in the Labs tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,7 +636,20 @@ npm run typecheck  # tsc -b (must use build mode to follow project references)
 npm run preview    # Preview production build
 npm test           # Vitest in watch mode
 npm run test:run   # Vitest single pass (CI-style)
+npm run test:coverage  # Vitest + v8 coverage (enforces thresholds in vitest.config.ts)
 ```
+
+> **Coverage scope (`vitest.config.ts`).** Coverage is deliberately scoped to
+> *logic worth unit-testing* — `lib/` parsers/utilities/protocol code, `hooks/`,
+> and `plugins/`. The React **view layer is excluded**: presentational
+> components (`src/components/**/*.tsx`), route/page shells (`src/pages/**`),
+> context providers (`src/contexts/**`), `App.tsx`, vendored `ui/`, and the
+> generated Supabase client. Note the exclude targets `components/**/*.tsx`
+> *only* — the `.ts` logic files under `components/video-overlays/` stay in
+> scope. Don't widen the include to pull view code back in (it tanks the number
+> with code nobody unit-tests) and don't exclude `hooks/`/`lib/` to inflate it
+> (that hides real test debt). Thresholds are floors a few points below current
+> actuals — ratchet them up as coverage grows.
 
 > **Why `tsc -b`?** The root `tsconfig.json` has `files: []` and only uses
 > `references` to point at `tsconfig.app.json` + `tsconfig.node.json`. Plain
@@ -644,9 +657,11 @@ npm run test:run   # Vitest single pass (CI-style)
 > `tsc -b` (build mode) follows references; both referenced configs have
 > `noEmit: true` so nothing is emitted.
 
-CI is split into four parallel workflows under `.github/workflows/`
-(`lint.yml`, `typecheck.yml`, `test.yml`, `build.yml`). Each runs on every PR
-and push to `main` and shows up as its own status check + README badge.
+CI is split into five parallel workflows under `.github/workflows/`
+(`lint.yml`, `typecheck.yml`, `test.yml`, `build.yml`, `coverage.yml`). Each
+runs on every PR and push to `main` and shows up as its own status check +
+README badge. `coverage.yml` also enforces the thresholds in `vitest.config.ts`,
+posts a per-PR summary comment, and publishes the % badge JSON.
 
 ---
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,20 +15,32 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text-summary", "json-summary", "lcov"],
       include: ["src/**/*.{ts,tsx}"],
+      // Coverage is scoped to *logic* worth unit-testing (parsers, utilities,
+      // protocol code, hooks, plugins). The React view layer is deliberately
+      // out of scope — presentational components, route/page shells, and
+      // context providers are validated by integration/visual testing, not
+      // Vitest line coverage. We exclude view code, NOT untested logic: hooks
+      // and lib/ stay in the report so the number is an honest signal.
       exclude: [
         "src/**/*.{test,spec}.{ts,tsx}",
+        "src/components/**/*.tsx", // presentational React components (keeps video-overlays/*.ts logic in scope)
+        "src/pages/**", // route/page shells — view layer
+        "src/contexts/**", // provider wiring — view layer
+        "src/App.tsx", // app shell / routing
         "src/components/ui/**", // vendored shadcn/ui primitives
         "src/integrations/supabase/**", // auto-generated — DO NOT EDIT
         "src/**/*.d.ts",
         "src/main.tsx",
         "src/vite-env.d.ts",
       ],
-      // Gate intentionally low so it can be ratcheted up later as coverage grows.
+      // Floors guard against regressions in the logic we test. Set a few points
+      // below current actuals so routine churn doesn't redden CI; ratchet up as
+      // coverage grows.
       thresholds: {
-        lines: 1,
-        functions: 1,
-        branches: 1,
-        statements: 1,
+        lines: 20,
+        functions: 18,
+        branches: 18,
+        statements: 20,
       },
     },
   },


### PR DESCRIPTION
First concrete extension point for the plugin system: plugins contribute
self-contained React panels to a named slot, and the host mounts them.
Built so future personal/third-party plugins plug in the same way.

- panels.ts: PluginPanel/PluginPanelProps contract, PANELS_POINT, PanelSlot,
  getPanelsForSlot. PluginPanelProps is a curated, read-only session snapshot
  so plugins never depend on the host's internal session context.
- PluginPanelHost: mounts every panel for a slot in a titled card, each behind
  a per-panel error boundary so a buggy plugin can't crash the tab.
- LabsTab renders the "labs" slot; Index shows the Labs tab automatically when
  a plugin contributes a labs panel, even with the experimental setting off.

https://claude.ai/code/session_01QF56Xjp5ZMgXrqfTWD14Le