### PR TITLE
Add a Premium subscription tier ($3/mo, Pro storage, no AI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Paid subscription tiers**: Stripe-backed `Plus` ($1/mo, 500 MB logs) and
-  `Pro` ($10/mo, 1 GB logs) plans on top of the free 20 MB tier. Plan limits are
+- **Paid subscription tiers**: Stripe-backed `Plus` ($1/mo, 500 MB logs),
+  `Premium` ($3/mo, 1 GB logs), and `Pro` ($10/mo, 1 GB logs + AI coaching)
+  plans on top of the free 20 MB tier. Plan limits are
   data-driven (`subscription_tiers` table) and the cloud-sync storage quota is
   enforced per the user's tier. Backed by `create-checkout-session`,
   `stripe-webhook`, and `create-portal-session` edge functions; entitlements are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,7 +504,9 @@ escape hatch confined to that one module.
 ### Subscriptions / Stripe (`..._stripe_subscriptions.sql` + 3 edge functions)
 
 Paid tiers scale the cloud-sync **logs** quota (`free` 20 MB → `plus` $1 500 MB
-→ `pro` $10 1 GB; docs stay 5 MB). Tiers are **data**, not code:
+→ `premium` $3 1 GB → `pro` $10 1 GB; docs stay 5 MB). `premium` matches `pro`'s
+storage but carries no AI credits. Tiers are **data**, not code (numbers are
+provisional):
 
 | Object | Type | Notes |
 |--------|------|-------|

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ The app includes an optional admin system for managing a community track databas
 > **Note:** `TURNSTILE_SECRET_KEY` is a server-side secret stored in Lovable Cloud, not a `VITE_` client variable. If not set, Turnstile verification is skipped.
 
 > **Stripe / paid tiers:** `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are
-> edge-function secrets (not `VITE_` client vars). After creating the Plus/Pro
-> Products + recurring Prices in Stripe, store each Price id in the matching
+> edge-function secrets (not `VITE_` client vars). After creating the
+> Plus/Premium/Pro Products + recurring Prices in Stripe, store each Price id in the matching
 > `subscription_tiers.stripe_price_id` row, and point a Stripe webhook (events:
 > `checkout.session.completed`, `customer.subscription.created/updated/deleted`)
 > at the `stripe-webhook` function URL. Use Stripe **test mode** first. Tier

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -19,7 +19,7 @@ interface Tier {
   highlight?: boolean;
   comingSoon?: boolean;
   /** Maps the card to a subscription tier slug (the offline card has none). */
-  slug?: "free" | "plus" | "pro";
+  slug?: "free" | "plus" | "premium" | "pro";
 }
 
 const TIERS: Tier[] = [
@@ -59,14 +59,24 @@ const TIERS: Tier[] = [
     features: ["500 MB cloud log storage"],
   },
   {
+    name: "Premium",
+    blurb: "Max storage",
+    price: "$3",
+    cadence: "/mo",
+    comingSoon: true,
+    slug: "premium",
+    inherits: "Everything in Plus, plus",
+    features: ["1 GB cloud log storage"],
+  },
+  {
     name: "Pro",
     blurb: "With AI coaching",
     price: "$10",
     cadence: "/mo",
     comingSoon: true,
     slug: "pro",
-    inherits: "Everything in Plus, plus",
-    features: ["1 GB cloud log storage", "AI coaching (coming soon)"],
+    inherits: "Everything in Premium, plus",
+    features: ["AI coaching (coming soon)"],
   },
 ];
 
@@ -152,7 +162,7 @@ export function PricingCards({ className }: { className?: string }) {
           Start free and fully offline. Add an account for cross-device sync — upgrade only if you need more.
         </p>
       </div>
-      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
         {TIERS.map((tier) => {
           const kind = pricingCta({
             slug: tier.slug,

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -50,8 +50,10 @@ describe("pricingCta", () => {
     expect(pricingCta({ ...base, slug: "pro", currentTier: "pro" })).toBe("current");
   });
 
-  it("offers an upgrade for a purchasable paid tier above the current one", () => {
+  it("offers an upgrade for any purchasable paid tier (slug-agnostic)", () => {
     expect(pricingCta({ ...base, slug: "plus", currentTier: "free", purchasable: true })).toBe("upgrade");
+    expect(pricingCta({ ...base, slug: "premium", currentTier: "free", purchasable: true })).toBe("upgrade");
+    expect(pricingCta({ ...base, slug: "premium", currentTier: "premium", purchasable: true })).toBe("current");
   });
 
   it("keeps a paid tier non-actionable (Coming soon) when no Stripe Price is set", () => {

--- a/supabase/migrations/20260527000000_premium_tier.sql
+++ b/supabase/migrations/20260527000000_premium_tier.sql
@@ -1,0 +1,22 @@
+-- Add a "Premium" subscription tier.
+--
+-- Premium has the same storage as Pro (the paid logs ceiling) but no AI credits,
+-- at a lower price — it slots between Plus and Pro. Tiers are data, so this is a
+-- pure seed change on top of the catalogue introduced in the stripe-subscriptions
+-- migration; no schema, trigger, or function changes are needed. Pro's sort_order
+-- is bumped so the catalogue stays ordered free → plus → premium → pro.
+--
+-- NOTE: pricing + storage numbers here are provisional and expected to change.
+
+insert into public.subscription_tiers
+  (tier,      label,     price_cents, logs_bytes,  doc_bytes, ai_credits, sort_order) values
+  ('premium', 'Premium',         300, 1073741824,    5242880,          0, 2)  -- 1 GB logs / 5 MB docs, no AI
+on conflict (tier) do update set
+  label       = excluded.label,
+  price_cents = excluded.price_cents,
+  logs_bytes  = excluded.logs_bytes,
+  doc_bytes   = excluded.doc_bytes,
+  ai_credits  = excluded.ai_credits,
+  sort_order  = excluded.sort_order;
+
+update public.subscription_tiers set sort_order = 3 where tier = 'pro';


### PR DESCRIPTION
## Summary

Adds a fourth subscription tier, **Premium** — same cloud-log storage as Pro but **no AI credits**, at a lower price. It slots between Plus and Pro:

| tier | price | logs quota | docs quota | AI credits |
|------|-------|-----------|-----------|-----------|
| `free` | $0 | 20 MB | 5 MB | 0 |
| `plus` | $1/mo | 500 MB | 5 MB | 0 |
| **`premium`** | **$3/mo** | **1 GB** | **5 MB** | **0** |
| `pro` | $10/mo | 1 GB | 5 MB | 0 |

> Pricing + storage numbers are **provisional** and expected to change — this just wires the tier in.

Builds on the Stripe backend (#62) + client UI (#66), both already in BETA.

## What's in it

- **Migration** `20260527000000_premium_tier.sql` — data-only seed: inserts the `premium` row and bumps `pro`'s `sort_order` so the catalogue stays ordered `free → plus → premium → pro`. No schema/trigger/function changes — tiers are data, so the quota enforcement + usage RPC pick it up for free.
- **`PricingCards`** — a fifth card between Plus and Pro ("Max storage", $3/mo, 1 GB logs, no AI). Pro now reads *"Everything in Premium, plus → AI coaching"*. Grid widened to `xl:grid-cols-5`. Inherits the existing Upgrade / Current plan / Coming-soon behavior automatically (the slug is just data).
- **Tests** — added a `premium` case to `billing.test.ts` confirming the CTA logic is slug-agnostic.
- Docs: CHANGELOG, CLAUDE.md, README tier list updated.

## Going live

Same operator step as the other paid tiers: create a **Premium** Product + recurring Price in Stripe and store its id in `subscription_tiers.stripe_price_id` for the `premium` row. Until then the card correctly shows **"Coming soon"**, flipping to **Upgrade** automatically once the Price id is set — no code change.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run test:run` — **698 passed**.
- [x] `npm run build` — clean.
- [ ] After deploy: confirm `subscription_tiers` has the `premium` row and `sync_storage_usage()` returns its 1 GB logs limit for a `premium` subscriber; confirm the 5-card grid renders well on mobile/desktop.

https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4mWVsXnwhtEi92FVBVhB3)_