### PR TITLE
GDPR: self-service data export, account deletion & IP retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **GDPR self-service data tools** (Profile → **Data & privacy**, cloud builds):
+  - **Download my data** — exports everything we hold about you as a single ZIP:
+    your account data (profile, subscription, roles, synced garage records,
+    contact messages, synced log files) plus the data stored locally in your
+    browser (settings, garage stores, local session files). Backed by the new
+    `export-account-data` edge function.
+  - **Delete my account** — full self-service erasure. Confirmed by an emailed
+    one-time code (guards against a hijacked session), then **scheduled 7 days
+    out** and cancellable during that window, after which the account, its
+    Storage files and all associated rows are permanently erased. Backed by the
+    `request-account-deletion` and (cron-driven) `process-account-deletions`
+    edge functions.
+- **Automatic IP-address retention (TTL):** a daily job nulls the submitter IP on
+  contact messages and community submissions **90 days** after they're received,
+  and clears expired IP bans and stale sign-in rate-limit records — so
+  abuse-prevention data is minimised even without traffic to trigger the existing
+  reactive cleanup.
+- **Banned-IP expiry in the admin panel:** banning an IP now takes a selectable
+  duration (1 / 7 / 30 / 90 / 365 days or permanent), defaulting to **90 days**;
+  expired bans are purged automatically.
 - **Terms of Service page** (`/terms`) and a rewritten **Privacy Policy** that
   now accurately reflect the optional online features — accounts, cloud sync,
   Stripe-billed plans, and AI coaching — instead of the old "nothing ever leaves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Storage files and all associated rows are permanently erased. Backed by the
     `request-account-deletion` and (cron-driven) `process-account-deletions`
     edge functions.
-- **Automatic IP-address retention (TTL):** a daily job nulls the submitter IP on
+- **Automatic data-retention (TTL):** a daily job nulls the submitter IP on
   contact messages and community submissions **90 days** after they're received,
-  and clears expired IP bans and stale sign-in rate-limit records — so
-  abuse-prevention data is minimised even without traffic to trigger the existing
-  reactive cleanup.
+  then deletes the rows in full after **1 year** (contact messages entirely;
+  community submissions once they've been reviewed — pending ones are kept for
+  moderation), and clears expired IP bans and stale sign-in rate-limit records —
+  so abuse-prevention and contact data are minimised even without traffic to
+  trigger the existing reactive cleanup.
+- **Age confirmation at sign-up:** account creation (email and Google) now
+  requires ticking a checkbox confirming you are **16 or older**, alongside the
+  existing Terms/Privacy agreement.
 - **Banned-IP expiry in the admin panel:** banning an IP now takes a selectable
   duration (1 / 7 / 30 / 90 / 365 days or permanent), defaulting to **90 days**;
   expired bans are purged automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,45 @@ stays "Coming soon" — graceful pre-config state); cloud-sync's Profile-tab
 subscribed. **Stripe setup (create Products/Prices, set `stripe_price_id`, secrets,
 webhook) is still operator config — see README.**
 
+### Data Rights & Retention / GDPR (`..._gdpr_compliance.sql` + 3 edge functions)
+
+Self-service data access, portability and erasure, plus automatic IP
+minimisation. All account-gated (cloud-only) except the IP purge, which is
+backend cron.
+
+| Object | Type | Notes |
+|--------|------|-------|
+| `account_deletions` | table | `(user_id PK→auth.users, requested_at, scheduled_for)`. RLS: owner can **select** + **delete** (cancel); **no insert policy** — only the service role schedules, so the 7-day window can't be shortened client-side. |
+| `purge_expired_personal_data()` | fn (SECURITY DEFINER) | Nulls `submitted_by_ip` on `submissions`/`messages` older than **90 days**; deletes expired `banned_ips` + stale `login_attempts`. Run daily by `pg_cron`. |
+| `due_account_deletions()` | fn (SECURITY DEFINER) | User ids whose `scheduled_for <= now()`. Read by the deletion worker. |
+
+Edge functions (all `verify_jwt = false`; the two user-facing ones verify the
+JWT manually):
+
+- `export-account-data` — auth user → service-role gather of everything we hold
+  (profile, subscription, roles, `sync_records`, contact `messages` by email,
+  pending deletion). Returns JSON; the client adds cloud-file blobs + all local
+  browser data and zips it.
+- `request-account-deletion` — auth user → inserts an `account_deletions` row
+  `scheduled_for = now()+7d` (idempotent; never shortens an in-flight request).
+- `process-account-deletions` — **cron-only** (`x-cron-secret` must equal
+  `DELETION_CRON_SECRET`). For each due user: removes their `user-files` Storage
+  objects, then `auth.admin.deleteUser` (cascades profiles/sync_records/
+  subscription/roles/account_deletions via FKs).
+
+Scheduling: the migration always schedules the IP purge (pure SQL). The deletion
+worker is auto-wired via `pg_cron` + `pg_net` **only if** a Vault secret
+`deletion_cron_secret` exists (matching `DELETION_CRON_SECRET` on the function);
+otherwise the migration raises a NOTICE and it's a documented operator step.
+
+**Client** (cloud-sync plugin): `exportManifest.ts` (pure, unit-tested — assembles
+the zip's text entries), `accountExport.ts` (I/O orchestrator: edge fn + local
+stores + blob download → JSZip), `accountDeletion.ts` (email-OTP gate via
+`signInWithOtp`/`verifyOtp` + schedule/cancel), and `DataPrivacyPanel.tsx` (the
+Profile-tab "Data & privacy" panel). Admin `BannedIpsTab` exposes a ban TTL
+(defaults to 90 days). Privacy policy "Your Rights" / "Data Retention" describe
+all of the above.
+
 ---
 
 ## Course Layouts (Drawing Feature)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,7 +553,7 @@ backend cron.
 | Object | Type | Notes |
 |--------|------|-------|
 | `account_deletions` | table | `(user_id PK→auth.users, requested_at, scheduled_for)`. RLS: owner can **select** + **delete** (cancel); **no insert policy** — only the service role schedules, so the 7-day window can't be shortened client-side. |
