### PR TITLE
Customizable engine-type combobox for vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Customizable engine types for vehicles**: the vehicle form's *Engine* field
+  is now a searchable combobox backed by a reusable, per-user engine list. Type
+  to filter previously used engines; if the name isn't found, create it inline.
+  Existing vehicles' engine names are auto-imported into the list, and a *manage*
+  link beside the field opens a small menu for deleting saved engines (engines
+  currently in use by a vehicle are protected from deletion). The engine list is
+  stored locally (IndexedDB) and travels with the rest of your garage data over
+  cloud sync.
 - **Terms of Service page** (`/terms`) and a rewritten **Privacy Policy** that
   now accurately reflect the optional online features — accounts, cloud sync,
   Stripe-billed plans, and AI coaching — instead of the old "nothing ever leaves

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 │   ├── admin/             # Admin tabs: TracksTab, CoursesTab, SubmissionsTab, BannedIpsTab, ToolsTab, MessagesTab
 │   ├── tabs/              # Main view tabs: GraphViewTab, RaceLineTab, LapTimesTab, LabsTab, CoachTab, ProfileTab
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, InfoBox
-│   ├── drawer/            # File manager drawer tabs: FilesTab, KartsTab, NotesTab, SetupsTab, DeviceSettingsTab, DeviceTracksTab
+│   ├── drawer/            # File manager drawer tabs: FilesTab, KartsTab/VehiclesTab, NotesTab, SetupsTab, DeviceSettingsTab, DeviceTracksTab, EngineCombobox
 │   ├── track-editor/      # Track editor sub-components
 │   ├── RaceLineView.tsx   # Leaflet map with race line, speed heatmap, braking zones
 │   ├── TelemetryChart.tsx # Canvas-based speed/telemetry chart (simple mode)
@@ -114,6 +114,7 @@ src/
 │   ├── useFileManager.ts      # IndexedDB file CRUD
 │   ├── useKartManager.ts      # Backward compat re-export → useVehicleManager
 │   ├── useVehicleManager.ts   # Vehicle profiles CRUD
+│   ├── useEngineManager.ts    # Reusable engine-type list CRUD (search/create/import)
 │   ├── useTemplateManager.ts  # Vehicle types & setup templates CRUD
 │   ├── useNoteManager.ts      # Session notes CRUD
 │   ├── useSetupManager.ts     # Generic setup sheets CRUD (template-driven)
@@ -151,6 +152,8 @@ src/
 │   ├── fileStorage.ts         # IndexedDB: raw file blobs
 │   ├── kartStorage.ts         # Old kart storage (kept for compat)
 │   ├── vehicleStorage.ts     # ★ Vehicle profiles CRUD (replaces kartStorage)
+│   ├── engineStorage.ts      # IndexedDB: reusable engine-type list (emits garage events)
+│   ├── engineUtils.ts        # Pure engine search/dedup/create-offer helpers
 │   ├── templateStorage.ts    # ★ Vehicle types + setup templates, default kart schema
 │   ├── noteStorage.ts         # IndexedDB: session notes
 │   ├── setupStorage.ts        # IndexedDB: kart setups
@@ -395,7 +398,7 @@ GPS data is always parseable even if metadata is corrupted. Metadata is attached
 
 ## IndexedDB Storage (`src/lib/dbUtils.ts`)
 
-Single shared database: `"dove-file-manager"`, version 9.
+Single shared database: `"dove-file-manager"`, version 10.
 
 | Store | Key | Module |
 |-------|-----|--------|
@@ -409,6 +412,7 @@ Single shared database: `"dove-file-manager"`, version 9.
 | `vehicle-types` | `id` | `templateStorage.ts` |
 | `setup-templates` | `id` | `templateStorage.ts` |
 | `session-videos` | `sessionFileName` | `videoFileStorage.ts` |
+| `engines` | `id` | `engineStorage.ts` |
 
 To add a new store: increment `DB_VERSION`, add store name to `STORE_NAMES`, add creation logic in `openDB()`, create a corresponding storage module.
 

