### PR TITLE
Complete Stripe integration: monthly/annual, signup plan select, grace + log trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **No-Stripe failback**: when no Stripe secret key is configured, the pricing
   UI shows only the two free cards (Guest + Free) and hides the paid tiers
   entirely instead of showing them as "Coming soon".
+- **AI (Pro) tier is "coming soon"**: the AI-coaching plan is shown as a teaser
+  but isn't self-service purchasable — it's not selectable at sign-up, has no
+  Upgrade button, and `create-checkout-session` rejects it. It can still be
+  comped to a tester by creating the subscription directly in Stripe (the
+  webhook grants whatever tier the price maps to). Gated by a single
+  `COMING_SOON_TIERS` set in `lib/billing.ts`.
 - **Cancellation grace + log trimming**: cancelling ends service at the period
   boundary and drops you to the free tier's limits, but your cloud logs are kept
   for a **60-day grace window** to re-subscribe or download. After it expires, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paid tier stays "Coming soon" until its Stripe Price is configured), and the
   **Profile** tab shows your plan with a **Manage subscription** link to the
   Stripe billing portal.
+- **Monthly & annual billing**: each paid tier now offers a monthly or annual
+  price, resolved live from Stripe by **lookup_key** (`plus_monthly`,
+  `plus_annual`, `premium_monthly`, …) so the Stripe dashboard is the single
+  source of truth — no Price ids in code. The pricing cards gain a
+  **monthly/annual toggle**, and sign-up lets you **pick a plan + interval**: a
+  paid choice creates the account first, then resumes to Stripe Checkout on your
+  first sign-in (after email confirmation). A new public `stripe-prices` edge
+  function feeds the catalogue.
+- **No-Stripe failback**: when no Stripe secret key is configured, the pricing
+  UI shows only the two free cards (Guest + Free) and hides the paid tiers
+  entirely instead of showing them as "Coming soon".
+- **Cancellation grace + log trimming**: cancelling ends service at the period
+  boundary and drops you to the free tier's limits, but your cloud logs are kept
+  for a **60-day grace window** to re-subscribe or download. After it expires, a
+  daily `pg_cron` job (`trim_expired_logs()`) trims synced logs **newest-first**
+  to the free allowance. The Profile tab surfaces the cancellation/grace date.
 - Document storage + **auto-sync**: when you're signed in, your garage
   (vehicles, setups, setup templates, notes) now backs up to the cloud
   automatically as you change it — no manual push. The "documents" storage type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,14 @@ Stripe Price tagged with a lookup_key `${tier}_${interval}` (`plus_monthly`,
 `plus_annual`, `premium_monthly`, …). Checkout and the catalogue resolve prices
 live by lookup_key, so the Stripe dashboard is the single source of truth.
 
+**Coming-soon tiers:** `COMING_SOON_TIERS` in `lib/billing.ts` (currently `pro`,
+the AI plan) lists tiers that exist but aren't self-service purchasable yet —
+shown as "Coming soon", excluded from `PlanChooser`, no Upgrade button, and
+rejected by `create-checkout-session` (mirror the set there). They can still be
+**comped** by creating the subscription directly in Stripe (set the
+subscription's `metadata.user_id`, or change an existing customer's price); the
+webhook grants whatever tier the price's lookup_key maps to.
+
 **Cancellation grace:** a cancelled sub ends at the period boundary (Stripe
 `customer.subscription.deleted`), dropping to free limits immediately (via
 `user_tier`), but `grace_until = period_end + 60 days` keeps the user's logs so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ src/
 │   ├── useSettings.ts         # User preferences (units, smoothing, dark mode, etc.)
 │   ├── useSessionMetadata.ts  # Per-file metadata (selected track/course)
 │   ├── useSubscription.ts     # Reads subscription tier catalogue + the user's plan (online, account-gated)
+│   ├── useStripePrices.ts     # Reads the live Stripe price catalogue (configured? + monthly/annual prices); drives the no-Stripe failback
 │   └── useOnlineStatus.ts     # Navigator.onLine wrapper
 ├── lib/
 │   ├── datalogParser.ts       # ★ Format auto-detection router (entry point for all parsing)
@@ -177,8 +178,9 @@ src/
 │   │   ├── types.ts           # ITrackDatabase interface
 │   │   ├── supabaseAdapter.ts # Supabase implementation
 │   │   └── index.ts           # Factory: getDatabase()
-│   ├── billing.ts             # ★ Pure subscription logic + row shapes (effectiveTier, pricingCta) — unit-tested, no Supabase import
-│   ├── billingClient.ts       # Supabase I/O for tiers/subscriptions + Stripe checkout/portal (functions.invoke)
+│   ├── billing.ts             # ★ Pure subscription logic + row/price shapes (effectiveTier, pricingCta, lookupKey, paidTiersVisible, priceFor, formatPrice) — unit-tested, no Supabase import
+│   ├── billingClient.ts       # Supabase I/O for tiers/subscriptions + Stripe prices/checkout/portal (functions.invoke)
+│   ├── pendingCheckout.ts     # localStorage stash for a plan chosen at sign-up; redeemed on first sign-in (account-first paid flow) — pure parse is unit-tested
 │   └── utils.ts               # Tailwind cn() helper
 ├── plugins/                   # ★ Plugin framework (auto-discovered via import.meta.glob)
 │   ├── types.ts               # DataViewerPlugin / PluginContext / PluginRegistry contracts
@@ -501,48 +503,71 @@ After a migration, Lovable regenerates `integrations/supabase/types.ts`. Until
 then `cloudClient.ts` accesses the new table/bucket through a narrowly-typed
 escape hatch confined to that one module.
 
-### Subscriptions / Stripe (`..._stripe_subscriptions.sql` + 3 edge functions)
+### Subscriptions / Stripe (`..._stripe_subscriptions.sql`, `..._subscription_grace_trim.sql` + 4 edge functions)
 
 Paid tiers scale the cloud-sync **logs** quota (`free` 20 MB → `plus` $1 500 MB
 → `premium` $3 1 GB → `pro` $10 1 GB; docs stay 5 MB). `premium` matches `pro`'s
-storage but carries no AI credits. Tiers are **data**, not code (numbers are
-provisional):
+storage but carries no AI credits. Each paid tier bills **monthly or annual**.
+Tiers are **data**, not code (numbers are provisional):
 
 | Object | Type | Notes |
 |--------|------|-------|
-| `subscription_tiers` | table | One row per plan: `(tier PK, label, price_cents, logs_bytes, doc_bytes, ai_credits, stripe_price_id, sort_order)`. Authenticated read-all. Change a limit/price = UPDATE here. `stripe_price_id` is set after creating the Stripe Price. |
-| `user_subscriptions` | table | `(user_id PK→auth.users, tier→subscription_tiers, status, stripe_customer_id, stripe_subscription_id, current_period_end, updated_at)`. RLS: owner **read-only** — only the service role (webhook) writes, so no one can self-grant a tier. |
+| `subscription_tiers` | table | One row per plan: `(tier PK, label, price_cents, logs_bytes, doc_bytes, ai_credits, stripe_price_id, sort_order)`. Authenticated read-all. Change a limit = UPDATE here. (`stripe_price_id` is a legacy fallback only — prices now resolve by lookup_key, see below.) |
+| `user_subscriptions` | table | `(user_id PK→auth.users, tier→subscription_tiers, status, stripe_customer_id, stripe_subscription_id, current_period_end, cancel_at_period_end, billing_interval, grace_until, logs_trimmed_at, updated_at)`. RLS: owner **read-only** — only the service role (webhook) writes, so no one can self-grant a tier. |
 | `user_tier(uuid)` | fn (SECURITY DEFINER) | Effective tier: the subscription tier when `status in (active, trialing, past_due)`, else `free`. |
 | `tier_limit(uuid, type)` | fn (SECURITY DEFINER) | Byte limit for a user + storage type from their tier; falls back to `free`, then `quota_limits`. Used by the quota trigger + usage RPC. |
+| `encode_uri_component(text)` | fn | SQL parity with JS `encodeURIComponent`, so the trim job can address the right `user-files` bucket object (`{user_id}/{encoded name}`). |
+| `trim_expired_logs()` | fn (SECURITY DEFINER) | For users past their `grace_until`, deletes synced **log** files newest-first (index row + bucket object) down to the free `logs_bytes`. Scheduled daily via `pg_cron` (guarded; enable the extension or run externally). Not granted to `authenticated`. |
+
+**Prices via lookup_key (no Price ids in code):** each (tier × interval) has a
+Stripe Price tagged with a lookup_key `${tier}_${interval}` (`plus_monthly`,
+`plus_annual`, `premium_monthly`, …). Checkout and the catalogue resolve prices
+live by lookup_key, so the Stripe dashboard is the single source of truth.
+
+**Cancellation grace:** a cancelled sub ends at the period boundary (Stripe
+`customer.subscription.deleted`), dropping to free limits immediately (via
+`user_tier`), but `grace_until = period_end + 60 days` keeps the user's logs so
+they can re-subscribe/download. After grace, `trim_expired_logs()` trims them.
 
 Edge functions (all `verify_jwt = false`; checkout/portal verify the JWT
 manually like the rest of the repo, the webhook verifies the Stripe signature):
 
