### PR TITLE
Wire up subscription tier UI (upgrade / current / manage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Paid subscription tiers (backend)**: Stripe-backed `Plus` ($1/mo, 500 MB
-  logs) and `Pro` ($10/mo, 1 GB logs) plans on top of the free 20 MB tier. Plan
-  limits are data-driven (`subscription_tiers` table) and the cloud-sync storage
-  quota is now enforced per the user's tier. New `create-checkout-session`,
+- **Paid subscription tiers**: Stripe-backed `Plus` ($1/mo, 500 MB logs) and
+  `Pro` ($10/mo, 1 GB logs) plans on top of the free 20 MB tier. Plan limits are
+  data-driven (`subscription_tiers` table) and the cloud-sync storage quota is
+  enforced per the user's tier. Backed by `create-checkout-session`,
   `stripe-webhook`, and `create-portal-session` edge functions; entitlements are
-  granted solely by the verified Stripe webhook. (Upgrade buttons in the UI land
-  in a follow-up.)
+  granted solely by the verified Stripe webhook. The **Plans & pricing** cards
+  now show live **Upgrade** / **Current plan** actions for signed-in users (a
+  paid tier stays "Coming soon" until its Stripe Price is configured), and the
+  **Profile** tab shows your plan with a **Manage subscription** link to the
+  Stripe billing portal.
 - Document storage + **auto-sync**: when you're signed in, your garage
   (vehicles, setups, setup templates, notes) now backs up to the cloud
   automatically as you change it — no manual push. The "documents" storage type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ src/
 │   ├── useSetupManager.ts     # Generic setup sheets CRUD (template-driven)
 │   ├── useSettings.ts         # User preferences (units, smoothing, dark mode, etc.)
 │   ├── useSessionMetadata.ts  # Per-file metadata (selected track/course)
+│   ├── useSubscription.ts     # Reads subscription tier catalogue + the user's plan (online, account-gated)
 │   └── useOnlineStatus.ts     # Navigator.onLine wrapper
 ├── lib/
 │   ├── datalogParser.ts       # ★ Format auto-detection router (entry point for all parsing)
@@ -176,6 +177,8 @@ src/
 │   │   ├── types.ts           # ITrackDatabase interface
 │   │   ├── supabaseAdapter.ts # Supabase implementation
 │   │   └── index.ts           # Factory: getDatabase()
+│   ├── billing.ts             # ★ Pure subscription logic + row shapes (effectiveTier, pricingCta) — unit-tested, no Supabase import
+│   ├── billingClient.ts       # Supabase I/O for tiers/subscriptions + Stripe checkout/portal (functions.invoke)
 │   └── utils.ts               # Tailwind cn() helper
 ├── plugins/                   # ★ Plugin framework (auto-discovered via import.meta.glob)
 │   ├── types.ts               # DataViewerPlugin / PluginContext / PluginRegistry contracts
@@ -200,7 +203,7 @@ src/
 │   │   ├── storageTypes.ts      # Pure: storage types (documents 5MB / logs 20MB) + usage math (tested)
 │   │   ├── syncEngine.ts         # pushAll/pushFile/pullAll + incremental pushRecord/deleteRecord + getStorageUsage + deleteCloudFile (rolls back orphan blob on index failure) + cleanupOrphanBlobs. Doc pushes chunk to a per-record fallback on quota (partial push + skipped count)
 │   │   ├── autoSync.ts           # Background doc auto-sync: subscribes to garageEvents, debounced upsert/delete + reconcile on sign-in
-│   │   ├── StoragePanel.tsx      # Profile-tab panel: display-name editor + storage usage meters (lazy)
+│   │   ├── StoragePanel.tsx      # Profile-tab panel: display-name editor + plan/Manage-subscription + storage usage meters (lazy)
 │   │   ├── CloudLogsPanel.tsx    # Profile-tab panel: list + delete cloud log files (cloud-only; opt-in local delete) (lazy)
 │   │   ├── profile.ts            # getMyProfile / updateDisplayName (unique display names; taken-name handling)
 │   │   └── cloudClient.ts        # Typed access to sync_records + bucket + sync_storage_usage RPC (escape hatch until types regen)
@@ -523,8 +526,21 @@ manually like the rest of the repo, the webhook verifies the Stripe signature):
 - `create-portal-session` — returns a Stripe Billing Portal URL for
   manage/cancel (no in-app billing UI).
 