--- a/src/components/drawer/EngineCombobox.tsx
+++ b/src/components/drawer/EngineCombobox.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from "react";
+import { Plus, Trash2, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import type { Engine } from "@/lib/engineStorage";
+import {
+  engineNameKey,
+  filterEngines,
+  normalizeEngineName,
+  shouldOfferCreate,
+} from "@/lib/engineUtils";
+
+interface EngineComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  engines: Engine[];
+  /** Persist a new engine name to the reusable list. */
+  onCreate: (name: string) => Promise<unknown> | void;
+  /** Remove a saved engine from the reusable list. */
+  onDelete: (id: string) => Promise<void> | void;
+  /** Engine names currently used by a vehicle — deletion is blocked for these. */
+  usedNames?: string[];
+  label?: string;
+}
+
+export function EngineCombobox({
+  value,
+  onChange,
+  engines,
+  onCreate,
+  onDelete,
+  usedNames = [],
+  label = "Engine",
+}: EngineComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [manageOpen, setManageOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const matches = filterEngines(engines, value);
+  const offerCreate = shouldOfferCreate(value, engines);
+
+  const usedKeys = new Set(usedNames.map(engineNameKey));
+
+  const pick = (name: string) => {
+    onChange(name);
+    setOpen(false);
+  };
+
+  const create = async () => {
+    const name = normalizeEngineName(value);
+    if (!name) return;
+    await onCreate(name);
+    onChange(name);
+    setOpen(false);
+  };
+
+  return (
+    <div className="space-y-1" ref={wrapRef}>
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">{label}</Label>
+        <button
+          type="button"
+          className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+          onClick={() => setManageOpen(true)}
+        >
+          manage
+        </button>
+      </div>
+
+      <div className="relative">
+        <Input
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setOpen(false);
+            else if (e.key === "Enter" && offerCreate) {
+              e.preventDefault();
+              create();
+            }
+          }}
+          placeholder="Engine type"
+          className="h-8 text-sm"
+        />
+
+        {open && (matches.length > 0 || offerCreate) && (
+          <div className="absolute z-50 bottom-full mb-1 w-full max-h-44 overflow-y-auto rounded-md border border-border bg-popover shadow-md py-1">
+            {matches.map((engine) => (
+              <button
+                key={engine.id}
+                type="button"
+                className="w-full text-left px-2 py-1.5 text-sm hover:bg-muted/60 transition-colors truncate"
+                onClick={() => pick(engine.name)}
+              >
+                {engine.name}
+              </button>
+            ))}
+            {offerCreate && (
+              <button
+                type="button"
+                className="w-full flex items-center gap-1.5 px-2 py-1.5 text-sm text-primary hover:bg-muted/60 transition-colors"
+                onClick={create}
+              >
+                <Plus className="w-3.5 h-3.5 shrink-0" />
+                <span className="truncate">Create "{normalizeEngineName(value)}"</span>
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <Dialog open={manageOpen} onOpenChange={setManageOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-base">
+              <Settings className="w-4 h-4" /> Manage engines
+            </DialogTitle>
+            <DialogDescription>
+              Remove saved engine types. Engines in use by a vehicle can't be deleted.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-72 overflow-y-auto space-y-1">
+            {engines.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">No saved engines yet</p>
+            ) : (
+              filterEngines(engines, "").map((engine) => {
+                const inUse = usedKeys.has(engineNameKey(engine.name));
+                return (
+                  <div
+                    key={engine.id}
+                    className="flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors"
+                  >
+                    <span className="flex-1 min-w-0 truncate text-sm text-foreground">{engine.name}</span>
+                    {inUse && <span className="text-[11px] text-muted-foreground shrink-0">in use</span>}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100 hover:text-destructive disabled:opacity-25 disabled:hover:text-current"
+                      disabled={inUse}
+                      title={inUse ? "In use by a vehicle" : "Delete"}
+                      onClick={() => onDelete(engine.id)}
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/drawer/VehiclesTab.tsx
+++ b/src/components/drawer/VehiclesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { Pencil, Trash2, Car } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,6 +7,8 @@ import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleType } from "@/lib/templateStorage";
+import { useEngineManager } from "@/hooks/useEngineManager";
+import { EngineCombobox } from "./EngineCombobox";
 
 interface VehiclesTabProps {
   vehicles: Vehicle[];
@@ -30,6 +32,24 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState(emptyForm(defaultTypeId));
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const { engines, addEngine, importEngines, removeEngine } = useEngineManager();
+
+  // Seed the reusable engine list from engines already saved on vehicles.
+  const vehicleEngineKey = useMemo(
+    () => vehicles.map(v => v.engine).filter(Boolean).join("|"),
+    [vehicles],
+  );
+  useEffect(() => {
+    const names = vehicles.map(v => v.engine).filter(Boolean);
+    if (names.length) importEngines(names);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vehicleEngineKey, importEngines]);
+
+  const usedEngineNames = useMemo(
+    () => vehicles.map(v => v.engine).filter(Boolean),
+    [vehicles],
+  );
 
   const resetForm = useCallback(() => {
     setEditingId(null);
@@ -129,10 +149,14 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
             <Label className="text-xs">Name</Label>
             <Input value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} placeholder="Vehicle name" className="h-8 text-sm" />
           </div>
-          <div className="space-y-1">
-            <Label className="text-xs">Engine</Label>
-            <Input value={form.engine} onChange={e => setForm(f => ({ ...f, engine: e.target.value }))} placeholder="Engine type" className="h-8 text-sm" />
-          </div>
+          <EngineCombobox
+            value={form.engine}
+            onChange={engine => setForm(f => ({ ...f, engine }))}
+            engines={engines}
+            onCreate={addEngine}
+            onDelete={removeEngine}
+            usedNames={usedEngineNames}
+          />
           <div className="space-y-1">
             <Label className="text-xs">Number</Label>
             <Input type="number" value={form.number || ""} onChange={e => setForm(f => ({ ...f, number: parseInt(e.target.value) || 0 }))} placeholder="0" className="h-8 text-sm" />

--- a/src/hooks/useEngineManager.ts
+++ b/src/hooks/useEngineManager.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+import { Engine, listEngines, saveEngine, deleteEngine } from "@/lib/engineStorage";
+import { distinctEngineNames, findEngineByName, normalizeEngineName } from "@/lib/engineUtils";
+
+export function useEngineManager() {
+  const [engines, setEngines] = useState<Engine[]>([]);
+
+  const refresh = useCallback(async () => {
+    setEngines(await listEngines());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  /** Create an engine by name (deduped, case-insensitive). Returns the engine name. */
+  const addEngine = useCallback(
+    async (name: string): Promise<string | null> => {
+      const display = normalizeEngineName(name);
+      if (!display) return null;
+      const existing = findEngineByName(engines, display);
+      if (existing) return existing.name;
+      await saveEngine({ id: crypto.randomUUID(), name: display, createdAt: Date.now() });
+      await refresh();
+      return display;
+    },
+    [engines, refresh],
+  );
+
+  /** Ensure every supplied name exists in the list (used to seed from existing vehicles). */
+  const importEngines = useCallback(
+    async (names: string[]) => {
+      const current = await listEngines();
+      const missing = distinctEngineNames(names).filter((n) => !findEngineByName(current, n));
+      if (missing.length === 0) return;
+      for (const name of missing) {
+        await saveEngine({ id: crypto.randomUUID(), name, createdAt: Date.now() });
+      }
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const removeEngine = useCallback(
+    async (id: string) => {
+      await deleteEngine(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  return { engines, refresh, addEngine, importEngines, removeEngine };
+}

--- a/src/lib/dbUtils.ts
+++ b/src/lib/dbUtils.ts
@@ -5,7 +5,7 @@
  */
 
 export const DB_NAME = "dove-file-manager";
-export const DB_VERSION = 9;
+export const DB_VERSION = 10;
 
 export const STORE_NAMES = {
   FILES: "files",
@@ -18,6 +18,7 @@ export const STORE_NAMES = {
   VEHICLE_TYPES: "vehicle-types",
   SETUP_TEMPLATES: "setup-templates",
   SESSION_VIDEOS: "session-videos",
+  ENGINES: "engines",       // reusable engine-type list for vehicle profiles
 } as const;
 
 /**
@@ -66,6 +67,11 @@ export function openDB(): Promise<IDBDatabase> {
       // v9: Session videos store
       if (!db.objectStoreNames.contains(STORE_NAMES.SESSION_VIDEOS)) {
         db.createObjectStore(STORE_NAMES.SESSION_VIDEOS, { keyPath: "sessionFileName" });
+      }
+
+      // v10: Reusable engine-type list
+      if (!db.objectStoreNames.contains(STORE_NAMES.ENGINES)) {
+        db.createObjectStore(STORE_NAMES.ENGINES, { keyPath: "id" });
       }
 
       // v8 migration: add vehicleId index to setups if upgrading from v7

--- a/src/lib/engineStorage.ts
+++ b/src/lib/engineStorage.ts
@@ -1,0 +1,55 @@
+/**
+ * IndexedDB CRUD for the "engines" object store — a reusable list of engine
+ * types users build up while creating vehicles. Each write/delete emits a
+ * garage change so the cloud-sync plugin can carry it across devices.
+ */
+
+import { openDB, STORE_NAMES } from './dbUtils';
+import { emitGarageChange } from './garageEvents';
+
+export interface Engine {
+  id: string;
+  name: string;
+  createdAt: number;
+  /** Last local edit time (ms) — set by saveEngine; used for sync merge. */
+  updatedAt?: number;
+}
+
+const ENGINES_STORE = STORE_NAMES.ENGINES;
+
+export async function saveEngine(engine: Engine): Promise<void> {
+  const stamped: Engine = { ...engine, updatedAt: Date.now() };
+  const db = await openDB();
+  const tx = db.transaction(ENGINES_STORE, "readwrite");
+  tx.objectStore(ENGINES_STORE).put(stamped);
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+  emitGarageChange({ store: ENGINES_STORE, key: engine.id, type: "put" });
+}
+
+export async function listEngines(): Promise<Engine[]> {
+  const db = await openDB();
+  const tx = db.transaction(ENGINES_STORE, "readonly");
+  const request = tx.objectStore(ENGINES_STORE).getAll();
+  const results = await new Promise<Engine[]>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  db.close();
+  return results;
+}
+
+export async function deleteEngine(id: string): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(ENGINES_STORE, "readwrite");
+  tx.objectStore(ENGINES_STORE).delete(id);
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+  emitGarageChange({ store: ENGINES_STORE, key: id, type: "delete" });
+}

--- a/src/lib/engineUtils.test.ts
+++ b/src/lib/engineUtils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import type { Engine } from "./engineStorage";
+import {
+  normalizeEngineName,
+  engineNameKey,
+  findEngineByName,
+  filterEngines,
+  shouldOfferCreate,
+  distinctEngineNames,
+} from "./engineUtils";
+
+const engine = (name: string): Engine => ({ id: name, name, createdAt: 0 });
+
+describe("normalizeEngineName / engineNameKey", () => {
+  it("trims the display name and lowercases the key", () => {
+    expect(normalizeEngineName("  IAME X30  ")).toBe("IAME X30");
+    expect(engineNameKey("  IAME X30  ")).toBe("iame x30");
+  });
+});
+
+describe("findEngineByName", () => {
+  const engines = [engine("IAME X30"), engine("Rotax Max")];
+
+  it("matches case-insensitively and ignores surrounding whitespace", () => {
+    expect(findEngineByName(engines, "  iame x30 ")?.name).toBe("IAME X30");
+  });
+
+  it("returns undefined for no match or empty query", () => {
+    expect(findEngineByName(engines, "Briggs")).toBeUndefined();
+    expect(findEngineByName(engines, "   ")).toBeUndefined();
+  });
+});
+
+describe("filterEngines", () => {
+  const engines = [engine("Rotax Max"), engine("IAME X30"), engine("IAME KA100")];
+
+  it("returns all sorted by name when the query is empty", () => {
+    expect(filterEngines(engines, "").map((e) => e.name)).toEqual([
+      "IAME KA100",
+      "IAME X30",
+      "Rotax Max",
+    ]);
+  });
+
+  it("filters by case-insensitive substring", () => {
+    expect(filterEngines(engines, "iame").map((e) => e.name)).toEqual(["IAME KA100", "IAME X30"]);
+  });
+});
+
+describe("shouldOfferCreate", () => {
+  const engines = [engine("IAME X30")];
+
+  it("offers create for a novel, non-empty name", () => {
+    expect(shouldOfferCreate("Rotax", engines)).toBe(true);
+  });
+
+  it("does not offer create for an existing name (case-insensitive) or blank input", () => {
+    expect(shouldOfferCreate(" iame x30 ", engines)).toBe(false);
+    expect(shouldOfferCreate("   ", engines)).toBe(false);
+  });
+});
+
+describe("distinctEngineNames", () => {
+  it("dedupes case-insensitively, drops blanks, and keeps first-seen casing", () => {
+    expect(distinctEngineNames(["IAME X30", "", "  iame x30 ", "Rotax", "rotax"])).toEqual([
+      "IAME X30",
+      "Rotax",
+    ]);
+  });
+});

--- a/src/lib/engineUtils.ts
+++ b/src/lib/engineUtils.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure helpers for the reusable engine-type list.
+ * Kept free of IndexedDB so the search / dedup / create-offer logic stays
+ * unit-testable and can be shared by the storage hook and the combobox UI.
+ */
+
+import type { Engine } from "./engineStorage";
+
+/** Trimmed display form of a typed engine name. */
+export function normalizeEngineName(name: string): string {
+  return name.trim();
+}
+
+/** Case-insensitive comparison key for an engine name. */
+export function engineNameKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/** Find a saved engine matching a name (case-insensitive, trimmed). */
+export function findEngineByName(engines: Engine[], name: string): Engine | undefined {
+  const key = engineNameKey(name);
+  if (!key) return undefined;
+  return engines.find((e) => engineNameKey(e.name) === key);
+}
+
+/** Filter the saved list by a query (case-insensitive substring; empty → all), sorted by name. */
+export function filterEngines(engines: Engine[], query: string): Engine[] {
+  const q = engineNameKey(query);
+  const matches = q ? engines.filter((e) => engineNameKey(e.name).includes(q)) : engines.slice();
+  return matches.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Whether to offer "create" for the typed query (non-empty and not an exact saved match). */
+export function shouldOfferCreate(query: string, engines: Engine[]): boolean {
+  const name = normalizeEngineName(query);
+  if (!name) return false;
+  return !findEngineByName(engines, name);
+}
+
+/** Distinct, trimmed, non-empty engine names from raw values (first-seen casing wins). */
+export function distinctEngineNames(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of values) {
+    const name = normalizeEngineName(raw ?? "");
+    if (!name) continue;
+    const key = engineNameKey(name);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(name);
+  }
+  return result;
+}

--- a/src/plugins/cloud-sync/syncStores.ts
+++ b/src/plugins/cloud-sync/syncStores.ts
@@ -16,6 +16,7 @@ const KEY_FIELD: Record<string, string> = {
   // with them or pulled setups can't render.
   [STORE_NAMES.VEHICLE_TYPES]: "id",
   [STORE_NAMES.SETUP_TEMPLATES]: "id",
+  [STORE_NAMES.ENGINES]: "id",
   [TRACKS_SYNC_STORE]: "name", // user tracks (localStorage, via a store accessor)
   [STORE_NAMES.FILES]: "name",
 };
@@ -29,6 +30,7 @@ export const DOC_STORES = [
   STORE_NAMES.GRAPH_PREFS,
   STORE_NAMES.VEHICLE_TYPES,
   STORE_NAMES.SETUP_TEMPLATES,
+  STORE_NAMES.ENGINES,
   TRACKS_SYNC_STORE,
 ] as const;
 


### PR DESCRIPTION
## Summary
Replaces the vehicle form's plain free-text **Engine** input with a searchable combobox backed by a reusable, per-user engine list:

- **Type to search** previously saved engines; **create inline** when the typed name isn't found.
- **Auto-imports** engine names already saved on existing vehicles, so the list is populated immediately (no manual migration).
- A small **"manage"** link beside the *Engine* label opens a delete-only menu. Engines currently **in use by a vehicle are protected** from deletion (per request).
- Engines persist in a new IndexedDB store (`engines`, DB **v10**) and **emit garage change events**, so they ride along with the rest of the garage over cloud sync (added to `syncStores`).

Pure search / dedup / create-offer logic lives in `engineUtils.ts` with full Vitest coverage. The combobox lands in the lazy `FileManagerDrawer` chunk, keeping it off the initial bundle path.

### Files
- `lib/dbUtils.ts` — bump DB version 9→10, new `engines` store
- `lib/engineStorage.ts` (new) — IndexedDB CRUD + garage events
- `lib/engineUtils.ts` (new) + `engineUtils.test.ts` (new) — pure helpers + tests
- `hooks/useEngineManager.ts` (new) — list/add/import/remove
- `components/drawer/EngineCombobox.tsx` (new) — searchable field + manage dialog
- `components/drawer/VehiclesTab.tsx` — wire in the combobox + auto-import
- `plugins/cloud-sync/syncStores.ts` — sync the `engines` store
- `CHANGELOG.md`, `CLAUDE.md` — docs

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 706 passing (incl. new `engineUtils` tests)
- [x] `npm run build` — succeeds
- [ ] Manual UI: open file-manager drawer → Vehicles → type an engine, confirm filter + inline "Create", confirm "manage" deletes unused engines and blocks in-use ones. *(No browser/Chromium available in the remote container, so this was not exercised interactively.)*

https://claude.ai/code/session_014aFrVH8nLTmVuRHhAU4gmt

---
_Generated by [Claude Code](https://claude.ai/code/session_014aFrVH8nLTmVuRHhAU4gmt)_