### PR TITLE
Move pricing cards above the registration form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Registration page** now shows the **Plans & pricing** cards above the
   sign-up form instead of below it.
+- **Privacy Policy** updated to name the operating entity (**PerchWerks LLC**,
+  Windermere, Florida), reconcile the local-first claims with optional accounts /
+  cloud sync / Stripe billing, add a generic AI-processing clause, and add a
+  governing-law section (Florida, USA).
 - **Cloud Sync moved out of the Labs tab**: sign-in and manual push/pull now live
   on the **Profile** tab as an "Account" panel. The Labs tab no longer appears
   unless the experimental setting is on or a plugin contributes to it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejects **disposable / temporary email** addresses.
 
 ### Changed
+- **Registration page** now shows the **Plans & pricing** cards above the
+  sign-up form instead of below it.
 - **Cloud Sync moved out of the Labs tab**: sign-in and manual push/pull now live
   on the **Profile** tab as an "Account" panel. The Labs tab no longer appears
   unless the experimental setting is on or a plugin contributes to it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Registration page** now shows the **Plans & pricing** cards above the
   sign-up form instead of below it.
-- **Privacy Policy** updated to name the operating entity (**PerchWerks LLC**,
-  Windermere, Florida), reconcile the local-first claims with optional accounts /
-  cloud sync / Stripe billing, add a generic AI-processing clause, and add a
-  governing-law section (Florida, USA).
 - **Cloud Sync moved out of the Labs tab**: sign-in and manual push/pull now live
   on the **Profile** tab as an "Account" panel. The Labs tab no longer appears
   unless the experimental setting is on or a plugin contributes to it.

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -7,7 +7,7 @@ const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const Privacy = () => {
   useDocumentHead({
     title: "Privacy Policy — HackTheTrack",
-    description: "How HackTheTrack handles your data: 100% local-first telemetry storage in your browser, no cookies, no analytics, no tracking.",
+    description: "How HackTheTrack handles your data: local-first telemetry storage in your browser with optional cloud sync, no cookies, no analytics, no tracking.",
     canonical: "https://hackthetrack.net/privacy",
   });
   return (
@@ -21,11 +21,44 @@ const Privacy = () => {
 
     <div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
       <section>
+        <h2 className="text-base font-semibold text-foreground mb-2">Who Operates This Service</h2>
+        <p>
+          HackTheTrack is operated by <strong className="text-foreground">PerchWerks LLC</strong>,
+          based in Windermere, Florida, United States. Where this policy refers to
+          &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our,&rdquo; it means PerchWerks LLC.
+        </p>
+      </section>
+
+      <section>
         <h2 className="text-base font-semibold text-foreground mb-2">Local-First Data Storage</h2>
         <p>
-          All of your telemetry data, session files, lap notes, kart profiles, setup sheets,
-          graph preferences, and video sync settings are stored entirely in your browser using
-          IndexedDB and localStorage. <strong className="text-foreground">Nothing leaves your device.</strong>
+          By default, all of your telemetry data, session files, lap notes, kart profiles, setup
+          sheets, graph preferences, and video sync settings are stored entirely in your browser
+          using IndexedDB and localStorage. <strong className="text-foreground">Unless you sign in
+          and opt into cloud sync, nothing leaves your device.</strong>
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-base font-semibold text-foreground mb-2">Optional Accounts &amp; Cloud Sync</h2>
+        <p>
+          If you choose to create an account and enable cloud sync, the data you sync (such as
+          session logs, your garage, setups, and notes) is stored on our cloud infrastructure so it
+          is available across your devices. This is entirely optional — the core app works fully
+          offline without an account. We use your email address for authentication and account-related
+          communication only. Paid subscriptions are processed by our payment provider (Stripe); we do
+          not store your full payment card details.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-base font-semibold text-foreground mb-2">AI-Powered Features</h2>
+        <p>
+          Some optional features may use AI processing. When you use such a feature, the relevant
+          data (for example, telemetry from the session you are analyzing) may be sent to a
+          third-party AI provider to generate the result. These features are opt-in and are not
+          used unless you actively invoke them. The specific AI provider may change over time; this
+          policy will be updated to reflect the provider in use.
         </p>
       </section>
 
@@ -52,7 +85,8 @@ const Privacy = () => {
         <h2 className="text-base font-semibold text-foreground mb-2">No Personal Information Required</h2>
         <p>
           No account, email address, or personal information is required to use any core feature
-          of this application. It works fully offline once loaded.
+          of this application. It works fully offline once loaded. An account is only needed if you
+          choose to use the optional cloud features described above.
         </p>
       </section>
 
@@ -65,9 +99,17 @@ const Privacy = () => {
           the IndexedDB database and localStorage entries for this site.
         </p>
       </section>
+
+      <section>
+        <h2 className="text-base font-semibold text-foreground mb-2">Governing Law</h2>
+        <p>
+          This Privacy Policy and any dispute arising from it are governed by the laws of the State
+          of Florida, United States, without regard to its conflict-of-law provisions.
+        </p>
+      </section>
     </div>
 
-    <p className="mt-10 text-xs text-muted-foreground/60">Last updated: February 2026</p>
+    <p className="mt-10 text-xs text-muted-foreground/60">Last updated: May 2026</p>
   </div>
   );
 };

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -7,7 +7,7 @@ const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const Privacy = () => {
   useDocumentHead({
     title: "Privacy Policy — HackTheTrack",
-    description: "How HackTheTrack handles your data: local-first telemetry storage in your browser with optional cloud sync, no cookies, no analytics, no tracking.",
+    description: "How HackTheTrack handles your data: 100% local-first telemetry storage in your browser, no cookies, no analytics, no tracking.",
     canonical: "https://hackthetrack.net/privacy",
   });
   return (
@@ -21,44 +21,11 @@ const Privacy = () => {
 
     <div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
       <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">Who Operates This Service</h2>
-        <p>
-          HackTheTrack is operated by <strong className="text-foreground">PerchWerks LLC</strong>,
-          based in Windermere, Florida, United States. Where this policy refers to
-          &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our,&rdquo; it means PerchWerks LLC.
-        </p>
-      </section>
-
-      <section>
         <h2 className="text-base font-semibold text-foreground mb-2">Local-First Data Storage</h2>
         <p>
-          By default, all of your telemetry data, session files, lap notes, kart profiles, setup
-          sheets, graph preferences, and video sync settings are stored entirely in your browser
-          using IndexedDB and localStorage. <strong className="text-foreground">Unless you sign in
-          and opt into cloud sync, nothing leaves your device.</strong>
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">Optional Accounts &amp; Cloud Sync</h2>
-        <p>
-          If you choose to create an account and enable cloud sync, the data you sync (such as
-          session logs, your garage, setups, and notes) is stored on our cloud infrastructure so it
-          is available across your devices. This is entirely optional — the core app works fully
-          offline without an account. We use your email address for authentication and account-related
-          communication only. Paid subscriptions are processed by our payment provider (Stripe); we do
-          not store your full payment card details.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">AI-Powered Features</h2>
-        <p>
-          Some optional features may use AI processing. When you use such a feature, the relevant
-          data (for example, telemetry from the session you are analyzing) may be sent to a
-          third-party AI provider to generate the result. These features are opt-in and are not
-          used unless you actively invoke them. The specific AI provider may change over time; this
-          policy will be updated to reflect the provider in use.
+          All of your telemetry data, session files, lap notes, kart profiles, setup sheets,
+          graph preferences, and video sync settings are stored entirely in your browser using
+          IndexedDB and localStorage. <strong className="text-foreground">Nothing leaves your device.</strong>
         </p>
       </section>
 
@@ -85,8 +52,7 @@ const Privacy = () => {
         <h2 className="text-base font-semibold text-foreground mb-2">No Personal Information Required</h2>
         <p>
           No account, email address, or personal information is required to use any core feature
-          of this application. It works fully offline once loaded. An account is only needed if you
-          choose to use the optional cloud features described above.
+          of this application. It works fully offline once loaded.
         </p>
       </section>
 
@@ -99,17 +65,9 @@ const Privacy = () => {
           the IndexedDB database and localStorage entries for this site.
         </p>
       </section>
-
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">Governing Law</h2>
-        <p>
-          This Privacy Policy and any dispute arising from it are governed by the laws of the State
-          of Florida, United States, without regard to its conflict-of-law provisions.
-        </p>
-      </section>
     </div>
 
-    <p className="mt-10 text-xs text-muted-foreground/60">Last updated: May 2026</p>
+    <p className="mt-10 text-xs text-muted-foreground/60">Last updated: February 2026</p>
   </div>
   );
 };

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -70,12 +70,14 @@ export default function Register() {
 
   return (
     <div className="min-h-screen bg-background flex flex-col items-center p-8 gap-12">
-      <div className="w-full max-w-sm space-y-6 mt-4">
-        <div className="flex items-center gap-3 justify-center">
-          <Gauge className="w-8 h-8 text-primary" />
-          <h1 className="text-xl font-semibold text-foreground">HackTheTrack.net</h1>
-        </div>
+      <div className="flex items-center gap-3 justify-center mt-4">
+        <Gauge className="w-8 h-8 text-primary" />
+        <h1 className="text-xl font-semibold text-foreground">HackTheTrack.net</h1>
+      </div>
 
+      <PricingCards className="w-full max-w-5xl" />
+
+      <div className="w-full max-w-sm space-y-6">
         <div className="racing-card p-6 space-y-4">
           <h2 className="text-lg font-semibold text-foreground">Create account</h2>
 
@@ -121,8 +123,6 @@ export default function Register() {
           <ArrowLeft className="w-4 h-4" /> Back to Home
         </Button>
       </div>
-
-      <PricingCards className="w-full max-w-5xl" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- On the registration page, the **Plans & pricing** cards previously sat below the sign-up details. This moves them above the form so visitors see plan options first.
- The HackTheTrack branding header stays at the very top, then pricing, then the registration card.

## Changes
- `src/pages/Register.tsx`: lifted `<PricingCards>` above the registration card; pulled the logo header out of the `max-w-sm` wrapper so it stays full-width at the top.
- `CHANGELOG.md`: added a `Changed` entry under `[Unreleased]`.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] Visually confirm pricing renders above the form on `/register`

https://claude.ai/code/session_01LbrorWzLKPgH6wsnKYxXb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbrorWzLKPgH6wsnKYxXb5)_