### PR TITLE
Update @perchwerks/eye-in-the-sky to 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dedicated AI Coach tab: a new top-level view (`PanelSlot.Coach`) that hosts the
   coaching plugin's session-debrief dashboard. Like Labs, it is self-gating — the
   tab only appears when the coach plugin is installed and contributes a panel. The
-  bundled coach (`@perchwerks/eye-in-the-sky` 0.2.0) ships a full-bleed analysis
+  bundled coach (`@perchwerks/eye-in-the-sky` 0.2.5) ships a full-bleed analysis
   dashboard (uPlot telemetry charts, corner/sector breakdowns) that loads lazily,
   off the initial bundle.
 - Plugin panels can now be **chromeless** — a panel may render full-bleed without

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.2.4"
+        "@perchwerks/eye-in-the-sky": "0.2.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.4.tgz",
-      "integrity": "sha512-KLITvw1kwA/kR5kJbn7Vhz2UxAxqDYoPi6vD4SXtsyuPUpAr4L4N1fSRea7CyiQoorhlsGGCs9pN6Bg8RG12Cg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.5.tgz",
+      "integrity": "sha512-AbWDkL1ERzb9FBvvxONmp6oZBISBAP7txDaBo1L2mAmIx7BLLGzjLT/RF8DHf6dotQJ+L0yGvGCSlSmROsATig==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.2.4"
+    "@perchwerks/eye-in-the-sky": "0.2.5"
   }
 }


### PR DESCRIPTION
Bump the bundled AI coach plugin from 0.2.4 to 0.2.5. No dependency or peer-dependency changes; typecheck, build (loads the external plugin), lint, and the full test suite all pass. Changelog reference updated to match the shipped coach version.

https://claude.ai/code/session_017fmZ5GDJkNec7sxGWt343G

