### PR TITLE
Add missing lap_snapshots (user, course, engine) unique index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NODE_AUTH_TOKEN`.)
 
 ### Fixed
+- **Lap-snapshot upsert failed with "no unique or exclusion constraint matching
+  the ON CONFLICT specification"** when the `lap_snapshots` table pre-existed
+  the snapshots migration — the inline `unique (user_id, course_key, engine_key)`
+  in `CREATE TABLE IF NOT EXISTS` was skipped along with the table, so reconcile
+  and the manual "Sync local snapshots" button both errored. A follow-up
+  migration adds the constraint as an idempotent unique index so existing
+  deployments self-repair on apply.
 - **PostgREST schema cache reload** after the subscriptions/snapshots migration
   batch. Newly-created tables and functions (`subscription_tiers`,
   `user_subscriptions`, `lap_snapshots`, `snapshot_usage()`, …) existed in the

--- a/supabase/migrations/20260530010000_lap_snapshots_unique_index.sql
+++ b/supabase/migrations/20260530010000_lap_snapshots_unique_index.sql
@@ -1,0 +1,18 @@
+-- Ensure the lap_snapshots (user, course, engine) unique constraint exists.
+--
+-- 20260529_lap_snapshots declared `unique (user_id, course_key, engine_key)`
+-- inline in the CREATE TABLE, but if the table pre-existed (e.g. a partial
+-- earlier run, or some other path created it), the `if not exists` skipped and
+-- the inline constraint never landed. The upsert in pushSnapshot
+-- (ON CONFLICT (user_id, course_key, engine_key) DO UPDATE) then fails with
+-- "there is no unique or exclusion constraint matching the ON CONFLICT
+-- specification", so reconcile and manual sync both error.
+--
+-- Add the constraint as a unique INDEX (idempotent via `if not exists` and
+-- equally matchable by ON CONFLICT) so existing deployments self-repair on
+-- migration apply, and the constraint is guaranteed even when the table
+-- pre-existed. Finally reload PostgREST so it sees the new index.
+create unique index if not exists lap_snapshots_user_course_engine_uidx
+  on public.lap_snapshots (user_id, course_key, engine_key);
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

After merging #75 (schema-cache reload + reconcile-on-open) the snapshot panel stopped hard-erroring and the schema-cache symptoms cleared, but a single local snapshot still wouldn't sync — the **Sync local snapshots** button toasted:

> *there is no unique or exclusion constraint matching the ON CONFLICT specification*

That's Postgres rejecting `pushSnapshot`'s upsert. `pushSnapshot` does `upsert ... ON CONFLICT (user_id, course_key, engine_key)`, which requires a matching unique constraint or unique index on those exact columns. `20260529_lap_snapshots` declared one inline in `CREATE TABLE IF NOT EXISTS`:

```sql
create table if not exists public.lap_snapshots (
  ...
  unique (user_id, course_key, engine_key)
);
```

If the table pre-existed when that migration ran (partial earlier run, or any other path that created it), `IF NOT EXISTS` skipped the whole declaration — table **and** inline constraint. Result: table is there, constraint isn't, upsert errors out, reconcile and the manual sync button both fail.

## Fix

A follow-up migration adds the constraint as an idempotent unique INDEX (Postgres' `ON CONFLICT` matches against unique indexes equally well as constraints) and reloads the PostgREST schema cache:

```sql
create unique index if not exists lap_snapshots_user_course_engine_uidx
  on public.lap_snapshots (user_id, course_key, engine_key);

notify pgrst, 'reload schema';
```

This self-repairs existing deployments on apply, and guarantees the constraint exists even when the table pre-existed.

## Operational note

To unblock the **currently-deployed** BETA DB before this migration deploys, the same two statements above run in the SQL editor will immediately make the Sync local snapshots button work.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test:run` — 737 passed
- [ ] After deploy / running the SQL manually: opening Profile → Lap snapshots while signed in pushes the local snapshot to the cloud (the panel's reconcile-on-open from #75 fires), no toast error, and "Synced snapshots" reflects the uploaded count.

https://claude.ai/code/session_017wyJik7iHRfxTKeuKFc4Xs

---
_Generated by [Claude Code](https://claude.ai/code/session_017wyJik7iHRfxTKeuKFc4Xs)_