-- `create-checkout-session` — auth user → ensure Stripe customer (persisted on
-  `user_subscriptions`) → Checkout Session (subscription mode) for the tier's
-  `stripe_price_id` → returns the hosted URL.
+- `stripe-prices` — **public**, no auth. Reports `{ configured, prices[] }`:
+  `configured:false` when `STRIPE_SECRET_KEY` is absent (→ client free-only
+  failback), else live monthly/annual prices fetched by lookup_key.
+- `create-checkout-session` — auth user + `{ tier, interval }` → ensure Stripe
+  customer (persisted on `user_subscriptions`) → resolve Price by lookup_key →
+  Checkout Session (subscription mode) → returns the hosted URL.
 - `stripe-webhook` — **the only writer of entitlements**. Verifies the signature
   (`STRIPE_WEBHOOK_SECRET`), then on `checkout.session.completed` /
   `customer.subscription.created|updated|deleted` upserts `user_subscriptions`
-  (tier resolved from the Price id; `deleted` → `free`) via the service role.
+  (tier + interval resolved from the Price's lookup_key; sets
+  `cancel_at_period_end`; on cancellation sets `grace_until`; `deleted` → `free`)
+  via the service role.
 - `create-portal-session` — returns a Stripe Billing Portal URL for
-  manage/cancel (no in-app billing UI).
+  manage/upgrade/downgrade/cancel (no in-app billing UI).
 
 Secrets: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
 
 **Client wiring** (core, not the cloud-sync plugin — billing is account-level and
 PricingCards renders even with cloud disabled): `lib/billing.ts` is the pure,
-unit-tested layer (`isActiveStatus`/`effectiveTier`/`isPaidTier`/`pricingCta` +
-row shapes); `lib/billingClient.ts` is the Supabase I/O (`fetchTiers`,
-`fetchMySubscription`, `createCheckout`, `createPortal` via `functions.invoke`),
-through the same untyped escape hatch as `cloudClient.ts`. `hooks/useSubscription.ts`
-reads the tier catalogue + the user's subscription (online + account-gated,
-returns the free baseline otherwise). `PricingCards` shows live **Upgrade** /
-**Current plan** actions for signed-in users (a paid tier with no `stripe_price_id`
-stays "Coming soon" — graceful pre-config state); cloud-sync's Profile-tab
-`StoragePanel` shows the current plan + a **Manage subscription** portal link when
-subscribed. **Stripe setup (create Products/Prices, set `stripe_price_id`, secrets,
-webhook) is still operator config — see README.**
+unit-tested layer (`isActiveStatus`/`effectiveTier`/`isPaidTier`/`pricingCta`,
+plus `lookupKey`/`tiersWithPrices`/`paidTiersVisible`/`priceFor`/`formatPrice` +
+row/price shapes); `lib/billingClient.ts` is the Supabase I/O (`fetchTiers`,
+`fetchMySubscription`, `fetchStripeConfig`, `createCheckout(tier, interval)`,
+`createPortal`), through the same untyped escape hatch as `cloudClient.ts`.
+`hooks/useSubscription.ts` reads the tier catalogue + the user's subscription;
+`hooks/useStripePrices.ts` reads the live price catalogue (online, never throws).
+`PricingCards` has a **monthly/annual toggle**, shows live **Upgrade** /
+**Current plan** actions, and — the **failback** — hides the paid tiers entirely
+when `paidTiersVisible(config)` is false (only Guest + Free cards). `PlanChooser`
+(sign-up) picks tier + interval; a paid choice stashes a `lib/pendingCheckout.ts`
+intent that `components/PendingCheckoutRedirect.tsx` (mounted in `App.tsx` for
+cloud builds) redeems → Checkout on first sign-in after email confirmation.
+cloud-sync's Profile-tab `StoragePanel` shows the plan + renewal/cancellation/
+grace date + a **Manage subscription** portal link. **Stripe setup (create
+Products/Prices with the lookup_keys, secrets, webhook, enable pg_cron) is
+operator config — see README.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ The app includes an optional admin system for managing a community track databas
 > Stripe **test mode** first. Tier entitlements are granted only by the webhook,
 > never the client.
 >
+> **Coming-soon / comped tiers:** the AI (Pro) tier is listed in
+> `COMING_SOON_TIERS` (`src/lib/billing.ts`, mirrored in `create-checkout-session`)
+> so it shows as "Coming soon" and can't be bought via the app. To give it to a
+> tester/friend, create the subscription directly in Stripe on the `pro_*` price
+> and set the subscription's `metadata.user_id` to their account id (or change an
+> existing customer's price) — the webhook grants it. Remove the tier from both
+> `COMING_SOON_TIERS` sets to open self-service purchase.
+>
 > **Cancellation grace + log trimming:** a cancelled subscription ends at the
 > period boundary and drops to the free tier's limits immediately, but the
 > user's cloud logs are kept for a 60-day grace window (`grace_until`). After it