-| `purge_expired_personal_data()` | fn (SECURITY DEFINER) | Nulls `submitted_by_ip` on `submissions`/`messages` older than **90 days**; deletes expired `banned_ips` + stale `login_attempts`. Run daily by `pg_cron`. |
+| `purge_expired_personal_data()` | fn (SECURITY DEFINER) | (a) Nulls `submitted_by_ip` on `submissions`/`messages` older than **90 days**; (b) deletes `messages` and *reviewed* `submissions` older than **1 year** (pending submissions kept for moderation); deletes expired `banned_ips` + stale `login_attempts`. Run daily by `pg_cron`. |
 | `due_account_deletions()` | fn (SECURITY DEFINER) | User ids whose `scheduled_for <= now()`. Read by the deletion worker. |
 
 Edge functions (all `verify_jwt = false`; the two user-facing ones verify the

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The app includes an optional admin system for managing a community track databas
 | `TURNSTILE_SECRET_KEY` | No | Cloudflare Turnstile secret key (edge function secret — `???`) |
 | `STRIPE_SECRET_KEY` | No (required for paid tiers) | Stripe secret key used by the `create-checkout-session`, `stripe-webhook`, and `create-portal-session` edge functions (edge function secret — `???`) |
 | `STRIPE_WEBHOOK_SECRET` | No (required for paid tiers) | Signing secret for the `stripe-webhook` endpoint, from the Stripe dashboard webhook config (edge function secret — `???`) |
+| `DELETION_CRON_SECRET` | No (required for scheduled account deletion) | Shared secret the `process-account-deletions` edge function requires in the `x-cron-secret` header. Must match the Vault secret `deletion_cron_secret` that the daily pg_cron job sends (edge function secret — `???`) |
 | `DOVE_PLUGIN_PACKAGES` | No | Build-time: comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`, the public AI coach) when set |
 
 > **Note:** `TURNSTILE_SECRET_KEY` is a server-side secret stored in Lovable Cloud, not a `VITE_` client variable. If not set, Turnstile verification is skipped.
@@ -146,6 +147,17 @@ The admin system uses Lovable Cloud (Supabase) for the database. The schema is c
 - **user_roles** — Admin/user role assignments (uses `has_role()` security definer)
 - **sync_records** — Per-user cloud-sync documents (files/garage data), RLS-scoped to the owner
 - **user-files** (Storage bucket) — Private per-user session file blobs for cloud sync
+- **account_deletions** — Pending self-service account-deletion requests (7-day, reversible grace window)
+
+> **Data retention (GDPR):** a daily `pg_cron` job runs
+> `purge_expired_personal_data()`, which nulls the submitter IP on `submissions`
+> and `messages` 90 days after they were received and deletes expired
+> `banned_ips` / stale `login_attempts`. Account deletion is scheduled 7 days out
+> (cancellable); the `process-account-deletions` worker then removes the user's
+> Storage objects and auth row. To auto-schedule that worker, add a Supabase
+> **Vault** secret named `deletion_cron_secret` and set the matching
+> `DELETION_CRON_SECRET` env on the function, then re-run the GDPR migration —
+> it wires the daily `pg_cron` + `pg_net` job for you.
 
 > Cloud sync is independent of the admin system — it only needs a signed-in user
 > account, not the admin role. It's an online-only, opt-in feature; the core app
@@ -168,7 +180,7 @@ src/lib/db/
 - **Tracks CRUD** — Add, edit, enable/disable, delete tracks (with short names)
 - **Courses CRUD** — Manage courses per track with coordinate editing
 - **Tools** — Build `tracks.json` from DB, download tracks ZIP, import JSON to rebuild DB, export/import course drawings
-- **Banned IPs** — View and manage banned IP addresses
+- **Banned IPs** — View and manage banned IP addresses, with a selectable expiry (TTL; defaults to 90 days, expired bans auto-purged)
 
 ### Edge Functions
 
@@ -177,6 +189,9 @@ src/lib/db/
 | `submit-track` | Public endpoint for track submissions (with IP ban check) |
 | `admin-build-zip` | Admin-only: generates per-track JSON files |
 | `check-login-rate` | Rate limiting for login attempts |
+| `export-account-data` | Authenticated: returns all server-side data for the caller (GDPR access/portability) |
+| `request-account-deletion` | Authenticated: schedules the caller's account for deletion 7 days out |
+| `process-account-deletions` | Cron-only (`x-cron-secret`): erases Storage objects + auth rows for accounts past their grace window |
 
 ### Track Short Names
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ The admin system uses Lovable Cloud (Supabase) for the database. The schema is c
 
 > **Data retention (GDPR):** a daily `pg_cron` job runs
 > `purge_expired_personal_data()`, which nulls the submitter IP on `submissions`
-> and `messages` 90 days after they were received and deletes expired
-> `banned_ips` / stale `login_attempts`. Account deletion is scheduled 7 days out
+> and `messages` 90 days after they were received, deletes the rows entirely
+> after 1 year (all `messages`; `submissions` only once reviewed — pending ones
+> are kept for moderation), and deletes expired `banned_ips` / stale
+> `login_attempts`. Account deletion is scheduled 7 days out
 > (cancellable); the `process-account-deletions` worker then removes the user's
 > Storage objects and auth row. To auto-schedule that worker, add a Supabase
 > **Vault** secret named `deletion_cron_secret` and set the matching

--- a/src/components/admin/BannedIpsTab.tsx
+++ b/src/components/admin/BannedIpsTab.tsx
@@ -13,6 +13,8 @@ export function BannedIpsTab() {
   const [showAdd, setShowAdd] = useState(false);
   const [newIp, setNewIp] = useState('');
   const [newReason, setNewReason] = useState('');
+  // Default to a 90-day TTL (data minimisation) rather than a permanent ban.
+  const [newDurationDays, setNewDurationDays] = useState('90');
 
   const db = getDatabase();
 
@@ -31,8 +33,12 @@ export function BannedIpsTab() {
   const handleBan = async () => {
     if (!newIp.trim()) return;
     try {
-      await db.banIp(newIp.trim(), newReason.trim() || undefined);
-      setNewIp(''); setNewReason(''); setShowAdd(false);
+      const days = Number(newDurationDays);
+      const expiresAt = days > 0
+        ? new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+        : undefined;
+      await db.banIp(newIp.trim(), newReason.trim() || undefined, expiresAt);
+      setNewIp(''); setNewReason(''); setNewDurationDays('90'); setShowAdd(false);
       toast({ title: 'IP banned' });
       load();
     } catch (e: unknown) {
@@ -66,6 +72,21 @@ export function BannedIpsTab() {
           <div>
             <Label>Reason (optional)</Label>
             <Input value={newReason} onChange={e => setNewReason(e.target.value)} placeholder="Spam submissions" />
+          </div>
+          <div>
+            <Label>Expires after</Label>
+            <select
+              value={newDurationDays}
+              onChange={e => setNewDurationDays(e.target.value)}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <option value="1">1 day</option>
+              <option value="7">7 days</option>
+              <option value="30">30 days</option>
+              <option value="90">90 days</option>
+              <option value="365">1 year</option>
+              <option value="0">Permanent</option>
+            </select>
           </div>
           <Button size="sm" onClick={handleBan}>Ban</Button>
         </div>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -261,8 +261,10 @@ const Privacy = () => {
             <ul className="list-disc pl-5 space-y-1">
               <li>
                 <strong className="text-foreground">Access &amp; portability:</strong>{" "}
-                your synced data is your own telemetry — you can pull and download
-                it from within the app at any time.
+                download a complete copy of everything we hold — your account data
+                plus the data stored in this browser — as a ZIP from{" "}
+                <strong className="text-foreground">Profile → Data &amp; privacy</strong>
+                . Synced files can also be pulled back to any device at any time.
               </li>
               <li>
                 <strong className="text-foreground">Rectification:</strong> edit
@@ -270,9 +272,15 @@ const Privacy = () => {
               </li>
               <li>
                 <strong className="text-foreground">Erasure:</strong> delete cloud
-                copies of your files and garage data from within the app, or
-                request full deletion of your account and all associated data via
-                the contact form.
+                copies of individual files and garage data from within the app, or
+                delete your <strong className="text-foreground">entire account</strong>{" "}
+                and all associated data yourself from{" "}
+                <strong className="text-foreground">Profile → Data &amp; privacy</strong>
+                . For your protection (e.g. against a hijacked session), account
+                deletion is confirmed by an emailed code and then scheduled{" "}
+                <strong className="text-foreground">7 days</strong> out — you can
+                cancel any time before then, after which all your data is
+                permanently erased.
               </li>
               <li>
                 <strong className="text-foreground">Objection / restriction:</strong>{" "}
@@ -297,9 +305,14 @@ const Privacy = () => {
               <p>
                 We keep your account and synced data for as long as your account
                 exists. When you delete data or your account, we remove it from
-                active storage. Abuse-prevention records (such as IP-based
-                rate-limit data) are kept only as long as needed for that purpose
-                and then cleared.
+                active storage; a deleted account and all its data are permanently
+                erased 7 days after you request deletion (the cancellable grace
+                window described under “Your Rights”). Abuse-prevention IP
+                addresses are minimised automatically: the IP attached to a
+                contact-form message or community submission is erased{" "}
+                <strong className="text-foreground">90 days</strong> after it was
+                received, and expired IP bans and sign-in rate-limit records are
+                cleared daily.
               </p>
             </section>
 
@@ -353,7 +366,7 @@ const Privacy = () => {
             → Site data) or by deleting the IndexedDB database and localStorage
             entries via your browser’s developer tools.
             {enableCloud
-              ? " Cloud data is removed separately using the in-app delete controls or by requesting account deletion."
+              ? " Cloud data is removed separately using the in-app delete controls, or all at once by deleting your account from Profile → Data & privacy."
               : ""}
           </p>
         </section>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -307,12 +307,14 @@ const Privacy = () => {
                 exists. When you delete data or your account, we remove it from
                 active storage; a deleted account and all its data are permanently
                 erased 7 days after you request deletion (the cancellable grace
-                window described under “Your Rights”). Abuse-prevention IP
-                addresses are minimised automatically: the IP attached to a
-                contact-form message or community submission is erased{" "}
+                window described under “Your Rights”). We also minimise
+                abuse-prevention and contact data automatically: the IP attached
+                to a contact-form message or community submission is erased{" "}
                 <strong className="text-foreground">90 days</strong> after it was
-                received, and expired IP bans and sign-in rate-limit records are
-                cleared daily.
+                received; contact-form messages and reviewed community submissions
+                are then deleted in full after{" "}
+                <strong className="text-foreground">1 year</strong>; and expired
+                IP bans and sign-in rate-limit records are cleared daily.
               </p>
             </section>
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -23,6 +23,7 @@ export default function Register() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [confirmAge, setConfirmAge] = useState(false);
   const { signUp, signInWithGoogle } = useAuth();
   const navigate = useNavigate();
 
@@ -48,6 +49,10 @@ export default function Register() {
       toast({ title: 'Please complete the captcha', variant: 'destructive' });
       return;
     }
+    if (!confirmAge) {
+      toast({ title: 'Please confirm you are 16 or older', variant: 'destructive' });
+      return;
+    }
     setIsLoading(true);
     const { error } = await signUp(email, password, displayName, captchaToken ?? undefined);
     setIsLoading(false);
@@ -60,6 +65,10 @@ export default function Register() {
   };
 
   const handleGoogle = async () => {
+    if (!confirmAge) {
+      toast({ title: 'Please confirm you are 16 or older', variant: 'destructive' });
+      return;
+    }
     setIsLoading(true);
     const { error } = await signInWithGoogle();
     if (error) {
@@ -108,16 +117,24 @@ export default function Register() {
               <Input id="confirmPassword" type="password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} required />
             </div>
             <Turnstile onToken={setCaptchaToken} className="flex justify-center" />
-            <Button type="submit" className="w-full" disabled={isLoading}>
+            <label htmlFor="confirmAge" className="flex items-start gap-2 text-xs text-muted-foreground">
+              <input
+                id="confirmAge"
+                type="checkbox"
+                checked={confirmAge}
+                onChange={e => setConfirmAge(e.target.checked)}
+                className="mt-0.5 h-4 w-4 shrink-0 rounded border-input accent-primary"
+              />
+              <span>
+                I confirm I am 16 or older, and I agree to the{' '}
+                <Link to="/terms" className="text-primary hover:underline">Terms of Service</Link>{' '}
+                and{' '}
+                <Link to="/privacy" className="text-primary hover:underline">Privacy Policy</Link>.
+              </span>
+            </label>
+            <Button type="submit" className="w-full" disabled={isLoading || !confirmAge}>
               {isLoading ? 'Please wait...' : 'Create Account'}
             </Button>
-            <p className="text-xs text-muted-foreground text-center">
-              You must be 16 or older to create an account. By continuing you
-              agree to our{' '}
-              <Link to="/terms" className="text-primary hover:underline">Terms of Service</Link>{' '}
-              and{' '}
-              <Link to="/privacy" className="text-primary hover:underline">Privacy Policy</Link>.
-            </p>
           </form>
 
           <p className="text-sm text-muted-foreground text-center">

--- a/src/plugins/cloud-sync/DataPrivacyPanel.tsx
+++ b/src/plugins/cloud-sync/DataPrivacyPanel.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, Download, Loader2, ShieldX, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import { downloadAccountExport } from "./accountExport";
+import {
+  cancelAccountDeletion,
+  getPendingDeletion,
+  scheduleAccountDeletion,
+  sendDeletionCode,
+  verifyDeletionCode,
+  type PendingDeletion,
+} from "./accountDeletion";
+
+type DeleteStep = "idle" | "code" | "working";
+
+// Profile-tab panel for GDPR self-service: export everything as a ZIP, and a
+// scheduled (7-day, reversible) account deletion gated by an emailed code.
+export default function DataPrivacyPanel(_props: PluginPanelProps) {
+  const { user } = useAuth();
+  const online = useOnlineStatus();
+  const email = user?.email ?? "";
+
+  const [exporting, setExporting] = useState(false);
+  const [exportPhase, setExportPhase] = useState("");
+  const [pending, setPending] = useState<PendingDeletion | null>(null);
+
+  const refreshPending = useCallback(async () => {
+    if (!user) return setPending(null);
+    try {
+      setPending(await getPendingDeletion(user.id));
+    } catch {
+      /* non-fatal: leave as-is */
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refreshPending();
+  }, [refreshPending]);
+
+  const runExport = async () => {
+    setExporting(true);
+    try {
+      await downloadAccountExport((p) => setExportPhase(p.phase));
+      toast.success("Your data export has been downloaded.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Export failed.");
+    } finally {
+      setExporting(false);
+      setExportPhase("");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Your data</p>
+        <p className="text-xs text-muted-foreground">
+          Download a copy of everything we hold about you — {user ? "your account data plus " : ""}
+          the data stored in this browser — as a ZIP. This is your right to access and portability.
+        </p>
+        <Button onClick={() => void runExport()} disabled={exporting} variant="outline">
+          {exporting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Download className="mr-1.5 h-4 w-4" />}
+          {exporting ? (exportPhase || "Preparing…") : "Download my data"}
+        </Button>
+      </section>
+
+      {user && (
+        <section className="space-y-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Delete account</p>
+          {pending ? (
+            <PendingNotice pending={pending} userId={user.id} online={online} onChange={refreshPending} />
+          ) : (
+            <DeleteFlow email={email} online={online} onScheduled={refreshPending} />
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function PendingNotice({
+  pending,
+  userId,
+  online,
+  onChange,
+}: {
+  pending: PendingDeletion;
+  userId: string;
+  online: boolean;
+  onChange: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const when = new Date(pending.scheduled_for).toLocaleString();
+
+  const cancel = async () => {
+    setBusy(true);
+    try {
+      await cancelAccountDeletion(userId);
+      toast.success("Account deletion cancelled.");
+      await onChange();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't cancel deletion.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/10 p-3">
+      <div className="flex items-start gap-2 text-sm text-destructive">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>
+          Your account and all its data are scheduled for permanent deletion on{" "}
+          <strong>{when}</strong>. You can cancel any time before then.
+        </span>
+      </div>
+      <Button variant="outline" size="sm" disabled={busy || !online} onClick={() => void cancel()}>
+        {busy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+        Cancel deletion
+      </Button>
+    </div>
+  );
+}
+
+function DeleteFlow({
+  email,
+  online,
+  onScheduled,
+}: {
+  email: string;
+  online: boolean;
+  onScheduled: () => Promise<void>;
+}) {
+  const [step, setStep] = useState<DeleteStep>("idle");
+  const [code, setCode] = useState("");
+
+  const startCode = async () => {
+    setStep("working");
+    try {
+      await sendDeletionCode(email);
+      toast.success(`We emailed a confirmation code to ${email}.`);
+      setStep("code");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't send the code.");
+      setStep("idle");
+    }
+  };
+
+  const confirm = async () => {
+    setStep("working");
+    try {
+      await verifyDeletionCode(email, code);
+      const result = await scheduleAccountDeletion();
+      toast.success(`Deletion scheduled for ${new Date(result.scheduled_for).toLocaleDateString()}.`);
+      setCode("");
+      setStep("idle");
+      await onScheduled();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "That code didn't work — try again.");
+      setStep("code");
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Deletes your account and everything stored under it (profile, synced files, garage data,
+        subscription record). To protect against a hijacked session, we email you a code first and
+        then wait <strong>7 days</strong> before erasing anything — you can cancel during that time.
+        Data stored only in this browser is not removed by this; clear it from your browser settings.
+      </p>
+
+      {step === "idle" && (
+        <Button variant="destructive" size="sm" disabled={!online} onClick={() => void startCode()}>
+          <Trash2 className="mr-1.5 h-4 w-4" /> Delete my account
+        </Button>
+      )}
+
+      {step === "working" && (
+        <Button variant="destructive" size="sm" disabled>
+          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> Working…
+        </Button>
+      )}
+
+      {step === "code" && (
+        <div className="space-y-2">
+          <Input
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="6-digit code"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={10}
+            className="h-9 w-40"
+          />
+          <div className="flex gap-2">
+            <Button variant="destructive" size="sm" disabled={!code.trim() || !online} onClick={() => void confirm()}>
+              <ShieldX className="mr-1.5 h-4 w-4" /> Confirm deletion
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => { setCode(""); setStep("idle"); }}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!online && (
+        <p className="text-xs text-muted-foreground">You're offline — account deletion needs a connection.</p>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/accountDeletion.ts
+++ b/src/plugins/cloud-sync/accountDeletion.ts
@@ -1,0 +1,60 @@
+// Client side of self-service account deletion.
+//
+// Flow: the user proves control of the account email via a one-time code
+// (Supabase Auth email OTP — no extra mail provider needed), then we ask the
+// request-account-deletion edge function to schedule deletion 7 days out. The
+// window is reversible: cancel deletes the pending row (RLS allows the owner).
+// Until then the app shows a deletion banner. The irreversible purge is done
+// server-side by the process-account-deletions worker once the window elapses.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+
+// account_deletions isn't in the generated Database type yet (regenerated after
+// the migration deploys), so route it through an untyped view — same pattern as
+// cloudClient.ts / billingClient.ts.
+const untyped = supabase as unknown as SupabaseClient;
+
+export interface PendingDeletion {
+  requested_at: string;
+  scheduled_for: string;
+}
+
+/** Email a one-time code to the signed-in user's address (re-verification). */
+export async function sendDeletionCode(email: string): Promise<void> {
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: { shouldCreateUser: false },
+  });
+  if (error) throw new Error(error.message);
+}
+
+/** Verify the emailed code. Resolves on success; throws on a bad/expired code. */
+export async function verifyDeletionCode(email: string, token: string): Promise<void> {
+  const { error } = await supabase.auth.verifyOtp({ email, token: token.trim(), type: "email" });
+  if (error) throw new Error(error.message);
+}
+
+/** Schedule deletion (idempotent server-side). Returns the scheduled date. */
+export async function scheduleAccountDeletion(): Promise<PendingDeletion> {
+  const { data, error } = await supabase.functions.invoke("request-account-deletion");
+  if (error) throw new Error(error.message);
+  return data as PendingDeletion;
+}
+
+/** The caller's pending deletion request, or null if none. */
+export async function getPendingDeletion(userId: string): Promise<PendingDeletion | null> {
+  const { data, error } = await untyped
+    .from("account_deletions")
+    .select("requested_at, scheduled_for")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as PendingDeletion | null;
+}
+
+/** Cancel a pending deletion (owner-only via RLS). */
+export async function cancelAccountDeletion(userId: string): Promise<void> {
+  const { error } = await untyped.from("account_deletions").delete().eq("user_id", userId);
+  if (error) throw new Error(error.message);
+}

--- a/src/plugins/cloud-sync/accountExport.ts
+++ b/src/plugins/cloud-sync/accountExport.ts
@@ -1,0 +1,95 @@
+// Orchestrates the "Download my data" export: pulls the server-side account
+// document (when signed in), gathers all local browser data, downloads the
+// cloud + local file blobs, and zips the lot for the user. The pure manifest
+// assembly lives in exportManifest.ts; this layer does the I/O.
+
+import JSZip from "jszip";
+import { supabase } from "@/integrations/supabase/client";
+import { getFile, listFiles } from "@/lib/fileStorage";
+import { getAccessor } from "./storeAccessors";
+import { downloadCloudFile } from "./syncEngine";
+import { DOC_STORES } from "./syncStores";
+import { buildExportTextFiles, type CloudExport, type LocalExport } from "./exportManifest";
+
+const SETTINGS_KEY = "dove-dataviewer-settings";
+
+/** Fetch the server-side account export. Returns null when signed out. */
+async function fetchCloudExport(): Promise<CloudExport | null> {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return null;
+  const { data, error } = await supabase.functions.invoke("export-account-data");
+  if (error) throw new Error(error.message);
+  return data as CloudExport;
+}
+
+/** Read all local browser data the export should include. */
+async function gatherLocal(): Promise<LocalExport> {
+  let settings: unknown = null;
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    settings = raw ? JSON.parse(raw) : null;
+  } catch {
+    settings = null;
+  }
+
+  const stores: Record<string, unknown[]> = {};
+  for (const store of DOC_STORES) {
+    try {
+      stores[store] = await getAccessor(store).readAll();
+    } catch {
+      stores[store] = [];
+    }
+  }
+
+  const fileNames = (await listFiles()).map((f) => f.name);
+  return { settings, stores, fileNames };
+}
+
+export interface ExportProgress {
+  /** Human-readable phase, surfaced in the UI. */
+  phase: string;
+}
+
+/**
+ * Build the export ZIP and trigger a browser download. `onProgress` is optional
+ * and reports coarse phases ("Gathering…", "Downloading files…", "Zipping…").
+ */
+export async function downloadAccountExport(onProgress?: (p: ExportProgress) => void): Promise<void> {
+  onProgress?.({ phase: "Gathering your data…" });
+  const [cloud, local] = await Promise.all([fetchCloudExport(), gatherLocal()]);
+
+  const zip = new JSZip();
+  for (const [path, content] of Object.entries(buildExportTextFiles(cloud, local))) {
+    zip.file(path, content);
+  }
+
+  // Local session-file blobs.
+  onProgress?.({ phase: "Adding local files…" });
+  for (const name of local.fileNames) {
+    const blob = await getFile(name);
+    if (blob) zip.file(`local/files/${name}`, blob);
+  }
+
+  // Cloud session-file blobs (downloaded with the user's own session).
+  const cloudFiles = cloud?.cloud_files ?? [];
+  if (cloudFiles.length) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      onProgress?.({ phase: `Downloading ${cloudFiles.length} cloud file${cloudFiles.length === 1 ? "" : "s"}…` });
+      for (const f of cloudFiles) {
+        const blob = await downloadCloudFile(user.id, f.name);
+        if (blob) zip.file(`cloud/files/${f.name}`, blob);
+      }
+    }
+  }
+
+  onProgress?.({ phase: "Zipping…" });
+  const out = await zip.generateAsync({ type: "blob" });
+  const url = URL.createObjectURL(out);
+  const a = document.createElement("a");
+  a.href = url;
+  const date = new Date().toISOString().slice(0, 10);
+  a.download = `hackthetrack-data-export-${date}.zip`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/plugins/cloud-sync/exportManifest.test.ts
+++ b/src/plugins/cloud-sync/exportManifest.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { buildExportTextFiles, buildReadme, type CloudExport, type LocalExport } from "./exportManifest";
+
+const localFixture: LocalExport = {
+  settings: { useKph: true },
+  stores: {
+    karts: [{ id: "k1", name: "Kart" }],
+    notes: [],
+  },
+  fileNames: ["session1.csv", "session2.ubx"],
+};
+
+describe("buildExportTextFiles", () => {
+  it("includes local settings + one file per store, plus a README", () => {
+    const files = buildExportTextFiles(null, localFixture);
+    expect(Object.keys(files)).toContain("local/settings.json");
+    expect(Object.keys(files)).toContain("local/stores/karts.json");
+    expect(Object.keys(files)).toContain("local/stores/notes.json");
+    expect(Object.keys(files)).toContain("README.txt");
+    expect(JSON.parse(files["local/stores/karts.json"])).toEqual([{ id: "k1", name: "Kart" }]);
+  });
+
+  it("omits all cloud/* entries when signed out (no cloud export)", () => {
+    const files = buildExportTextFiles(null, localFixture);
+    expect(Object.keys(files).some((p) => p.startsWith("cloud/"))).toBe(false);
+  });
+
+  it("includes cloud entries when a cloud export is present", () => {
+    const cloud: CloudExport = {
+      account: { user_id: "u1", email: "a@b.com" },
+      profile: { display_name: "Speedy" },
+      subscription: { tier: "pro" },
+      roles: ["user"],
+      garage_records: [{ store: "notes", record_key: "n1", data: {} }],
+      contact_messages: [{ category: "Bug Report", message: "hi" }],
+      cloud_files: [{ name: "lap.csv" }],
+    };
+    const files = buildExportTextFiles(cloud, localFixture);
+    expect(JSON.parse(files["cloud/profile.json"])).toEqual({ display_name: "Speedy" });
+    expect(JSON.parse(files["cloud/roles.json"])).toEqual(["user"]);
+    expect(JSON.parse(files["cloud/cloud-files-index.json"])).toEqual([{ name: "lap.csv" }]);
+    // No pending deletion → that file is absent.
+    expect(Object.keys(files)).not.toContain("cloud/pending-deletion.json");
+  });
+
+  it("adds a pending-deletion file only when one exists", () => {
+    const cloud: CloudExport = { pending_deletion: { scheduled_for: "2026-06-01T00:00:00Z" } };
+    const files = buildExportTextFiles(cloud, localFixture);
+    expect(Object.keys(files)).toContain("cloud/pending-deletion.json");
+  });
+});
+
+describe("buildReadme", () => {
+  it("reports cloud + local file counts", () => {
+    const readme = buildReadme({ cloud_files: [{ name: "a" }, { name: "b" }] }, localFixture);
+    expect(readme).toContain("Cloud session files: 2");
+    expect(readme).toContain("Local session files: 2");
+  });
+
+  it("treats a null cloud export as zero cloud files", () => {
+    const readme = buildReadme(null, localFixture);
+    expect(readme).toContain("Cloud session files: 0");
+  });
+});

--- a/src/plugins/cloud-sync/exportManifest.ts
+++ b/src/plugins/cloud-sync/exportManifest.ts
@@ -1,0 +1,85 @@
+// Pure assembly of a GDPR data-export bundle's *text* entries (JSON + README).
+// File blobs (cloud + local) are binary and get added by the orchestrator
+// (accountExport.ts); keeping this layer pure makes the manifest unit-testable
+// without a browser, IndexedDB, or the Supabase client.
+
+/** Server-side export document returned by the export-account-data function. */
+export interface CloudExport {
+  export_version?: number;
+  exported_at?: string;
+  account?: unknown;
+  profile?: unknown;
+  subscription?: unknown;
+  roles?: unknown;
+  pending_deletion?: unknown;
+  cloud_files?: Array<{ name: string }>;
+  garage_records?: unknown;
+  contact_messages?: unknown;
+}
+
+/** Local browser data gathered by the orchestrator. */
+export interface LocalExport {
+  settings: unknown;
+  /** Document stores (IndexedDB + the localStorage tracks), keyed by store name. */
+  stores: Record<string, unknown[]>;
+  /** Names of local session-file blobs (added as binaries separately). */
+  fileNames: string[];
+}
+
+const pretty = (v: unknown): string => JSON.stringify(v ?? null, null, 2);
+
+/**
+ * The text (JSON) entries of the export zip, keyed by their path inside the
+ * archive. Binary blobs are added separately by the caller.
+ */
+export function buildExportTextFiles(cloud: CloudExport | null, local: LocalExport): Record<string, string> {
+  const files: Record<string, string> = {};
+
+  if (cloud) {
+    files['cloud/account.json'] = pretty(cloud.account);
+    files['cloud/profile.json'] = pretty(cloud.profile);
+    files['cloud/subscription.json'] = pretty(cloud.subscription);
+    files['cloud/roles.json'] = pretty(cloud.roles ?? []);
+    files['cloud/garage-records.json'] = pretty(cloud.garage_records ?? []);
+    files['cloud/contact-messages.json'] = pretty(cloud.contact_messages ?? []);
+    files['cloud/cloud-files-index.json'] = pretty(cloud.cloud_files ?? []);
+    if (cloud.pending_deletion) {
+      files['cloud/pending-deletion.json'] = pretty(cloud.pending_deletion);
+    }
+  }
+
+  files['local/settings.json'] = pretty(local.settings);
+  for (const [store, rows] of Object.entries(local.stores)) {
+    files[`local/stores/${store}.json`] = pretty(rows);
+  }
+
+  files['README.txt'] = buildReadme(cloud, local);
+  return files;
+}
+
+export function buildReadme(cloud: CloudExport | null, local: LocalExport): string {
+  const localFileCount = local.fileNames.length;
+  const cloudFileCount = cloud?.cloud_files?.length ?? 0;
+  const lines = [
+    'HackTheTrack / Dove\'s DataViewer — your data export',
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    'This archive contains everything we hold about you, for your records and for',
+    'portability (GDPR Article 20). It is yours to keep.',
+    '',
+    'cloud/    — data stored on our backend under your account (only present if you',
+    '            are signed in): your profile, subscription, roles, synced garage',
+    '            records, contact messages you sent, and any pending account-deletion',
+    '            request. cloud/files/ holds the raw session logs you chose to sync.',
+    'local/    — data stored only in this browser on this device: app settings, the',
+    '            garage stores (vehicles, setups, notes, custom tracks, …), and',
+    '            local/files/ session logs that live only on this device.',
+    '',
+    `Cloud session files: ${cloudFileCount}`,
+    `Local session files: ${localFileCount}`,
+    '',
+    'JSON files are UTF-8 and can be opened in any text editor. Session logs keep',
+    'their original file names and formats (CSV, UBX, etc.).',
+  ];
+  return lines.join('\n');
+}

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Cloud, User } from "lucide-react";
+import { Cloud, ShieldCheck, User } from "lucide-react";
 import { toast } from "sonner";
 import type { DataViewerPlugin } from "@/plugins/types";
 import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
@@ -23,6 +23,8 @@ const DownloadAllCloudLogs = lazy(() => import("./DownloadAllCloudLogs"));
 // Profile tab panels: storage usage meters + account, and cloud-log management.
 const StoragePanel = lazy(() => import("./StoragePanel"));
 const CloudLogsPanel = lazy(() => import("./CloudLogsPanel"));
+// Profile tab: GDPR self-service — export everything + scheduled account deletion.
+const DataPrivacyPanel = lazy(() => import("./DataPrivacyPanel"));
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 
@@ -100,6 +102,17 @@ const plugin: DataViewerPlugin = {
       order: 10,
       icon: Cloud,
       component: CloudLogsPanel,
+    } satisfies PluginPanel);
+
+    // Profile tab: data export + account deletion (GDPR self-service). Last so
+    // the destructive controls sit at the bottom of the tab.
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "cloud-sync-data-privacy",
+      title: "Data & privacy",
+      slot: PanelSlot.Profile,
+      order: 20,
+      icon: ShieldCheck,
+      component: DataPrivacyPanel,
     } satisfies PluginPanel);
 
     // Background document auto-sync. Dynamically imported so the sync engine

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,3 +20,12 @@ verify_jwt = false
 
 [functions.create-portal-session]
 verify_jwt = false
+
+[functions.export-account-data]
+verify_jwt = false
+
+[functions.request-account-deletion]
+verify_jwt = false
+
+[functions.process-account-deletions]
+verify_jwt = false

--- a/supabase/functions/export-account-data/index.ts
+++ b/supabase/functions/export-account-data/index.ts
@@ -1,0 +1,89 @@
+// Returns everything we hold server-side for the authenticated caller, as one
+// JSON document (GDPR access / portability). The client merges this with the
+// local browser data and zips it — see the cloud-sync data-export panel.
+//
+// Runs with the service role so it can also include admin-gated rows the user
+// can't read directly (their user_roles, and contact messages they sent by
+// email). Every query is still scoped to the caller's own id/email — never a
+// blanket export.
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: userErr } = await authClient.auth.getUser();
+    if (userErr || !user) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const [profile, subscription, roles, syncRecords, messages, pendingDeletion] = await Promise.all([
+      admin.from('profiles').select('display_name, created_at, updated_at').eq('user_id', user.id).maybeSingle(),
+      admin.from('user_subscriptions').select('tier, status, stripe_customer_id, stripe_subscription_id, current_period_end, updated_at').eq('user_id', user.id).maybeSingle(),
+      admin.from('user_roles').select('role').eq('user_id', user.id),
+      admin.from('sync_records').select('store, record_key, data, updated_at').eq('user_id', user.id),
+      user.email
+        ? admin.from('messages').select('category, email, message, created_at').eq('email', user.email)
+        : Promise.resolve({ data: [] }),
+      admin.from('account_deletions').select('requested_at, scheduled_for').eq('user_id', user.id).maybeSingle(),
+    ]);
+
+    const records = (syncRecords.data ?? []) as Array<{ store: string; record_key: string; data: unknown; updated_at?: string }>;
+    // The file store holds only index rows (size); the raw blobs live in the
+    // user-files bucket and the client downloads them directly via its session.
+    const cloudFiles = records
+      .filter((r) => r.store === 'files')
+      .map((r) => ({ name: r.record_key, ...(r.data as Record<string, unknown> ?? {}) }));
+
+    const exportDoc = {
+      export_version: 1,
+      exported_at: new Date().toISOString(),
+      account: {
+        user_id: user.id,
+        email: user.email ?? null,
+        created_at: user.created_at,
+        last_sign_in_at: user.last_sign_in_at ?? null,
+        provider: user.app_metadata?.provider ?? null,
+      },
+      profile: profile.data ?? null,
+      subscription: subscription.data ?? null,
+      roles: (roles.data ?? []).map((r: { role: string }) => r.role),
+      pending_deletion: pendingDeletion.data ?? null,
+      cloud_files: cloudFiles,
+      garage_records: records.filter((r) => r.store !== 'files'),
+      contact_messages: messages.data ?? [],
+    };
+
+    return json(exportDoc);
+  } catch (e) {
+    console.error('export-account-data error', e);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/functions/process-account-deletions/index.ts
+++ b/supabase/functions/process-account-deletions/index.ts
@@ -1,0 +1,75 @@
+// Hard-deletes accounts whose 7-day grace window has elapsed. Cron-invoked: a
+// daily pg_cron job posts here with the shared `x-cron-secret`. Does the
+// irreversible work SQL shouldn't: removes the user's Storage objects, then
+// deletes the auth user (which cascades profiles, sync_records,
+// user_subscriptions, user_roles and the account_deletions row via FKs).
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
+};
+
+const SYNC_BUCKET = 'user-files';
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+
+/** Remove every object under `${userId}/` in the private user-files bucket. */
+async function removeUserFiles(admin: ReturnType<typeof createClient>, userId: string): Promise<void> {
+  const bucket = admin.storage.from(SYNC_BUCKET);
+  // List in pages; the folder is flat ({userId}/{filename}), so one level is enough.
+  for (;;) {
+    const { data: objects, error } = await bucket.list(userId, { limit: 1000 });
+    if (error || !objects || objects.length === 0) return;
+    const paths = objects.map((o) => `${userId}/${o.name}`);
+    const { error: rmErr } = await bucket.remove(paths);
+    if (rmErr) throw rmErr;
+    if (objects.length < 1000) return;
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  // Cron-only: reject anything without the shared secret.
+  const secret = Deno.env.get('DELETION_CRON_SECRET');
+  if (!secret || req.headers.get('x-cron-secret') !== secret) {
+    return json({ error: 'Forbidden' }, 403);
+  }
+
+  try {
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const { data: due, error } = await admin.rpc('due_account_deletions');
+    if (error) throw error;
+
+    const userIds = (due ?? []) as string[];
+    const results: Array<{ user_id: string; ok: boolean; error?: string }> = [];
+
+    for (const userId of userIds) {
+      try {
+        await removeUserFiles(admin, userId);
+        const { error: delErr } = await admin.auth.admin.deleteUser(userId);
+        if (delErr) throw delErr;
+        // The account_deletions row is removed by the auth.users FK cascade.
+        results.push({ user_id: userId, ok: true });
+      } catch (e) {
+        console.error('process-account-deletions: failed for', userId, e);
+        results.push({ user_id: userId, ok: false, error: e instanceof Error ? e.message : String(e) });
+      }
+    }
+
+    return json({ processed: results.length, results });
+  } catch (e) {
+    console.error('process-account-deletions error', e);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/functions/request-account-deletion/index.ts
+++ b/supabase/functions/request-account-deletion/index.ts
@@ -1,0 +1,74 @@
+// Schedules deletion of the authenticated caller's account for 7 days out
+// (reversible). The client performs an email-OTP re-verification before calling
+// this (so a hijacked session alone can't trigger it via the normal UI); the
+// 7-day reversible window is the durable safeguard, and only the service role
+// can write the row so the window can't be shortened client-side.
+//
+// Idempotent: calling again keeps the original schedule (never extends or
+// shortens an in-flight request).
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+const GRACE_DAYS = 7;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: { user }, error: userErr } = await authClient.auth.getUser();
+    if (userErr || !user) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    // Keep an existing request's schedule; only create one if none is pending.
+    const { data: existing } = await admin
+      .from('account_deletions')
+      .select('requested_at, scheduled_for')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (existing) {
+      return json({ scheduled_for: existing.scheduled_for, requested_at: existing.requested_at });
+    }
+
+    const now = new Date();
+    const scheduledFor = new Date(now.getTime() + GRACE_DAYS * 24 * 60 * 60 * 1000);
+    const { error } = await admin.from('account_deletions').insert({
+      user_id: user.id,
+      requested_at: now.toISOString(),
+      scheduled_for: scheduledFor.toISOString(),
+    });
+    if (error) throw error;
+
+    return json({ scheduled_for: scheduledFor.toISOString(), requested_at: now.toISOString() });
+  } catch (e) {
+    console.error('request-account-deletion error', e);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/migrations/20260527010000_gdpr_compliance.sql
+++ b/supabase/migrations/20260527010000_gdpr_compliance.sql
@@ -1,0 +1,141 @@
+-- GDPR compliance: personal-data retention (IP TTL) + scheduled account deletion.
+--
+-- Two concerns:
+--   1. Abuse-prevention IP minimisation. `submitted_by_ip` on submissions and
+--      messages is nulled 90 days after the row was created; expired `banned_ips`
+--      and stale `login_attempts` rows are deleted. A daily pg_cron job runs the
+--      purge so data is cleared even when there's no traffic to trigger the
+--      reactive cleanup the edge functions already do.
+--   2. Self-service account deletion is *scheduled*, not immediate. A 7-day grace
+--      window (reversible by the user) guards against a hijacked session wiping a
+--      user's race history. `account_deletions` holds the pending request; the
+--      `process-account-deletions` edge function does the irreversible work
+--      (Storage objects + the auth row — neither of which SQL should delete
+--      directly) once the window elapses.
+
+-- ── Extensions (scheduling + outbound HTTP for the deletion worker) ───────────
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- ── 1. IP retention purge ─────────────────────────────────────────────────────
+-- SECURITY DEFINER so the cron job (and an authorized edge function) can run it
+-- regardless of the caller. Touches only abuse-prevention columns/rows.
+create or replace function public.purge_expired_personal_data()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Drop the submitter IP once the abuse-investigation window has passed; the
+  -- submission/message content itself is retained for the operator.
+  update public.submissions
+     set submitted_by_ip = null
+   where submitted_by_ip is not null
+     and created_at < now() - interval '90 days';
+
+  update public.messages
+     set submitted_by_ip = null
+   where submitted_by_ip is not null
+     and created_at < now() - interval '90 days';
+
+  -- Expired bans no longer protect anything — remove the IP entirely.
+  delete from public.banned_ips
+   where expires_at is not null
+     and expires_at < now();
+
+  -- Stale rate-limit rows (the edge function also clears these reactively).
+  delete from public.login_attempts
+   where locked_until is not null
+     and locked_until < now();
+end;
+$$;
+
+revoke all on function public.purge_expired_personal_data() from public, anon, authenticated;
+
+-- ── 2. Scheduled account deletion ─────────────────────────────────────────────
+create table if not exists public.account_deletions (
+  user_id       uuid primary key references auth.users (id) on delete cascade,
+  requested_at  timestamptz not null default now(),
+  scheduled_for timestamptz not null
+);
+
+alter table public.account_deletions enable row level security;
+
+-- A user may SEE and CANCEL (delete) their own pending request. There is no
+-- INSERT/UPDATE policy: only the service role (the request-account-deletion edge
+-- function) can create a request, so a client can never shorten the 7-day window
+-- or schedule a deletion for someone else.
+drop policy if exists "Users read own deletion" on public.account_deletions;
+create policy "Users read own deletion"
+  on public.account_deletions for select to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists "Users cancel own deletion" on public.account_deletions;
+create policy "Users cancel own deletion"
+  on public.account_deletions for delete to authenticated
+  using (auth.uid() = user_id);
+
+-- Accounts whose grace window has elapsed — read by the deletion worker.
+create or replace function public.due_account_deletions()
+returns setof uuid
+language sql
+security definer
+set search_path = public
+as $$
+  select user_id from public.account_deletions where scheduled_for <= now();
+$$;
+
+revoke all on function public.due_account_deletions() from public, anon, authenticated;
+
+-- ── 3. Schedule the jobs (idempotent, and tolerant of missing config) ─────────
+do $$
+declare
+  v_secret text;
+  v_url    text := 'https://svjlieovpyiffbqwhtgk.supabase.co/functions/v1/process-account-deletions';
+begin
+  -- Re-running the migration must not error on already-scheduled jobs.
+  if exists (select 1 from cron.job where jobname = 'purge-expired-personal-data') then
+    perform cron.unschedule('purge-expired-personal-data');
+  end if;
+  if exists (select 1 from cron.job where jobname = 'process-account-deletions') then
+    perform cron.unschedule('process-account-deletions');
+  end if;
+
+  -- IP retention purge: pure SQL, no secret needed — always scheduled. 03:17 UTC.
+  perform cron.schedule(
+    'purge-expired-personal-data',
+    '17 3 * * *',
+    $job$ select public.purge_expired_personal_data(); $job$
+  );
+
+  -- Account-deletion worker: posts to the edge function, which needs a shared
+  -- secret (DELETION_CRON_SECRET env on the function). The secret lives in Vault
+  -- under `deletion_cron_secret`; when present we auto-wire the daily job, else
+  -- we leave a notice so the operator can add it (see README). 03:37 UTC.
+  begin
+    select decrypted_secret into v_secret
+      from vault.decrypted_secrets
+     where name = 'deletion_cron_secret'
+     limit 1;
+  exception when others then
+    v_secret := null;
+  end;
+
+  if v_secret is not null then
+    perform cron.schedule(
+      'process-account-deletions',
+      '37 3 * * *',
+      format(
+        $job$ select net.http_post(
+          url := %L,
+          headers := jsonb_build_object('Content-Type', 'application/json', 'x-cron-secret', %L),
+          body := '{}'::jsonb
+        ); $job$,
+        v_url, v_secret
+      )
+    );
+  else
+    raise notice 'account_deletions: set Vault secret "deletion_cron_secret" (and the matching DELETION_CRON_SECRET env on the process-account-deletions function), then re-run this migration to auto-schedule the worker. See README.';
+  end if;
+end $$;

--- a/supabase/migrations/20260527010000_gdpr_compliance.sql
+++ b/supabase/migrations/20260527010000_gdpr_compliance.sql
@@ -1,11 +1,15 @@
 -- GDPR compliance: personal-data retention (IP TTL) + scheduled account deletion.
 --
 -- Two concerns:
---   1. Abuse-prevention IP minimisation. `submitted_by_ip` on submissions and
---      messages is nulled 90 days after the row was created; expired `banned_ips`
---      and stale `login_attempts` rows are deleted. A daily pg_cron job runs the
---      purge so data is cleared even when there's no traffic to trigger the
---      reactive cleanup the edge functions already do.
+--   1. Personal-data minimisation, in two layers:
+--        a. `submitted_by_ip` on submissions and messages is nulled 90 days
+--           after the row was created (the abuse-investigation window);
+--        b. the rows themselves are then deleted once their content is no longer
+--           needed — contact messages and *reviewed* submissions after 1 year
+--           (pending submissions are kept so they can still be moderated).
+--      Expired `banned_ips` and stale `login_attempts` rows are deleted too. A
+--      daily pg_cron job runs the purge so data is cleared even when there's no
+--      traffic to trigger the reactive cleanup the edge functions already do.
 --   2. Self-service account deletion is *scheduled*, not immediate. A 7-day grace
 --      window (reversible by the user) guards against a hijacked session wiping a
 --      user's race history. `account_deletions` holds the pending request; the
@@ -27,8 +31,7 @@ security definer
 set search_path = public
 as $$
 begin
-  -- Drop the submitter IP once the abuse-investigation window has passed; the
-  -- submission/message content itself is retained for the operator.
+  -- (a) Drop the submitter IP once the abuse-investigation window (90d) passes.
   update public.submissions
      set submitted_by_ip = null
    where submitted_by_ip is not null
@@ -38,6 +41,17 @@ begin
      set submitted_by_ip = null
    where submitted_by_ip is not null
      and created_at < now() - interval '90 days';
+
+  -- (b) Delete the rows themselves once their content is no longer needed (1y).
+  -- Contact messages (email + free-text) go entirely.
+  delete from public.messages
+   where created_at < now() - interval '1 year';
+
+  -- Reviewed submissions go; pending ones are kept so they can still be
+  -- moderated regardless of age.
+  delete from public.submissions
+   where status <> 'pending'
+     and created_at < now() - interval '1 year';
 
   -- Expired bans no longer protect anything — remove the IP entirely.
   delete from public.banned_ips


### PR DESCRIPTION
## Summary

Closes the gap between what the Privacy Policy already promises (data portability, erasure, IP-retention limits) and what the app actually does. Builds on the legal-docs work already in `BETA`.

### 1. IP-address retention (TTL)
- New migration adds `purge_expired_personal_data()` + a daily **pg_cron** job that:
  - nulls `submitted_by_ip` on `submissions` and `messages` **90 days** after the row was received,
  - deletes expired `banned_ips` and stale `login_attempts`.
- Admin **Banned IPs** tab now takes a selectable expiry (1 / 7 / 30 / 90 / 365 days or permanent), defaulting to **90 days** (the column already existed; the UI just couldn't set it).

### 2. Download my data (access & portability)
- New `export-account-data` edge function returns everything held server-side for the caller (profile, subscription, roles, synced garage records, contact messages by email, pending deletion).
- Client zips that **plus all local browser data** (settings, garage stores, local session files) and the cloud file blobs. Pure manifest assembly is unit-tested (`exportManifest.ts`).
- Surfaced in a new Profile → **Data & privacy** panel.

### 3. Self-service account deletion (erasure)
- Confirmed by an **emailed one-time code** (`signInWithOtp`/`verifyOtp` — no new mail provider needed), then **scheduled 7 days out and cancellable**.
- The 7-day reversible window guards against a hijacked session permanently wiping a user's race history (legal & best-practice: immediate deactivation isn't required, a short disclosed grace window is fine).
- `request-account-deletion` schedules it (service-role only, so the window can't be shortened client-side); the cron-driven `process-account-deletions` worker erases Storage objects + the auth row once due.

### 4. Docs
- Privacy Policy "Your Rights" / "Data Retention" updated to describe self-service export + scheduled deletion + 90-day IP purge.
- README (env vars incl. `DELETION_CRON_SECRET`, new tables, edge functions, retention notes), CHANGELOG, and CLAUDE.md updated.

### Operator notes
- The IP purge auto-schedules with no config. The deletion worker auto-wires its daily `pg_cron` + `pg_net` job **only if** a Supabase Vault secret `deletion_cron_secret` exists (matching `DELETION_CRON_SECRET` on the function); otherwise the migration raises a NOTICE and it's a one-line documented step — see README.
- Requires `pg_cron` + `pg_net` (the migration creates them).

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run build` all green
- [x] `npm run test:run` — 704 tests pass, incl. new `exportManifest.test.ts`
- [ ] After deploy: export ZIP contains `cloud/*` + `local/*`; delete flow emails a code, schedules +7d, shows the cancel banner, and cancel clears it
- [ ] Confirm `pg_cron` jobs are scheduled and the deletion worker rejects requests without `x-cron-secret`

https://claude.ai/code/session_013mqN9aCP2Leghar6oPdM8t

---
_Generated by [Claude Code](https://claude.ai/code/session_013mqN9aCP2Leghar6oPdM8t)_