### PR TITLE
Add Terms of Service + rewrite Privacy Policy for cloud/AI/billing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Terms of Service page** (`/terms`) and a rewritten **Privacy Policy** that
+  now accurately reflect the optional online features — accounts, cloud sync,
+  Stripe-billed plans, and AI coaching — instead of the old "nothing ever leaves
+  your device" copy. Both pages adapt to the build flags (offline-only builds
+  show the simpler policy) and are linked from the landing-page footer. Account
+  sign-up now states the **16+ age requirement** and links both documents
+  (under-16 users use the app offline only). AI coaching is documented as
+  informational only — not safety or professional advice.
 - **Paid subscription tiers**: Stripe-backed `Plus` ($1/mo, 500 MB logs) and
   `Pro` ($10/mo, 1 GB logs) plans on top of the free 20 MB tier. Plan limits are
   data-driven (`subscription_tiers` table) and the cloud-sync storage quota is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ src/
 ├── pages/
 │   ├── Index.tsx          # Main SPA — file import, tab views, all state orchestration
 │   ├── Admin.tsx          # Admin panel (behind VITE_ENABLE_ADMIN)
-│   ├── Login.tsx / Register.tsx / Privacy.tsx
+│   ├── Login.tsx / Register.tsx / Privacy.tsx / Terms.tsx
 │   └── NotFound.tsx
 ├── components/
 │   ├── ui/                # shadcn/ui primitives (button, dialog, tabs, etc.)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const Login = lazy(() => import("./pages/Login"));
 const Admin = lazy(() => import("./pages/Admin"));
 const Register = lazy(() => import("./pages/Register"));
 const Privacy = lazy(() => import("./pages/Privacy"));
+const Terms = lazy(() => import("./pages/Terms"));
 const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const AuthCallback = lazy(() => import("./pages/AuthCallback"));
@@ -52,6 +53,7 @@ const App = () => {
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/privacy" element={<Privacy />} />
+              <Route path="/terms" element={<Terms />} />
               {(enableAdmin || enableCloud) && <Route path="/login" element={<Login />} />}
               {enableAdmin && <Route path="/admin" element={<Admin />} />}
               {enableCloud && <Route path="/register" element={<Register />} />}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Gauge, Github, Heart, Shield, BookOpen, Play, Loader2, LogIn, LogOut } from "lucide-react";