--- a/README.md
+++ b/README.md
@@ -121,12 +121,26 @@ The app includes an optional admin system for managing a community track databas
 > **Note:** `TURNSTILE_SECRET_KEY` is a server-side secret stored in Lovable Cloud, not a `VITE_` client variable. If not set, Turnstile verification is skipped.
 
 > **Stripe / paid tiers:** `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are
-> edge-function secrets (not `VITE_` client vars). After creating the
-> Plus/Premium/Pro Products + recurring Prices in Stripe, store each Price id in the matching
-> `subscription_tiers.stripe_price_id` row, and point a Stripe webhook (events:
+> edge-function secrets (not `VITE_` client vars). Prices are resolved live by
+> **lookup_key** — there are no Price ids in code or env. Create the
+> Plus/Premium/Pro Products in Stripe with one recurring Price per billing
+> interval, each tagged with the matching lookup_key:
+> `plus_monthly`, `plus_annual`, `premium_monthly`, `premium_annual`,
+> `pro_monthly`, `pro_annual`. Then point a Stripe webhook (events:
 > `checkout.session.completed`, `customer.subscription.created/updated/deleted`)
-> at the `stripe-webhook` function URL. Use Stripe **test mode** first. Tier
-> entitlements are granted only by the webhook, never the client.
+> at the `stripe-webhook` function URL. When `STRIPE_SECRET_KEY` is absent the
+> pricing UI falls back to showing only the two free cards (Guest + Free). Use
+> Stripe **test mode** first. Tier entitlements are granted only by the webhook,
+> never the client.
+>
+> **Cancellation grace + log trimming:** a cancelled subscription ends at the
+> period boundary and drops to the free tier's limits immediately, but the
+> user's cloud logs are kept for a 60-day grace window (`grace_until`). After it
+> expires, the `trim_expired_logs()` function (scheduled daily via `pg_cron` in
+> the `subscription_grace_trim` migration) deletes their synced log files
+> newest-first down to the free `logs_bytes` allowance. If `pg_cron` isn't
+> enabled on the project, enable it (Dashboard → Database → Extensions) or invoke
+> `select public.trim_expired_logs();` from an external scheduler.
 
 > **Note:** `DOVE_PLUGIN_PACKAGES` is build-time only (read by `vite.config.ts`), not a client `VITE_` variable. It overrides which external plugin packages the build loads; by default the build pulls in the public AI coach (`@perchwerks/eye-in-the-sky`) from npm as an optional dependency — see `src/plugins/README.md`.
 
@@ -146,6 +160,10 @@ The admin system uses Lovable Cloud (Supabase) for the database. The schema is c
 - **user_roles** — Admin/user role assignments (uses `has_role()` security definer)
 - **sync_records** — Per-user cloud-sync documents (files/garage data), RLS-scoped to the owner
 - **user-files** (Storage bucket) — Private per-user session file blobs for cloud sync
+- **quota_limits** — Baseline per-storage-type byte limits (documents/logs)
+- **subscription_tiers** — Data-driven plan catalogue (free/plus/premium/pro): label, price, per-type byte limits
+- **user_subscriptions** — Per-user tier + Stripe customer/subscription state, status, renewal date, cancellation grace (service-role-written only)
+- **profiles** — Per-user unique, editable display name
 
 > Cloud sync is independent of the admin system — it only needs a signed-in user
 > account, not the admin role. It's an online-only, opt-in feature; the core app
@@ -177,6 +195,11 @@ src/lib/db/
 | `submit-track` | Public endpoint for track submissions (with IP ban check) |
 | `admin-build-zip` | Admin-only: generates per-track JSON files |
 | `check-login-rate` | Rate limiting for login attempts |
+| `submit-message` | Public contact-form endpoint (with IP ban + rate limit) |
+| `stripe-prices` | Public: reports whether Stripe is configured + live monthly/annual prices (resolved by lookup_key) for the pricing UI |
+| `create-checkout-session` | Auth: starts Stripe Checkout for a tier + interval |
+| `create-portal-session` | Auth: opens the Stripe Billing Portal (manage/cancel/renewal) |
+| `stripe-webhook` | Stripe-signed: the only writer of subscription tier/status + grace window |
 
 ### Track Short Names
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,9 @@ const Terms = lazy(() => import("./pages/Terms"));
 const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const AuthCallback = lazy(() => import("./pages/AuthCallback"));
+const PendingCheckoutRedirect = lazy(() =>
+  import("./components/PendingCheckoutRedirect").then((m) => ({ default: m.PendingCheckoutRedirect })),
+);
 
 const SETTINGS_KEY = "dove-dataviewer-settings";
 
@@ -50,6 +53,7 @@ const App = () => {
         <Sonner />
         <BrowserRouter>
           <Suspense fallback={null}>
+            {enableCloud && <PendingCheckoutRedirect />}
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/privacy" element={<Privacy />} />

--- a/src/components/PendingCheckoutRedirect.tsx
+++ b/src/components/PendingCheckoutRedirect.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import { useSubscription } from "@/hooks/useSubscription";
+import { isPaidTier } from "@/lib/billing";
+import { createCheckout } from "@/lib/billingClient";
+import { clearPendingCheckout, getPendingCheckout } from "@/lib/pendingCheckout";
+
+/**
+ * Resumes a paid plan chosen at sign-up. Sign-up creates the account first
+ * (email confirmation, no session), so the choice is stashed and redeemed here
+ * on the user's first signed-in, online load while still on the free tier:
+ * redirect to Stripe Checkout, then the webhook provisions the tier. Renders
+ * nothing. Mounted once at the app root in cloud builds.
+ */
+export function PendingCheckoutRedirect() {
+  const { user, loading: authLoading } = useAuth();
+  const online = useOnlineStatus();
+  const { currentTier, loading: subLoading } = useSubscription();
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    if (authLoading || subLoading || !user || !online) return;
+    if (currentTier !== "free") {
+      // Already on a paid tier — the intent (if any) is satisfied; drop it.
+      clearPendingCheckout();
+      return;
+    }
+    const intent = getPendingCheckout();
+    if (!intent || !isPaidTier(intent.tier)) return;
+
+    started.current = true;
+    clearPendingCheckout();
+    createCheckout(intent.tier, intent.interval, window.location.origin)
+      .then((url) => {
+        window.location.href = url;
+      })
+      .catch((e) => {
+        started.current = false;
+        toast.error(e instanceof Error ? e.message : "Couldn't resume checkout.");
+      });
+  }, [user, authLoading, subLoading, currentTier, online]);
+
+  return null;
+}

--- a/src/components/PlanChooser.tsx
+++ b/src/components/PlanChooser.tsx
@@ -9,6 +9,7 @@ import { useStripePrices } from "@/hooks/useStripePrices";
 import {
   type BillingInterval,
   formatPrice,
+  isComingSoon,
   paidTiersVisible,
   priceFor,
   tiersWithPrices,
@@ -43,7 +44,10 @@ export function PlanChooser({
   if (!paidTiersVisible(config)) return null;
 
   const available = tiersWithPrices(config.prices);
-  const paidTiers = PAID_ORDER.filter((t) => available.has(t));
+  // Coming-soon tiers (e.g. the AI plan) aren't self-service purchasable at
+  // sign-up — they're comped manually via Stripe, not chosen here.
+  const paidTiers = PAID_ORDER.filter((t) => available.has(t) && !isComingSoon(t));
+  if (paidTiers.length === 0) return null;
   const isPaid = value.tier !== "free";
 
   const setInterval = (interval: BillingInterval) => {

--- a/src/components/PlanChooser.tsx
+++ b/src/components/PlanChooser.tsx
@@ -1,0 +1,112 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useStripePrices } from "@/hooks/useStripePrices";
+import {
+  type BillingInterval,
+  formatPrice,
+  paidTiersVisible,
+  priceFor,
+  tiersWithPrices,
+} from "@/lib/billing";
+
+export interface PlanSelection {
+  tier: string;
+  interval: BillingInterval;
+}
+
+const TIER_LABEL: Record<string, string> = {
+  free: "Free",
+  plus: "Plus",
+  premium: "Premium",
+  pro: "Pro",
+};
+const PAID_ORDER = ["plus", "premium", "pro"];
+
+/**
+ * Plan + billing-interval picker for sign-up. Renders nothing when Stripe isn't
+ * configured (the account is simply free), so the failback needs no special
+ * handling. Controlled: the parent owns the selection so it can act on submit.
+ */
+export function PlanChooser({
+  value,
+  onChange,
+}: {
+  value: PlanSelection;
+  onChange: (v: PlanSelection) => void;
+}) {
+  const { config } = useStripePrices();
+  if (!paidTiersVisible(config)) return null;
+
+  const available = tiersWithPrices(config.prices);
+  const paidTiers = PAID_ORDER.filter((t) => available.has(t));
+  const isPaid = value.tier !== "free";
+
+  const setInterval = (interval: BillingInterval) => {
+    // If the chosen tier isn't priced for the new interval, fall back to free.
+    if (value.tier !== "free" && !priceFor(config.prices, value.tier, interval)) {
+      onChange({ tier: "free", interval });
+    } else {
+      onChange({ ...value, interval });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium text-foreground" htmlFor="plan">
+        Plan
+      </label>
+      <Select value={value.tier} onValueChange={(tier) => onChange({ ...value, tier })}>
+        <SelectTrigger id="plan">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="free">Free — $0</SelectItem>
+          {paidTiers.map((tier) => {
+            const price = priceFor(config.prices, tier, value.interval);
+            return (
+              <SelectItem key={tier} value={tier}>
+                {TIER_LABEL[tier] ?? tier}
+                {price
+                  ? ` — ${formatPrice(price.unitAmount, price.currency)}${
+                      value.interval === "annual" ? "/yr" : "/mo"
+                    }`
+                  : ""}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+
+      {isPaid && (
+        <div className="inline-flex items-center rounded-full border border-border bg-card p-0.5 text-sm">
+          {(["monthly", "annual"] as const).map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => setInterval(opt)}
+              className={`rounded-full px-3 py-1 capitalize transition-colors ${
+                value.interval === opt
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              aria-pressed={value.interval === opt}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isPaid && (
+        <p className="text-xs text-muted-foreground">
+          You'll be sent to secure checkout after confirming your email and signing in.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -8,6 +8,7 @@ import { useSubscription } from "@/hooks/useSubscription";
 import {
   type BillingInterval,
   formatPrice,
+  isComingSoon,
   paidTiersVisible,
   priceFor,
   pricingCta,
@@ -101,6 +102,7 @@ function TierCard({
   inherits,
   features,
   highlight,
+  comingSoon,
   cta,
 }: {
   name: string;
@@ -110,6 +112,7 @@ function TierCard({
   inherits?: string;
   features: string[];
   highlight?: boolean;
+  comingSoon?: boolean;
   cta?: ReactNode;
 }) {
   return (
@@ -123,14 +126,21 @@ function TierCard({
           Recommended
         </span>
       )}
+      {comingSoon && (
+        <span className="absolute -top-2.5 right-4 rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Coming soon
+        </span>
+      )}
       <div className="space-y-0.5">
         <h3 className="text-base font-semibold text-foreground">{name}</h3>
         <p className="text-xs text-muted-foreground">{blurb}</p>
       </div>
-      <div className="mt-3 flex items-baseline gap-1">
-        <span className="text-2xl font-bold text-foreground">{price}</span>
-        {cadence && <span className="text-sm text-muted-foreground">{cadence}</span>}
-      </div>
+      {price && (
+        <div className="mt-3 flex items-baseline gap-1">
+          <span className="text-2xl font-bold text-foreground">{price}</span>
+          {cadence && <span className="text-sm text-muted-foreground">{cadence}</span>}
+        </div>
+      )}
       {inherits && <p className="mt-3 text-xs font-medium text-muted-foreground">{inherits}</p>}
       <ul className="mt-2 space-y-2">
         {features.map((f) => (
@@ -258,18 +268,22 @@ export function PricingCards({ className }: { className?: string }) {
         ))}
         {showPaid &&
           PAID_TIERS.map((tier) => {
+            const soon = isComingSoon(tier.slug);
             const price = priceFor(config.prices, tier.slug, interval);
-            if (!price) return null; // this interval isn't priced for this tier
+            // Purchasable tiers without a price for this interval are hidden;
+            // coming-soon tiers always show (as a teaser) but can't be bought.
+            if (!soon && !price) return null;
             return (
               <TierCard
                 key={tier.slug}
                 name={tier.name}
                 blurb={tier.blurb}
-                price={formatPrice(price.unitAmount, price.currency)}
-                cadence={cadence}
+                price={price ? formatPrice(price.unitAmount, price.currency) : ""}
+                cadence={price ? cadence : undefined}
                 inherits={tier.inherits}
                 features={tier.features}
-                cta={ctaFor(tier.slug, true)}
+                comingSoon={soon}
+                cta={soon ? null : ctaFor(tier.slug, true)}
               />
             );
           })}

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -3,26 +3,43 @@ import { Check, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
+import { useStripePrices } from "@/hooks/useStripePrices";
 import { useSubscription } from "@/hooks/useSubscription";
-import { pricingCta } from "@/lib/billing";
+import {
+  type BillingInterval,
+  formatPrice,
+  paidTiersVisible,
+  priceFor,
+  pricingCta,
+  tiersWithPrices,
+} from "@/lib/billing";
 import { createCheckout } from "@/lib/billingClient";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
-interface Tier {
+type PaidSlug = "plus" | "premium" | "pro";
+
+interface FreeTier {
   name: string;
   blurb: string;
   price: string;
-  cadence?: string;
   inherits?: string;
   features: string[];
   highlight?: boolean;
-  comingSoon?: boolean;
   /** Maps the card to a subscription tier slug (the offline card has none). */
-  slug?: "free" | "plus" | "premium" | "pro";
+  slug?: "free";
 }
 
-const TIERS: Tier[] = [
+interface PaidTier {
+  name: string;
+  blurb: string;
+  inherits: string;
+  features: string[];
+  slug: PaidSlug;
+}
+
+// The two always-on free cards. Prices are fixed ($0) — no Stripe needed.
+const FREE_TIERS: FreeTier[] = [
   {
     name: "Free",
     blurb: "Offline",
@@ -48,12 +65,14 @@ const TIERS: Tier[] = [
       "20 MB cloud log storage",
     ],
   },
+];
+
+// Paid tiers — feature copy is static; the price is resolved live from Stripe
+// (by lookup_key) and these cards are hidden entirely when Stripe isn't wired up.
+const PAID_TIERS: PaidTier[] = [
   {
     name: "Plus",
     blurb: "For bigger garages",
-    price: "$1",
-    cadence: "/mo",
-    comingSoon: true,
     slug: "plus",
     inherits: "Everything in Free online, plus",
     features: ["500 MB cloud log storage"],
@@ -61,9 +80,6 @@ const TIERS: Tier[] = [
   {
     name: "Premium",
     blurb: "Max storage",
-    price: "$3",
-    cadence: "/mo",
-    comingSoon: true,
     slug: "premium",
     inherits: "Everything in Plus, plus",
     features: ["1 GB cloud log storage"],
@@ -71,9 +87,6 @@ const TIERS: Tier[] = [
   {
     name: "Pro",
     blurb: "With AI coaching",
-    price: "$10",
-    cadence: "/mo",
-    comingSoon: true,
     slug: "pro",
     inherits: "Everything in Premium, plus",
     features: ["AI coaching (coming soon)"],
@@ -81,43 +94,46 @@ const TIERS: Tier[] = [
 ];
 
 function TierCard({
-  tier,
+  name,
+  blurb,
+  price,
+  cadence,
+  inherits,
+  features,
+  highlight,
   cta,
-  showComingSoon,
 }: {
-  tier: Tier;
+  name: string;
+  blurb: string;
+  price: string;
+  cadence?: string;
+  inherits?: string;
+  features: string[];
+  highlight?: boolean;
   cta?: ReactNode;
-  showComingSoon: boolean;
 }) {
   return (
     <div
       className={`relative flex flex-col rounded-xl border bg-card p-5 text-left ${
-        tier.highlight ? "border-primary ring-1 ring-primary/40" : "border-border"
+        highlight ? "border-primary ring-1 ring-primary/40" : "border-border"
       }`}
     >
-      {tier.highlight && (
+      {highlight && (
         <span className="absolute -top-2.5 left-4 rounded-full bg-primary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-foreground">
           Recommended
         </span>
       )}
-      {showComingSoon && (
-        <span className="absolute -top-2.5 right-4 rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Coming soon
-        </span>
-      )}
       <div className="space-y-0.5">
-        <h3 className="text-base font-semibold text-foreground">{tier.name}</h3>
-        <p className="text-xs text-muted-foreground">{tier.blurb}</p>
+        <h3 className="text-base font-semibold text-foreground">{name}</h3>
+        <p className="text-xs text-muted-foreground">{blurb}</p>
       </div>
       <div className="mt-3 flex items-baseline gap-1">
-        <span className="text-2xl font-bold text-foreground">{tier.price}</span>
-        {tier.cadence && <span className="text-sm text-muted-foreground">{tier.cadence}</span>}
+        <span className="text-2xl font-bold text-foreground">{price}</span>
+        {cadence && <span className="text-sm text-muted-foreground">{cadence}</span>}
       </div>
-      {tier.inherits && (
-        <p className="mt-3 text-xs font-medium text-muted-foreground">{tier.inherits}</p>
-      )}
+      {inherits && <p className="mt-3 text-xs font-medium text-muted-foreground">{inherits}</p>}
       <ul className="mt-2 space-y-2">
-        {tier.features.map((f) => (
+        {features.map((f) => (
           <li key={f} className="flex items-start gap-2 text-sm text-foreground">
             <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
             <span>{f}</span>
@@ -129,29 +145,89 @@ function TierCard({
   );
 }
 
+function IntervalToggle({
+  value,
+  onChange,
+}: {
+  value: BillingInterval;
+  onChange: (v: BillingInterval) => void;
+}) {
+  return (
+    <div className="mt-4 inline-flex items-center rounded-full border border-border bg-card p-0.5 text-sm">
+      {(["monthly", "annual"] as const).map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          onClick={() => onChange(opt)}
+          className={`rounded-full px-3 py-1 capitalize transition-colors ${
+            value === opt
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+          aria-pressed={value === opt}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 /**
  * Plans / pricing grid. Shown on the landing page (the empty-state of the main
- * app) and on the registration page. Informational for signed-out visitors;
- * signed-in users get live "Upgrade" / "Current plan" actions on the paid tiers
- * (a paid tier whose Stripe Price isn't configured yet stays "Coming soon").
+ * app) and on the registration page. The two free cards always render;
+ * signed-in users get live "Upgrade" / "Current plan" actions on the paid tiers.
+ * When Stripe isn't configured the paid tiers are hidden entirely (free-only
+ * failback), and a monthly/annual toggle appears only when paid plans are shown.
  */
 export function PricingCards({ className }: { className?: string }) {
   const { user } = useAuth();
-  const { tiers, currentTier } = useSubscription();
+  const { currentTier } = useSubscription();
+  const { config } = useStripePrices();
+  const [interval, setInterval] = useState<BillingInterval>("monthly");
   const [busy, setBusy] = useState<string | null>(null);
 
   const signedIn = !!user;
-  const purchasable = new Set(tiers.filter((t) => t.stripe_price_id).map((t) => t.tier));
+  const showPaid = paidTiersVisible(config);
+  const purchasable = tiersWithPrices(config.prices);
+  const cadence = interval === "annual" ? "/yr" : "/mo";
 
-  const onUpgrade = async (slug: string) => {
+  const onUpgrade = async (slug: PaidSlug) => {
     setBusy(slug);
     try {
-      const url = await createCheckout(slug, window.location.href);
+      const url = await createCheckout(slug, interval, window.location.href);
       window.location.href = url;
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Couldn't start checkout.");
       setBusy(null);
     }
+  };
+
+  const ctaFor = (slug: "free" | PaidSlug, isPaid: boolean): ReactNode => {
+    const kind = pricingCta({
+      slug,
+      signedIn,
+      cloudEnabled: enableCloud,
+      currentTier,
+      purchasable: purchasable.has(slug),
+    });
+    if (kind === "current") {
+      return (
+        <Button variant="outline" className="w-full" disabled>
+          <Check className="h-4 w-4" /> Current plan
+        </Button>
+      );
+    }
+    if (kind === "upgrade" && isPaid) {
+      const isBusy = busy === slug;
+      return (
+        <Button className="w-full" disabled={isBusy} onClick={() => void onUpgrade(slug as PaidSlug)}>
+          {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {isBusy ? "Redirecting…" : "Upgrade"}
+        </Button>
+      );
+    }
+    return null;
   };
 
   return (
@@ -161,44 +237,42 @@ export function PricingCards({ className }: { className?: string }) {
         <p className="text-sm text-muted-foreground">
           Start free and fully offline. Add an account for cross-device sync — upgrade only if you need more.
         </p>
+        {showPaid && (
+          <div className="flex justify-center">
+            <IntervalToggle value={interval} onChange={setInterval} />
+          </div>
+        )}
       </div>
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-        {TIERS.map((tier) => {
-          const kind = pricingCta({
-            slug: tier.slug,
-            signedIn,
-            cloudEnabled: enableCloud,
-            currentTier,
-            purchasable: !!tier.slug && purchasable.has(tier.slug),
-          });
-
-          let cta: ReactNode = null;
-          if (kind === "current") {
-            cta = (
-              <Button variant="outline" className="w-full" disabled>
-                <Check className="h-4 w-4" /> Current plan
-              </Button>
+        {FREE_TIERS.map((tier) => (
+          <TierCard
+            key={`${tier.name}-${tier.blurb}`}
+            name={tier.name}
+            blurb={tier.blurb}
+            price={tier.price}
+            inherits={tier.inherits}
+            features={tier.features}
+            highlight={tier.highlight}
+            cta={tier.slug ? ctaFor(tier.slug, false) : null}
+          />
+        ))}
+        {showPaid &&
+          PAID_TIERS.map((tier) => {
+            const price = priceFor(config.prices, tier.slug, interval);
+            if (!price) return null; // this interval isn't priced for this tier
+            return (
+              <TierCard
+                key={tier.slug}
+                name={tier.name}
+                blurb={tier.blurb}
+                price={formatPrice(price.unitAmount, price.currency)}
+                cadence={cadence}
+                inherits={tier.inherits}
+                features={tier.features}
+                cta={ctaFor(tier.slug, true)}
+              />
             );
-          } else if (kind === "upgrade" && tier.slug) {
-            const slug = tier.slug;
-            const isBusy = busy === slug;
-            cta = (
-              <Button className="w-full" disabled={isBusy} onClick={() => void onUpgrade(slug)}>
-                {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-                {isBusy ? "Redirecting…" : "Upgrade"}
-              </Button>
-            );
-          }
-
-          return (
-            <TierCard
-              key={`${tier.name}-${tier.blurb}`}
-              tier={tier}
-              cta={cta}
-              showComingSoon={!!tier.comingSoon && kind === "none"}
-            />
-          );
-        })}
+          })}
       </div>
     </section>
   );

--- a/src/hooks/useStripePrices.ts
+++ b/src/hooks/useStripePrices.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import type { StripeConfig } from "@/lib/billing";
+import { fetchStripeConfig } from "@/lib/billingClient";
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+export interface StripePricesState {
+  loading: boolean;
+  config: StripeConfig;
+}
+
+const UNCONFIGURED: StripeConfig = { configured: false, prices: [] };
+
+/**
+ * Reads the live Stripe pricing catalogue (monthly/annual prices per paid tier)
+ * for the pricing UI. Online-only and cloud-gated; never throws into render —
+ * any failure reads as "not configured", which collapses the UI to the free
+ * cards. Public data, so it works signed-out.
+ */
+export function useStripePrices(): StripePricesState {
+  const online = useOnlineStatus();
+  const [config, setConfig] = useState<StripeConfig>(UNCONFIGURED);
+  const [loading, setLoading] = useState(enableCloud);
+
+  useEffect(() => {
+    if (!enableCloud) {
+      setConfig(UNCONFIGURED);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    fetchStripeConfig()
+      .then((c) => {
+        if (!cancelled) setConfig(c);
+      })
+      .catch(() => {
+        if (!cancelled) setConfig(UNCONFIGURED);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [online]);
+
+  return { loading, config };
+}

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -9,6 +9,7 @@ import {
   paidTiersVisible,
   priceFor,
   formatPrice,
+  isComingSoon,
   type StripePrice,
 } from "./billing";
 
@@ -121,6 +122,17 @@ describe("priceFor", () => {
   });
   it("returns undefined when the interval isn't priced", () => {
     expect(priceFor(prices, "pro", "monthly")).toBeUndefined();
+  });
+});
+
+describe("isComingSoon", () => {
+  it("flags the AI (pro) tier as not-yet-purchasable", () => {
+    expect(isComingSoon("pro")).toBe(true);
+  });
+  it("treats the other tiers as available", () => {
+    expect(isComingSoon("free")).toBe(false);
+    expect(isComingSoon("plus")).toBe(false);
+    expect(isComingSoon("premium")).toBe(false);
   });
 });
 

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { isActiveStatus, effectiveTier, isPaidTier, pricingCta } from "./billing";
+import {
+  isActiveStatus,
+  effectiveTier,
+  isPaidTier,
+  pricingCta,
+  lookupKey,
+  tiersWithPrices,
+  paidTiersVisible,
+  priceFor,
+  formatPrice,
+  type StripePrice,
+} from "./billing";
+
+const price = (tier: string, interval: "monthly" | "annual", unitAmount: number): StripePrice => ({
+  tier,
+  interval,
+  lookupKey: `${tier}_${interval}`,
+  priceId: `price_${tier}_${interval}`,
+  unitAmount,
+  currency: "usd",
+});
 
 describe("isActiveStatus", () => {
   it("treats active / trialing / past_due as granting access", () => {
@@ -62,5 +82,54 @@ describe("pricingCta", () => {
 
   it("never offers an upgrade to the free-online card", () => {
     expect(pricingCta({ ...base, slug: "free", currentTier: "pro" })).toBe("none");
+  });
+});
+
+describe("lookupKey", () => {
+  it("joins tier + interval the way Stripe lookup_keys are named", () => {
+    expect(lookupKey("plus", "monthly")).toBe("plus_monthly");
+    expect(lookupKey("pro", "annual")).toBe("pro_annual");
+  });
+});
+
+describe("tiersWithPrices", () => {
+  it("collects the distinct tiers that have a price", () => {
+    const prices = [price("plus", "monthly", 100), price("plus", "annual", 1000), price("pro", "monthly", 1000)];
+    expect(tiersWithPrices(prices)).toEqual(new Set(["plus", "pro"]));
+  });
+  it("is empty for no prices", () => {
+    expect(tiersWithPrices([]).size).toBe(0);
+  });
+});
+
+describe("paidTiersVisible (no-Stripe failback)", () => {
+  it("is false when unconfigured, configured-but-empty, or null", () => {
+    expect(paidTiersVisible(null)).toBe(false);
+    expect(paidTiersVisible({ configured: false, prices: [] })).toBe(false);
+    expect(paidTiersVisible({ configured: false, prices: [price("plus", "monthly", 100)] })).toBe(false);
+    expect(paidTiersVisible({ configured: true, prices: [] })).toBe(false);
+  });
+  it("is true only when configured with at least one price", () => {
+    expect(paidTiersVisible({ configured: true, prices: [price("plus", "monthly", 100)] })).toBe(true);
+  });
+});
+
+describe("priceFor", () => {
+  const prices = [price("plus", "monthly", 100), price("plus", "annual", 1000)];
+  it("matches on tier + interval", () => {
+    expect(priceFor(prices, "plus", "annual")?.unitAmount).toBe(1000);
+  });
+  it("returns undefined when the interval isn't priced", () => {
+    expect(priceFor(prices, "pro", "monthly")).toBeUndefined();
+  });
+});
+
+describe("formatPrice", () => {
+  it("drops cents for whole amounts and keeps them otherwise", () => {
+    expect(formatPrice(100, "usd")).toBe("$1");
+    expect(formatPrice(1099, "usd")).toBe("$10.99");
+  });
+  it("returns empty string for null (metered) amounts", () => {
+    expect(formatPrice(null, "usd")).toBe("");
   });
 });

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -107,6 +107,17 @@ export function isPaidTier(tier: string): boolean {
   return tier !== "free";
 }
 
+// Tiers that exist but aren't yet self-service purchasable — shown as
+// "Coming soon" and never selectable for checkout (the create-checkout-session
+// edge function rejects them too). They can still be granted manually (e.g.
+// comping a tester) by creating the subscription in Stripe, which the webhook
+// honours. Keep this in sync with create-checkout-session's COMING_SOON set.
+export const COMING_SOON_TIERS = new Set<string>(["pro"]);
+
+export function isComingSoon(tier: string): boolean {
+  return COMING_SOON_TIERS.has(tier);
+}
+
 export type PricingCtaKind = "none" | "current" | "upgrade";
 
 export interface PricingCtaInput {

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -18,6 +18,73 @@ export interface UserSubscriptionRow {
   tier: string;
   status: string;
   current_period_end: string | null;
+  cancel_at_period_end?: boolean;
+  billing_interval?: string | null;
+  grace_until?: string | null;
+}
+
+// Paid plans bill either monthly or annually. The slug encodes both halves of a
+// Stripe lookup_key: `${tier}_${interval}` (e.g. "pro_annual").
+export type BillingInterval = "monthly" | "annual";
+
+/** A live Stripe Price for one (tier × interval), as returned by stripe-prices. */
+export interface StripePrice {
+  tier: string;
+  interval: BillingInterval;
+  lookupKey: string;
+  priceId: string;
+  /** Amount in the currency's minor unit (cents); null for metered prices. */
+  unitAmount: number | null;
+  currency: string;
+}
+
+/** The pricing-catalogue response: whether Stripe is wired up + its live prices. */
+export interface StripeConfig {
+  configured: boolean;
+  prices: StripePrice[];
+}
+
+/** The Stripe lookup_key for a tier + interval. */
+export function lookupKey(tier: string, interval: BillingInterval): string {
+  return `${tier}_${interval}`;
+}
+
+/** The set of tiers that have at least one purchasable price configured. */
+export function tiersWithPrices(prices: StripePrice[]): Set<string> {
+  return new Set(prices.map((p) => p.tier));
+}
+
+/**
+ * Whether the paid tiers should be shown at all. The failback when Stripe isn't
+ * wired up (no secret key / no prices) is to surface only the free cards — paid
+ * tiers are hidden entirely, not shown as "coming soon".
+ */
+export function paidTiersVisible(config: StripeConfig | null | undefined): boolean {
+  return !!config?.configured && (config?.prices.length ?? 0) > 0;
+}
+
+/** Find the live price for a tier + interval, if configured. */
+export function priceFor(
+  prices: StripePrice[],
+  tier: string,
+  interval: BillingInterval,
+): StripePrice | undefined {
+  return prices.find((p) => p.tier === tier && p.interval === interval);
+}
+
+/** Format a minor-unit amount as a localized currency string (no trailing .00). */
+export function formatPrice(unitAmount: number | null | undefined, currency: string): string {
+  if (unitAmount == null) return "";
+  const major = unitAmount / 100;
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency.toUpperCase(),
+      maximumFractionDigits: Number.isInteger(major) ? 0 : 2,
+    }).format(major);
+  } catch {
+    return `${major}`;
+  }
 }
 
 // A subscription grants its tier only while the status is one of these; anything

--- a/src/lib/billingClient.ts
+++ b/src/lib/billingClient.ts
@@ -9,7 +9,12 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
-import type { SubscriptionTierRow, UserSubscriptionRow } from "./billing";
+import type {
+  BillingInterval,
+  StripeConfig,
+  SubscriptionTierRow,
+  UserSubscriptionRow,
+} from "./billing";
 
 const untyped = supabase as unknown as SupabaseClient;
 
@@ -25,17 +30,35 @@ export async function fetchTiers(): Promise<SubscriptionTierRow[]> {
 export async function fetchMySubscription(userId: string): Promise<UserSubscriptionRow | null> {
   const { data, error } = await untyped
     .from("user_subscriptions")
-    .select("user_id, tier, status, current_period_end")
+    .select("user_id, tier, status, current_period_end, cancel_at_period_end, billing_interval, grace_until")
     .eq("user_id", userId)
     .maybeSingle();
   if (error) throw new Error(`Failed to load subscription: ${error.message}`);
   return (data ?? null) as UserSubscriptionRow | null;
 }
 
-/** Start Stripe Checkout for a tier; resolves to the hosted URL to redirect to. */
-export async function createCheckout(tier: string, returnUrl: string): Promise<string> {
+/**
+ * The live pricing catalogue (whether Stripe is wired up + its prices). Never
+ * throws into render: a network/function error reads as "not configured", which
+ * makes the UI fall back to the free-only cards.
+ */
+export async function fetchStripeConfig(): Promise<StripeConfig> {
+  const { data, error } = await supabase.functions.invoke("stripe-prices", { body: {} });
+  if (error || !data) return { configured: false, prices: [] };
+  return data as StripeConfig;
+}
+
+/**
+ * Start Stripe Checkout for a tier + billing interval; resolves to the hosted
+ * URL to redirect to.
+ */
+export async function createCheckout(
+  tier: string,
+  interval: BillingInterval,
+  returnUrl: string,
+): Promise<string> {
   const { data, error } = await supabase.functions.invoke("create-checkout-session", {
-    body: { tier, returnUrl },
+    body: { tier, interval, returnUrl },
   });
   if (error) throw new Error(error.message);
   const url = (data as { url?: string } | null)?.url;

--- a/src/lib/pendingCheckout.test.ts
+++ b/src/lib/pendingCheckout.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { parsePendingCheckout } from "./pendingCheckout";
+
+const NOW = 1_000_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("parsePendingCheckout", () => {
+  it("returns null for empty / malformed input", () => {
+    expect(parsePendingCheckout(null, NOW)).toBeNull();
+    expect(parsePendingCheckout("not json", NOW)).toBeNull();
+    expect(parsePendingCheckout("{}", NOW)).toBeNull();
+  });
+
+  it("rejects the free tier and unknown intervals", () => {
+    expect(parsePendingCheckout(JSON.stringify({ tier: "free", interval: "monthly", ts: NOW }), NOW)).toBeNull();
+    expect(parsePendingCheckout(JSON.stringify({ tier: "pro", interval: "weekly", ts: NOW }), NOW)).toBeNull();
+  });
+
+  it("expires intents older than 24h", () => {
+    const stale = { tier: "pro", interval: "annual", ts: NOW - DAY - 1 };
+    expect(parsePendingCheckout(JSON.stringify(stale), NOW)).toBeNull();
+  });
+
+  it("parses a valid, fresh paid intent", () => {
+    const intent = { tier: "plus", interval: "annual", ts: NOW - 1000 };
+    expect(parsePendingCheckout(JSON.stringify(intent), NOW)).toEqual(intent);
+  });
+});

--- a/src/lib/pendingCheckout.ts
+++ b/src/lib/pendingCheckout.ts
@@ -1,0 +1,54 @@
+// A paid plan chosen at sign-up can't go straight to Stripe Checkout: sign-up
+// requires email confirmation, so there's no session yet. We stash the choice
+// here (localStorage) and redirect to Checkout on the user's first authenticated
+// load (see usePendingCheckout). The intent expires so a stale choice never
+// hijacks a later, unrelated sign-in.
+
+import type { BillingInterval } from "./billing";
+
+const KEY = "dove-pending-checkout";
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+
+export interface PendingCheckout {
+  tier: string;
+  interval: BillingInterval;
+  ts: number;
+}
+
+/** Parse + validate a stored intent, dropping anything malformed or expired. Pure. */
+export function parsePendingCheckout(raw: string | null, now: number): PendingCheckout | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Partial<PendingCheckout>;
+    if (typeof v.tier !== "string" || v.tier === "free") return null;
+    if (v.interval !== "monthly" && v.interval !== "annual") return null;
+    if (typeof v.ts !== "number" || now - v.ts > MAX_AGE_MS) return null;
+    return { tier: v.tier, interval: v.interval, ts: v.ts };
+  } catch {
+    return null;
+  }
+}
+
+export function setPendingCheckout(tier: string, interval: BillingInterval): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify({ tier, interval, ts: Date.now() }));
+  } catch {
+    /* storage unavailable — checkout just won't auto-resume */
+  }
+}
+
+export function getPendingCheckout(): PendingCheckout | null {
+  try {
+    return parsePendingCheckout(localStorage.getItem(KEY), Date.now());
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingCheckout(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -9,7 +9,10 @@ import { Gauge, ArrowLeft } from 'lucide-react';
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 import { Turnstile, turnstileEnabled } from '@/components/Turnstile';
 import { PricingCards } from '@/components/PricingCards';
+import { PlanChooser, type PlanSelection } from '@/components/PlanChooser';
 import { isDisposableEmail, looksLikeEmail } from '@/lib/emailValidation';
+import { isPaidTier } from '@/lib/billing';
+import { setPendingCheckout } from '@/lib/pendingCheckout';
 
 export default function Register() {
   useDocumentHead({
@@ -23,6 +26,7 @@ export default function Register() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [plan, setPlan] = useState<PlanSelection>({ tier: 'free', interval: 'monthly' });
   const { signUp, signInWithGoogle } = useAuth();
   const navigate = useNavigate();
 
@@ -54,7 +58,17 @@ export default function Register() {
     if (error) {
       toast({ title: 'Registration failed', description: error.message, variant: 'destructive' });
     } else {
-      toast({ title: 'Account created', description: 'Check your email to confirm your account.' });
+      // Account-first paid flow: stash the chosen plan so checkout resumes on
+      // the user's first sign-in after confirming their email.
+      if (isPaidTier(plan.tier)) {
+        setPendingCheckout(plan.tier, plan.interval);
+        toast({
+          title: 'Account created',
+          description: 'Confirm your email, then sign in to finish checkout for your plan.',
+        });
+      } else {
+        toast({ title: 'Account created', description: 'Check your email to confirm your account.' });
+      }
       navigate('/login');
     }
   };
@@ -99,6 +113,7 @@ export default function Register() {
               <Label htmlFor="displayName">Display name <span className="text-muted-foreground font-normal">(optional)</span></Label>
               <Input id="displayName" type="text" maxLength={40} placeholder="Leave blank for a random name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
             </div>
+            <PlanChooser value={plan} onChange={setPlan} />
             <div className="space-y-2">
               <Label htmlFor="password">Password</Label>
               <Input id="password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -187,6 +187,14 @@ function PlanSection() {
   const renews = subscription?.current_period_end
     ? new Date(subscription.current_period_end).toLocaleDateString()
     : null;
+  const cancelsAtPeriodEnd = !!subscription?.cancel_at_period_end;
+  // A cancelled subscription drops to free but keeps a grace window before logs
+  // are trimmed; the row persists (with a Stripe customer) so they can resubscribe.
+  const graceUntil = subscription?.grace_until
+    ? new Date(subscription.grace_until).toLocaleDateString()
+    : null;
+  const inGrace = !subscribed && !!graceUntil;
+  const canManage = !!subscription?.current_period_end || subscribed || inGrace;
 
   const manage = async () => {
     setBusy(true);
@@ -206,13 +214,20 @@ function PlanSection() {
         <div className="min-w-0">
           <p className="text-sm font-medium text-foreground">{loading ? "…" : label}</p>
           {subscribed && renews && (
-            <p className="text-[11px] text-muted-foreground">Renews {renews}</p>
+            <p className="text-[11px] text-muted-foreground">
+              {cancelsAtPeriodEnd ? `Cancels ${renews}` : `Renews ${renews}`}
+            </p>
           )}
-          {!subscribed && (
+          {inGrace && (
+            <p className="text-[11px] text-amber-600 dark:text-amber-500">
+              Subscription ended. Cloud logs trim to the free tier on {graceUntil} — resubscribe to keep them.
+            </p>
+          )}
+          {!subscribed && !inGrace && (
             <p className="text-[11px] text-muted-foreground">Upgrade from the Plans &amp; pricing cards.</p>
           )}
         </div>
-        {subscribed && (
+        {canManage && (
           <Button size="sm" variant="outline" className="shrink-0" disabled={busy} onClick={() => void manage()}>
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
             Manage subscription

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,3 +20,6 @@ verify_jwt = false
 
 [functions.create-portal-session]
 verify_jwt = false
+
+[functions.stripe-prices]
+verify_jwt = false

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -48,6 +48,13 @@ Deno.serve(async (req) => {
     if (!tier || typeof tier !== 'string' || tier === 'free') {
       return json({ error: 'Invalid tier' }, 400);
     }
+    // Tiers that exist but aren't self-service purchasable yet (e.g. the AI
+    // plan). They can still be comped by creating the subscription directly in
+    // Stripe — the webhook honours it. Keep in sync with billing.ts COMING_SOON_TIERS.
+    const COMING_SOON = new Set(['pro']);
+    if (COMING_SOON.has(tier)) {
+      return json({ error: 'Tier is coming soon and not yet available to purchase' }, 400);
+    }
     const billingInterval = interval === 'annual' ? 'annual' : 'monthly';
 
     const admin = createClient(

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,7 +1,8 @@
-// Creates a Stripe Checkout Session for a subscription tier and returns its URL.
-// The caller's Supabase JWT (Authorization: Bearer …) identifies the user; the
-// tier's Price id lives in the subscription_tiers table (set after you create
-// the Price in Stripe). The actual entitlement is granted by stripe-webhook on
+// Creates a Stripe Checkout Session for a subscription tier + billing interval
+// and returns its URL. The caller's Supabase JWT (Authorization: Bearer …)
+// identifies the user; the Price is resolved live by lookup_key ("{tier}_{interval}",
+// e.g. "plus_annual") so the Stripe dashboard is the source of truth — no Price
+// ids in code or DB. The actual entitlement is granted by stripe-webhook on
 // completion — never by the client.
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import Stripe from "https://esm.sh/stripe@17.7.0?target=deno";
@@ -43,23 +44,36 @@ Deno.serve(async (req) => {
       return json({ error: 'Unauthorized' }, 401);
     }
 
-    const { tier, returnUrl } = await req.json().catch(() => ({}));
+    const { tier, interval, returnUrl } = await req.json().catch(() => ({}));
     if (!tier || typeof tier !== 'string' || tier === 'free') {
       return json({ error: 'Invalid tier' }, 400);
     }
+    const billingInterval = interval === 'annual' ? 'annual' : 'monthly';
 
     const admin = createClient(
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
     );
 
-    // Resolve the tier's Stripe Price.
+    // The tier must exist in our catalogue (and not be the free tier).
     const { data: tierRow } = await admin
       .from('subscription_tiers')
-      .select('stripe_price_id')
+      .select('tier')
       .eq('tier', tier)
       .maybeSingle();
-    if (!tierRow?.stripe_price_id) {
+    if (!tierRow) {
+      return json({ error: 'Unknown tier' }, 400);
+    }
+
+    // Resolve the live Price by lookup_key — the dashboard is the source of truth.
+    const lookupKey = `${tier}_${billingInterval}`;
+    const { data: prices } = await stripe.prices.list({
+      lookup_keys: [lookupKey],
+      active: true,
+      limit: 1,
+    });
+    const price = prices[0];
+    if (!price) {
       return json({ error: 'Tier is not purchasable' }, 400);
     }
 
@@ -87,9 +101,9 @@ Deno.serve(async (req) => {
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       customer: customerId,
-      line_items: [{ price: tierRow.stripe_price_id, quantity: 1 }],
+      line_items: [{ price: price.id, quantity: 1 }],
       client_reference_id: user.id,
-      subscription_data: { metadata: { user_id: user.id, tier } },
+      subscription_data: { metadata: { user_id: user.id, tier, interval: billingInterval } },
       allow_promotion_codes: true,
       success_url: `${base}?checkout=success`,
       cancel_url: `${base}?checkout=cancel`,

--- a/supabase/functions/stripe-prices/index.ts
+++ b/supabase/functions/stripe-prices/index.ts
@@ -1,0 +1,70 @@
+// Public price catalogue for the pricing UI. Returns whether Stripe is wired up
+// (a secret key is present) plus the live monthly/annual Prices for the paid
+// tiers, resolved by lookup_key so the dashboard is the single source of truth —
+// no Price ids in code or env. When STRIPE_SECRET_KEY is absent it reports
+// { configured: false }, which is the client's signal to fall back to showing
+// only the free cards. No auth: prices are public marketing data.
+import Stripe from "https://esm.sh/stripe@17.7.0?target=deno";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+// One lookup_key per (tier × interval). Create matching Prices in Stripe with
+// these exact lookup keys; anything missing simply won't appear in the UI.
+const LOOKUP_KEYS = [
+  'plus_monthly', 'plus_annual',
+  'premium_monthly', 'premium_annual',
+  'pro_monthly', 'pro_annual',
+];
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' },
+  });
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const secret = Deno.env.get('STRIPE_SECRET_KEY');
+  if (!secret) {
+    return json({ configured: false, prices: [] });
+  }
+
+  try {
+    const stripe = new Stripe(secret, {
+      apiVersion: '2025-03-31.basil',
+      httpClient: Stripe.createFetchHttpClient(),
+    });
+
+    const { data } = await stripe.prices.list({
+      lookup_keys: LOOKUP_KEYS,
+      active: true,
+      expand: ['data.product'],
+    });
+
+    const prices = data
+      .filter((p) => p.lookup_key)
+      .map((p) => {
+        const [tier, interval] = (p.lookup_key as string).split('_');
+        return {
+          tier,
+          interval,                 // 'monthly' | 'annual'
+          lookupKey: p.lookup_key,
+          priceId: p.id,
+          unitAmount: p.unit_amount, // cents, may be null for metered
+          currency: p.currency,
+        };
+      });
+
+    return json({ configured: true, prices });
+  } catch (e) {
+    console.error('stripe-prices error', e);
+    // Configured but errored — let the client fall back gracefully.
+    return json({ configured: false, prices: [] });
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -16,15 +16,28 @@ const admin = (): SupabaseClient => createClient(
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
 );
 
-// Map a Stripe Price id → our tier slug (falls back to 'free' if unknown).
-async function tierForPrice(db: SupabaseClient, priceId: string | undefined): Promise<string> {
-  if (!priceId) return 'free';
+// 60-day window after a subscription ends before logs are trimmed to free.
+const GRACE_DAYS = 60;
+
+// Resolve our tier slug + billing interval from a price. Prices carry a
+// lookup_key of "{tier}_{interval}" (e.g. "pro_annual"); fall back to the
+// subscription_tiers.stripe_price_id mapping, then to free/null.
+async function tierForPrice(
+  db: SupabaseClient,
+  price: Stripe.Price | undefined,
+): Promise<{ tier: string; interval: string | null }> {
+  if (!price) return { tier: 'free', interval: null };
+  if (price.lookup_key) {
+    const [tier, interval] = price.lookup_key.split('_');
+    if (tier) return { tier, interval: interval ?? null };
+  }
+  const intervalFromRecurring = price.recurring?.interval === 'year' ? 'annual' : 'monthly';
   const { data } = await db
     .from('subscription_tiers')
     .select('tier')
-    .eq('stripe_price_id', priceId)
+    .eq('stripe_price_id', price.id)
     .maybeSingle();
-  return data?.tier ?? 'free';
+  return { tier: data?.tier ?? 'free', interval: data ? intervalFromRecurring : null };
 }
 
 // Resolve our user_id for a subscription: prefer the metadata we stamped at
@@ -54,6 +67,8 @@ function periodEnd(sub: Stripe.Subscription): string | null {
   return typeof ts === 'number' ? new Date(ts * 1000).toISOString() : null;
 }
 
+const ENTITLING_STATUSES = ['active', 'trialing', 'past_due'];
+
 async function applySubscription(
   db: SupabaseClient,
   sub: Stripe.Subscription,
@@ -65,20 +80,53 @@ async function applySubscription(
     return;
   }
 
-  const priceId = sub.items?.data?.[0]?.price?.id;
+  const price = sub.items?.data?.[0]?.price;
   const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer?.id;
-  const tier = opts.deleted ? 'free' : await tierForPrice(db, priceId);
   const status = opts.deleted ? 'canceled' : sub.status;
+  const entitled = !opts.deleted && ENTITLING_STATUSES.includes(status);
 
-  await db.from('user_subscriptions').upsert({
+  const resolved = await tierForPrice(db, price);
+  const tier = entitled ? resolved.tier : 'free';
+  const endsAt = periodEnd(sub);
+
+  // Cancellation grace: once the subscription stops entitling access, keep the
+  // user's logs for GRACE_DAYS so they can re-subscribe / download. We only
+  // *set* grace_until on the transition (don't keep pushing it later on repeat
+  // webhooks), and clear it — plus re-arm logs_trimmed_at — when access resumes.
+  let graceUntil: string | null | undefined;
+  let logsTrimmedAt: string | null | undefined;
+  if (entitled) {
+    graceUntil = null;
+    logsTrimmedAt = null;
+  } else {
+    const { data: existing } = await db
+      .from('user_subscriptions')
+      .select('grace_until')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (existing?.grace_until) {
+      graceUntil = undefined; // leave the already-set deadline untouched
+    } else {
+      const base = endsAt ? new Date(endsAt) : new Date();
+      graceUntil = new Date(base.getTime() + GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    }
+  }
+
+  const row: Record<string, unknown> = {
     user_id: userId,
     tier,
     status,
     stripe_customer_id: customerId,
     stripe_subscription_id: sub.id,
-    current_period_end: periodEnd(sub),
+    current_period_end: endsAt,
+    cancel_at_period_end: !!sub.cancel_at_period_end,
+    billing_interval: entitled ? resolved.interval : null,
     updated_at: new Date().toISOString(),
-  }, { onConflict: 'user_id' });
+  };
+  if (graceUntil !== undefined) row.grace_until = graceUntil;
+  if (logsTrimmedAt !== undefined) row.logs_trimmed_at = logsTrimmedAt;
+
+  await db.from('user_subscriptions').upsert(row, { onConflict: 'user_id' });
 }
 
 Deno.serve(async (req) => {

--- a/supabase/migrations/20260528000000_subscription_grace_trim.sql
+++ b/supabase/migrations/20260528000000_subscription_grace_trim.sql
@@ -1,0 +1,135 @@
+-- Cancellation grace window + log trimming.
+--
+-- When a paid subscription is cancelled it ends at the period boundary (Stripe
+-- fires customer.subscription.deleted then). At that point the user drops to the
+-- free tier's *limits* immediately (user_tier() already returns 'free' for any
+-- non-active status), but their existing cloud logs are kept for a 60-day grace
+-- so they can re-subscribe (or download everything) before anything is removed.
+-- After the grace expires, trim_expired_logs() deletes their synced log files
+-- newest-first until they fit the free tier's logs_bytes allowance.
+--
+-- New user_subscriptions columns track the cancellation state the webhook needs:
+--   • cancel_at_period_end — Stripe flag: cancels at the next renewal.
+--   • billing_interval     — 'monthly' | 'annual' (from the price lookup_key).
+--   • grace_until          — when the 60-day window closes (set on cancellation).
+--   • logs_trimmed_at      — last time trim_expired_logs() ran for this user, so
+--                            a re-subscribe + re-cancel re-arms the trim.
+
+alter table public.user_subscriptions
+  add column if not exists cancel_at_period_end boolean not null default false,
+  add column if not exists billing_interval     text,
+  add column if not exists grace_until           timestamptz,
+  add column if not exists logs_trimmed_at        timestamptz;
+
+-- ── encodeURIComponent() parity ──────────────────────────────────────────────
+-- File blobs live in the user-files bucket at "{user_id}/{encodeURIComponent(name)}"
+-- (see cloud-sync syncEngine.blobPath). To delete the right storage object from
+-- SQL we must reproduce JS encodeURIComponent exactly: keep the unreserved set
+-- (A-Z a-z 0-9 - _ . ! ~ * ' ( )) and percent-encode every other UTF-8 byte as
+-- uppercase %XX.
+create or replace function public.encode_uri_component(p_text text)
+returns text language plpgsql immutable set search_path = public as $$
+declare
+  v_bytes bytea := convert_to(coalesce(p_text, ''), 'UTF8');
+  v_out   text  := '';
+  v_byte  int;
+  i       int;
+begin
+  for i in 0 .. length(v_bytes) - 1 loop
+    v_byte := get_byte(v_bytes, i);
+    if (v_byte between 48 and 57)        -- 0-9
+       or (v_byte between 65 and 90)     -- A-Z
+       or (v_byte between 97 and 122)    -- a-z
+       or v_byte in (45, 95, 46, 33, 126, 42, 39, 40, 41)  -- - _ . ! ~ * ' ( )
+    then
+      v_out := v_out || chr(v_byte);
+    else
+      v_out := v_out || '%' || upper(lpad(to_hex(v_byte), 2, '0'));
+    end if;
+  end loop;
+  return v_out;
+end;
+$$;
+
+-- ── Trim expired-grace users' logs to the free allowance ─────────────────────
+-- For every user whose subscription no longer grants access and whose grace has
+-- expired (and who hasn't already been trimmed for this grace window), delete
+-- their synced log files newest-first until the cumulative size of the kept
+-- (oldest) files fits the free tier's logs_bytes. Both the index row and the
+-- bucket object are removed. SECURITY DEFINER so it can cross RLS + storage;
+-- intentionally NOT granted to authenticated — only the scheduled job / service
+-- role runs it.
+create or replace function public.trim_expired_logs()
+returns integer language plpgsql security definer set search_path = public, storage as $$
+declare
+  v_free_limit bigint;
+  v_user       uuid;
+  v_deleted    int := 0;
+  r            record;
+begin
+  select logs_bytes into v_free_limit from public.subscription_tiers where tier = 'free';
+  if v_free_limit is null then
+    return 0;
+  end if;
+
+  for v_user in
+    select user_id
+      from public.user_subscriptions
+     where status not in ('active', 'trialing', 'past_due')
+       and grace_until is not null
+       and grace_until < now()
+       and (logs_trimmed_at is null or logs_trimmed_at < grace_until)
+  loop
+    for r in
+      with ranked as (
+        select id, record_key,
+               sum(public.sync_record_size(store, data)) over (
+                 order by updated_at asc, id asc
+                 rows between unbounded preceding and current row
+               ) as cum
+          from public.sync_records
+         where user_id = v_user
+           and public.sync_storage_type(store) = 'logs'
+      )
+      select id, record_key from ranked where cum > v_free_limit
+    loop
+      delete from storage.objects
+       where bucket_id = 'user-files'
+         and name = v_user::text || '/' || public.encode_uri_component(r.record_key);
+      delete from public.sync_records where id = r.id;
+      v_deleted := v_deleted + 1;
+    end loop;
+
+    update public.user_subscriptions
+       set logs_trimmed_at = now()
+     where user_id = v_user;
+  end loop;
+
+  return v_deleted;
+end;
+$$;
+
+-- ── Daily schedule via pg_cron ───────────────────────────────────────────────
+-- Guarded: if pg_cron isn't enabled on the project the migration still succeeds;
+-- enable the extension (Dashboard → Database → Extensions) and re-run the
+-- schedule block, or invoke trim_expired_logs() from an external scheduler.
+do $$
+begin
+  create extension if not exists pg_cron;
+exception when others then
+  raise notice 'pg_cron unavailable (%); schedule public.trim_expired_logs() manually.', sqlerrm;
+end $$;
+
+do $$
+begin
+  perform cron.unschedule('trim-expired-logs');
+exception when others then
+  null; -- no existing job (or pg_cron absent) — nothing to remove
+end $$;
+
+do $$
+begin
+  perform cron.schedule('trim-expired-logs', '0 3 * * *', 'select public.trim_expired_logs();');
+exception when others then
+  raise notice 'Could not schedule trim-expired-logs (%); run it from an external scheduler.', sqlerrm;
+end $$;


### PR DESCRIPTION
## Summary

Completes the Stripe subscription integration on top of the existing foundation (tiers, `user_subscriptions`, checkout/webhook/portal edge functions).

- **Monthly & annual billing** resolved live from Stripe by **lookup_key** (`plus_monthly`, `plus_annual`, `premium_monthly`, …) — the dashboard is the source of truth, no Price ids in code. New public `stripe-prices` edge function feeds the pricing catalogue.
- **No-Stripe failback**: when no `STRIPE_SECRET_KEY` is configured, the pricing UI shows only the two free cards (Guest + Free) and hides the paid tiers entirely (not "Coming soon").
- **Plan + interval selection at sign-up** via `PlanChooser`. Account-first flow: a paid choice creates the account, stashes a `pendingCheckout` intent, and resumes to Stripe Checkout on the user's first sign-in after email confirmation (`PendingCheckoutRedirect`). The webhook provisions the tier.
- **Upgrade/downgrade/cancel + renewal date** via the existing Stripe Billing Portal; Profile panel surfaces renewal/cancellation/grace dates.
- **Cancellation grace + log trimming**: webhook now tracks `cancel_at_period_end` / `billing_interval` and sets a 60-day `grace_until` on cancellation. New `subscription_grace_trim` migration adds a `pg_cron`-scheduled `trim_expired_logs()` that trims synced logs **newest-first** to the free `logs_bytes` allowance once grace expires (`encode_uri_component` parity targets the right `user-files` bucket objects).

## Operator setup still required
- Create Stripe Products/Prices tagged with the lookup_keys above (monthly + annual per paid tier).
- Set edge-function secrets `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`; point a webhook (`checkout.session.completed`, `customer.subscription.created/updated/deleted`) at `stripe-webhook`.
- Enable the `pg_cron` extension (or run `select public.trim_expired_logs();` from an external scheduler).

See README "Stripe / paid tiers" + "Cancellation grace + log trimming" notes.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` (711 passing; new pure-logic tests for prices/failback + pending-checkout parser)
- [x] `npm run build`
- [ ] Live Stripe checkout / webhook / portal flows — **cannot be exercised until keys are added** (test mode recommended first)
- [ ] Verify `trim_expired_logs()` against a seeded over-quota cancelled user once deployed

https://claude.ai/code/session_012D8zxba3CCmUdqgT16zZav

---
_Generated by [Claude Code](https://claude.ai/code/session_012D8zxba3CCmUdqgT16zZav)_