### PR TITLE
Re-set lap_snapshots column defaults (id, updated_at)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NODE_AUTH_TOKEN`.)
 
 ### Fixed
+- **Lap-snapshot insert failed with `null value in column "id" of relation
+  "lap_snapshots" violates not-null constraint`** — same root pattern as the
+  missing unique constraint: when the `lap_snapshots` table pre-existed the
+  snapshots migration, `CREATE TABLE IF NOT EXISTS` skipped the whole
+  declaration, so the `id uuid primary key default gen_random_uuid()` column
+  came in without its default. `pushSnapshot` doesn't send an id (it shouldn't),
+  so the insert had nothing to fill it with. A follow-up migration re-sets the
+  column defaults idempotently so existing deployments self-repair.
 - **Lap-snapshot upsert failed with "no unique or exclusion constraint matching
   the ON CONFLICT specification"** when the `lap_snapshots` table pre-existed
   the snapshots migration — the inline `unique (user_id, course_key, engine_key)`

--- a/supabase/migrations/20260530020000_lap_snapshots_column_defaults.sql
+++ b/supabase/migrations/20260530020000_lap_snapshots_column_defaults.sql
@@ -1,0 +1,21 @@
+-- Self-repair lap_snapshots column-level defaults that the original
+-- 20260529_lap_snapshots `CREATE TABLE IF NOT EXISTS` skipped when the table
+-- pre-existed (same root pattern that left the unique constraint missing).
+--
+-- The previous error surfaced first as the missing ON CONFLICT target (fixed by
+-- 20260530010000_lap_snapshots_unique_index). With the conflict target in place
+-- the upsert reaches the INSERT, which now fails with:
+--   null value in column "id" of relation "lap_snapshots" violates not-null
+--   constraint
+-- because the `default gen_random_uuid()` on `id` never landed either —
+-- pushSnapshot doesn't (and shouldn't) send an id, so the column default has
+-- to supply one. Re-set the defaults idempotently (setting a column default is
+-- a metadata change; existing rows are untouched), then reload PostgREST so
+-- inserts pick the defaults up.
+alter table public.lap_snapshots
+  alter column id set default gen_random_uuid();
+
+alter table public.lap_snapshots
+  alter column updated_at set default now();
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

After #77 landed the unique index, the **Sync local snapshots** button gets past the ON CONFLICT error and now toasts:

> *null value in column "id" of relation "lap_snapshots" violates not-null constraint*

Same root pattern as the missing unique constraint. The `lap_snapshots` table pre-existed when `20260529_lap_snapshots` ran, so `CREATE TABLE IF NOT EXISTS` skipped the entire declaration — table **and** every inline column property. The unique constraint was the first thing we hit; the column defaults (`id uuid primary key default gen_random_uuid()` and `updated_at timestamptz not null default now()`) are the next.

`pushSnapshot` upserts without sending `id` (it shouldn't — the table's job to mint it), so without the default, `id` lands NULL and trips the NOT NULL.

## Fix

One migration, two idempotent `ALTER COLUMN ... SET DEFAULT` statements plus a PostgREST reload. Setting a default is metadata-only — existing rows are untouched, so it's safe to re-run.

```sql
alter table public.lap_snapshots
  alter column id set default gen_random_uuid();

alter table public.lap_snapshots
  alter column updated_at set default now();

notify pgrst, 'reload schema';
```

The `updated_at` default is technically belt-and-suspenders (the `lap_snapshots_touch` BEFORE INSERT trigger stamps it anyway), but it's harmless to set and matches the original migration's intent — so a fresh `CREATE TABLE` and a self-repaired one end up identical.

## Operational note

To unblock the **currently-deployed** BETA DB without waiting for the migration to deploy, run the same SQL above in the SQL editor.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test:run` — 737 passed
- [ ] After deploy / running the SQL manually: opening Profile → Lap snapshots while signed in pushes the local snapshot to the cloud, no toast error, and "Synced snapshots" reflects the uploaded count.

https://claude.ai/code/session_017wyJik7iHRfxTKeuKFc4Xs

---
_Generated by [Claude Code](https://claude.ai/code/session_017wyJik7iHRfxTKeuKFc4Xs)_