+import { Gauge, Github, Heart, Shield, BookOpen, Play, Loader2, LogIn, LogOut, FileText } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { FileImport } from "@/components/FileImport";
@@ -157,6 +157,10 @@ export function LandingPage({
             <Link to="/privacy" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
               <Shield className="w-3 h-3" />
               Privacy Policy
+            </Link>
+            <Link to="/terms" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+              <FileText className="w-3 h-3" />
+              Terms of Service
             </Link>
             <ContactDialog />
             <CreditsDialog />

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -2,73 +2,378 @@ import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
 
-const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
+const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === "true";
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+// NOTE FOR THE OPERATOR: this policy adapts to the build flags. With cloud
+// features off it describes the offline-only app; with VITE_ENABLE_CLOUD on it
+// also covers accounts, payments and AI. Placeholders to confirm before relying
+// on this for the hosted service: the operating entity's legal name, a contact
+// email, and the specific AI provider used by the coaching plugin. This is a
+// drafted policy, not legal advice — have it reviewed for your jurisdiction.
 
 const Privacy = () => {
   useDocumentHead({
     title: "Privacy Policy — HackTheTrack",
-    description: "How HackTheTrack handles your data: 100% local-first telemetry storage in your browser, no cookies, no analytics, no tracking.",
+    description:
+      "How HackTheTrack handles your data: offline-first telemetry stored in your browser, with optional cloud sync and AI features when you create an account.",
     canonical: "https://hackthetrack.net/privacy",
   });
   return (
-  <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
-    <Link to="/" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8">
-      <ArrowLeft className="w-4 h-4" />
-      <span className="text-sm">Back to app</span>
-    </Link>
+    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        <span className="text-sm">Back to app</span>
+      </Link>
 
-    <h1 className="text-2xl font-bold mb-6">Privacy Policy</h1>
+      <h1 className="text-2xl font-bold mb-6">Privacy Policy</h1>
 
-    <div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">Local-First Data Storage</h2>
-        <p>
-          All of your telemetry data, session files, lap notes, kart profiles, setup sheets,
-          graph preferences, and video sync settings are stored entirely in your browser using
-          IndexedDB and localStorage. <strong className="text-foreground">Nothing leaves your device.</strong>
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">No Cookies or Tracking</h2>
-        <p>
-          This application does not use cookies, analytics scripts, or any third-party tracking.
-          There are no advertising networks, no telemetry beacons, and no fingerprinting.
-        </p>
-      </section>
-
-      {enableAdmin && (
+      <div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
         <section>
-          <h2 className="text-base font-semibold text-foreground mb-2">Track &amp; Course Submissions</h2>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            The short version
+          </h2>
           <p>
-            When you submit a track or course to the community database, your IP address is logged
-            solely for the purpose of spam prevention and rate limiting. This information is not
-            shared with any third party and is used only to enforce submission limits and block abuse.
+            HackTheTrack is offline-first. By default, everything you do —
+            importing telemetry, taking notes, building kart profiles and setup
+            sheets — stays in your browser and{" "}
+            <strong className="text-foreground">never leaves your device</strong>.
+            {enableCloud
+              ? " Some features are optional and online: creating an account to back up and sync your data, paid storage plans, and AI coaching. Those features only send data off your device after you choose to use them, and this policy explains exactly what each one collects."
+              : " This build has no accounts, no cloud sync and no analytics."}
           </p>
         </section>
-      )}
 
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">No Personal Information Required</h2>
-        <p>
-          No account, email address, or personal information is required to use any core feature
-          of this application. It works fully offline once loaded.
-        </p>
-      </section>
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            Local-First Data Storage
+          </h2>
+          <p>
+            Your telemetry data, session files, lap notes, kart profiles, setup
+            sheets, graph preferences, and video sync settings are stored in your
+            browser using IndexedDB and localStorage. Using the core app requires{" "}
+            <strong className="text-foreground">
+              no account and no personal information
+            </strong>
+            , and works fully offline once loaded.
+          </p>
+        </section>
 
-      <section>
-        <h2 className="text-base font-semibold text-foreground mb-2">Clearing Your Data</h2>
-        <p>
-          Since all data is stored locally in your browser, you can remove it at any time by
-          clearing your site data through your browser's settings (Settings → Privacy → Clear
-          browsing data → Site data), or by using your browser's developer tools to delete
-          the IndexedDB database and localStorage entries for this site.
-        </p>
-      </section>
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            No Tracking or Advertising
+          </h2>
+          <p>
+            We do not use analytics scripts, advertising networks, telemetry
+            beacons, or fingerprinting, and we do not sell or rent your data to
+            anyone. We use only the storage strictly necessary to run the app
+            (see “Cookies &amp; Local Storage” below).
+          </p>
+        </section>
+
+        {enableCloud && (
+          <>
+            <section>
+              <h2 className="text-base font-semibold text-foreground mb-2">
+                Optional Accounts &amp; Cloud Sync
+              </h2>
+              <p className="mb-2">
+                If you create an account, you can back up and sync your data
+                across devices. This is entirely optional and opt-in. When you
+                use it, the following is stored on our backend (Supabase) under
+                your account and protected so that only you can access it:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>
+                  <strong className="text-foreground">Account details:</strong>{" "}
+                  your email address, an encrypted password (or a Google sign-in
+                  identifier if you use Google), and a display name (which you
+                  choose, or which is randomly generated).
+                </li>
+                <li>
+                  <strong className="text-foreground">Garage data:</strong>{" "}
+                  vehicles, setup sheets, setup templates, notes, graph
+                  preferences and your custom tracks/courses. Notes and names are
+                  free text — anything you type there is stored as written.
+                </li>
+                <li>
+                  <strong className="text-foreground">Session logs:</strong>{" "}
+                  only the telemetry files you explicitly choose to sync. These
+                  contain{" "}
+                  <strong className="text-foreground">
+                    precise GPS location traces
+                  </strong>{" "}
+                  of where and when you drove.
+                </li>
+              </ul>
+              <p className="mt-2">
+                Our legal basis for this processing is performance of our
+                agreement with you — we cannot provide sync without storing your
+                data. You can delete cloud copies at any time (see “Your Rights”).
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-base font-semibold text-foreground mb-2">
+                Payments &amp; Subscriptions
+              </h2>
+              <p>
+                Paid storage plans are processed by{" "}
+                <strong className="text-foreground">Stripe</strong>. We do not
+                receive or store your full card number — Stripe handles card data
+                directly. We receive only what we need to manage your
+                subscription (e.g. plan, status, and a Stripe customer/
+                subscription identifier). Stripe’s handling of your payment data
+                is governed by{" "}
+                <a
+                  href="https://stripe.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground underline hover:no-underline"
+                >
+                  Stripe’s Privacy Policy
+                </a>
+                .
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-base font-semibold text-foreground mb-2">
+                AI Coaching
+              </h2>
+              <p>
+                If you use the optional AI coaching feature, the telemetry needed
+                to generate feedback (such as GPS traces and lap data, and any
+                driver name attached to the session) is sent to a{" "}
+                <strong className="text-foreground">
+                  third-party AI provider
+                </strong>{" "}
+                to be processed. We send this only when you choose to run the
+                coach. AI output is generated automatically and may be inaccurate
+                — it is informational only and must not be relied on for safety
+                decisions (see our{" "}
+                <Link to="/terms" className="text-foreground underline hover:no-underline">
+                  Terms of Service
+                </Link>
+                ).
+              </p>
+            </section>
+          </>
+        )}
+
+        {(enableCloud || enableAdmin) && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              Security &amp; Abuse Prevention (IP logging)
+            </h2>
+            <p>
+              To prevent spam and abuse, we briefly log the{" "}
+              <strong className="text-foreground">IP address</strong> associated
+              with certain actions — {enableCloud ? "sign-in attempts, " : ""}
+              contact-form messages
+              {enableAdmin ? ", and community track/course submissions" : ""}.
+              This is used solely for rate-limiting and blocking abuse (our
+              legitimate interest in keeping the service available) and is not
+              used to track you or shared with advertisers.
+            </p>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            Contact Form
+          </h2>
+          <p>
+            If you send us a message through the in-app contact form, we receive
+            your message, the category you select, and — only if you provide it —
+            your email address so we can reply. Providing an email is optional.
+          </p>
+        </section>
+
+        {enableCloud && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              Third-Party Services (Sub-processors)
+            </h2>
+            <p className="mb-2">
+              When you use the optional online features, the following providers
+              process data on our behalf:
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                <strong className="text-foreground">Supabase</strong> — account,
+                database and file storage for cloud sync.
+              </li>
+              <li>
+                <strong className="text-foreground">Stripe</strong> — subscription
+                payments.
+              </li>
+              <li>
+                <strong className="text-foreground">Google</strong> — only if you
+                choose “Sign in with Google”.
+              </li>
+              <li>
+                <strong className="text-foreground">Cloudflare Turnstile</strong>{" "}
+                — bot/abuse protection on sign-up.
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  The AI coaching provider
+                </strong>{" "}
+                — only if you use AI coaching.
+              </li>
+            </ul>
+            <p className="mt-2">
+              Map tiles (CartoDB, Esri) and weather (OpenWeatherMap) are loaded
+              from third parties when you view a map or fetch weather; like any
+              web request, these receive your IP address and the data needed to
+              serve the request.
+            </p>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            Cookies &amp; Local Storage
+          </h2>
+          <p>
+            We do not use advertising or tracking cookies.
+            {enableCloud
+              ? " If you sign in, we store a session/authentication token in your browser so you stay logged in — this is strictly necessary for the account feature to work."
+              : ""}{" "}
+            All other storage (IndexedDB and localStorage) holds your own app data
+            on your device.
+          </p>
+        </section>
+
+        {enableCloud && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              Your Rights
+            </h2>
+            <p className="mb-2">
+              If you have an account, you have rights over your data, including
+              under the EU/UK GDPR and similar laws (e.g. California’s CCPA/CPRA):
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                <strong className="text-foreground">Access &amp; portability:</strong>{" "}
+                your synced data is your own telemetry — you can pull and download
+                it from within the app at any time.
+              </li>
+              <li>
+                <strong className="text-foreground">Rectification:</strong> edit
+                your display name, notes and other data directly in the app.
+              </li>
+              <li>
+                <strong className="text-foreground">Erasure:</strong> delete cloud
+                copies of your files and garage data from within the app, or
+                request full deletion of your account and all associated data via
+                the contact form.
+              </li>
+              <li>
+                <strong className="text-foreground">Objection / restriction:</strong>{" "}
+                you can stop using online features at any time and continue using
+                the app fully offline.
+              </li>
+            </ul>
+            <p className="mt-2">
+              To exercise any right we can’t fully self-serve in the app, contact
+              us through the in-app contact form. You also have the right to
+              complain to your local data-protection authority.
+            </p>
+          </section>
+        )}
+
+        {enableCloud && (
+          <>
+            <section>
+              <h2 className="text-base font-semibold text-foreground mb-2">
+                Data Retention
+              </h2>
+              <p>
+                We keep your account and synced data for as long as your account
+                exists. When you delete data or your account, we remove it from
+                active storage. Abuse-prevention records (such as IP-based
+                rate-limit data) are kept only as long as needed for that purpose
+                and then cleared.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-base font-semibold text-foreground mb-2">
+                International Transfers
+              </h2>
+              <p>
+                Our providers may process data in countries outside your own,
+                including the United States. Where required, transfers are covered
+                by appropriate safeguards (such as the providers’ Standard
+                Contractual Clauses).
+              </p>
+            </section>
+          </>
+        )}
+
+        {enableCloud && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              Children
+            </h2>
+            <p>
+              Online accounts are intended for users{" "}
+              <strong className="text-foreground">16 or older</strong>. If you are
+              under 16, please use the app in its offline mode only and do not
+              create an account. If you believe a child under 16 has created an
+              account, contact us and we will remove it.
+            </p>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            Self-Hosting
+          </h2>
+          <p>
+            HackTheTrack is open source. If someone else runs their own instance,
+            they — not us — control any data collected by that instance, and this
+            policy describes only the official hosted service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            Clearing Your Data
+          </h2>
+          <p>
+            Because local data lives in your browser, you can remove it any time
+            by clearing this site’s data (Settings → Privacy → Clear browsing data
+            → Site data) or by deleting the IndexedDB database and localStorage
+            entries via your browser’s developer tools.
+            {enableCloud
+              ? " Cloud data is removed separately using the in-app delete controls or by requesting account deletion."
+              : ""}
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            Changes &amp; Contact
+          </h2>
+          <p>
+            We may update this policy as the app evolves; material changes will be
+            reflected by the “Last updated” date below. Questions or requests can
+            be sent through the in-app contact form.
+          </p>
+        </section>
+      </div>
+
+      <p className="mt-10 text-xs text-muted-foreground/60">
+        Last updated: May 2026
+      </p>
     </div>
-
-    <p className="mt-10 text-xs text-muted-foreground/60">Last updated: February 2026</p>
-  </div>
   );
 };
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -109,6 +109,13 @@ export default function Register() {
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading ? 'Please wait...' : 'Create Account'}
             </Button>
+            <p className="text-xs text-muted-foreground text-center">
+              You must be 16 or older to create an account. By continuing you
+              agree to our{' '}
+              <Link to="/terms" className="text-primary hover:underline">Terms of Service</Link>{' '}
+              and{' '}
+              <Link to="/privacy" className="text-primary hover:underline">Privacy Policy</Link>.
+            </p>
           </form>
 
           <p className="text-sm text-muted-foreground text-center">

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,249 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { useDocumentHead } from "@/hooks/useDocumentHead";
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+// NOTE FOR THE OPERATOR: drafted Terms, not legal advice. Before relying on
+// these for the hosted service, confirm: the operating entity's legal name, a
+// contact email, and the governing-law jurisdiction (left as a placeholder
+// below). Have them reviewed by a lawyer for your jurisdiction.
+
+const Terms = () => {
+  useDocumentHead({
+    title: "Terms of Service — HackTheTrack",
+    description:
+      "The terms for using HackTheTrack: offline-first telemetry app with optional cloud sync, paid storage plans, and AI coaching.",
+    canonical: "https://hackthetrack.net/terms",
+  });
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        <span className="text-sm">Back to app</span>
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">Terms of Service</h1>
+
+      <div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            1. Acceptance
+          </h2>
+          <p>
+            By using HackTheTrack (“the Service”), you agree to these Terms and to
+            our{" "}
+            <Link to="/privacy" className="text-foreground underline hover:no-underline">
+              Privacy Policy
+            </Link>
+            . If you do not agree, please do not use the Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            2. The Service
+          </h2>
+          <p>
+            HackTheTrack is an offline-first motorsport telemetry viewer. The core
+            app runs entirely in your browser and stores your data on your device.
+            {enableCloud
+              ? " Optional online features — creating an account, cloud sync, paid storage plans, and AI coaching — are available but are not required to use the core app."
+              : ""}
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            3. Eligibility
+          </h2>
+          <p>
+            The offline app is available to anyone.{" "}
+            {enableCloud
+              ? "You must be at least 16 years old to create an account or use any online feature. If you are under 16, you may use the app in offline mode only and must not create an account."
+              : "There is no account in this build."}
+          </p>
+        </section>
+
+        {enableCloud && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              4. Accounts &amp; Security
+            </h2>
+            <p>
+              You are responsible for keeping your account credentials secure and
+              for activity under your account. Provide accurate information when
+              registering, and let us know if you suspect unauthorized access.
+            </p>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            5. Acceptable Use
+          </h2>
+          <p>
+            Don’t misuse the Service: no unlawful activity, no attempts to break,
+            overload, or gain unauthorized access to the Service or other users’
+            data, no uploading of content you don’t have the right to use, and no
+            using the Service to store or transmit malicious or infringing
+            material.
+          </p>
+        </section>
+
+        {enableCloud && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              6. Subscriptions &amp; Billing
+            </h2>
+            <p className="mb-2">
+              Paid storage plans are billed through Stripe on a recurring basis
+              (e.g. monthly) until cancelled. By subscribing, you authorize the
+              recurring charge for your chosen plan.
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                You can cancel at any time from the billing portal; cancellation
+                stops future renewals and your plan remains active until the end
+                of the current paid period.
+              </li>
+              <li>
+                Prices and plan limits are shown in-app and may change with notice;
+                changes apply from your next billing period.
+              </li>
+              <li>
+                Where required by law (for example, EU/UK consumer withdrawal
+                rights), you may be entitled to a refund — contact us and we’ll
+                honor your statutory rights.
+              </li>
+              <li>
+                If a payment fails or a subscription lapses, online storage limits
+                revert to the free tier; your data on your device is unaffected.
+              </li>
+            </ul>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            7. Your Content &amp; Data
+          </h2>
+          <p>
+            Your telemetry, notes, and other content remain yours. We don’t claim
+            ownership of it.
+            {enableCloud
+              ? " If you use cloud sync, you grant us the limited permission needed to store, transmit, and process your content solely to provide the Service to you (for example, to sync it across your devices or generate AI coaching when you request it)."
+              : ""}
+          </p>
+        </section>
+
+        {enableCloud && (
+          <section>
+            <h2 className="text-base font-semibold text-foreground mb-2">
+              8. AI Features — No Professional or Safety Advice
+            </h2>
+            <p>
+              AI coaching is generated automatically and may be incomplete or
+              wrong. It is provided for informational and entertainment purposes
+              only. It is{" "}
+              <strong className="text-foreground">not</strong> professional
+              coaching, engineering, or safety advice, and you must not rely on it
+              for decisions affecting safety on or off the track. You are solely
+              responsible for how you drive. Using the AI feature sends the
+              necessary session data to a third-party AI provider for processing
+              (see the{" "}
+              <Link to="/privacy" className="text-foreground underline hover:no-underline">
+                Privacy Policy
+              </Link>
+              ).
+            </p>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            9. Open Source &amp; Self-Hosting
+          </h2>
+          <p>
+            HackTheTrack’s source code is open source and licensed separately
+            under its repository license; these Terms govern your use of the{" "}
+            <em>official hosted Service</em>, not the code itself. If you run your
+            own instance, you are responsible for it and for any data your
+            instance collects, and you must provide your own terms and privacy
+            notice to your users.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            10. Disclaimer of Warranties
+          </h2>
+          <p>
+            The Service is provided{" "}
+            <strong className="text-foreground">“as is” and “as available,”</strong>{" "}
+            without warranties of any kind, whether express or implied, including
+            fitness for a particular purpose, accuracy of telemetry or timing, and
+            uninterrupted availability. Telemetry, lap times, and derived data may
+            contain errors; do not rely on them for competition scoring or safety.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            11. Limitation of Liability
+          </h2>
+          <p>
+            To the maximum extent permitted by law, HackTheTrack and its operators
+            are not liable for any indirect, incidental, or consequential damages,
+            or for loss of data, arising from your use of the Service. Nothing in
+            these Terms limits liability that cannot be limited by law. Keep your
+            own backups of important data.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            12. Termination
+          </h2>
+          <p>
+            You may stop using the Service at any time
+            {enableCloud ? " and delete your account" : ""}. We may suspend or
+            terminate access that violates these Terms or harms the Service or its
+            users.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            13. Changes to These Terms
+          </h2>
+          <p>
+            We may update these Terms as the Service evolves. Material changes will
+            be reflected by the “Last updated” date below; continuing to use the
+            Service after changes means you accept them.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
+            14. Governing Law &amp; Contact
+          </h2>
+          <p>
+            These Terms are governed by the laws of [JURISDICTION TO BE
+            CONFIRMED], without regard to conflict-of-laws rules. Questions about
+            these Terms can be sent through the in-app contact form.
+          </p>
+        </section>
+      </div>
+
+      <p className="mt-10 text-xs text-muted-foreground/60">
+        Last updated: May 2026
+      </p>
+    </div>
+  );
+};
+
+export default Terms;


### PR DESCRIPTION
The old privacy policy claimed nothing ever leaves the device and no account is needed — both false once cloud sync, Stripe billing, and AI coaching are enabled. Rewrote it to accurately describe each online feature (what's collected, why, sub-processors, retention, GDPR/CCPA rights, 16+ age policy, self-hosting), and added a Terms of Service page (as-is/liability disclaimers, subscription billing terms, AI "not safety advice" disclaimer). Both pages adapt to the build flags so offline-only deployments show the simpler, accurate text.

Surfaced via a /terms route, a footer link, and a passive 16+ / agreement notice on sign-up. Content/links only — no data-flow changes; account deletion, IP retention TTLs, and an AI opt-in gate are deferred.

Placeholders the operator must confirm: governing-law jurisdiction, operating entity name, contact email, and the specific AI provider.

https://claude.ai/code/session_017fmZ5GDJkNec7sxGWt343G

