### PR TITLE
Bump @perchwerks/eye-in-the-sky to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejects **disposable / temporary email** addresses.
 
 ### Changed
+- Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
+  `0.2.5` to `0.3.0`.
 - **Registration page** now shows the **Plans & pricing** cards above the
   sign-up form instead of below it.
 - **Cloud Sync moved out of the Labs tab**: sign-in and manual push/pull now live

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.2.5"
+        "@perchwerks/eye-in-the-sky": "0.3.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.2.5.tgz",
-      "integrity": "sha512-AbWDkL1ERzb9FBvvxONmp6oZBISBAP7txDaBo1L2mAmIx7BLLGzjLT/RF8DHf6dotQJ+L0yGvGCSlSmROsATig==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.3.0.tgz",
+      "integrity": "sha512-XJ6Riez1x5A210Kj0Vxt+NU8P+QZGHo7ZYgqN684uBWaB/JjY9sjWEAp5nxxtZrNN17NzHYM/NsOK/xN3AyHfA==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.2.5"
+    "@perchwerks/eye-in-the-sky": "0.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from `0.2.5` → `0.3.0` in `package.json` + `package-lock.json`.
- Adds a `CHANGELOG.md` entry under `[Unreleased] → Changed` noting the bump.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` (737 tests passing)
- [x] `npm run build`

https://claude.ai/code/session_01RsjUmquZT5uNC1cLEytHHE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsjUmquZT5uNC1cLEytHHE)_