-Secrets: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`. **Client upgrade/manage
-buttons (PricingCards + Profile StoragePanel) are a follow-up.**
+Secrets: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
+
+**Client wiring** (core, not the cloud-sync plugin — billing is account-level and
+PricingCards renders even with cloud disabled): `lib/billing.ts` is the pure,
+unit-tested layer (`isActiveStatus`/`effectiveTier`/`isPaidTier`/`pricingCta` +
+row shapes); `lib/billingClient.ts` is the Supabase I/O (`fetchTiers`,
+`fetchMySubscription`, `createCheckout`, `createPortal` via `functions.invoke`),
+through the same untyped escape hatch as `cloudClient.ts`. `hooks/useSubscription.ts`
+reads the tier catalogue + the user's subscription (online + account-gated,
+returns the free baseline otherwise). `PricingCards` shows live **Upgrade** /
+**Current plan** actions for signed-in users (a paid tier with no `stripe_price_id`
+stays "Coming soon" — graceful pre-config state); cloud-sync's Profile-tab
+`StoragePanel` shows the current plan + a **Manage subscription** portal link when
+subscribed. **Stripe setup (create Products/Prices, set `stripe_price_id`, secrets,
+webhook) is still operator config — see README.**
 
 ---
 

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -1,4 +1,13 @@
-import { Check } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { Check, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useSubscription } from "@/hooks/useSubscription";
+import { pricingCta } from "@/lib/billing";
+import { createCheckout } from "@/lib/billingClient";
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
 interface Tier {
   name: string;
@@ -9,6 +18,8 @@ interface Tier {
   features: string[];
   highlight?: boolean;
   comingSoon?: boolean;
+  /** Maps the card to a subscription tier slug (the offline card has none). */
+  slug?: "free" | "plus" | "pro";
 }
 
 const TIERS: Tier[] = [
@@ -29,6 +40,7 @@ const TIERS: Tier[] = [
     blurb: "Online account",
     price: "$0",
     highlight: true,
+    slug: "free",
     inherits: "Everything in Free, plus",
     features: [
       "Setup info synced across all your devices",
@@ -42,6 +54,7 @@ const TIERS: Tier[] = [
     price: "$1",
     cadence: "/mo",
     comingSoon: true,
+    slug: "plus",
     inherits: "Everything in Free online, plus",
     features: ["500 MB cloud log storage"],
   },
@@ -51,12 +64,21 @@ const TIERS: Tier[] = [
     price: "$10",
     cadence: "/mo",
     comingSoon: true,
+    slug: "pro",
     inherits: "Everything in Plus, plus",
     features: ["1 GB cloud log storage", "AI coaching (coming soon)"],
   },
 ];
 
-function TierCard({ tier }: { tier: Tier }) {
+function TierCard({
+  tier,
+  cta,
+  showComingSoon,
+}: {
+  tier: Tier;
+  cta?: ReactNode;
+  showComingSoon: boolean;
+}) {
   return (
     <div
       className={`relative flex flex-col rounded-xl border bg-card p-5 text-left ${
@@ -68,7 +90,7 @@ function TierCard({ tier }: { tier: Tier }) {
           Recommended
         </span>
       )}
