### PR TITLE
Lap snapshots: frozen "course fastest lap" per engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Lap snapshots — frozen "course fastest lap" per engine.** Capture a single
+  lap (its GPS samples plus a 5-second buffer on each side, the course geometry,
+  the engine, and a copy of the vehicle/setup) as an immutable baseline you can
+  load and compare against any later session on that course — regardless of the
+  engine you're running now (the loaded snapshot shows its engine, so 2-stroke
+  vs 4-stroke reads clearly).
+  - **One per (course, engine).** Assigning an engine + setup to a log prompts to
+    save/update the course fastest lap when its best lap beats (or has no) stored
+    snapshot; a manual **Save as snapshot** action lives in the lap-list
+    **Snapshots** picker too. A faster lap replaces the snapshot in place.
+  - **Loaded as a comparison overlay only** — never auto-plays, and is excluded
+    from playback and the video player (it rides the reference-overlay slot, not
+    the lap selection). Available next to the lap dropdown in both simple and
+    pro mode.
+  - **Local-first & unlimited on-device; cloud-synced with per-tier COUNT limits**
+    (free 5 / plus 10 / premium 20 / pro 50) via a dedicated `lap_snapshots`
+    table — not byte document storage. Snapshots always push on save, but a local
+    delete never removes the cloud copy (like the log menu); the cloud copy is
+    removed only explicitly from **Profile → Lap snapshots**, which also lists
+    on-device snapshots when signed out.
 - **GDPR self-service data tools** (Profile → **Data & privacy**, cloud builds):
   - **Download my data** — exports everything we hold about you as a single ZIP:
     your account data (profile, subscription, roles, synced garage records,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,12 +104,15 @@ src/
 │   ├── FileImport.tsx     # Drag-and-drop file import
 │   ├── DataloggerDownload.tsx  # BLE device download UI
 │   ├── ContactDialog.tsx  # Public contact form dialog (categories shared const)
+│   ├── LapSnapshotControls.tsx   # ★ Lap-list snapshot picker: save + load-as-overlay
+│   ├── LapSnapshotPromptDialog.tsx # ★ "New course fastest lap" save prompt
 │   └── ...
 ├── hooks/
 │   ├── useSessionData.ts      # Parses imported file → ParsedData
 │   ├── useLapManagement.ts    # Lap calculation, selection, visible range
 │   ├── usePlayback.ts         # Playback cursor (shared across chart + map)
 │   ├── useReferenceLap.ts     # Reference lap overlay logic
+│   ├── useLapSnapshots.ts     # ★ Lap snapshot orchestration (capture/prompt/overlay)
 │   ├── useVideoSync.ts        # Video ↔ telemetry synchronization
 │   ├── useFileManager.ts      # IndexedDB file CRUD
 │   ├── useKartManager.ts      # Backward compat re-export → useVehicleManager
@@ -138,6 +141,8 @@ src/
 │   ├── fieldResolver.ts       # Settings-facing adapter over channels.ts (canonical id resolution + field categories)
 │   ├── courseDetection.ts     # ★ Auto course detection, direction detection, waypoint mode
 │   ├── lapCalculation.ts      # Start/finish line crossing detection → Lap[]
+│   ├── lapSnapshot.ts         # ★ Pure snapshot types/keying/buffer (course+engine identity)
+│   ├── lapSnapshotStorage.ts  # ★ IndexedDB CRUD for lap snapshots (emits garageEvents)
 │   ├── brakingZones.ts        # Braking zone detection from G-force data
 │   ├── speedEvents.ts         # Min/max speed event detection
 │   ├── speedBounds.ts         # Speed range utilities
@@ -400,7 +405,7 @@ GPS data is always parseable even if metadata is corrupted. Metadata is attached
 
 ## IndexedDB Storage (`src/lib/dbUtils.ts`)
 
-Single shared database: `"dove-file-manager"`, version 10.
+Single shared database: `"dove-file-manager"`, version 11.
 
 | Store | Key | Module |
 |-------|-----|--------|
@@ -415,8 +420,44 @@ Single shared database: `"dove-file-manager"`, version 10.
 | `setup-templates` | `id` | `templateStorage.ts` |
 | `session-videos` | `sessionFileName` | `videoFileStorage.ts` |
 | `engines` | `id` | `engineStorage.ts` |
+| `lap-snapshots` | `id` (indexed by `courseKey`, `engineKey`) | `lapSnapshotStorage.ts` |
 
 To add a new store: increment `DB_VERSION`, add store name to `STORE_NAMES`, add creation logic in `openDB()`, create a corresponding storage module.
+
+---
+
+## Lap Snapshots (`src/lib/lapSnapshot.ts` + `lapSnapshotStorage.ts`)
+
+Frozen "course fastest lap" captures — an immutable single-lap baseline for
+cross-session comparison (and future AI coaching).
+
+- **Identity = (course + engine).** Engine is the layman's "primary key"; the
+  chassis travels inside the frozen `setup`. Exactly one snapshot per pair — a
+  faster lap upserts in place (same deterministic `id`), so the count never
+  inflates. `engine` is the free-text `Vehicle.engine` string, matched via
+  `engineKey` (trimmed + lowercased).
+- **What's frozen:** the lap's GPS samples **± a 5s buffer** on each side (so a
+  later start/finish nudge still fits), `lapStartMs`/`lapEndMs` markers, the
+  `Course` geometry, lap time, source file/lap, and a copy of the vehicle/setup.
+  `snapshotLapSamples()` trims the buffer back to the clean lap for overlay.
+- **Capture triggers:** assigning an engine + setup to a log prompts
+  (`LapSnapshotPromptDialog`) when its best lap beats (or has no) stored
+  snapshot; a manual "Save as snapshot" lives in `LapSnapshotControls` (the
+  lap-list **Snapshots** picker, in the header so it serves simple + pro mode).
+  Orchestrated by `useLapSnapshots`.
+- **Loaded as a comparison overlay only.** Selecting a snapshot feeds its clean
+  samples into the **external-reference slot** (`externalRefSamples`), so it
+  renders like a reference lap and is **excluded from playback + the video
+  player** — it is never an appended lap. Engine is shown in the overlay label.
+- **Sync (cloud-sync plugin):** a **dedicated `lap_snapshots` table** with a
+  per-tier **COUNT** quota (free 5 / plus 10 / premium 20 / pro 50 via
+  `subscription_tiers.snapshot_count`), enforced by a trigger — NOT byte document
+  storage. Always pushes on save; a local delete **never** propagates to the
+  cloud (the cloud copy is removed only explicitly from **Profile → Lap
+  snapshots**, like the log menu). Cloud deletes are tombstoned
+  (`snapshotTombstones.ts`) so reconcile won't resurrect a surviving local copy.
+  `reconcileSnapshots()` pulls cloud→local additively and pushes local-only up.
+  Local storage is always unlimited.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - 3-sector split timing with optimal lap
 - Pro graph view with multi-series telemetry charts
 - Reference lap overlay & pace delta comparison
+- Lap snapshots — save a "course fastest lap" per engine, frozen for cross-session comparison (local-first, optionally cloud-synced)
 - Video sync with telemetry playback
 - 9 overlay gauge types (digital, analog, graph, bar, bubble, map, pace, sector, lap time)
 - MP4 video export with overlays & audio (H.264 + AAC)
@@ -170,7 +171,8 @@ The admin system uses Lovable Cloud (Supabase) for the database. The schema is c
 - **sync_records** — Per-user cloud-sync documents (files/garage data), RLS-scoped to the owner
 - **user-files** (Storage bucket) — Private per-user session file blobs for cloud sync
 - **quota_limits** — Baseline per-storage-type byte limits (documents/logs)
-- **subscription_tiers** — Data-driven plan catalogue (free/plus/premium/pro): label, price, per-type byte limits
+- **lap_snapshots** — Per-user frozen "course fastest lap" captures (one per course+engine), RLS-scoped; a dedicated, count-quota'd data type (not byte storage)
+- **subscription_tiers** — Data-driven plan catalogue (free/plus/premium/pro): label, price, per-type byte limits, and lap-snapshot count limit (`snapshot_count`: 5/10/20/50)
 - **user_subscriptions** — Per-user tier + Stripe customer/subscription state, status, renewal date, cancellation grace (service-role-written only)
 - **profiles** — Per-user unique, editable display name
 - **account_deletions** — Pending self-service account-deletion requests (7-day, reversible grace window)

--- a/src/components/LapSnapshotControls.tsx
+++ b/src/components/LapSnapshotControls.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { Camera, Check, Plus, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+import { formatLapTime } from "@/lib/lapCalculation";
+import type { LapSnapshot } from "@/lib/lapSnapshot";
+import type { SaveSnapshotResult } from "@/hooks/useLapSnapshots";
+
+interface LapSnapshotControlsProps {
+  snapshotsForCourse: LapSnapshot[];
+  activeSnapshotId: string | null;
+  canSnapshot: boolean;
+  hasCourse: boolean;
+  onLoad: (snap: LapSnapshot) => void;
+  onClear: () => void;
+  onSave: () => Promise<SaveSnapshotResult>;
+}
+
+/**
+ * Lap-list companion for snapshots: save the current lap as a "course fastest
+ * lap", and load a saved snapshot as a comparison overlay. Loading a snapshot
+ * NEVER affects playback or the video player — it rides the reference-overlay
+ * slot, not the lap selection.
+ */
+export function LapSnapshotControls({
+  snapshotsForCourse, activeSnapshotId, canSnapshot, hasCourse,
+  onLoad, onClear, onSave,
+}: LapSnapshotControlsProps) {
+  const [open, setOpen] = useState(false);
+  if (!hasCourse) return null;
+
+  const count = snapshotsForCourse.length;
+
+  const handleSave = async () => {
+    const result = await onSave();
+    if (result.saved) {
+      toast.success(result.replaced ? "Course fastest lap updated." : "Lap snapshot saved.");
+      setOpen(false);
+    } else if (result.reason === "no-engine") {
+      toast.error("Assign an engine (vehicle) to this session first.");
+    } else if (result.reason === "no-lap") {
+      toast.error("No lap to snapshot yet.");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 gap-1.5 text-sm">
+          <Camera className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Snapshots</span>
+          {count > 0 && (
+            <span className="ml-0.5 rounded bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">
+              {count}
+            </span>
+          )}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md max-h-[70vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Lap Snapshots</DialogTitle>
+        </DialogHeader>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full justify-start gap-2"
+          disabled={!canSnapshot}
+          onClick={() => void handleSave()}
+        >
+          <Plus className="h-4 w-4" />
+          Save current lap as snapshot
+        </Button>
+        {!canSnapshot && (
+          <p className="-mt-1 text-[11px] text-muted-foreground">
+            Assign an engine to this session to capture its fastest lap.
+          </p>
+        )}
+
+        <div className="mt-1 flex items-center justify-between">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Compare a snapshot (this course)
+          </p>
+          {activeSnapshotId && (
+            <Button variant="ghost" size="sm" className="h-6 gap-1 px-2 text-xs" onClick={onClear}>
+              <X className="h-3 w-3" />
+              Clear
+            </Button>
+          )}
+        </div>
+
+        <div className="-mx-1 flex-1 overflow-y-auto">
+          {count === 0 ? (
+            <p className="px-1 py-2 text-xs text-muted-foreground">
+              No snapshots saved for this course yet.
+            </p>
+          ) : (
+            <ul className="space-y-0.5">
+              {snapshotsForCourse.map((snap) => {
+                const isActive = snap.id === activeSnapshotId;
+                return (
+                  <li key={snap.id}>
+                    <button
+                      type="button"
+                      className={`flex w-full items-center gap-2 rounded px-2 py-2 text-left transition-colors hover:bg-muted/50 ${
+                        isActive ? "bg-primary/10" : ""
+                      }`}
+                      onClick={() => {
+                        if (isActive) {
+                          onClear();
+                        } else {
+                          onLoad(snap);
+                          setOpen(false);
+                        }
+                      }}
+                    >
+                      {isActive ? (
+                        <Check className="h-4 w-4 shrink-0 text-primary" />
+                      ) : (
+                        <Camera className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      )}
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm text-foreground">
+                          {snap.engine || "Unknown engine"}
+                        </span>
+                        <span className="block text-[11px] tabular-nums text-muted-foreground">
+                          {formatLapTime(snap.lapTimeMs)}
+                          {snap.vehicle?.name ? ` · ${snap.vehicle.name}` : ""}
+                        </span>
+                      </span>
+                      {isActive && <span className="shrink-0 text-[11px] text-primary">Showing</span>}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/LapSnapshotPromptDialog.tsx
+++ b/src/components/LapSnapshotPromptDialog.tsx
@@ -1,0 +1,62 @@
+import { Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import { formatLapTime } from "@/lib/lapCalculation";
+import type { SnapshotPromptState } from "@/hooks/useLapSnapshots";
+
+interface LapSnapshotPromptDialogProps {
+  prompt: SnapshotPromptState | null;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * "New course fastest lap" prompt, shown when an engine is assigned to a session
+ * whose best lap beats (or has no) stored snapshot for that engine + course.
+ */
+export function LapSnapshotPromptDialog({ prompt, onConfirm, onDismiss }: LapSnapshotPromptDialogProps) {
+  const candidate = prompt?.candidate;
+  return (
+    <Dialog open={!!prompt} onOpenChange={(open) => !open && onDismiss()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Trophy className="h-5 w-5 text-racing-lapBest" />
+            {prompt?.kind === "faster" ? "New course fastest lap!" : "Save course fastest lap?"}
+          </DialogTitle>
+          <DialogDescription>
+            {candidate && (
+              <>
+                Save <strong>{candidate.engine}</strong> at {candidate.trackName} — {candidate.courseName}.
+              </>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        {candidate && (
+          <div className="space-y-1.5 rounded-md border border-border bg-muted/30 px-3 py-2.5 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Lap {candidate.sourceLapNumber}</span>
+              <span className="font-mono font-medium text-foreground">{formatLapTime(candidate.lapTimeMs)}</span>
+            </div>
+            {prompt?.existing && (
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">Previous best</span>
+                <span className="font-mono text-muted-foreground line-through">
+                  {formatLapTime(prompt.existing.lapTimeMs)}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onDismiss}>Not now</Button>
+          <Button onClick={onConfirm}>{prompt?.kind === "faster" ? "Update snapshot" : "Save snapshot"}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useLapSnapshots.ts
+++ b/src/hooks/useLapSnapshots.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { GpsSample, Lap, ParsedData, TrackCourseSelection } from "@/types/racing";
+import type { Vehicle } from "@/lib/vehicleStorage";
+import type { VehicleSetup } from "@/lib/setupStorage";
+import { STORE_NAMES } from "@/lib/dbUtils";
+import { onGarageChange } from "@/lib/garageEvents";
+import { formatLapTime } from "@/lib/lapCalculation";
+import {
+  buildSnapshot, fastestLap, makeCourseKey, makeSnapshotId, normalizeEngine,
+  snapshotLapSamples, snapshotPromptKind,
+  type LapSnapshot, type SnapshotPromptKind,
+} from "@/lib/lapSnapshot";
+import {
+  deleteSnapshot, listSnapshots, saveSnapshot,
+} from "@/lib/lapSnapshotStorage";
+
+export interface UseLapSnapshotsParams {
+  data: ParsedData | null;
+  laps: Lap[];
+  selection: TrackCourseSelection | null;
+  selectedLapNumber: number | null;
+  currentFileName: string | null;
+  vehicles: Vehicle[];
+  setups: VehicleSetup[];
+  sessionKartId: string | null;
+  sessionSetupId: string | null;
+  /** Load a lap's samples as the (non-playable) comparison overlay. */
+  onLoadOverlay: (samples: GpsSample[], label: string) => void;
+  onClearOverlay: () => void;
+}
+
+export interface SnapshotPromptState {
+  kind: SnapshotPromptKind;
+  candidate: LapSnapshot;
+  existing: LapSnapshot | null;
+}
+
+/** Human label for a loaded snapshot overlay — engine is shown so 2t vs 4t reads clearly. */
+export function snapshotLabel(snap: LapSnapshot): string {
+  return `${snap.engine || "Snapshot"} · ${formatLapTime(snap.lapTimeMs)}`;
+}
+
+export interface SaveSnapshotResult {
+  saved: boolean;
+  replaced: boolean;
+  reason?: "no-engine" | "no-course" | "no-lap";
+}
+
+/**
+ * Orchestrates lap snapshots for the active session: the per-course list, the
+ * save-as-snapshot action, the "new course fastest lap" prompt on engine
+ * assignment, and loading a snapshot as a comparison overlay.
+ */
+export function useLapSnapshots(params: UseLapSnapshotsParams) {
+  const {
+    data, laps, selection, selectedLapNumber, currentFileName,
+    vehicles, setups, sessionKartId, sessionSetupId, onLoadOverlay, onClearOverlay,
+  } = params;
+
+  const [snapshots, setSnapshots] = useState<LapSnapshot[]>([]);
+  const [activeSnapshotId, setActiveSnapshotId] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState<SnapshotPromptState | null>(null);
+
+  const refresh = useCallback(async () => {
+    setSnapshots(await listSnapshots());
+  }, []);
+
+  // Load on mount + whenever the snapshot store changes (local saves, cloud pulls).
+  useEffect(() => {
+    void refresh();
+    return onGarageChange((change) => {
+      if (change.store === STORE_NAMES.LAP_SNAPSHOTS) void refresh();
+    });
+  }, [refresh]);
+
+  const courseKey = useMemo(
+    () => (selection ? makeCourseKey(selection.trackName, selection.courseName) : null),
+    [selection],
+  );
+
+  const snapshotsForCourse = useMemo(
+    () => (courseKey ? snapshots.filter((s) => s.courseKey === courseKey).sort((a, b) => a.lapTimeMs - b.lapTimeMs) : []),
+    [snapshots, courseKey],
+  );
+
+  // The engine/vehicle/setup a snapshot would be saved under, for given assignment.
+  const resolveContext = useCallback(
+    (kartId: string | null, setupId: string | null) => {
+      const vehicle = kartId ? vehicles.find((v) => v.id === kartId) ?? null : null;
+      const setup = setupId ? setups.find((s) => s.id === setupId) ?? null : null;
+      const engine = (vehicle?.engine ?? "").trim();
+      return { vehicle, setup, engine };
+    },
+    [vehicles, setups],
+  );
+
+  /** Build the snapshot for a lap under a given engine/setup assignment, or null. */
+  const buildCandidate = useCallback(
+    (lap: Lap | null, kartId: string | null, setupId: string | null): LapSnapshot | null => {
+      if (!lap || !data || !selection?.course) return null;
+      const { vehicle, setup, engine } = resolveContext(kartId, setupId);
+      if (!engine) return null;
+
+      const id = makeSnapshotId(
+        makeCourseKey(selection.trackName, selection.courseName),
+        normalizeEngine(engine),
+      );
+      const existing = snapshots.find((s) => s.id === id) ?? null;
+
+      return buildSnapshot({
+        lap,
+        samples: data.samples,
+        course: selection.course,
+        trackName: selection.trackName,
+        courseName: selection.courseName,
+        engine,
+        sourceFileName: currentFileName ?? "session",
+        recordedAt: data.startDate?.getTime(),
+        vehicle: vehicle ? { id: vehicle.id, name: vehicle.name, number: vehicle.number } : undefined,
+        setup: setup ?? undefined,
+        createdAt: existing?.createdAt,
+      });
+    },
+    [data, selection, snapshots, currentFileName, resolveContext],
+  );
+
+  /** True when the session has everything needed to capture a snapshot. */
+  const canSnapshot = useMemo(
+    () => Boolean(selection?.course && laps.length > 0 && resolveContext(sessionKartId, sessionSetupId).engine),
+    [selection, laps.length, resolveContext, sessionKartId, sessionSetupId],
+  );
+
+  // ── Overlay loading (shares the external-reference slot; never auto-plays) ───
+  const loadSnapshot = useCallback(
+    (snap: LapSnapshot) => {
+      onLoadOverlay(snapshotLapSamples(snap), snapshotLabel(snap));
+      setActiveSnapshotId(snap.id);
+    },
+    [onLoadOverlay],
+  );
+
+  const clearActive = useCallback(() => {
+    onClearOverlay();
+    setActiveSnapshotId(null);
+  }, [onClearOverlay]);
+
+  // ── Save (manual) ────────────────────────────────────────────────────────
+  const saveSelectedLap = useCallback(async (): Promise<SaveSnapshotResult> => {
+    if (!selection?.course) return { saved: false, replaced: false, reason: "no-course" };
+    const lap =
+      (selectedLapNumber !== null ? laps.find((l) => l.lapNumber === selectedLapNumber) : null) ??
+      fastestLap(laps);
+    if (!lap) return { saved: false, replaced: false, reason: "no-lap" };
+    const candidate = buildCandidate(lap, sessionKartId, sessionSetupId);
+    if (!candidate) return { saved: false, replaced: false, reason: "no-engine" };
+    const replaced = snapshots.some((s) => s.id === candidate.id);
+    await saveSnapshot(candidate);
+    return { saved: true, replaced };
+  }, [selection, selectedLapNumber, laps, buildCandidate, sessionKartId, sessionSetupId, snapshots]);
+
+  const removeSnapshot = useCallback(
+    async (id: string) => {
+      await deleteSnapshot(id);
+      if (activeSnapshotId === id) clearActive();
+    },
+    [activeSnapshotId, clearActive],
+  );
+
+  // ── Auto-prompt on engine/setup assignment ──────────────────────────────────
+  const maybePromptOnAssignment = useCallback(
+    (kartId: string | null, setupId: string | null) => {
+      const best = fastestLap(laps);
+      const candidate = buildCandidate(best, kartId, setupId);
+      if (!candidate) return;
+      const existing = snapshots.find((s) => s.id === candidate.id) ?? null;
+      const kind = snapshotPromptKind(candidate.lapTimeMs, existing);
+      if (!kind) return;
+      setPrompt({ kind, candidate, existing });
+    },
+    [laps, buildCandidate, snapshots],
+  );
+
+  const confirmPrompt = useCallback(async () => {
+    if (!prompt) return;
+    await saveSnapshot(prompt.candidate);
+    setPrompt(null);
+  }, [prompt]);
+
+  const dismissPrompt = useCallback(() => setPrompt(null), []);
+
+  return {
+    snapshots,
+    snapshotsForCourse,
+    activeSnapshotId,
+    canSnapshot,
+    loadSnapshot,
+    clearActive,
+    setActiveSnapshotId,
+    saveSelectedLap,
+    removeSnapshot,
+    refresh,
+    prompt,
+    maybePromptOnAssignment,
+    confirmPrompt,
+    dismissPrompt,
+  };
+}

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -9,6 +9,8 @@ export interface SubscriptionTierRow {
   logs_bytes: number;
   doc_bytes: number;
   ai_credits: number;
+  /** Max cloud lap snapshots for the tier (count, not bytes). */
+  snapshot_count: number;
   stripe_price_id: string | null;
   sort_order: number;
 }

--- a/src/lib/dbUtils.ts
+++ b/src/lib/dbUtils.ts
@@ -5,7 +5,7 @@
  */
 
 export const DB_NAME = "dove-file-manager";
-export const DB_VERSION = 10;
+export const DB_VERSION = 11;
 
 export const STORE_NAMES = {
   FILES: "files",
@@ -19,6 +19,7 @@ export const STORE_NAMES = {
   SETUP_TEMPLATES: "setup-templates",
   SESSION_VIDEOS: "session-videos",
   ENGINES: "engines",       // reusable engine-type list for vehicle profiles
+  LAP_SNAPSHOTS: "lap-snapshots", // frozen "course fastest lap" captures per engine
 } as const;
 
 /**
@@ -72,6 +73,14 @@ export function openDB(): Promise<IDBDatabase> {
       // v10: Reusable engine-type list
       if (!db.objectStoreNames.contains(STORE_NAMES.ENGINES)) {
         db.createObjectStore(STORE_NAMES.ENGINES, { keyPath: "id" });
+      }
+
+      // v11: Lap snapshots ("course fastest lap" per engine), keyed by a stable
+      // id and indexed by course (for the lap-list picker) and engine.
+      if (!db.objectStoreNames.contains(STORE_NAMES.LAP_SNAPSHOTS)) {
+        const snapStore = db.createObjectStore(STORE_NAMES.LAP_SNAPSHOTS, { keyPath: "id" });
+        snapStore.createIndex("courseKey", "courseKey", { unique: false });
+        snapStore.createIndex("engineKey", "engineKey", { unique: false });
       }
 
       // v8 migration: add vehicleId index to setups if upgrading from v7

--- a/src/lib/lapSnapshot.test.ts
+++ b/src/lib/lapSnapshot.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { Course, GpsSample, Lap } from "@/types/racing";
+import {
+  buildSnapshot, fastestLap, makeCourseKey, makeSnapshotId, normalizeEngine,
+  snapshotLapSamples, snapshotPromptKind, SNAPSHOT_BUFFER_MS,
+} from "./lapSnapshot";
+
+const course: Course = {
+  name: "Full CW",
+  startFinishA: { lat: 35.0, lon: -97.0 },
+  startFinishB: { lat: 35.0, lon: -97.001 },
+};
+
+// 31 samples at 1s intervals, t = 0..30000.
+function makeSamples(): GpsSample[] {
+  return Array.from({ length: 31 }, (_, i) => ({
+    t: i * 1000,
+    lat: 35 + i * 1e-5,
+    lon: -97 + i * 1e-5,
+    speedMps: 20,
+    speedMph: 44.7,
+    speedKph: 72,
+    extraFields: {},
+  }));
+}
+
+function makeLap(startIndex: number, endIndex: number, samples: GpsSample[], lapNumber = 1): Lap {
+  return {
+    lapNumber,
+    startTime: samples[startIndex].t,
+    endTime: samples[endIndex].t,
+    lapTimeMs: samples[endIndex].t - samples[startIndex].t,
+    maxSpeedMph: 44.7, maxSpeedKph: 72, minSpeedMph: 0, minSpeedKph: 0,
+    startIndex, endIndex,
+  };
+}
+
+describe("normalizeEngine", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeEngine("  Rotax Max ")).toBe("rotax max");
+  });
+});
+
+describe("key helpers", () => {
+  it("derives a stable id from course + engine", () => {
+    const ck = makeCourseKey("OKC", "Full CW");
+    const id = makeSnapshotId(ck, normalizeEngine("Rotax"));
+    expect(id).toBe(makeSnapshotId(makeCourseKey("OKC", "Full CW"), "rotax"));
+  });
+
+  it("distinguishes different courses and engines", () => {
+    const a = makeSnapshotId(makeCourseKey("OKC", "Full CW"), "rotax");
+    const b = makeSnapshotId(makeCourseKey("OKC", "Full CCW"), "rotax");
+    const c = makeSnapshotId(makeCourseKey("OKC", "Full CW"), "tm");
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+});
+
+describe("buildSnapshot", () => {
+  const samples = makeSamples();
+  const lap = makeLap(10, 20, samples); // lap t = 10000..20000
+
+  it("captures the lap with a 5s buffer on each side, clamped to the data", () => {
+    const snap = buildSnapshot({
+      lap, samples, course, trackName: "OKC", courseName: "Full CW",
+      engine: "Rotax", sourceFileName: "s.dove",
+    });
+    // Buffer reaches exactly ±5000ms: t 5000..25000 (21 samples).
+    expect(snap.samples[0].t).toBe(lap.startTime - SNAPSHOT_BUFFER_MS);
+    expect(snap.samples[snap.samples.length - 1].t).toBe(lap.endTime + SNAPSHOT_BUFFER_MS);
+    expect(snap.lapStartMs).toBe(10000);
+    expect(snap.lapEndMs).toBe(20000);
+    expect(snap.id).toBe(makeSnapshotId(makeCourseKey("OKC", "Full CW"), "rotax"));
+    expect(snap.engine).toBe("Rotax");
+    expect(snap.engineKey).toBe("rotax");
+    expect(snap.lapTimeMs).toBe(10000);
+  });
+
+  it("does not run past the start/end of the sample array", () => {
+    const earlyLap = makeLap(0, 3, samples);
+    const snap = buildSnapshot({
+      lap: earlyLap, samples, course, trackName: "OKC", courseName: "Full CW",
+      engine: "X", sourceFileName: "s.dove",
+    });
+    expect(snap.samples[0].t).toBe(0); // clamped to the first sample
+  });
+
+  it("preserves createdAt when replacing an existing snapshot", () => {
+    const snap = buildSnapshot({
+      lap, samples, course, trackName: "OKC", courseName: "Full CW",
+      engine: "Rotax", sourceFileName: "s.dove", createdAt: 12345, now: 99999,
+    });
+    expect(snap.createdAt).toBe(12345);
+    expect(snap.updatedAt).toBe(99999);
+  });
+
+  it("trims the buffer back to the clean lap for overlay comparison", () => {
+    const snap = buildSnapshot({
+      lap, samples, course, trackName: "OKC", courseName: "Full CW",
+      engine: "Rotax", sourceFileName: "s.dove",
+    });
+    const clean = snapshotLapSamples(snap);
+    expect(clean[0].t).toBe(10000);
+    expect(clean[clean.length - 1].t).toBe(20000);
+    expect(clean.length).toBe(11);
+  });
+});
+
+describe("fastestLap", () => {
+  it("returns the min lapTimeMs lap, or null when empty", () => {
+    const samples = makeSamples();
+    const laps = [makeLap(0, 10, samples, 1), makeLap(0, 5, samples, 2), makeLap(0, 8, samples, 3)];
+    expect(fastestLap(laps)?.lapNumber).toBe(2);
+    expect(fastestLap([])).toBeNull();
+  });
+});
+
+describe("snapshotPromptKind", () => {
+  it("prompts 'new' when nothing exists", () => {
+    expect(snapshotPromptKind(60000, null)).toBe("new");
+  });
+  it("prompts 'faster' only when the candidate beats the existing", () => {
+    expect(snapshotPromptKind(59000, { lapTimeMs: 60000 })).toBe("faster");
+    expect(snapshotPromptKind(60000, { lapTimeMs: 60000 })).toBeNull();
+    expect(snapshotPromptKind(61000, { lapTimeMs: 60000 })).toBeNull();
+  });
+});

--- a/src/lib/lapSnapshot.ts
+++ b/src/lib/lapSnapshot.ts
@@ -1,0 +1,173 @@
+// Lap snapshots — frozen, single-lap "course fastest lap" captures.
+//
+// A snapshot freezes one lap (its GPS samples ± a 5s buffer), the course
+// geometry, the engine string, and a copy of the vehicle/setup at capture time.
+// It NEVER changes once saved (unless deleted); that historical immutability is
+// the whole point — it's a baseline you can load and compare against any later
+// session on the same course, regardless of the engine you're running now.
+//
+// Identity is (course + engine): the engine is the layman's "primary key" for
+// the comparison, the chassis travels with the frozen setup. There's exactly one
+// snapshot per (course, engine) — a faster lap replaces it in place (same id), so
+// it can never inflate the stored count. This module is pure (no IndexedDB / no
+// React) so the keying + buffer logic stays unit-testable.
+
+import type { Course, GpsSample, Lap } from "@/types/racing";
+import type { VehicleSetup } from "./setupStorage";
+
+/** Samples kept on each side of the lap, so a later start/finish nudge still fits. */
+export const SNAPSHOT_BUFFER_MS = 5000;
+
+// Separator for composite keys — only ever compared for equality, never split.
+// ASCII unit separator (0x1F): never appears in a track / course / engine name.
+const SEP = String.fromCharCode(31);
+
+/** Frozen vehicle context stored with a snapshot (engine is the match key). */
+export interface SnapshotVehicle {
+  id?: string;
+  name?: string;
+  number?: number;
+}
+
+export interface LapSnapshot {
+  /** Stable id derived from courseKey + engineKey — one snapshot per engine+course. */
+  id: string;
+
+  // ── Matching identity ──────────────────────────────────────────────────────
+  trackName: string;
+  courseName: string;
+  /** Composite of track + course — indexed for per-course lookup. */
+  courseKey: string;
+  /** Display engine string (free-text, from the vehicle). */
+  engine: string;
+  /** Normalized engine (trimmed + lowercased) for matching — indexed. */
+  engineKey: string;
+
+  // ── Frozen lap payload (immutable once saved) ───────────────────────────────
+  /** Course geometry at capture time, so overlays survive later course edits. */
+  course: Course;
+  lapTimeMs: number;
+  sourceFileName: string;
+  sourceLapNumber: number;
+  /** Session start (epoch ms) if known — for display. */
+  recordedAt?: number;
+  /** Buffered samples: the actual lap ± SNAPSHOT_BUFFER_MS on each side. */
+  samples: GpsSample[];
+  /** `sample.t` of the actual lap start within `samples`. */
+  lapStartMs: number;
+  /** `sample.t` of the actual lap end within `samples`. */
+  lapEndMs: number;
+
+  // ── Frozen setup / chassis context ──────────────────────────────────────────
+  vehicle?: SnapshotVehicle;
+  setup?: VehicleSetup;
+
+  // ── Bookkeeping ─────────────────────────────────────────────────────────────
+  createdAt: number;
+  /** Last local write (ms) — used for sync merge. */
+  updatedAt: number;
+}
+
+/** Normalize an engine string so "Rotax Max", " rotax max " match. */
+export function normalizeEngine(engine: string): string {
+  return engine.trim().toLowerCase();
+}
+
+/** Composite course identity (track + course); only ever compared for equality. */
+export function makeCourseKey(trackName: string, courseName: string): string {
+  return `${trackName.trim()}${SEP}${courseName.trim()}`;
+}
+
+/** Stable snapshot id for a (course, engine) pair — same pair ⇒ same id ⇒ replace. */
+export function makeSnapshotId(courseKey: string, engineKey: string): string {
+  return `snap${SEP}${courseKey}${SEP}${engineKey}`;
+}
+
+export interface BuildSnapshotInput {
+  lap: Lap;
+  /** Full session samples (`ParsedData.samples`). */
+  samples: GpsSample[];
+  course: Course;
+  trackName: string;
+  courseName: string;
+  engine: string;
+  sourceFileName: string;
+  recordedAt?: number;
+  vehicle?: SnapshotVehicle;
+  setup?: VehicleSetup;
+  /** Preserve the original capture time when replacing an existing snapshot. */
+  createdAt?: number;
+  now?: number;
+}
+
+/** Slice the lap from session samples with a ±5s buffer, returning a frozen snapshot. */
+export function buildSnapshot(input: BuildSnapshotInput): LapSnapshot {
+  const {
+    lap, samples, course, trackName, courseName, engine,
+    sourceFileName, recordedAt, vehicle, setup,
+  } = input;
+  const now = input.now ?? Date.now();
+
+  const lapStartMs = samples[lap.startIndex]?.t ?? 0;
+  const lapEndMs = samples[lap.endIndex]?.t ?? lapStartMs;
+
+  // Expand the slice outwards by the buffer window, clamped to the array.
+  let startIdx = lap.startIndex;
+  while (startIdx > 0 && lapStartMs - samples[startIdx - 1].t <= SNAPSHOT_BUFFER_MS) startIdx--;
+  let endIdx = lap.endIndex;
+  while (endIdx < samples.length - 1 && samples[endIdx + 1].t - lapEndMs <= SNAPSHOT_BUFFER_MS) endIdx++;
+
+  const buffered = samples.slice(startIdx, endIdx + 1).map((s) => ({ ...s }));
+
+  const courseKey = makeCourseKey(trackName, courseName);
+  const engineKey = normalizeEngine(engine);
+
+  return {
+    id: makeSnapshotId(courseKey, engineKey),
+    trackName: trackName.trim(),
+    courseName: courseName.trim(),
+    courseKey,
+    engine: engine.trim(),
+    engineKey,
+    course,
+    lapTimeMs: lap.lapTimeMs,
+    sourceFileName,
+    sourceLapNumber: lap.lapNumber,
+    recordedAt,
+    samples: buffered,
+    lapStartMs,
+    lapEndMs,
+    vehicle,
+    setup,
+    createdAt: input.createdAt ?? now,
+    updatedAt: now,
+  };
+}
+
+/** The clean lap samples (buffer trimmed) — used as the comparison overlay. */
+export function snapshotLapSamples(snap: LapSnapshot): GpsSample[] {
+  const clean = snap.samples.filter((s) => s.t >= snap.lapStartMs && s.t <= snap.lapEndMs);
+  // Defensive: if the markers don't line up (legacy/edited data), fall back to all.
+  return clean.length > 0 ? clean : snap.samples;
+}
+
+/** The fastest lap in a list (min lapTimeMs), or null when empty. */
+export function fastestLap(laps: Lap[]): Lap | null {
+  if (laps.length === 0) return null;
+  return laps.reduce((min, l) => (l.lapTimeMs < min.lapTimeMs ? l : min), laps[0]);
+}
+
+export type SnapshotPromptKind = "new" | "faster";
+
+/**
+ * Decide whether assigning an engine to this session should prompt to save/update
+ * the course fastest-lap snapshot. Returns the prompt kind, or null when the
+ * existing snapshot is already as fast or faster (no prompt).
+ */
+export function snapshotPromptKind(
+  candidateLapMs: number,
+  existing: Pick<LapSnapshot, "lapTimeMs"> | null | undefined,
+): SnapshotPromptKind | null {
+  if (!existing) return "new";
+  return candidateLapMs < existing.lapTimeMs ? "faster" : null;
+}

--- a/src/lib/lapSnapshotStorage.ts
+++ b/src/lib/lapSnapshotStorage.ts
@@ -1,0 +1,80 @@
+// IndexedDB CRUD for the "lap-snapshots" object store.
+//
+// Local-first and unlimited on-device (the cloud count quota is enforced
+// server-side by the sync plugin). Saving emits a garage change so the cloud-sync
+// plugin can push it; unlike garage docs, a local DELETE never propagates to the
+// cloud (the sync plugin ignores snapshot deletes) — the cloud copy is removed
+// only explicitly from the profile page, just like the log menu.
+
+import { openDB, STORE_NAMES } from "./dbUtils";
+import { emitGarageChange } from "./garageEvents";
+import type { LapSnapshot } from "./lapSnapshot";
+
+const STORE = STORE_NAMES.LAP_SNAPSHOTS;
+
+function reqPromise<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** All snapshots, newest first. */
+export async function listSnapshots(): Promise<LapSnapshot[]> {
+  const db = await openDB();
+  const tx = db.transaction(STORE, "readonly");
+  const all = await reqPromise<LapSnapshot[]>(tx.objectStore(STORE).getAll());
+  db.close();
+  return all.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/** Snapshots for one course (any engine), sorted fastest-first. */
+export async function listSnapshotsForCourse(courseKey: string): Promise<LapSnapshot[]> {
+  const db = await openDB();
+  const tx = db.transaction(STORE, "readonly");
+  const all = await reqPromise<LapSnapshot[]>(tx.objectStore(STORE).index("courseKey").getAll(courseKey));
+  db.close();
+  return all.sort((a, b) => a.lapTimeMs - b.lapTimeMs);
+}
+
+export async function getSnapshot(id: string): Promise<LapSnapshot | null> {
+  const db = await openDB();
+  const tx = db.transaction(STORE, "readonly");
+  const result = await reqPromise<LapSnapshot | undefined>(tx.objectStore(STORE).get(id));
+  db.close();
+  return result ?? null;
+}
+
+/** Save (or replace) a snapshot and notify the sync plugin to push it. */
+export async function saveSnapshot(snap: LapSnapshot): Promise<void> {
+  await putSnapshotRaw({ ...snap, updatedAt: Date.now() });
+  emitGarageChange({ store: STORE, key: snap.id, type: "put" });
+}
+
+/**
+ * Write without emitting a garage event or re-stamping — the cloud pull path
+ * (mirrors the sync engine's `putOne`), so a pulled snapshot doesn't echo back.
+ */
+export async function putSnapshotRaw(snap: LapSnapshot): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE, "readwrite");
+  tx.objectStore(STORE).put(snap);
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+}
+
+/** Delete locally. The cloud copy is untouched (deletes don't propagate). */
+export async function deleteSnapshot(id: string): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE, "readwrite");
+  tx.objectStore(STORE).delete(id);
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+  emitGarageChange({ store: STORE, key: id, type: "delete" });
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -44,6 +44,9 @@ import { useTemplateManager } from "@/hooks/useTemplateManager";
 import { useSessionData } from "@/hooks/useSessionData";
 import { useLapManagement } from "@/hooks/useLapManagement";
 import { useReferenceLap, useExternalReference } from "@/hooks/useReferenceLap";
+import { useLapSnapshots } from "@/hooks/useLapSnapshots";
+import { LapSnapshotControls } from "@/components/LapSnapshotControls";
+import { LapSnapshotPromptDialog } from "@/components/LapSnapshotPromptDialog";
 import { useSessionMetadata } from "@/hooks/useSessionMetadata";
 import { useVideoSync } from "@/hooks/useVideoSync";
 import { useDataLoader } from "@/hooks/useDataLoader";
@@ -148,17 +151,55 @@ export default function Index() {
     allTracks, gpsCenter,
   } = dataLoader;
 
+  // Lap snapshots: frozen "course fastest lap" captures, loaded as a comparison
+  // overlay through the same external-reference slot (so they never auto-play or
+  // appear in the video player).
+  const loadSnapshotOverlay = useCallback((samples: typeof filteredSamples, label: string) => {
+    externalRef.setExternalRefSamples(samples);
+    externalRef.setExternalRefLabel(label);
+    setReferenceLapNumber(null);
+  }, [externalRef, setReferenceLapNumber]);
+
+  const snapshots = useLapSnapshots({
+    data,
+    laps,
+    selection,
+    selectedLapNumber,
+    currentFileName,
+    vehicles: vehicleManager.vehicles,
+    setups: setupManager.setups,
+    sessionKartId,
+    sessionSetupId,
+    onLoadOverlay: loadSnapshotOverlay,
+    onClearOverlay: handleClearExternalRef,
+  });
+
   // Reference-lap handlers: clear the other side when one is set.
   const handleSetReferenceWithClear = useCallback((lapNumber: number) => {
     handleSetReference(lapNumber);
     externalRef.setExternalRefSamples(null);
     externalRef.setExternalRefLabel(null);
-  }, [handleSetReference, externalRef]);
+    snapshots.setActiveSnapshotId(null);
+  }, [handleSetReference, externalRef, snapshots]);
 
   const handleSelectExternalLapWithClear = useCallback((fileName: string, lapNumber: number) => {
     handleSelectExternalLap(fileName, lapNumber);
     setReferenceLapNumber(null);
-  }, [handleSelectExternalLap, setReferenceLapNumber]);
+    snapshots.setActiveSnapshotId(null);
+  }, [handleSelectExternalLap, setReferenceLapNumber, snapshots]);
+
+  // Assigning an engine/setup may set a new course fastest lap → prompt to save.
+  const handleSaveSessionSetupWithSnapshot = useCallback(async (kartId: string | null, setupId: string | null) => {
+    await sessionMeta.handleSaveSessionSetup(kartId, setupId);
+    snapshots.maybePromptOnAssignment(kartId, setupId);
+  }, [sessionMeta, snapshots]);
+
+  // Clearing the shared reference slot (e.g. the ExternalRefBar X) must also drop
+  // the active snapshot, since a loaded snapshot rides that same slot.
+  const handleClearExternalRefWithSnapshot = useCallback(() => {
+    handleClearExternalRef();
+    snapshots.setActiveSnapshotId(null);
+  }, [handleClearExternalRef, snapshots]);
 
   const hasReference = referenceLapNumber !== null || externalRefSamples !== null;
 
@@ -249,13 +290,13 @@ export default function Index() {
     onLapSelect: handleLapSelect,
     onSetReference: handleSetReferenceWithClear,
     onSelectExternalLap: handleSelectExternalLapWithClear,
-    onClearExternalRef: handleClearExternalRef,
+    onClearExternalRef: handleClearExternalRefWithSnapshot,
     onLoadFileForRef: handleLoadFileForRef,
     onRefreshSavedFiles: refreshSavedFiles,
     onRangeChange: handleRangeChange,
     onFieldToggle: sessionData.handleFieldToggle,
     onWeatherStationResolved: sessionMeta.handleWeatherStationResolved,
-    onSaveSessionSetup: sessionMeta.handleSaveSessionSetup,
+    onSaveSessionSetup: handleSaveSessionSetupWithSnapshot,
     formatRangeLabel,
   }), [
     data, visibleSamples, filteredSamples, referenceSamples, currentSample, fieldMappings,
@@ -269,10 +310,10 @@ export default function Index() {
     vehicleManager.vehicles, setupManager.setups, templateManager.templates,
     videoSync.state, videoSync.actions, videoSync.handleLoadedMetadata,
     handleScrub, handleLapSelect, handleSetReferenceWithClear,
-    handleSelectExternalLapWithClear, handleClearExternalRef, handleLoadFileForRef,
+    handleSelectExternalLapWithClear, handleClearExternalRefWithSnapshot, handleLoadFileForRef,
     refreshSavedFiles, handleRangeChange,
     sessionData.handleFieldToggle, sessionMeta.handleWeatherStationResolved,
-    sessionMeta.handleSaveSessionSetup, formatRangeLabel,
+    handleSaveSessionSetupWithSnapshot, formatRangeLabel,
   ]);
 
   // Shared FileManagerDrawer props
@@ -309,7 +350,7 @@ export default function Index() {
     onRemoveVehicleType: templateManager.removeVehicleType,
     sessionKartId,
     sessionSetupId,
-    onSaveSessionSetup: sessionMeta.handleSaveSessionSetup,
+    onSaveSessionSetup: handleSaveSessionSetupWithSnapshot,
   }), [
     fileManager.isOpen, fileManager.files, fileManager.fileMetadataMap, fileManager.storageUsed, fileManager.storageQuota,
     fileManager.close, fileManager.loadFile, fileManager.removeFile, fileManager.exportFile, fileManager.saveFile,
@@ -319,7 +360,7 @@ export default function Index() {
     currentFileName,
     noteManager.notes, noteManager.addNote, noteManager.updateNote, noteManager.removeNote,
     setupManager.setups, setupManager.addSetup, setupManager.updateSetup, setupManager.removeSetup, setupManager.getLatestForVehicle,
-    sessionKartId, sessionSetupId, sessionMeta.handleSaveSessionSetup,
+    sessionKartId, sessionSetupId, handleSaveSessionSetupWithSnapshot,
   ]);
 
   // No data loaded - show import UI
@@ -391,6 +432,16 @@ export default function Index() {
             </Select>
           )}
 
+          <LapSnapshotControls
+            snapshotsForCourse={snapshots.snapshotsForCourse}
+            activeSnapshotId={snapshots.activeSnapshotId}
+            canSnapshot={snapshots.canSnapshot}
+            hasCourse={!!selectedCourse}
+            onLoad={snapshots.loadSnapshot}
+            onClear={snapshots.clearActive}
+            onSave={snapshots.saveSelectedLap}
+          />
+
           <SettingsModal settings={settings} onSettingsChange={setSettings} onToggleFieldDefault={toggleFieldDefault} />
           <Button variant="outline" size="icon" className="h-8 w-8" onClick={fileManager.open}>
             <FolderOpen className="w-4 h-4" />
@@ -425,6 +476,11 @@ export default function Index() {
         onSelect={handleTrackPromptSelect}
         initialCenter={gpsCenter}
         detectionResult={detectionResult}
+      />
+      <LapSnapshotPromptDialog
+        prompt={snapshots.prompt}
+        onConfirm={snapshots.confirmPrompt}
+        onDismiss={snapshots.dismissPrompt}
       />
     </div>
     </SessionProvider>

--- a/src/plugins/cloud-sync/LapSnapshotsPanel.tsx
+++ b/src/plugins/cloud-sync/LapSnapshotsPanel.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from "react";
+import { Camera, Trash2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/contexts/AuthContext";
+import { formatLapTime } from "@/lib/lapCalculation";
+import type { LapSnapshot } from "@/lib/lapSnapshot";
+import { deleteSnapshot, listSnapshots } from "@/lib/lapSnapshotStorage";
+import { fetchSnapshotUsage } from "./cloudClient";
+import { deleteCloudSnapshot, listCloudSnapshots, reconcileSnapshots } from "./snapshotSync";
+
+function formatDate(ms?: number): string {
+  if (!ms) return "";
+  const d = new Date(ms);
+  return isNaN(d.getTime())
+    ? ""
+    : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+// Profile-tab panel for lap snapshots. Signed in: manage the snapshots stored in
+// YOUR cloud (delete removes the cloud copy; local copies on devices are kept).
+// Signed out: manage the snapshots saved on THIS device — the only thing you can
+// do with them until you sign in to sync.
+export default function LapSnapshotsPanel(_props: PluginPanelProps) {
+  const { user, loading } = useAuth();
+  const [items, setItems] = useState<LapSnapshot[] | null>(null);
+  const [localIds, setLocalIds] = useState<Set<string>>(new Set());
+  const [usage, setUsage] = useState<{ usedCount: number; limitCount: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+  const [alsoLocal, setAlsoLocal] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const local = await listSnapshots();
+      setLocalIds(new Set(local.map((s) => s.id)));
+      if (user) {
+        const [cloud, u] = await Promise.all([listCloudSnapshots(user.id), fetchSnapshotUsage()]);
+        setItems(cloud.map((c) => c.data));
+        setUsage(u);
+      } else {
+        setItems(local);
+        setUsage(null);
+      }
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load snapshots");
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+
+  const startConfirm = (id: string) => {
+    setConfirming(id);
+    setAlsoLocal(false);
+  };
+
+  const handleDelete = async (snap: LapSnapshot) => {
+    setBusy(snap.id);
+    try {
+      if (user) {
+        await deleteCloudSnapshot(user.id, snap);
+        if (alsoLocal && localIds.has(snap.id)) await deleteSnapshot(snap.id);
+        toast.success(
+          alsoLocal && localIds.has(snap.id)
+            ? "Deleted snapshot from the cloud and this device."
+            : "Deleted snapshot from the cloud.",
+        );
+      } else {
+        await deleteSnapshot(snap.id);
+        toast.success("Deleted snapshot from this device.");
+      }
+      setConfirming(null);
+      await refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleSyncLocal = async () => {
+    if (!user) return;
+    setSyncing(true);
+    try {
+      const { pushed, skipped } = await reconcileSnapshots(user.id);
+      if (skipped > 0) toast.error(`${skipped} snapshot${skipped === 1 ? "" : "s"} didn't fit your plan's limit.`);
+      else if (pushed > 0) toast.success(`Synced ${pushed} snapshot${pushed === 1 ? "" : "s"}.`);
+      else toast("Everything is already synced.");
+      await refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  if (error) return <p className="text-xs text-destructive">{error}</p>;
+  if (!items) return <p className="text-xs text-muted-foreground">Loading snapshots…</p>;
+
+  const unsyncedLocal = user ? localIds.size > items.length : false;
+
+  return (
+    <div className="space-y-2">
+      {user ? (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            {usage ? `${usage.usedCount} of ${usage.limitCount} synced` : "Synced snapshots"}
+          </p>
+          {unsyncedLocal && (
+            <Button size="sm" variant="outline" className="h-7 text-xs" disabled={syncing} onClick={() => void handleSyncLocal()}>
+              {syncing ? "Syncing…" : "Sync local snapshots"}
+            </Button>
+          )}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          On this device. Sign in to sync snapshots across devices.
+        </p>
+      )}
+
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {user ? "No snapshots in your cloud yet." : "No snapshots saved on this device yet."}
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {items.map((snap) => {
+            const isConfirming = confirming === snap.id;
+            const onDevice = localIds.has(snap.id);
+            return (
+              <div key={snap.id} className="rounded-md border border-border">
+                <div className="flex items-center gap-2 px-3 py-2">
+                  <Camera className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-foreground">
+                      {snap.engine || "Unknown engine"}
+                      <span className="ml-1.5 font-mono text-xs text-muted-foreground">
+                        {formatLapTime(snap.lapTimeMs)}
+                      </span>
+                    </p>
+                    <p className="truncate text-[11px] text-muted-foreground">
+                      {snap.trackName} — {snap.courseName}
+                      {formatDate(snap.recordedAt ?? snap.createdAt) && ` · ${formatDate(snap.recordedAt ?? snap.createdAt)}`}
+                      {user && onDevice && " · on this device"}
+                    </p>
+                  </div>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                    disabled={busy === snap.id}
+                    onClick={() => startConfirm(snap.id)}
+                    aria-label="Delete snapshot"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                {isConfirming && (
+                  <div className="space-y-2 border-t border-destructive/30 bg-destructive/5 px-3 py-2.5">
+                    <p className="flex items-start gap-1.5 text-xs text-destructive">
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span>
+                        {user
+                          ? "Permanently delete the cloud copy? This can't be undone."
+                          : "Delete this snapshot from this device? This can't be undone."}
+                      </span>
+                    </p>
+                    {user && onDevice && (
+                      <div className="flex items-center gap-2">
+                        <Switch id={`local-${snap.id}`} checked={alsoLocal} onCheckedChange={setAlsoLocal} disabled={busy === snap.id} />
+                        <Label htmlFor={`local-${snap.id}`} className="text-xs text-muted-foreground">
+                          Also delete the local copy on this device
+                        </Label>
+                      </div>
+                    )}
+                    <div className="flex justify-end gap-2">
+                      <Button size="sm" variant="ghost" className="h-7 text-xs" disabled={busy === snap.id} onClick={() => setConfirming(null)}>
+                        Cancel
+                      </Button>
+                      <Button size="sm" variant="destructive" className="h-7 text-xs" disabled={busy === snap.id} onClick={() => void handleDelete(snap)}>
+                        {busy === snap.id ? "Deleting…" : "Delete"}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -10,9 +10,11 @@
 // here; log blobs stay manual/opt-in.
 
 import { supabase } from "@/integrations/supabase/client";
+import { STORE_NAMES } from "@/lib/dbUtils";
 import { onGarageChange, type GarageChange } from "@/lib/garageEvents";
-import { isQuotaError } from "./cloudClient";
+import { isQuotaError, isSnapshotQuotaError } from "./cloudClient";
 import { deleteCloudFile, deleteRecord, pushRecord, reconcileDocs } from "./syncEngine";
+import { clearSnapshotTombstone, pushSnapshot, reconcileSnapshots } from "./snapshotSync";
 import { clearPending, listPending, markPending, pendingKeySet } from "./pendingSync";
 import { unselectFile } from "./fileSync";
 import { pendingId } from "./merge";
@@ -37,6 +39,14 @@ function isOnline(): boolean {
 }
 
 async function pushOne(userId: string, change: GarageChange): Promise<void> {
+  if (change.store === STORE_NAMES.LAP_SNAPSHOTS) {
+    // Snapshots always push on save; a local delete never propagates to the
+    // cloud (the cloud copy is removed only explicitly, from the profile page).
+    if (change.type === "delete") return;
+    await clearSnapshotTombstone(change.key); // a fresh save re-enables cloud sync
+    await pushSnapshot(userId, change.key);
+    return;
+  }
   if (change.store === FILE_STORE) {
     // Files only ever queue here as a deferred *delete* (a log removed while
     // offline). Remove the blob + its index, and drop the stale selection.
@@ -61,7 +71,9 @@ async function flush(change: GarageChange): Promise<void> {
     await pushOne(userId, change);
     await clearPending(change.store, change.key);
   } catch (err) {
-    if (isQuotaError(err)) {
+    if (isSnapshotQuotaError(err)) {
+      notify("Cloud snapshot limit reached — saved locally. Delete one in Profile to sync.", "error");
+    } else if (isQuotaError(err)) {
       notify(
         `Cloud ${storageTypeForStore(change.store)} storage is full — saved locally, not synced.`,
         "error",
@@ -98,7 +110,9 @@ async function flushPending(userId: string): Promise<void> {
       await pushOne(userId, change);
       await clearPending(change.store, change.key);
     } catch (err) {
-      if (isQuotaError(err)) {
+      if (isSnapshotQuotaError(err)) {
+        notify("Cloud snapshot limit reached — delete one in Profile to sync.", "error");
+      } else if (isQuotaError(err)) {
         notify(
           `Cloud ${storageTypeForStore(change.store)} storage is full — some changes didn't sync.`,
           "error",
@@ -116,6 +130,13 @@ async function runReconcile(userId: string): Promise<void> {
     if (skipped > 0) {
       notify(
         `Cloud document storage is full — ${skipped} item${skipped === 1 ? "" : "s"} didn't sync.`,
+        "error",
+      );
+    }
+    const snap = await reconcileSnapshots(userId);
+    if (snap.skipped > 0) {
+      notify(
+        `Cloud snapshot limit reached — ${snap.skipped} snapshot${snap.skipped === 1 ? "" : "s"} didn't sync. Delete one in Profile.`,
         "error",
       );
     }

--- a/src/plugins/cloud-sync/cloudClient.ts
+++ b/src/plugins/cloud-sync/cloudClient.ts
@@ -30,6 +30,34 @@ export function syncRecords() {
   return untyped.from("sync_records");
 }
 
+/** A row in public.lap_snapshots — one frozen lap capture, one per engine+course. */
+export interface LapSnapshotRow {
+  id?: string;
+  user_id: string;
+  course_key: string;
+  engine_key: string;
+  data: unknown;
+  updated_at?: string;
+}
+
+/** Query builder for the lap_snapshots table (a dedicated, count-quota'd type). */
+export function lapSnapshotsTable() {
+  return untyped.from("lap_snapshots");
+}
+
+/** Current user's snapshot usage: how many of the tier's count limit are used. */
+export async function fetchSnapshotUsage(): Promise<{ usedCount: number; limitCount: number }> {
+  const { data, error } = await untyped.rpc("snapshot_usage");
+  if (error) throw new Error(`Failed to read snapshot usage: ${error.message}`);
+  const row = ((data ?? []) as { used_count?: number; limit_count?: number }[])[0];
+  return { usedCount: row?.used_count ?? 0, limitCount: row?.limit_count ?? 0 };
+}
+
+/** True when an error is the server's snapshot count-quota rejection. */
+export function isSnapshotQuotaError(err: unknown): boolean {
+  return err instanceof Error && /snapshot_quota_exceeded/i.test(err.message);
+}
+
 /** Storage API for the private per-user file bucket. */
 export function userFiles() {
   return untyped.storage.from(SYNC_BUCKET);

--- a/src/plugins/cloud-sync/index.ts
+++ b/src/plugins/cloud-sync/index.ts
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import { Cloud, ShieldCheck, User } from "lucide-react";
+import { Camera, Cloud, ShieldCheck, User } from "lucide-react";
 import { toast } from "sonner";
 import type { DataViewerPlugin } from "@/plugins/types";
 import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
@@ -23,6 +23,7 @@ const DownloadAllCloudLogs = lazy(() => import("./DownloadAllCloudLogs"));
 // Profile tab panels: storage usage meters + account, and cloud-log management.
 const StoragePanel = lazy(() => import("./StoragePanel"));
 const CloudLogsPanel = lazy(() => import("./CloudLogsPanel"));
+const LapSnapshotsPanel = lazy(() => import("./LapSnapshotsPanel"));
 // Profile tab: GDPR self-service — export everything + scheduled account deletion.
 const DataPrivacyPanel = lazy(() => import("./DataPrivacyPanel"));
 
@@ -92,6 +93,17 @@ const plugin: DataViewerPlugin = {
       order: 0,
       icon: User,
       component: StoragePanel,
+    } satisfies PluginPanel);
+
+    // Profile tab: view/delete lap snapshots (cloud when signed in, local when
+    // signed out — the one snapshot feature available before sign-in).
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "cloud-sync-snapshots",
+      title: "Lap snapshots",
+      slot: PanelSlot.Profile,
+      order: 5,
+      icon: Camera,
+      component: LapSnapshotsPanel,
     } satisfies PluginPanel);
 
     // Profile tab: manage (delete) the log files stored in the cloud.

--- a/src/plugins/cloud-sync/snapshotSync.ts
+++ b/src/plugins/cloud-sync/snapshotSync.ts
@@ -1,0 +1,118 @@
+// Cloud sync for lap snapshots — a dedicated data type (NOT byte document
+// storage), enforced by a per-tier COUNT quota server-side.
+//
+// Sync model (deliberately a hybrid of garage docs and log files):
+//   • Always push on local save (like garage docs) — snapshots are valuable.
+//   • A local delete NEVER deletes the cloud copy (like the log menu); the cloud
+//     row is removed only explicitly here (deleteCloudSnapshot), which tombstones
+//     the id so reconcile won't resurrect it.
+//   • One cloud row per (user, course, engine): a faster lap upserts in place and
+//     never increases the count.
+
+import type { LapSnapshot } from "@/lib/lapSnapshot";
+import { getSnapshot, listSnapshots, putSnapshotRaw } from "@/lib/lapSnapshotStorage";
+import { isSnapshotQuotaError, lapSnapshotsTable } from "./cloudClient";
+import {
+  addSnapshotTombstone, clearSnapshotTombstone, snapshotTombstoneSet,
+} from "./snapshotTombstones";
+
+export interface CloudSnapshot {
+  data: LapSnapshot;
+  updatedAt?: string;
+}
+
+interface RawRow {
+  course_key: string;
+  engine_key: string;
+  data: LapSnapshot;
+  updated_at?: string;
+}
+
+/** Upsert one local snapshot to the cloud (no-op if gone locally or tombstoned). */
+export async function pushSnapshot(userId: string, id: string): Promise<void> {
+  if ((await snapshotTombstoneSet()).has(id)) return;
+  const snap = await getSnapshot(id);
+  if (!snap) return;
+  const { error } = await lapSnapshotsTable().upsert(
+    [{ user_id: userId, course_key: snap.courseKey, engine_key: snap.engineKey, data: snap }],
+    { onConflict: "user_id,course_key,engine_key" },
+  );
+  if (error) throw new Error(error.message);
+}
+
+/** List the snapshots this user has in the cloud. */
+export async function listCloudSnapshots(userId: string): Promise<CloudSnapshot[]> {
+  const { data, error } = await lapSnapshotsTable()
+    .select("course_key,engine_key,data,updated_at")
+    .eq("user_id", userId);
+  if (error) throw new Error(`Failed to list cloud snapshots: ${error.message}`);
+  return ((data ?? []) as RawRow[])
+    .map((r) => ({ data: r.data, updatedAt: r.updated_at }))
+    .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+}
+
+/**
+ * Delete a snapshot from the cloud only (the local copy, if any, is kept). The id
+ * is tombstoned so the next reconcile doesn't re-push the surviving local copy.
+ */
+export async function deleteCloudSnapshot(userId: string, snap: LapSnapshot): Promise<void> {
+  const { error } = await lapSnapshotsTable()
+    .delete()
+    .eq("user_id", userId)
+    .eq("course_key", snap.courseKey)
+    .eq("engine_key", snap.engineKey);
+  if (error) throw new Error(`Failed to delete cloud snapshot: ${error.message}`);
+  await addSnapshotTombstone(snap.id);
+}
+
+export interface SnapshotReconcileResult {
+  pulled: number;
+  pushed: number;
+  /** Local snapshots that didn't fit under the tier's count limit. */
+  skipped: number;
+}
+
+/**
+ * Two-way snapshot sync. Pull cloud copies down (additive — never deletes local),
+ * then push local-only snapshots up, skipping tombstoned ids and counting any the
+ * server rejects for the count quota. Last-write-wins by `updatedAt` on overlap.
+ */
+export async function reconcileSnapshots(userId: string): Promise<SnapshotReconcileResult> {
+  const tombstones = await snapshotTombstoneSet();
+  const cloud = await listCloudSnapshots(userId);
+  const cloudById = new Map(cloud.map((c) => [c.data.id, c.data]));
+
+  const local = await listSnapshots();
+  const localById = new Map(local.map((s) => [s.id, s]));
+
+  // Pull: cloud copy wins when it's newer or absent locally.
+  let pulled = 0;
+  for (const c of cloud) {
+    const localCopy = localById.get(c.data.id);
+    if (!localCopy || c.data.updatedAt > localCopy.updatedAt) {
+      await putSnapshotRaw(c.data);
+      pulled++;
+    }
+  }
+
+  // Push: local snapshots the cloud lacks (or has an older copy of), unless the
+  // user has explicitly removed them from the cloud (tombstoned).
+  let pushed = 0;
+  let skipped = 0;
+  for (const s of local) {
+    if (tombstones.has(s.id)) continue;
+    const cloudCopy = cloudById.get(s.id);
+    if (cloudCopy && cloudCopy.updatedAt >= s.updatedAt) continue;
+    try {
+      await pushSnapshot(userId, s.id);
+      pushed++;
+    } catch (err) {
+      if (isSnapshotQuotaError(err)) skipped++;
+      else throw err;
+    }
+  }
+
+  return { pulled, pushed, skipped };
+}
+
+export { clearSnapshotTombstone };

--- a/src/plugins/cloud-sync/snapshotTombstones.ts
+++ b/src/plugins/cloud-sync/snapshotTombstones.ts
@@ -1,0 +1,33 @@
+// Tombstones for snapshots the user explicitly removed from the cloud.
+//
+// Snapshots always push on local save and a local delete never removes the cloud
+// copy (see snapshotSync). The one case that needs memory: when the user deletes
+// a snapshot from the *cloud* (in the profile page) but keeps it locally, the
+// reconcile pass would otherwise re-push and resurrect it. A tombstone records
+// "don't auto-push this id" until the user saves it again (which clears it).
+
+import { getPluginStore } from "@/plugins/storage";
+
+const store = getPluginStore("cloud-sync");
+const KEY = "snapshot-tombstones";
+
+async function read(): Promise<string[]> {
+  return (await store.get<string[]>(KEY)) ?? [];
+}
+
+export async function addSnapshotTombstone(id: string): Promise<void> {
+  const list = await read();
+  if (!list.includes(id)) {
+    list.push(id);
+    await store.set(KEY, list);
+  }
+}
+
+export async function clearSnapshotTombstone(id: string): Promise<void> {
+  const list = await read();
+  if (list.includes(id)) await store.set(KEY, list.filter((x) => x !== id));
+}
+
+export async function snapshotTombstoneSet(): Promise<Set<string>> {
+  return new Set(await read());
+}

--- a/supabase/migrations/20260529000000_lap_snapshots.sql
+++ b/supabase/migrations/20260529000000_lap_snapshots.sql
@@ -1,0 +1,116 @@
+-- Lap snapshots: frozen "course fastest lap" captures, count-quota'd by tier.
+--
+-- A NEW cloud data type (NOT byte document storage). Snapshots are chunky single
+-- laps that power cross-session comparison and future AI coaching, so they get
+-- their own table and a per-tier COUNT limit (free 5 / plus 10 / premium 20 /
+-- pro 50) rather than counting against the documents byte quota.
+--
+-- Sync model (mirrored client-side): snapshots always push on save, but a local
+-- delete never propagates — the cloud copy is removed only explicitly (profile
+-- page). One row per (user, course, engine): a faster lap upserts in place and
+-- never increases the count.
+
+-- ── Table ────────────────────────────────────────────────────────────────────
+create table if not exists public.lap_snapshots (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  course_key  text not null,
+  engine_key  text not null,
+  data        jsonb not null,
+  updated_at  timestamptz not null default now(),
+  unique (user_id, course_key, engine_key)
+);
+
+create index if not exists lap_snapshots_user_idx on public.lap_snapshots (user_id);
+
+alter table public.lap_snapshots enable row level security;
+
+drop policy if exists "Users read own snapshots"   on public.lap_snapshots;
+drop policy if exists "Users insert own snapshots"  on public.lap_snapshots;
+drop policy if exists "Users update own snapshots"  on public.lap_snapshots;
+drop policy if exists "Users delete own snapshots"  on public.lap_snapshots;
+
+create policy "Users read own snapshots"
+  on public.lap_snapshots for select to authenticated using (auth.uid() = user_id);
+create policy "Users insert own snapshots"
+  on public.lap_snapshots for insert to authenticated with check (auth.uid() = user_id);
+create policy "Users update own snapshots"
+  on public.lap_snapshots for update to authenticated using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "Users delete own snapshots"
+  on public.lap_snapshots for delete to authenticated using (auth.uid() = user_id);
+
+-- ── Per-tier snapshot COUNT limit (data-driven, like the byte limits) ────────
+alter table public.subscription_tiers
+  add column if not exists snapshot_count integer not null default 5;
+
+update public.subscription_tiers set snapshot_count = 5  where tier = 'free';
+update public.subscription_tiers set snapshot_count = 10 where tier = 'plus';
+update public.subscription_tiers set snapshot_count = 20 where tier = 'premium';
+update public.subscription_tiers set snapshot_count = 50 where tier = 'pro';
+
+-- The snapshot count limit for a user, from their effective tier (falls back to
+-- free, then to a hard default). SECURITY DEFINER so the trigger can resolve it.
+create or replace function public.snapshot_limit(p_user uuid)
+returns integer language sql stable security definer set search_path = public as $$
+  select coalesce(
+    (select t.snapshot_count from public.subscription_tiers t where t.tier = public.user_tier(p_user)),
+    (select t.snapshot_count from public.subscription_tiers t where t.tier = 'free'),
+    5);
+$$;
+grant execute on function public.snapshot_limit(uuid) to authenticated;
+
+-- ── Count-quota enforcement ──────────────────────────────────────────────────
+-- Fires BEFORE INSERT. An upsert that replaces an existing (user, course, engine)
+-- row keeps the count, so we exclude that row from the tally — only genuinely new
+-- combinations can be blocked.
+create or replace function public.enforce_snapshot_quota()
+returns trigger language plpgsql as $$
+declare
+  v_limit integer := public.snapshot_limit(NEW.user_id);
+  v_count integer;
+begin
+  if v_limit is null then
+    return NEW;
+  end if;
+
+  select count(*) into v_count
+    from public.lap_snapshots
+   where user_id = NEW.user_id
+     and not (course_key = NEW.course_key and engine_key = NEW.engine_key);
+
+  if v_count >= v_limit then
+    raise exception 'snapshot_quota_exceeded: % snapshots used >= % limit', v_count, v_limit
+      using errcode = 'check_violation';
+  end if;
+
+  return NEW;
+end;
+$$;
+
+drop trigger if exists lap_snapshots_quota on public.lap_snapshots;
+create trigger lap_snapshots_quota
+  before insert on public.lap_snapshots
+  for each row execute function public.enforce_snapshot_quota();
+
+-- Keep updated_at fresh on every write.
+create or replace function public.touch_lap_snapshot()
+returns trigger language plpgsql as $$
+begin
+  NEW.updated_at = now();
+  return NEW;
+end;
+$$;
+
+drop trigger if exists lap_snapshots_touch on public.lap_snapshots;
+create trigger lap_snapshots_touch
+  before insert or update on public.lap_snapshots
+  for each row execute function public.touch_lap_snapshot();
+
+-- ── Usage readout for the profile meter ──────────────────────────────────────
+create or replace function public.snapshot_usage()
+returns table(used_count integer, limit_count integer)
+language sql stable as $$
+  select (select count(*)::integer from public.lap_snapshots where user_id = auth.uid()),
+         public.snapshot_limit(auth.uid());
+$$;
+grant execute on function public.snapshot_usage() to authenticated;


### PR DESCRIPTION
## Summary

A **lap snapshot** is an immutable, single-lap "course fastest lap" baseline you can load and compare against any later session on the same course — regardless of the engine you're running now. The engine is the comparison key; the chassis travels inside the frozen setup. This is local-first, cloud-synced, and built with future AI coaching in mind.

### Data model — one per (course, engine)
- Identity is `(course + engine)`; exactly one snapshot per pair, keyed by a deterministic id. A faster lap **upserts in place** (same id), so the stored count never inflates.
- Frozen payload (never changes once saved, unless deleted): the lap's GPS samples **± a 5 s buffer** on each side (so a later start/finish nudge still fits), the `Course` geometry, lap time, source file/lap, and a **copy of the vehicle + setup**.

### Capture (both triggers, per the spec)
- **On engine+setup assignment** — if the session's best lap for that course+engine beats (or has no) stored snapshot, a prompt offers to save/update the course fastest lap.
- **Manual** — a "Save current lap as snapshot" action in the lap-list **Snapshots** picker (in the header, so it serves simple *and* pro mode).

### Loading / comparison
- A loaded snapshot rides the **external-reference overlay slot**, so it renders like a reference lap and is **excluded from playback and the video player** — it is never treated as an appended lap. The overlay label shows the engine (so 2-stroke vs 4-stroke reads clearly).

### Storage & sync
- **Local-first, unlimited on-device** (new IndexedDB store, `DB_VERSION` 10 → 11, indexed by `courseKey`/`engineKey`).
- **Cloud:** a **dedicated `lap_snapshots` table** with a per-tier **COUNT** quota — free 5 / plus 10 / premium 20 / pro 50 (`subscription_tiers.snapshot_count`), enforced by a trigger. This is a *new data type*, not byte document storage.
- Always **pushes on save**; a **local delete never propagates** to the cloud (the cloud copy is removed only explicitly from **Profile → Lap snapshots**, like the log menu). Cloud deletes are tombstoned so reconcile won't resurrect a surviving local copy.
- **Profile → Lap snapshots** lists synced snapshots when signed in (view/delete, with usage `X / N` and an optional "also delete local"), and on-device snapshots when signed out — the one snapshot feature available before sign-in.

### Files
- Core (offline): `lib/lapSnapshot.ts` (+ tests), `lib/lapSnapshotStorage.ts`, `hooks/useLapSnapshots.ts`, `components/LapSnapshotControls.tsx`, `components/LapSnapshotPromptDialog.tsx`, `dbUtils.ts`, `Index.tsx`.
- Cloud-sync plugin: `snapshotSync.ts`, `snapshotTombstones.ts`, `LapSnapshotsPanel.tsx`, `cloudClient.ts`, `autoSync.ts`, `index.ts`, `billing.ts`.
- Migration: `supabase/migrations/20260529000000_lap_snapshots.sql`.
- Docs: `CLAUDE.md`, `README.md`, `CHANGELOG.md`.

### Note on quota UX
When a cloud account is full and you save a **new** combination, the save still succeeds locally and a toast directs you to free a slot in **Profile → Lap snapshots** (consistent with how log/document quota is surfaced today). The inline "pick one to delete right here" modal can be a follow-up; the management UI + toast already give a complete, usable flow.

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (737 passing, incl. 10 new), `npm run build` all green
- [ ] Assign an engine+setup to a log → "New course fastest lap" prompt appears; saving stores it
- [ ] Snapshots picker: save a lap manually; load a snapshot → renders as overlay, engine shown, play/video unaffected
- [ ] Run a faster lap on the same course+engine → prompted to update; count unchanged
- [ ] Signed-out Profile lists on-device snapshots (view/delete); signed-in lists synced (view/delete, usage meter)
- [ ] Cloud count limit reached on a new combo → saved locally, toast guidance; deleting a cloud snapshot frees a slot and doesn't touch the local copy

https://claude.ai/code/session_01L9h3QDcyTEXmVe6tWMio6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9h3QDcyTEXmVe6tWMio6T)_