-      {tier.comingSoon && (
+      {showComingSoon && (
         <span className="absolute -top-2.5 right-4 rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
           Coming soon
         </span>
@@ -92,16 +114,36 @@ function TierCard({ tier }: { tier: Tier }) {
           </li>
         ))}
       </ul>
+      {cta && <div className="mt-auto pt-4">{cta}</div>}
     </div>
   );
 }
 
 /**
- * Plans / pricing grid. Shown on the landing page (below the sample box) and on
- * the registration page. Informational only — paid tiers are marked "Coming
- * soon" until billing is wired up.
+ * Plans / pricing grid. Shown on the landing page (the empty-state of the main
+ * app) and on the registration page. Informational for signed-out visitors;
+ * signed-in users get live "Upgrade" / "Current plan" actions on the paid tiers
+ * (a paid tier whose Stripe Price isn't configured yet stays "Coming soon").
  */
 export function PricingCards({ className }: { className?: string }) {
+  const { user } = useAuth();
+  const { tiers, currentTier } = useSubscription();
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const signedIn = !!user;
+  const purchasable = new Set(tiers.filter((t) => t.stripe_price_id).map((t) => t.tier));
+
+  const onUpgrade = async (slug: string) => {
+    setBusy(slug);
+    try {
+      const url = await createCheckout(slug, window.location.href);
+      window.location.href = url;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't start checkout.");
+      setBusy(null);
+    }
+  };
+
   return (
     <section className={className}>
       <div className="text-center space-y-1">
@@ -111,9 +153,42 @@ export function PricingCards({ className }: { className?: string }) {
         </p>
       </div>
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {TIERS.map((tier) => (
-          <TierCard key={`${tier.name}-${tier.blurb}`} tier={tier} />
-        ))}
+        {TIERS.map((tier) => {
+          const kind = pricingCta({
+            slug: tier.slug,
+            signedIn,
+            cloudEnabled: enableCloud,
+            currentTier,
+            purchasable: !!tier.slug && purchasable.has(tier.slug),
+          });
+
+          let cta: ReactNode = null;
+          if (kind === "current") {
+            cta = (
+              <Button variant="outline" className="w-full" disabled>
+                <Check className="h-4 w-4" /> Current plan
+              </Button>
+            );
+          } else if (kind === "upgrade" && tier.slug) {
+            const slug = tier.slug;
+            const isBusy = busy === slug;
+            cta = (
+              <Button className="w-full" disabled={isBusy} onClick={() => void onUpgrade(slug)}>
+                {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                {isBusy ? "Redirecting…" : "Upgrade"}
+              </Button>
+            );
+          }
+
+          return (
+            <TierCard
+              key={`${tier.name}-${tier.blurb}`}
+              tier={tier}
+              cta={cta}
+              showComingSoon={!!tier.comingSoon && kind === "none"}
+            />
+          );
+        })}
       </div>
     </section>
   );

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import { effectiveTier, type SubscriptionTierRow, type UserSubscriptionRow } from "@/lib/billing";
+import { fetchMySubscription, fetchTiers } from "@/lib/billingClient";
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+export interface SubscriptionState {
+  loading: boolean;
+  error: string | null;
+  /** All plans (sorted), for prices/labels/limits. Empty when signed out. */
+  tiers: SubscriptionTierRow[];
+  /** The user's raw subscription row (may be inactive). */
+  subscription: UserSubscriptionRow | null;
+  /** The effective tier ('free' when signed out or the subscription is inactive). */
+  currentTier: string;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Reads the catalogue of subscription tiers + the current user's subscription.
+ * Online-only and account-gated: returns the free baseline when cloud is
+ * disabled or no one is signed in, and never throws into render.
+ */
+export function useSubscription(): SubscriptionState {
+  const { user, loading: authLoading } = useAuth();
+  const online = useOnlineStatus();
+  const [tiers, setTiers] = useState<SubscriptionTierRow[]>([]);
+  const [subscription, setSubscription] = useState<UserSubscriptionRow | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enableCloud || !user) {
+      setTiers([]);
+      setSubscription(null);
+      setError(null);
+      return;
+    }
+    setLoading(true);
+    try {
+      const [t, s] = await Promise.all([fetchTiers(), fetchMySubscription(user.id)]);
+      setTiers(t);
+      setSubscription(s);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load subscription");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  // Re-read on mount, on sign-in/out, and when connectivity returns.
+  useEffect(() => {
+    void refresh();
+  }, [refresh, online]);
+
+  return {
+    loading: authLoading || loading,
+    error,
+    tiers,
+    subscription,
+    currentTier: effectiveTier(subscription),
+    refresh,
+  };
+}

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { isActiveStatus, effectiveTier, isPaidTier, pricingCta } from "./billing";
+
+describe("isActiveStatus", () => {
+  it("treats active / trialing / past_due as granting access", () => {
+    expect(isActiveStatus("active")).toBe(true);
+    expect(isActiveStatus("trialing")).toBe(true);
+    expect(isActiveStatus("past_due")).toBe(true);
+  });
+  it("treats everything else (and null) as inactive", () => {
+    expect(isActiveStatus("canceled")).toBe(false);
+    expect(isActiveStatus("incomplete")).toBe(false);
+    expect(isActiveStatus("unpaid")).toBe(false);
+    expect(isActiveStatus(null)).toBe(false);
+    expect(isActiveStatus(undefined)).toBe(false);
+  });
+});
+
+describe("effectiveTier", () => {
+  it("returns the tier when the subscription is active", () => {
+    expect(effectiveTier({ tier: "pro", status: "active" })).toBe("pro");
+    expect(effectiveTier({ tier: "plus", status: "trialing" })).toBe("plus");
+  });
+  it("falls back to free when inactive or missing", () => {
+    expect(effectiveTier({ tier: "pro", status: "canceled" })).toBe("free");
+    expect(effectiveTier(null)).toBe("free");
+    expect(effectiveTier(undefined)).toBe("free");
+  });
+});
+
+describe("isPaidTier", () => {
+  it("is true for anything but free", () => {
+    expect(isPaidTier("free")).toBe(false);
+    expect(isPaidTier("plus")).toBe(true);
+    expect(isPaidTier("pro")).toBe(true);
+  });
+});
+
+describe("pricingCta", () => {
+  const base = { signedIn: true, cloudEnabled: true, currentTier: "free", purchasable: true };
+
+  it("shows nothing when signed out, cloud disabled, or no slug", () => {
+    expect(pricingCta({ ...base, slug: "plus", signedIn: false })).toBe("none");
+    expect(pricingCta({ ...base, slug: "plus", cloudEnabled: false })).toBe("none");
+    expect(pricingCta({ ...base, slug: undefined })).toBe("none");
+  });
+
+  it("marks the user's current tier as current", () => {
+    expect(pricingCta({ ...base, slug: "free", currentTier: "free" })).toBe("current");
+    expect(pricingCta({ ...base, slug: "pro", currentTier: "pro" })).toBe("current");
+  });
+
+  it("offers an upgrade for a purchasable paid tier above the current one", () => {
+    expect(pricingCta({ ...base, slug: "plus", currentTier: "free", purchasable: true })).toBe("upgrade");
+  });
+
+  it("keeps a paid tier non-actionable (Coming soon) when no Stripe Price is set", () => {
+    expect(pricingCta({ ...base, slug: "pro", currentTier: "free", purchasable: false })).toBe("none");
+  });
+
+  it("never offers an upgrade to the free-online card", () => {
+    expect(pricingCta({ ...base, slug: "free", currentTier: "pro" })).toBe("none");
+  });
+});

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,67 @@
+// Pure subscription/billing logic + row shapes (no Supabase import, so it's
+// unit-testable and safe to pull into any component). The Supabase I/O lives in
+// billingClient.ts.
+
+export interface SubscriptionTierRow {
+  tier: string;
+  label: string;
+  price_cents: number;
+  logs_bytes: number;
+  doc_bytes: number;
+  ai_credits: number;
+  stripe_price_id: string | null;
+  sort_order: number;
+}
+
+export interface UserSubscriptionRow {
+  user_id: string;
+  tier: string;
+  status: string;
+  current_period_end: string | null;
+}
+
+// A subscription grants its tier only while the status is one of these; anything
+// else (canceled, incomplete, unpaid…) falls back to free. Mirrors the server's
+// user_tier() definition so client display and server enforcement agree.
+export const ACTIVE_STATUSES = ["active", "trialing", "past_due"] as const;
+
+export function isActiveStatus(status: string | null | undefined): boolean {
+  return !!status && (ACTIVE_STATUSES as readonly string[]).includes(status);
+}
+
+/** The tier a subscription row actually entitles the user to right now. */
+export function effectiveTier(
+  sub: Pick<UserSubscriptionRow, "tier" | "status"> | null | undefined,
+): string {
+  return sub && isActiveStatus(sub.status) ? sub.tier : "free";
+}
+
+export function isPaidTier(tier: string): boolean {
+  return tier !== "free";
+}
+
+export type PricingCtaKind = "none" | "current" | "upgrade";
+
+export interface PricingCtaInput {
+  /** The card's tier slug ('free' | 'plus' | 'pro'); undefined for the offline card. */
+  slug?: string;
+  signedIn: boolean;
+  cloudEnabled: boolean;
+  /** The user's effective tier. */
+  currentTier: string;
+  /** Whether this tier has a Stripe Price configured (purchasable). */
+  purchasable: boolean;
+}
+
+/**
+ * Which call-to-action a pricing card should show. Pure so it can be unit-tested.
+ * "none" means render no button (informational only — e.g. signed out, the free
+ * tiers, or a paid tier whose Stripe Price isn't configured yet, which keeps the
+ * "Coming soon" badge).
+ */
+export function pricingCta(i: PricingCtaInput): PricingCtaKind {
+  if (!i.slug || !i.cloudEnabled || !i.signedIn) return "none";
+  if (i.slug === i.currentTier) return "current";
+  if (i.slug === "free") return "none";
+  return i.purchasable ? "upgrade" : "none";
+}

--- a/src/lib/billingClient.ts
+++ b/src/lib/billingClient.ts
@@ -1,0 +1,55 @@
+// Supabase I/O for subscriptions + billing (Stripe). Pure logic + row shapes
+// live in billing.ts.
+//
+// subscription_tiers / user_subscriptions are not in the generated Database type
+// yet (Lovable regenerates `integrations/supabase/types.ts` after the migration
+// deploys), so — exactly like cloud-sync's cloudClient.ts — we route those
+// tables through an untyped view of the shared client. Checkout/portal go
+// through the typed `functions.invoke`.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+import type { SubscriptionTierRow, UserSubscriptionRow } from "./billing";
+
+const untyped = supabase as unknown as SupabaseClient;
+
+export async function fetchTiers(): Promise<SubscriptionTierRow[]> {
+  const { data, error } = await untyped
+    .from("subscription_tiers")
+    .select("*")
+    .order("sort_order", { ascending: true });
+  if (error) throw new Error(`Failed to load tiers: ${error.message}`);
+  return (data ?? []) as SubscriptionTierRow[];
+}
+
+export async function fetchMySubscription(userId: string): Promise<UserSubscriptionRow | null> {
+  const { data, error } = await untyped
+    .from("user_subscriptions")
+    .select("user_id, tier, status, current_period_end")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(`Failed to load subscription: ${error.message}`);
+  return (data ?? null) as UserSubscriptionRow | null;
+}
+
+/** Start Stripe Checkout for a tier; resolves to the hosted URL to redirect to. */
+export async function createCheckout(tier: string, returnUrl: string): Promise<string> {
+  const { data, error } = await supabase.functions.invoke("create-checkout-session", {
+    body: { tier, returnUrl },
+  });
+  if (error) throw new Error(error.message);
+  const url = (data as { url?: string } | null)?.url;
+  if (!url) throw new Error("No checkout URL returned");
+  return url;
+}
+
+/** Open the Stripe Billing Portal; resolves to the hosted URL to redirect to. */
+export async function createPortal(returnUrl: string): Promise<string> {
+  const { data, error } = await supabase.functions.invoke("create-portal-session", {
+    body: { returnUrl },
+  });
+  if (error) throw new Error(error.message);
+  const url = (data as { url?: string } | null)?.url;
+  if (!url) throw new Error("No portal URL returned");
+  return url;
+}

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, CloudOff, Pencil, User as UserIcon, X } from "lucide-react";
+import { Check, CloudOff, CreditCard, Loader2, Pencil, User as UserIcon, X } from "lucide-react";
 import { toast } from "sonner";
 import type { PluginPanelProps } from "@/plugins/panels";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import { useSubscription } from "@/hooks/useSubscription";
+import { isPaidTier } from "@/lib/billing";
+import { createPortal } from "@/lib/billingClient";
 import { getStorageUsage } from "./syncEngine";
 import { getMyProfile, updateDisplayName } from "./profile";
 import { pendingCount } from "./pendingSync";
@@ -59,6 +62,8 @@ export default function StoragePanel(_props: PluginPanelProps) {
   return (
     <div className="space-y-5">
       <DisplayName userId={user.id} email={user.email ?? ""} />
+
+      <PlanSection />
 
       {!online && (
         <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
@@ -167,6 +172,52 @@ function DisplayName({ userId, email }: { userId: string; email: string }) {
           </div>
         )}
         <p className="truncate text-xs text-muted-foreground">{email}</p>
+      </div>
+    </div>
+  );
+}
+
+function PlanSection() {
+  const { tiers, currentTier, subscription, loading } = useSubscription();
+  const [busy, setBusy] = useState(false);
+
+  const label = tiers.find((t) => t.tier === currentTier)?.label
+    ?? currentTier.charAt(0).toUpperCase() + currentTier.slice(1);
+  const subscribed = isPaidTier(currentTier);
+  const renews = subscription?.current_period_end
+    ? new Date(subscription.current_period_end).toLocaleDateString()
+    : null;
+
+  const manage = async () => {
+    setBusy(true);
+    try {
+      const url = await createPortal(window.location.href);
+      window.location.href = url;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't open the billing portal.");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Plan</p>
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">{loading ? "…" : label}</p>
+          {subscribed && renews && (
+            <p className="text-[11px] text-muted-foreground">Renews {renews}</p>
+          )}
+          {!subscribed && (
+            <p className="text-[11px] text-muted-foreground">Upgrade from the Plans &amp; pricing cards.</p>
+          )}
+        </div>
+        {subscribed && (
+          <Button size="sm" variant="outline" className="shrink-0" disabled={busy} onClick={() => void manage()}>
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
+            Manage subscription
+          </Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The **client UI** for the Stripe subscription backend (#62). Adds the upgrade/manage surface so signed-in users can act on the `free` / `plus` / `pro` tiers; the backend (tables, quota wiring, edge functions) already merged into BETA in #62.

Backend-config-aware by design: until you create the Stripe Products/Prices and populate `subscription_tiers.stripe_price_id`, the paid cards stay **"Coming soon"** — they flip to a live **Upgrade** button automatically, no code change, once a Price id exists.

## What's in it

- **`useSubscription()` hook** (`src/hooks/useSubscription.ts`) — reads the tier catalogue (`subscription_tiers`) + the user's row (`user_subscriptions`), exposing `currentTier` (effective tier), `tiers`, `subscription`, and a `refresh`. Online + account-gated: returns the `free` baseline when cloud is disabled or no one is signed in, and never throws into render.
- **`PricingCards`** — signed-in users get a live CTA per paid tier:
  - their effective tier → **Current plan** (disabled),
  - a purchasable higher tier → **Upgrade** → Stripe Checkout → redirect,
  - a paid tier with no `stripe_price_id` yet → stays **Coming soon**.
  Signed-out visitors see the same informational grid as before. Renders correctly whether or not the cloud flag is on.
- **Profile `StoragePanel`** (cloud-sync plugin) — a new **Plan** block showing the current plan label + renewal date, with a **Manage subscription** button → Stripe Billing Portal when subscribed.

## Architecture

Billing is **core**, not part of the cloud-sync plugin, because `PricingCards` renders regardless of `VITE_ENABLE_CLOUD`. Logic is split following the repo's pure/IO convention:

- `src/lib/billing.ts` — **pure**, no Supabase import: row shapes + `isActiveStatus` / `effectiveTier` / `isPaidTier` / `pricingCta`. Unit-tested.
- `src/lib/billingClient.ts` — Supabase **I/O**: `fetchTiers`, `fetchMySubscription`, and `createCheckout` / `createPortal` (via `functions.invoke`), through the same untyped-client escape hatch as `cloudClient.ts` (the new tables aren't in the generated `Database` type yet).

The split keeps the tier/CTA logic testable without importing the Supabase client (which touches `localStorage` at module load and breaks in the node test env).

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run test:run` — **355 passed** (10 new `billing.test.ts` cases covering status/effective-tier/CTA logic).
- [x] `npm run build` — clean; billing stays on the already-present `vendor-supabase`/initial path, no new heavy chunk on the landing route.
- [ ] **Manual (needs Stripe test mode + deploy — not done in-container):** as a signed-in free user, confirm Plus/Pro show "Coming soon" before Price ids are set; after setting `stripe_price_id`, confirm **Upgrade** → Checkout → tier flips to `plus`/`pro` → card shows **Current plan** and the Profile **Manage subscription** button opens the portal.

> Like #62, the live checkout/portal flow could not be exercised here (no Stripe keys / Supabase deploy). Smoke test on the project in Stripe **test mode**.

## Follow-ups
- Per-tier **AI-credit** metering in the coach plugin (the `ai_credits` column exists, seeded 0).

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3