### PR TITLE
Fix 15 security & data-integrity bugs (auth, billing, cloud-sync, snapshots, migrations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,7 +230,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required. (Previously a private GitHub Packages package gated behind
   `NODE_AUTH_TOKEN`.)
 
+### Security
+- **Password reset is now gated on a real recovery session.** `/reset-password`
+  only lets you set a new password when the page was opened from the emailed
+  recovery link (a `PASSWORD_RECOVERY` token) — so a merely signed-in session (a
+  shared/unattended tab, a stolen token) can no longer change the account
+  password without proving control of the email.
+- **Account deletion now verifies the emailed code server-side.** The
+  `request-account-deletion` function verifies the one-time code itself before
+  scheduling, so a stolen JWT alone can't schedule deletion via a direct call —
+  the caller must also possess the code we emailed.
+- **No more cross-account data bleed in cloud sync.** Pending offline changes,
+  cloud-deletion tombstones, and per-file sync selections are now partitioned per
+  user, so signing out of one account and into another on the same browser can
+  never flush the first account's queued state into the second's cloud.
+- **Duplicate paid subscriptions are blocked.** Checkout refuses to start a
+  second subscription when one is already active (plan changes route through the
+  billing portal instead), preventing a double-billed account from a mis-click.
+- **Stripe webhook is now replay- and ordering-safe.** Events are de-duplicated
+  by id, and a `subscription.deleted` for a superseded subscription is ignored,
+  so a retried or out-of-order delivery can't demote an active entitlement.
+- **Account-deletion worker deletes the auth user before wiping files**, so a
+  transient failure can no longer leave a half-deleted account whose files are
+  already gone but whose rows and cancellation window remain.
+- **GDPR retention restored to the documented window.** A later migration had
+  quietly loosened `purge_expired_personal_data` (keeping rejected-but-unreviewed
+  submissions and lock rows past their intended TTL); the documented predicates
+  are reasserted.
+- Fresh clones default to the **offline-first public app** again:
+  `VITE_ENABLE_ADMIN` and `VITE_ENABLE_CLOUD` now default to `false` in the
+  build fallbacks, so a build without injected env doesn't ship admin/cloud UI
+  pointed at an upstream backend. Production enables them explicitly.
+
 ### Fixed
+- **Lap snapshots are now direction-aware.** A course driven in reverse keeps a
+  separate "fastest lap" snapshot from the forward direction instead of
+  overwriting it (and the position-based pace overlay refuses to compare against
+  a reference recorded in the opposite direction, rather than showing nonsense
+  gains).
+- **Saving a snapshot manually won't silently destroy a faster one.** "Save
+  current lap as snapshot" now asks before replacing a stored snapshot that's
+  faster than the lap you're saving.
+- **Plugin tabs (Coach, Profile, Labs) appear even when a plugin registers its
+  panels asynchronously** — the tab list now reacts to plugin contributions
+  instead of freezing the snapshot at first render, so the AI coach tab no longer
+  goes missing until a full page reload.
+- **Pull no longer downgrades a newer local record** or silently opts files into
+  ongoing sync — a manual Pull keeps a local edit that's newer than the cloud
+  copy and just downloads files without flipping their sync state.
+- **Cloud orphan-blob cleanup no longer races a concurrent upload**: only objects
+  older than a grace window are reclaimed, so a file uploaded at the same moment
+  the Profile tab opens can't be deleted before its index row commits.
 - **Lap-snapshot insert failed with `null value in column "id" of relation
   "lap_snapshots" violates not-null constraint`** — same root pattern as the
   missing unique constraint: when the `lap_snapshots` table pre-existed the

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The app includes an optional admin system for managing a community track databas
 | `VITE_SUPABASE_URL` | Yes (if using Cloud) | Backend URL (auto-set by Lovable Cloud) |
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | Yes (if using Cloud) | Backend public/anon key (auto-set by Lovable Cloud) |
 | `VITE_SUPABASE_PROJECT_ID` | Yes (if using Cloud) | Backend project ID (auto-set by Lovable Cloud) |
-| `VITE_ENABLE_ADMIN` | No | Set to `true` to enable admin UI and `/admin` route. `/login` mounts when admin OR cloud is enabled. |
+| `VITE_ENABLE_ADMIN` | No | Set to `true` to enable admin UI and `/admin` route. `/login` mounts when admin OR cloud is enabled. Default `false` — a fresh clone ships the public, offline-first app, not admin UI pointed at an upstream backend. |
 | `VITE_ENABLE_CLOUD` | No | Set to `true` to enable public user accounts: Cloud Sync Labs panel, Google sign-in, `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`. Default `false` — flag-off builds ship zero cloud auth code (offline-first invariant). |
 | `VITE_TURNSTILE_SITE_KEY` | No | Cloudflare Turnstile site key for track submission CAPTCHA |
 | `TURNSTILE_SECRET_KEY` | No | Cloudflare Turnstile secret key (edge function secret — `???`) |

--- a/src/components/LapSnapshotControls.tsx
+++ b/src/components/LapSnapshotControls.tsx
@@ -16,7 +16,7 @@ interface LapSnapshotControlsProps {
   hasCourse: boolean;
   onLoad: (snap: LapSnapshot) => void;
   onClear: () => void;
-  onSave: () => Promise<SaveSnapshotResult>;
+  onSave: (force?: boolean) => Promise<SaveSnapshotResult>;
   /** Trigger button text (default "Snapshots"). */
   triggerLabel?: string;
   /** Show the "save current lap" action (default true). Off for a load-only entry. */
@@ -38,11 +38,17 @@ export function LapSnapshotControls({
 
   const count = snapshotsForCourse.length;
 
-  const handleSave = async () => {
-    const result = await onSave();
+  const handleSave = async (force = false) => {
+    const result = await onSave(force);
     if (result.saved) {
       toast.success(result.replaced ? "Course fastest lap updated." : "Lap snapshot saved.");
       setOpen(false);
+    } else if (result.reason === "slower") {
+      // Don't silently destroy a faster personal-best baseline — confirm first.
+      const ok = window.confirm(
+        `Your saved snapshot (${formatLapTime(result.existingLapMs ?? 0)}) is faster than this lap. Overwrite it anyway?`,
+      );
+      if (ok) await handleSave(true);
     } else if (result.reason === "no-engine") {
       toast.error("Assign an engine (vehicle) to this session first.");
     } else if (result.reason === "no-lap") {

--- a/src/components/LapTable.tsx
+++ b/src/components/LapTable.tsx
@@ -32,7 +32,7 @@ interface LapTableProps {
   canSnapshot?: boolean;
   onLoadSnapshot?: (snap: LapSnapshot) => void;
   onClearSnapshot?: () => void;
-  onSaveSnapshot?: () => Promise<SaveSnapshotResult>;
+  onSaveSnapshot?: (force?: boolean) => Promise<SaveSnapshotResult>;
 }
 
 export const LapTable = memo(function LapTable({ laps, course, samples, onLapSelect, selectedLapNumber, referenceLapNumber, onSetReference, externalRefLabel, savedFiles, onLoadFileForRef, onSelectExternalLap, onClearExternalRef, onRefreshSavedFiles, snapshotsForCourse, activeSnapshotId, canSnapshot, onLoadSnapshot, onClearSnapshot, onSaveSnapshot }: LapTableProps) {

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -14,7 +14,7 @@ import {
   pricingCta,
   tiersWithPrices,
 } from "@/lib/billing";
-import { createCheckout } from "@/lib/billingClient";
+import { createCheckout, createPortal } from "@/lib/billingClient";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -213,6 +213,20 @@ export function PricingCards({ className }: { className?: string }) {
     }
   };
 
+  // Already-subscribed users change plans through the billing portal (Stripe
+  // swaps the plan on the existing subscription with proration) — starting a new
+  // Checkout would create a duplicate, double-billed subscription.
+  const onManage = async (slug: PaidSlug) => {
+    setBusy(slug);
+    try {
+      const url = await createPortal(window.location.href);
+      window.location.href = url;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't open the billing portal.");
+      setBusy(null);
+    }
+  };
+
   const ctaFor = (slug: "free" | PaidSlug, isPaid: boolean): ReactNode => {
     const kind = pricingCta({
       slug,
@@ -234,6 +248,15 @@ export function PricingCards({ className }: { className?: string }) {
         <Button className="w-full" disabled={isBusy} onClick={() => void onUpgrade(slug as PaidSlug)}>
           {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
           {isBusy ? "Redirecting…" : "Upgrade"}
+        </Button>
+      );
+    }
+    if (kind === "manage" && isPaid) {
+      const isBusy = busy === slug;
+      return (
+        <Button variant="outline" className="w-full" disabled={isBusy} onClick={() => void onManage(slug as PaidSlug)}>
+          {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {isBusy ? "Redirecting…" : "Change plan"}
         </Button>
       );
     }

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -73,7 +73,7 @@ export interface SessionContextValue {
   canSnapshot: boolean;
   onLoadSnapshot: (snap: LapSnapshot) => void;
   onClearSnapshot: () => void;
-  onSaveSnapshot: () => Promise<SaveSnapshotResult>;
+  onSaveSnapshot: (force?: boolean) => Promise<SaveSnapshotResult>;
 
   // ── Session metadata ──────────────────────────────────────────────────────
   sessionGpsPoint?: { lat: number; lon: number };

--- a/src/hooks/useDataLoader.ts
+++ b/src/hooks/useDataLoader.ts
@@ -130,6 +130,7 @@ export function useDataLoader({
           trackName: detection.track.name,
           courseName: detection.course.name,
           course: detection.course,
+          direction: detection.direction,
         });
         lapMgmt.setLaps(detection.laps);
         lapMgmt.setSelectedLapNumber(pickFastestLapNumber(detection.laps));

--- a/src/hooks/useLapSnapshots.ts
+++ b/src/hooks/useLapSnapshots.ts
@@ -43,7 +43,9 @@ export function snapshotLabel(snap: LapSnapshot): string {
 export interface SaveSnapshotResult {
   saved: boolean;
   replaced: boolean;
-  reason?: "no-engine" | "no-course" | "no-lap";
+  reason?: "no-engine" | "no-course" | "no-lap" | "slower";
+  /** When reason === "slower": the faster existing snapshot's lap time (ms). */
+  existingLapMs?: number;
 }
 
 /**
@@ -74,7 +76,7 @@ export function useLapSnapshots(params: UseLapSnapshotsParams) {
   }, [refresh]);
 
   const courseKey = useMemo(
-    () => (selection ? makeCourseKey(selection.trackName, selection.courseName) : null),
+    () => (selection ? makeCourseKey(selection.trackName, selection.courseName, selection.direction) : null),
     [selection],
   );
 
@@ -102,7 +104,7 @@ export function useLapSnapshots(params: UseLapSnapshotsParams) {
       if (!engine) return null;
 
       const id = makeSnapshotId(
-        makeCourseKey(selection.trackName, selection.courseName),
+        makeCourseKey(selection.trackName, selection.courseName, selection.direction),
         normalizeEngine(engine),
       );
       const existing = snapshots.find((s) => s.id === id) ?? null;
@@ -113,6 +115,7 @@ export function useLapSnapshots(params: UseLapSnapshotsParams) {
         course: selection.course,
         trackName: selection.trackName,
         courseName: selection.courseName,
+        direction: selection.direction,
         engine,
         sourceFileName: currentFileName ?? "session",
         recordedAt: data.startDate?.getTime(),
@@ -145,7 +148,10 @@ export function useLapSnapshots(params: UseLapSnapshotsParams) {
   }, [onClearOverlay]);
 
   // ── Save (manual) ────────────────────────────────────────────────────────
-  const saveSelectedLap = useCallback(async (): Promise<SaveSnapshotResult> => {
+  // `force` overrides the "don't clobber a faster snapshot" guard. The auto-
+  // prompt path already gates on snapshotPromptKind; manual save must not blow
+  // away a faster personal-best baseline without an explicit confirm.
+  const saveSelectedLap = useCallback(async (force = false): Promise<SaveSnapshotResult> => {
     if (!selection?.course) return { saved: false, replaced: false, reason: "no-course" };
     const lap =
       (selectedLapNumber !== null ? laps.find((l) => l.lapNumber === selectedLapNumber) : null) ??
@@ -153,9 +159,13 @@ export function useLapSnapshots(params: UseLapSnapshotsParams) {
     if (!lap) return { saved: false, replaced: false, reason: "no-lap" };
     const candidate = buildCandidate(lap, sessionKartId, sessionSetupId);
     if (!candidate) return { saved: false, replaced: false, reason: "no-engine" };
-    const replaced = snapshots.some((s) => s.id === candidate.id);
+    const existing = snapshots.find((s) => s.id === candidate.id) ?? null;
+    if (!force && existing && candidate.lapTimeMs > existing.lapTimeMs) {
+      // Saving this would replace a FASTER stored snapshot — ask first.
+      return { saved: false, replaced: true, reason: "slower", existingLapMs: existing.lapTimeMs };
+    }
     await saveSnapshot(candidate);
-    return { saved: true, replaced };
+    return { saved: true, replaced: !!existing };
   }, [selection, selectedLapNumber, laps, buildCandidate, sessionKartId, sessionSetupId, snapshots]);
 
   const removeSnapshot = useCallback(

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -84,6 +84,17 @@ describe("pricingCta", () => {
   it("never offers an upgrade to the free-online card", () => {
     expect(pricingCta({ ...base, slug: "free", currentTier: "pro" })).toBe("none");
   });
+
+  it("routes paid→paid changes to the portal (manage), not a new checkout", () => {
+    // On a paid tier, both an up- and a down-grade must go through the portal so
+    // we never create a second, double-billed Stripe subscription.
+    expect(pricingCta({ ...base, slug: "premium", currentTier: "plus", purchasable: true })).toBe("manage");
+    expect(pricingCta({ ...base, slug: "plus", currentTier: "premium", purchasable: true })).toBe("manage");
+  });
+
+  it("still keeps an unconfigured paid tier non-actionable even when on a paid tier", () => {
+    expect(pricingCta({ ...base, slug: "pro", currentTier: "plus", purchasable: false })).toBe("none");
+  });
 });
 
 describe("lookupKey", () => {

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -120,7 +120,7 @@ export function isComingSoon(tier: string): boolean {
   return COMING_SOON_TIERS.has(tier);
 }
 
-export type PricingCtaKind = "none" | "current" | "upgrade";
+export type PricingCtaKind = "none" | "current" | "manage" | "upgrade";
 
 export interface PricingCtaInput {
   /** The card's tier slug ('free' | 'plus' | 'pro'); undefined for the offline card. */
@@ -137,11 +137,18 @@ export interface PricingCtaInput {
  * Which call-to-action a pricing card should show. Pure so it can be unit-tested.
  * "none" means render no button (informational only — e.g. signed out, the free
  * tiers, or a paid tier whose Stripe Price isn't configured yet, which keeps the
- * "Coming soon" badge).
+ * "Coming soon" badge). "manage" routes through the billing portal instead of a
+ * new Checkout Session.
  */
 export function pricingCta(i: PricingCtaInput): PricingCtaKind {
   if (!i.slug || !i.cloudEnabled || !i.signedIn) return "none";
   if (i.slug === i.currentTier) return "current";
   if (i.slug === "free") return "none";
-  return i.purchasable ? "upgrade" : "none";
+  if (!i.purchasable) return "none";
+  // A user already on a paid tier must NOT start a fresh Checkout for another
+  // paid tier — that would create a second, parallel Stripe subscription and
+  // double-bill them. Plan changes (up or down) go through the billing portal,
+  // which swaps the plan on the existing subscription. Only an upgrade from free
+  // starts a new Checkout Session.
+  return isPaidTier(i.currentTier) ? "manage" : "upgrade";
 }

--- a/src/lib/lapDelta.test.ts
+++ b/src/lib/lapDelta.test.ts
@@ -110,6 +110,21 @@ describe("computePositionDelta", () => {
     expect(rawDelta.some((d) => d === null)).toBe(true);
     expect(rawDelta.some((d) => d !== null)).toBe(true);
   });
+
+  it("does not flag a same-direction reference as reversed", () => {
+    const ref = resampleByDistance(lineLap(101, 1, 10), 2);
+    expect(computePositionDelta(lineLap(101, 1, 10), ref).reversed).toBe(false);
+  });
+
+  it("flags a reverse-direction reference and nulls the deltas instead of emitting garbage", () => {
+    // Reference runs south→north; the current lap runs north→south on the same
+    // line — the same course driven the other way.
+    const ref = resampleByDistance(lineLap(101, 1, 10), 2);
+    const reverse = Array.from({ length: 101 }, (_, i) => makeSample(100 - i, i * 10));
+    const res = computePositionDelta(reverse, ref);
+    expect(res.reversed).toBe(true);
+    expect(res.delta.every((d) => d === null)).toBe(true);
+  });
 });
 
 describe("computeLapPace", () => {

--- a/src/lib/lapDelta.ts
+++ b/src/lib/lapDelta.ts
@@ -71,6 +71,13 @@ export interface DeltaResult {
   matchIndex: number[];
   /** Fraction 0..1 along the matched segment. */
   matchFrac: number[];
+  /**
+   * True when the reference lap appears to have been recorded in the OPPOSITE
+   * direction of travel. The monotonic search can't rewind through the
+   * reference's arc, so such a reference would yield meaningless deltas — we
+   * null them out and flag it instead of reporting silent garbage.
+   */
+  reversed: boolean;
 }
 
 const DEFAULTS: Required<Omit<DeltaOptions, "maxMatchMeters">> & { maxMatchMeters: number | null } = {
@@ -173,6 +180,48 @@ export function smoothDelta(raw: (number | null)[], alpha = DEFAULTS.alpha, zero
 }
 
 /**
+ * Detect a reference recorded in the opposite direction of travel. Probe the
+ * current lap at coarse intervals, find each probe's GLOBAL nearest reference
+ * grid index, and check whether those indices trend up (same direction) or down
+ * (reversed) as the current lap progresses. Steps are unwrapped around the loop
+ * so the start/finish wrap doesn't masquerade as a reversal.
+ */
+function referenceIsReversed(current: GpsSample[], ref: ResampledLap): boolean {
+  const R = ref.xy.length;
+  if (R < 4 || current.length < 4) return false;
+  const probes = Math.min(16, current.length);
+  const idxs: number[] = [];
+  for (let s = 0; s < probes; s++) {
+    const ci = Math.floor((s / (probes - 1)) * (current.length - 1));
+    const p = projectToPlane(current[ci].lat, current[ci].lon, ref.centerLat, ref.centerLon);
+    let best = 0;
+    let bestD = Infinity;
+    for (let k = 0; k < R; k++) {
+      const dx = p.x - ref.xy[k].x;
+      const dy = p.y - ref.xy[k].y;
+      const d = dx * dx + dy * dy;
+      if (d < bestD) {
+        bestD = d;
+        best = k;
+      }
+    }
+    idxs.push(best);
+  }
+  let up = 0;
+  let down = 0;
+  for (let i = 1; i < idxs.length; i++) {
+    let d = idxs[i] - idxs[i - 1];
+    if (d > R / 2) d -= R; // unwrap forward across the loop seam
+    else if (d < -R / 2) d += R; // unwrap backward across the loop seam
+    if (d > 0) up++;
+    else if (d < 0) down++;
+  }
+  // Reversed only when downward steps clearly dominate, so a noisy/partial lap
+  // doesn't trip the guard.
+  return down > up * 2;
+}
+
+/**
  * Compute the position-based gap of `current` versus a resampled reference lap.
  * Returns one delta per native current sample (drop-in for `paceData`).
  */
@@ -189,7 +238,13 @@ export function computePositionDelta(
 
   const R = ref.xy.length;
   if (m === 0 || R < 2) {
-    return { delta: rawDelta.slice(), rawDelta, matchIndex, matchFrac };
+    return { delta: rawDelta.slice(), rawDelta, matchIndex, matchFrac, reversed: false };
+  }
+
+  // A reverse-direction reference can't be aligned by the forward monotonic
+  // search — bail with null deltas rather than emitting misleading pace numbers.
+  if (referenceIsReversed(current, ref)) {
+    return { delta: rawDelta.slice(), rawDelta, matchIndex, matchFrac, reversed: true };
   }
 
   const lookBackPts = Math.max(1, Math.ceil(o.lookBackMeters / ref.sampleMeters));
@@ -234,7 +289,7 @@ export function computePositionDelta(
     rawDelta[i] = Math.abs(d) > o.sanitySeconds ? null : d;
   }
 
-  return { delta: smoothDelta(rawDelta, o.alpha, o.zeroLag), rawDelta, matchIndex, matchFrac };
+  return { delta: smoothDelta(rawDelta, o.alpha, o.zeroLag), rawDelta, matchIndex, matchFrac, reversed: false };
 }
 
 export type DeltaMethod = "position" | "distance";

--- a/src/lib/lapSnapshot.test.ts
+++ b/src/lib/lapSnapshot.test.ts
@@ -54,6 +54,20 @@ describe("key helpers", () => {
     const c = makeSnapshotId(makeCourseKey("OKC", "Full CW"), "tm");
     expect(new Set([a, b, c]).size).toBe(3);
   });
+
+  it("distinguishes a course driven forward vs reverse", () => {
+    // A reverse lap must not collide with the forward snapshot.
+    const fwd = makeCourseKey("OKC", "Full CW", "forward");
+    const rev = makeCourseKey("OKC", "Full CW", "reverse");
+    expect(rev).not.toBe(fwd);
+    expect(makeSnapshotId(rev, "rotax")).not.toBe(makeSnapshotId(fwd, "rotax"));
+  });
+
+  it("keeps forward/undefined backward-compatible with the pre-direction key", () => {
+    const bare = makeCourseKey("OKC", "Full CW");
+    expect(makeCourseKey("OKC", "Full CW", "forward")).toBe(bare);
+    expect(makeCourseKey("OKC", "Full CW", undefined)).toBe(bare);
+  });
 });
 
 describe("buildSnapshot", () => {

--- a/src/lib/lapSnapshot.ts
+++ b/src/lib/lapSnapshot.ts
@@ -12,7 +12,7 @@
 // it can never inflate the stored count. This module is pure (no IndexedDB / no
 // React) so the keying + buffer logic stays unit-testable.
 
-import type { Course, GpsSample, Lap } from "@/types/racing";
+import type { Course, CourseDirection, GpsSample, Lap } from "@/types/racing";
 import type { VehicleSetup } from "./setupStorage";
 
 /** Samples kept on each side of the lap, so a later start/finish nudge still fits. */
@@ -73,9 +73,20 @@ export function normalizeEngine(engine: string): string {
   return engine.trim().toLowerCase();
 }
 
-/** Composite course identity (track + course); only ever compared for equality. */
-export function makeCourseKey(trackName: string, courseName: string): string {
-  return `${trackName.trim()}${SEP}${courseName.trim()}`;
+/**
+ * Composite course identity (track + course + direction); only ever compared for
+ * equality. A course driven in reverse is a different baseline — a reverse lap
+ * must not overwrite the forward snapshot (and vice versa). 'forward'/undefined
+ * keep the bare key so existing (pre-direction) snapshots stay addressable; only
+ * 'reverse' adds a suffix.
+ */
+export function makeCourseKey(
+  trackName: string,
+  courseName: string,
+  direction?: CourseDirection,
+): string {
+  const base = `${trackName.trim()}${SEP}${courseName.trim()}`;
+  return direction === "reverse" ? `${base}${SEP}reverse` : base;
 }
 
 /** Stable snapshot id for a (course, engine) pair — same pair ⇒ same id ⇒ replace. */
@@ -90,6 +101,8 @@ export interface BuildSnapshotInput {
   course: Course;
   trackName: string;
   courseName: string;
+  /** Direction the course was driven — part of the snapshot identity. */
+  direction?: CourseDirection;
   engine: string;
   sourceFileName: string;
   recordedAt?: number;
@@ -103,7 +116,7 @@ export interface BuildSnapshotInput {
 /** Slice the lap from session samples with a ±5s buffer, returning a frozen snapshot. */
 export function buildSnapshot(input: BuildSnapshotInput): LapSnapshot {
   const {
-    lap, samples, course, trackName, courseName, engine,
+    lap, samples, course, trackName, courseName, direction, engine,
     sourceFileName, recordedAt, vehicle, setup,
   } = input;
   const now = input.now ?? Date.now();
@@ -119,7 +132,7 @@ export function buildSnapshot(input: BuildSnapshotInput): LapSnapshot {
 
   const buffered = samples.slice(startIdx, endIdx + 1).map((s) => ({ ...s }));
 
-  const courseKey = makeCourseKey(trackName, courseName);
+  const courseKey = makeCourseKey(trackName, courseName, direction);
   const engineKey = normalizeEngine(engine);
 
   return {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,7 +32,7 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ParsedData } from "@/types/racing";
-import { getPanelsForSlot, PanelSlot } from "@/plugins/panels";
+import { usePanelsForSlot, PanelSlot } from "@/plugins/panels";
 import { TrackPromptDialog } from "@/components/TrackPromptDialog";
 import { useSettings } from "@/hooks/useSettings";
 import { usePlayback } from "@/hooks/usePlayback";
@@ -123,16 +123,18 @@ export default function Index() {
 
   const [topPanelView, setTopPanelView] = useState<TopPanelView>("raceline");
   const [showOverlays, setShowOverlays] = useState(true);
-  // Plugins are registered at startup, so a labs-slot panel means the Labs tab
-  // has real content — surface it even when the experimental setting is off.
-  const hasLabsPanels = useMemo(() => getPanelsForSlot(PanelSlot.Labs).length > 0, []);
+  // Plugin panels drive these tabs. A plugin's `setup` may register panels
+  // asynchronously (after this first render), so we read them through the
+  // reactive hook — a plain useMemo([]) would freeze the snapshot and the tabs
+  // would never appear that session.
+  const hasLabsPanels = usePanelsForSlot(PanelSlot.Labs).length > 0;
   const showLabs = settings.enableLabs || hasLabsPanels;
   // The Coach tab is self-gating: it appears only when a plugin contributes a
   // panel to the Coach slot (i.e. the coach package is installed).
-  const showCoach = useMemo(() => getPanelsForSlot(PanelSlot.Coach).length > 0, []);
+  const showCoach = usePanelsForSlot(PanelSlot.Coach).length > 0;
   // Profile tab is self-gating too: appears only when a plugin (cloud-sync)
   // contributes a Profile panel (i.e. the cloud build flag is on).
-  const showProfile = useMemo(() => getPanelsForSlot(PanelSlot.Profile).length > 0, []);
+  const showProfile = usePanelsForSlot(PanelSlot.Profile).length > 0;
 
   // Video sync for Labs tab
   const videoSync = useVideoSync({

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -7,6 +7,14 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
 import { Gauge, ArrowLeft } from 'lucide-react';
 import { useDocumentHead } from '@/hooks/useDocumentHead';
+
+/** True when the current page load arrived via a Supabase password-recovery link. */
+function hashHasRecovery(): boolean {
+  if (typeof window === 'undefined') return false;
+  // Implicit-flow recovery links carry `#...&type=recovery&...`; the PKCE flow
+  // uses `?code=...&type=recovery`. Check both before Supabase strips them.
+  return /[?#&]type=recovery(&|$)/.test(window.location.hash + window.location.search);
+}
 
 export default function ResetPassword() {
   useDocumentHead({
@@ -17,10 +25,34 @@ export default function ResetPassword() {
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  // Only a session established via a PASSWORD_RECOVERY token may set a new
+  // password here. Without this gate, anyone landing on /reset-password with an
+  // already-signed-in session (a shared/unattended tab, a stolen token) could
+  // reset the account password without proving control of the email — turning
+  // session theft into a full account takeover.
+  const [recoveryReady, setRecoveryReady] = useState(hashHasRecovery);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    // Supabase fires PASSWORD_RECOVERY after it processes the recovery token in
+    // the URL. We may mount before or after that, so we both seed from the URL
+    // (above) and listen for the event.
+    const { data } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'PASSWORD_RECOVERY') setRecoveryReady(true);
+    });
+    return () => data.subscription.unsubscribe();
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!recoveryReady) {
+      toast({
+        title: 'Recovery link required',
+        description: 'Open the reset link from your email to set a new password.',
+        variant: 'destructive',
+      });
+      return;
+    }
     if (password !== confirm) {
       toast({ title: 'Passwords do not match', variant: 'destructive' });
       return;
@@ -49,19 +81,26 @@ export default function ResetPassword() {
         </div>
         <div className="racing-card p-6 space-y-4">
           <h2 className="text-lg font-semibold text-foreground">Set New Password</h2>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="password">New Password</Label>
-              <Input id="password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="confirm">Confirm New Password</Label>
-              <Input id="confirm" type="password" value={confirm} onChange={e => setConfirm(e.target.value)} required />
-            </div>
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? 'Please wait...' : 'Update Password'}
-            </Button>
-          </form>
+          {recoveryReady ? (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="password">New Password</Label>
+                <Input id="password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirm">Confirm New Password</Label>
+                <Input id="confirm" type="password" value={confirm} onChange={e => setConfirm(e.target.value)} required />
+              </div>
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? 'Please wait...' : 'Update Password'}
+              </Button>
+            </form>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              This page only works when opened from the password-reset link in your email.
+              Request a reset from the sign-in page, then follow the emailed link.
+            </p>
+          )}
         </div>
         <Button variant="ghost" className="w-full gap-2" onClick={() => navigate('/')}>
           <ArrowLeft className="w-4 h-4" /> Back to Home

--- a/src/plugins/PluginMount.tsx
+++ b/src/plugins/PluginMount.tsx
@@ -1,5 +1,5 @@
-import { Component, Suspense, useMemo, type ReactNode } from "react";
-import { getMounts } from "./mounts";
+import { Component, Suspense, type ReactNode } from "react";
+import { useMounts } from "./mounts";
 
 /** Isolates a single mounted component so a plugin throw can't break core UI. */
 class MountErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
@@ -19,7 +19,7 @@ class MountErrorBoundary extends Component<{ children: ReactNode }, { failed: bo
  * Suspense-wrapped, so mounts may be `React.lazy`.
  */
 export function PluginMount<C>({ slot, ctx }: { slot: string; ctx: C }) {
-  const mounts = useMemo(() => getMounts<C>(slot), [slot]);
+  const mounts = useMounts<C>(slot);
   if (mounts.length === 0) return null;
   return (
     <>

--- a/src/plugins/PluginPanelHost.tsx
+++ b/src/plugins/PluginPanelHost.tsx
@@ -1,5 +1,5 @@
-import { Component, Suspense, useMemo, type ReactNode } from "react";
-import { getPanelsForSlot, isBareSlot, type PluginPanelProps } from "./panels";
+import { Component, Suspense, type ReactNode } from "react";
+import { isBareSlot, usePanelsForSlot, type PluginPanelProps } from "./panels";
 
 /**
  * Isolates a single plugin panel: a throw in one panel renders a local notice
@@ -37,7 +37,7 @@ export function PluginPanelHost({
   fallback,
   ...props
 }: { slot: string; fallback?: ReactNode } & PluginPanelProps) {
-  const panels = useMemo(() => getPanelsForSlot(slot), [slot]);
+  const panels = usePanelsForSlot(slot);
 
   if (panels.length === 0) return <>{fallback ?? null}</>;
 

--- a/src/plugins/cloud-sync/CloudSyncPanel.tsx
+++ b/src/plugins/cloud-sync/CloudSyncPanel.tsx
@@ -73,7 +73,7 @@ export default function CloudSyncPanel() {
   };
 
   const runPull = async () => {
-    if (!window.confirm("Pull merges your cloud copy into this device, overwriting any local records with the same name. Continue?")) return;
+    if (!window.confirm("Pull downloads your cloud copy to this device, replacing local records with the same name — unless your local copy is newer, which is kept. It doesn't change which files are synced. Continue?")) return;
     setBusy("pull");
     try {
       const r = await pullAll(user.id);

--- a/src/plugins/cloud-sync/DataPrivacyPanel.tsx
+++ b/src/plugins/cloud-sync/DataPrivacyPanel.tsx
@@ -12,7 +12,6 @@ import {
   getPendingDeletion,
   scheduleAccountDeletion,
   sendDeletionCode,
-  verifyDeletionCode,
   type PendingDeletion,
 } from "./accountDeletion";
 
@@ -154,8 +153,9 @@ function DeleteFlow({
   const confirm = async () => {
     setStep("working");
     try {
-      await verifyDeletionCode(email, code);
-      const result = await scheduleAccountDeletion();
+      // The edge function verifies the code server-side, so we pass it straight
+      // through rather than consuming it with a client-side verify first.
+      const result = await scheduleAccountDeletion(code);
       toast.success(`Deletion scheduled for ${new Date(result.scheduled_for).toLocaleDateString()}.`);
       setCode("");
       setStep("idle");

--- a/src/plugins/cloud-sync/accountDeletion.ts
+++ b/src/plugins/cloud-sync/accountDeletion.ts
@@ -1,11 +1,14 @@
 // Client side of self-service account deletion.
 //
 // Flow: the user proves control of the account email via a one-time code
-// (Supabase Auth email OTP — no extra mail provider needed), then we ask the
-// request-account-deletion edge function to schedule deletion 7 days out. The
-// window is reversible: cancel deletes the pending row (RLS allows the owner).
-// Until then the app shows a deletion banner. The irreversible purge is done
-// server-side by the process-account-deletions worker once the window elapses.
+// (Supabase Auth email OTP — no extra mail provider needed). The emailed code is
+// then passed to the request-account-deletion edge function, which VERIFIES it
+// server-side before scheduling deletion 7 days out. Verifying on the server (not
+// just in the UI) is what stops a stolen JWT from scheduling deletion via a
+// direct call — the caller must also possess the emailed code. The window is
+// reversible: cancel deletes the pending row (RLS allows the owner). The
+// irreversible purge is done by the process-account-deletions worker once the
+// window elapses.
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
@@ -29,15 +32,15 @@ export async function sendDeletionCode(email: string): Promise<void> {
   if (error) throw new Error(error.message);
 }
 
-/** Verify the emailed code. Resolves on success; throws on a bad/expired code. */
-export async function verifyDeletionCode(email: string, token: string): Promise<void> {
-  const { error } = await supabase.auth.verifyOtp({ email, token: token.trim(), type: "email" });
-  if (error) throw new Error(error.message);
-}
-
-/** Schedule deletion (idempotent server-side). Returns the scheduled date. */
-export async function scheduleAccountDeletion(): Promise<PendingDeletion> {
-  const { data, error } = await supabase.functions.invoke("request-account-deletion");
+/**
+ * Schedule deletion (idempotent server-side). The emailed `code` is verified by
+ * the edge function — DON'T verify it client-side first or it'll be consumed
+ * before the server can check it. Returns the scheduled date.
+ */
+export async function scheduleAccountDeletion(code: string): Promise<PendingDeletion> {
+  const { data, error } = await supabase.functions.invoke("request-account-deletion", {
+    body: { code: code.trim() },
+  });
   if (error) throw new Error(error.message);
   return data as PendingDeletion;
 }

--- a/src/plugins/cloud-sync/activeUser.ts
+++ b/src/plugins/cloud-sync/activeUser.ts
@@ -1,0 +1,23 @@
+// The signed-in user the plugin-local sync stores belong to.
+//
+// Pending changes, snapshot tombstones, and per-file sync selections all live in
+// this plugin's own IndexedDB (getPluginStore("cloud-sync")), which is SHARED by
+// every account that signs in on this browser. Without scoping, User A's queued
+// offline edits / cloud-deletion tombstones / file selections would be applied
+// to User B's cloud account on the next reconcile after a sign-out/sign-in.
+//
+// Each of those stores keys its data with `userScope()` so it is partitioned per
+// user. autoSync updates this on every auth state change BEFORE it reconciles,
+// so a reconcile for User B only ever sees User B's local state.
+
+let activeUserId: string | null = null;
+
+/** Set the active user (null when signed out). Called by autoSync on auth change. */
+export function setActiveUserId(id: string | null): void {
+  activeUserId = id;
+}
+
+/** Key suffix identifying the active user's partition ("anon" when signed out). */
+export function userScope(): string {
+  return activeUserId ?? "anon";
+}

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -17,6 +17,7 @@ import { deleteCloudFile, deleteRecord, pushRecord, reconcileDocs } from "./sync
 import { clearSnapshotTombstone, pushSnapshot, reconcileSnapshots } from "./snapshotSync";
 import { clearPending, listPending, markPending, pendingKeySet } from "./pendingSync";
 import { unselectFile } from "./fileSync";
+import { setActiveUserId } from "./activeUser";
 import { pendingId } from "./merge";
 import { storageTypeForStore } from "./storageTypes";
 import { FILE_STORE } from "./syncStores";
@@ -171,6 +172,7 @@ export function startAutoSync(): void {
 
   void supabase.auth.getSession().then(({ data }) => {
     currentUserId = data.session?.user?.id ?? null;
+    setActiveUserId(currentUserId);
     if (currentUserId) void runReconcile(currentUserId);
   });
 
@@ -178,6 +180,9 @@ export function startAutoSync(): void {
     const next = session?.user?.id ?? null;
     const newlySignedIn = next !== null && next !== currentUserId;
     currentUserId = next;
+    // Re-scope the plugin-local stores BEFORE any reconcile so a reconcile only
+    // ever reads/writes the now-active user's partition.
+    setActiveUserId(next);
     if (newlySignedIn) void runReconcile(next);
   });
 

--- a/src/plugins/cloud-sync/fileSync.ts
+++ b/src/plugins/cloud-sync/fileSync.ts
@@ -7,6 +7,7 @@
 // file stays synced — no "modified" state needed for the blob itself.
 
 import { getPluginStore } from "@/plugins/storage";
+import { userScope } from "./activeUser";
 
 export type FileSyncState = "off" | "pending" | "synced";
 
@@ -15,8 +16,10 @@ export interface FileSyncRecord {
 }
 
 const store = getPluginStore("cloud-sync");
-const PREFIX = "file:";
-const recordKey = (name: string) => `${PREFIX}${name}`;
+// Per-user prefix so one account's file-sync selections aren't visible to (and
+// uploaded under) another account that signs in on the same browser.
+const prefix = () => `file:${userScope()}:`;
+const recordKey = (name: string) => `${prefix()}${name}`;
 
 /** Derive the UI state from a stored record. Pure — unit-tested. */
 export function fileSyncStatus(rec: FileSyncRecord | undefined): FileSyncState {
@@ -43,10 +46,11 @@ export function unselectFile(name: string): Promise<void> {
   return store.delete(recordKey(name));
 }
 
-/** File names currently selected for sync. */
+/** File names currently selected for sync (for the active user). */
 export async function listSelectedFiles(): Promise<string[]> {
+  const p = prefix();
   const keys = await store.keys();
-  return keys.filter((k) => k.startsWith(PREFIX)).map((k) => k.slice(PREFIX.length));
+  return keys.filter((k) => k.startsWith(p)).map((k) => k.slice(p.length));
 }
 
 /** Cloud file names that aren't present locally (i.e. pullable). Pure. */

--- a/src/plugins/cloud-sync/pendingSync.ts
+++ b/src/plugins/cloud-sync/pendingSync.ts
@@ -8,6 +8,7 @@
 import { getPluginStore } from "@/plugins/storage";
 import type { GarageChangeType } from "@/lib/garageEvents";
 import { pendingId } from "./merge";
+import { userScope } from "./activeUser";
 
 export interface PendingChange {
   store: string;
@@ -16,10 +17,11 @@ export interface PendingChange {
 }
 
 const store = getPluginStore("cloud-sync");
-const KEY = "pending-changes";
+// Per-user so one account's queued changes never flush into another's cloud.
+const key = () => `pending-changes:${userScope()}`;
 
 async function read(): Promise<PendingChange[]> {
-  return (await store.get<PendingChange[]>(KEY)) ?? [];
+  return (await store.get<PendingChange[]>(key())) ?? [];
 }
 
 /** Record (or update) a pending change; the latest op for a key wins. */
@@ -28,15 +30,15 @@ export async function markPending(change: PendingChange): Promise<void> {
   const i = list.findIndex((c) => c.store === change.store && c.key === change.key);
   if (i >= 0) list[i] = change;
   else list.push(change);
-  await store.set(KEY, list);
+  await store.set(key(), list);
 }
 
 /** Drop a pending entry once it's been confirmed in the cloud. */
-export async function clearPending(store_: string, key: string): Promise<void> {
+export async function clearPending(store_: string, key_: string): Promise<void> {
   const list = await read();
   await store.set(
-    KEY,
-    list.filter((c) => !(c.store === store_ && c.key === key)),
+    key(),
+    list.filter((c) => !(c.store === store_ && c.key === key_)),
   );
 }
 

--- a/src/plugins/cloud-sync/snapshotTombstones.ts
+++ b/src/plugins/cloud-sync/snapshotTombstones.ts
@@ -7,25 +7,27 @@
 // "don't auto-push this id" until the user saves it again (which clears it).
 
 import { getPluginStore } from "@/plugins/storage";
+import { userScope } from "./activeUser";
 
 const store = getPluginStore("cloud-sync");
-const KEY = "snapshot-tombstones";
+// Per-user so one account's cloud deletions never suppress another's pushes.
+const key = () => `snapshot-tombstones:${userScope()}`;
 
 async function read(): Promise<string[]> {
-  return (await store.get<string[]>(KEY)) ?? [];
+  return (await store.get<string[]>(key())) ?? [];
 }
 
 export async function addSnapshotTombstone(id: string): Promise<void> {
   const list = await read();
   if (!list.includes(id)) {
     list.push(id);
-    await store.set(KEY, list);
+    await store.set(key(), list);
   }
 }
 
 export async function clearSnapshotTombstone(id: string): Promise<void> {
   const list = await read();
-  if (list.includes(id)) await store.set(KEY, list.filter((x) => x !== id));
+  if (list.includes(id)) await store.set(key(), list.filter((x) => x !== id));
 }
 
 export async function snapshotTombstoneSet(): Promise<Set<string>> {

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -111,12 +111,25 @@ export async function deleteCloudFile(userId: string, name: string): Promise<voi
 export async function cleanupOrphanBlobs(userId: string): Promise<number> {
   const { data: objects, error: listErr } = await userFiles().list(userId, { limit: 1000 });
   if (listErr || !objects) return 0;
+  // TOCTOU guard: uploadBlob writes the blob BEFORE inserting its index row, so a
+  // blob that's mid-upload (or whose index insert is in flight) briefly has no
+  // row and would look like an orphan. Only consider objects older than this
+  // grace window, so a concurrent upload is never mistaken for an orphan and
+  // deleted out from under the index row that's about to commit. A missing
+  // timestamp is treated as "too new" and skipped.
+  const ORPHAN_GRACE_MS = 10 * 60 * 1000;
+  const cutoff = Date.now() - ORPHAN_GRACE_MS;
+  const aged = objects.filter((o) => {
+    const ts = o.created_at ?? o.updated_at;
+    return ts != null && new Date(ts).getTime() < cutoff;
+  });
+  if (!aged.length) return 0;
   const { data: rows } = await syncRecords()
     .select("record_key")
     .eq("user_id", userId)
     .eq("store", FILE_STORE);
   const indexed = (rows ?? []).map((r) => (r as { record_key: string }).record_key);
-  const orphans = orphanedObjectNames(objects.map((o) => o.name), indexed);
+  const orphans = orphanedObjectNames(aged.map((o) => o.name), indexed);
   if (!orphans.length) return 0;
   const { error: rmErr } = await userFiles().remove(orphans.map((n) => `${userId}/${n}`));
   if (rmErr) return 0;
@@ -180,7 +193,14 @@ export async function pushAll(userId: string): Promise<SyncSummary> {
   return { records: pushed, files, skipped };
 }
 
-/** Bring the cloud copy down into local IndexedDB. */
+/**
+ * Bring the cloud copy down into local IndexedDB. Cloud-wins on same-name
+ * collisions, EXCEPT a strictly-newer local document is kept (so a manual Pull
+ * can't silently downgrade an edit you made more recently than the cloud copy).
+ * Pulled files are downloaded but NOT auto-selected for sync — Pull is a
+ * download, not an opt-in; the user controls which files sync in the file
+ * manager.
+ */
 export async function pullAll(userId: string): Promise<SyncSummary> {
   const { data, error } = await syncRecords()
     .select("store,record_key,data")
@@ -195,9 +215,11 @@ export async function pullAll(userId: string): Promise<SyncSummary> {
       const { data: blob, error: dlError } = await userFiles().download(blobPath(userId, row.record_key));
       if (dlError || !blob) continue;
       await saveFile(row.record_key, blob);
-      await markPushed(row.record_key); // pulled files are now synced locally
       files++;
     } else if ((DOC_STORES as readonly string[]).includes(row.store)) {
+      const local = await getAccessor(row.store).getOne(row.record_key);
+      // Keep a local copy that's been edited more recently than the cloud one.
+      if (local && recordUpdatedAt(local) > recordUpdatedAt(row.data)) continue;
       await writeOne(row.store, row.data);
       records++;
     }

--- a/src/plugins/mounts.ts
+++ b/src/plugins/mounts.ts
@@ -8,9 +8,9 @@
 // All mounts share one registry point (`MOUNTS_POINT`), discriminated by `slot`,
 // so adding a new mount location is just a new string — no registry change.
 
-import type { ComponentType } from "react";
+import { useSyncExternalStore, type ComponentType } from "react";
 import type { FileEntry, FileMetadata } from "@/lib/fileStorage";
-import { pluginRegistry } from "./registry";
+import { getContributionsVersion, pluginRegistry, subscribeContributions } from "./registry";
 
 export const MOUNTS_POINT = "ui:mounts";
 
@@ -71,4 +71,14 @@ export function getMounts<C = unknown>(slot: string): PluginMountDef<C>[] {
     .getContributions<PluginMountDef<C>>(MOUNTS_POINT)
     .filter((m) => m.slot === slot)
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+/**
+ * React hook form of `getMounts` that re-reads when plugins contribute (async
+ * plugin `setup` can register mounts after the first render — see
+ * `usePanelsForSlot`).
+ */
+export function useMounts<C = unknown>(slot: string): PluginMountDef<C>[] {
+  useSyncExternalStore(subscribeContributions, getContributionsVersion, getContributionsVersion);
+  return getMounts<C>(slot);
 }

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -9,10 +9,10 @@
 // New slots need no changes here: a host surface picks a slot string, plugins
 // target it, and `getPanelsForSlot` wires them together.
 
-import type { ComponentType } from "react";
+import { useSyncExternalStore, type ComponentType } from "react";
 import type { ParsedData, Lap, Course, GpsSample } from "@/types/racing";
 import type { VehicleSetup } from "@/lib/setupStorage";
-import { pluginRegistry } from "./registry";
+import { getContributionsVersion, pluginRegistry, subscribeContributions } from "./registry";
 
 /** Registry extension point that all UI panels are contributed to. */
 export const PANELS_POINT = "ui:panels";
@@ -111,6 +111,19 @@ export function getPanelsForSlot(slot: string): PluginPanel[] {
     .getContributions<PluginPanel>(PANELS_POINT)
     .filter((panel) => panel.slot === slot)
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+/**
+ * React hook form of `getPanelsForSlot` that re-reads when plugins contribute.
+ * A plugin's `setup` may be async (e.g. the external coach awaits before
+ * registering its panels), so panels can appear AFTER the first render — this
+ * subscribes to the registry so the host re-renders and the tab shows up. The
+ * snapshot is the contribution version (stable across renders), so the result
+ * only recomputes when `slot` changes or something is actually contributed.
+ */
+export function usePanelsForSlot(slot: string): PluginPanel[] {
+  useSyncExternalStore(subscribeContributions, getContributionsVersion, getContributionsVersion);
+  return getPanelsForSlot(slot);
 }
 
 /**

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -3,6 +3,13 @@ import type { DataViewerPlugin, PluginRegistry } from "./types";
 class Registry implements PluginRegistry {
   private plugins = new Map<string, DataViewerPlugin>();
   private contributions = new Map<string, unknown[]>();
+  // Bumped on every contribution so React consumers can re-read via
+  // useSyncExternalStore. A plugin's `setup` may be async (the external coach
+  // awaits before contributing its panels), so contributions can land AFTER the
+  // first render — without this, a useMemo([]) snapshot would freeze the tabs as
+  // absent for the whole session.
+  private version = 0;
+  private listeners = new Set<() => void>();
 
   register(plugin: DataViewerPlugin): void {
     const existing = this.plugins.get(plugin.id);
@@ -22,11 +29,35 @@ class Registry implements PluginRegistry {
     const arr = this.contributions.get(point) ?? [];
     arr.push(value);
     this.contributions.set(point, arr);
+    this.version++;
+    for (const fn of this.listeners) fn();
   }
 
   getContributions<T>(point: string): T[] {
     return (this.contributions.get(point) ?? []) as T[];
   }
+
+  /** Subscribe to contribution changes (for useSyncExternalStore). */
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  /** Monotonic counter — the stable snapshot for useSyncExternalStore. */
+  getVersion(): number {
+    return this.version;
+  }
 }
 
-export const pluginRegistry: PluginRegistry = new Registry();
+const registry = new Registry();
+export const pluginRegistry: PluginRegistry = registry;
+
+/** Subscribe to plugin contribution changes (not part of the plugin contract). */
+export function subscribeContributions(fn: () => void): () => void {
+  return registry.subscribe(fn);
+}
+
+/** Current contribution version — changes whenever a plugin contributes. */
+export function getContributionsVersion(): number {
+  return registry.getVersion();
+}

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -149,4 +149,10 @@ export interface TrackCourseSelection {
   trackName: string;
   courseName: string;
   course: Course;
+  /**
+   * Direction the course is being driven, when known (from auto-detection).
+   * Part of a lap snapshot's identity so a reverse-direction lap doesn't
+   * overwrite the forward snapshot. Undefined is treated as 'forward'.
+   */
+  direction?: CourseDirection;
 }

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -87,9 +87,23 @@ Deno.serve(async (req) => {
     // Reuse the user's Stripe customer if we have one, else create + persist it.
     const { data: sub } = await admin
       .from('user_subscriptions')
-      .select('stripe_customer_id')
+      .select('stripe_customer_id, status, stripe_subscription_id')
       .eq('user_id', user.id)
       .maybeSingle();
+
+    // Block a SECOND parallel subscription. If the user already has an active
+    // subscription, a plan change must go through the Billing Portal (which
+    // swaps the plan on the existing sub with proration) — not a new Checkout
+    // Session, which would create a duplicate Stripe subscription and bill the
+    // customer twice. The client routes paid→paid clicks to the portal; this is
+    // the server-side backstop.
+    const ENTITLING = ['active', 'trialing', 'past_due'];
+    if (sub?.stripe_subscription_id && ENTITLING.includes(sub.status ?? '')) {
+      return json(
+        { error: 'You already have an active subscription. Manage your plan from the billing portal.' },
+        409,
+      );
+    }
 
     let customerId = sub?.stripe_customer_id ?? undefined;
     if (!customerId) {

--- a/supabase/functions/process-account-deletions/index.ts
+++ b/supabase/functions/process-account-deletions/index.ts
@@ -56,10 +56,25 @@ Deno.serve(async (req) => {
 
     for (const userId of userIds) {
       try {
-        await removeUserFiles(admin, userId);
+        // Delete the auth user FIRST. It cascades profiles, sync_records,
+        // user_subscriptions, user_roles and the account_deletions row via FKs.
+        // Only once that irreversibly succeeds do we wipe the Storage blobs — so
+        // a transient auth-delete failure (429/5xx) leaves a fully intact,
+        // still-cancellable account instead of one whose files are already gone
+        // but whose rows + deletion window survive (UI would 404 on every file).
         const { error: delErr } = await admin.auth.admin.deleteUser(userId);
         if (delErr) throw delErr;
-        // The account_deletions row is removed by the auth.users FK cascade.
+
+        // Best-effort blob cleanup. The account is already gone, so a failure
+        // here only leaks orphaned objects (no row references them) — far less
+        // harmful than losing files before the account is confirmed deleted. The
+        // user is no longer in due_account_deletions, so log loudly for manual
+        // sweeping rather than failing the (successful) deletion.
+        try {
+          await removeUserFiles(admin, userId);
+        } catch (fileErr) {
+          console.error('process-account-deletions: blob cleanup failed after delete for', userId, fileErr);
+        }
         results.push({ user_id: userId, ok: true });
       } catch (e) {
         console.error('process-account-deletions: failed for', userId, e);

--- a/supabase/functions/request-account-deletion/index.ts
+++ b/supabase/functions/request-account-deletion/index.ts
@@ -1,11 +1,12 @@
 // Schedules deletion of the authenticated caller's account for 7 days out
-// (reversible). The client performs an email-OTP re-verification before calling
-// this (so a hijacked session alone can't trigger it via the normal UI); the
-// 7-day reversible window is the durable safeguard, and only the service role
-// can write the row so the window can't be shortened client-side.
+// (reversible). The caller must supply the email OTP code we mailed them, which
+// THIS function verifies server-side before scheduling — so a hijacked session
+// (stolen JWT) alone can't trigger deletion via a direct call; it would also
+// need the emailed code. Only the service role can write the row, so the 7-day
+// window can't be shortened client-side.
 //
-// Idempotent: calling again keeps the original schedule (never extends or
-// shortens an in-flight request).
+// Idempotent: if a request already exists we return it without consuming a code
+// (it's just a read); creating a new one requires a valid OTP.
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const corsHeaders = {
@@ -47,6 +48,7 @@ Deno.serve(async (req) => {
     );
 
     // Keep an existing request's schedule; only create one if none is pending.
+    // Returning an already-scheduled request is a read, so it needs no OTP.
     const { data: existing } = await admin
       .from('account_deletions')
       .select('requested_at, scheduled_for')
@@ -55,6 +57,28 @@ Deno.serve(async (req) => {
 
     if (existing) {
       return json({ scheduled_for: existing.scheduled_for, requested_at: existing.requested_at });
+    }
+
+    // Scheduling a NEW deletion requires the emailed OTP, verified here so the
+    // JWT alone is not enough. Verify with a fresh anon client (no session).
+    const { code } = await req.json().catch(() => ({}));
+    if (!code || typeof code !== 'string') {
+      return json({ error: 'A verification code is required' }, 400);
+    }
+    if (!user.email) {
+      return json({ error: 'Account has no email to verify against' }, 400);
+    }
+    const otpClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+    );
+    const { error: otpErr } = await otpClient.auth.verifyOtp({
+      email: user.email,
+      token: code.trim(),
+      type: 'email',
+    });
+    if (otpErr) {
+      return json({ error: 'Invalid or expired verification code' }, 400);
     }
 
     const now = new Date();

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -85,6 +85,29 @@ async function applySubscription(
   const status = opts.deleted ? 'canceled' : sub.status;
   const entitled = !opts.deleted && ENTITLING_STATUSES.includes(status);
 
+  const { data: existing } = await db
+    .from('user_subscriptions')
+    .select('grace_until, stripe_subscription_id')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  // Out-of-order protection: Stripe gives no cross-object ordering guarantee, so
+  // a delete for an OLD subscription can arrive after the user already moved to a
+  // newer one (e.g. plus canceled, pro active). Only honour a deletion for the
+  // subscription we currently track; a delete for a superseded sub is ignored so
+  // it can't demote the active entitlement.
+  if (
+    opts.deleted &&
+    existing?.stripe_subscription_id &&
+    existing.stripe_subscription_id !== sub.id
+  ) {
+    console.log(
+      'stripe-webhook: ignoring delete for superseded subscription',
+      sub.id, '(current:', existing.stripe_subscription_id, ')',
+    );
+    return;
+  }
+
   const resolved = await tierForPrice(db, price);
   const tier = entitled ? resolved.tier : 'free';
   const endsAt = periodEnd(sub);
@@ -99,11 +122,6 @@ async function applySubscription(
     graceUntil = null;
     logsTrimmedAt = null;
   } else {
-    const { data: existing } = await db
-      .from('user_subscriptions')
-      .select('grace_until')
-      .eq('user_id', userId)
-      .maybeSingle();
     if (existing?.grace_until) {
       graceUntil = undefined; // leave the already-set deadline untouched
     } else {
@@ -145,8 +163,26 @@ Deno.serve(async (req) => {
     return new Response('Invalid signature', { status: 400 });
   }
 
+  const db = admin();
+
+  // Idempotency: claim this event.id before processing. A unique violation means
+  // Stripe already delivered it (retry/replay) — acknowledge and skip so we
+  // don't re-apply (and possibly demote) subscription state.
+  const { error: claimErr } = await db
+    .from('stripe_events')
+    .insert({ id: event.id, type: event.type });
+  if (claimErr) {
+    if (claimErr.code === '23505') {
+      return new Response(JSON.stringify({ received: true, duplicate: true }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    // Couldn't record the claim for another reason — log and continue processing
+    // (better to risk a rare reprocess than to drop the event entirely).
+    console.error('stripe-webhook: failed to record event id', event.id, claimErr);
+  }
+
   try {
-    const db = admin();
     switch (event.type) {
       case 'checkout.session.completed': {
         const session = event.data.object as Stripe.Checkout.Session;
@@ -169,6 +205,12 @@ Deno.serve(async (req) => {
     }
   } catch (e) {
     console.error('stripe-webhook: handler error', e);
+    // Release the claim so Stripe's retry can reprocess this event.
+    try {
+      await db.from('stripe_events').delete().eq('id', event.id);
+    } catch (relErr) {
+      console.error('stripe-webhook: failed to release event claim', event.id, relErr);
+    }
     return new Response('Handler error', { status: 500 });
   }
 

--- a/supabase/migrations/20260531000000_stripe_event_dedup.sql
+++ b/supabase/migrations/20260531000000_stripe_event_dedup.sql
@@ -1,0 +1,24 @@
+-- Stripe webhook idempotency / replay protection.
+--
+-- Stripe retries deliveries and makes NO ordering guarantee across objects, so
+-- the webhook can see the same event twice, or a stale
+-- `customer.subscription.deleted` for an OLD subscription arrive after a newer
+-- `customer.subscription.updated`. Without a dedup record, a replayed or
+-- out-of-order event re-runs applySubscription and can demote an active
+-- entitlement (tier→free) or double-apply state.
+--
+-- This table records each processed event.id. The webhook claims the id before
+-- processing (unique-violation ⇒ already handled ⇒ skip) and releases the claim
+-- if processing fails, so failed events can still be retried. Service-role only
+-- (RLS on, no policies ⇒ no client access; the service role bypasses RLS).
+create table if not exists public.stripe_events (
+  id          text primary key,
+  type        text not null,
+  received_at timestamptz not null default now()
+);
+
+alter table public.stripe_events enable row level security;
+
+grant all on public.stripe_events to service_role;
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20260531010000_purge_predicate_fix.sql
+++ b/supabase/migrations/20260531010000_purge_predicate_fix.sql
@@ -1,0 +1,57 @@
+-- Restore the documented personal-data retention predicates.
+--
+-- 20260527010000_gdpr_compliance defined purge_expired_personal_data to delete
+-- submissions once they're no longer pending (status <> 'pending') after 1 year,
+-- and stale login_attempts as soon as their lock elapses (locked_until < now()).
+-- The later Lovable batch (20260528001943) redefined the same function with
+-- LOOSER predicates — submissions only when reviewed_at IS NOT NULL, and
+-- login_attempts only after locked_until < now() - 30 days. Because that
+-- migration runs later, it won the `create or replace`, silently retaining
+-- submitter free-text past the documented 1-year GDPR window for
+-- rejected-but-unreviewed rows (and lock rows 30 days longer than intended).
+--
+-- This re-asserts the documented contract as the final definition. Idempotent.
+create or replace function public.purge_expired_personal_data()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- (a) Drop the submitter IP once the abuse-investigation window (90d) passes.
+  update public.submissions
+     set submitted_by_ip = null
+   where submitted_by_ip is not null
+     and created_at < now() - interval '90 days';
+
+  update public.messages
+     set submitted_by_ip = null
+   where submitted_by_ip is not null
+     and created_at < now() - interval '90 days';
+
+  -- (b) Delete the rows themselves once their content is no longer needed (1y).
+  -- Contact messages (email + free-text) go entirely.
+  delete from public.messages
+   where created_at < now() - interval '1 year';
+
+  -- Reviewed/handled submissions go after a year; pending ones are kept so they
+  -- can still be moderated regardless of age. "Not pending" — NOT "reviewed_at
+  -- is set" — so a rejected row whose reviewed_at was never backfilled is still
+  -- purged on schedule.
+  delete from public.submissions
+   where status <> 'pending'
+     and created_at < now() - interval '1 year';
+
+  -- Expired bans no longer protect anything — remove the IP entirely.
+  delete from public.banned_ips
+   where expires_at is not null
+     and expires_at < now();
+
+  -- Stale rate-limit rows (the edge function also clears these reactively).
+  delete from public.login_attempts
+   where locked_until is not null
+     and locked_until < now();
+end;
+$$;
+
+revoke all on function public.purge_expired_personal_data() from public, anon, authenticated;

--- a/supabase/migrations/20260531020000_lap_snapshots_canonical.sql
+++ b/supabase/migrations/20260531020000_lap_snapshots_canonical.sql
@@ -1,0 +1,56 @@
+-- Canonicalize the lap_snapshots schema (consolidates the 0529/0530 drift).
+--
+-- The Lovable batch (20260528001943) created lap_snapshots with `id text not
+-- null` and PK (user_id, id), with NO unique on (course_key, engine_key); the
+-- hand-written 20260529 then no-op'd via CREATE TABLE IF NOT EXISTS, so
+-- pushSnapshot's ON CONFLICT (user_id, course_key, engine_key) upsert was broken
+-- until the 20260530 patch pair added the unique index + column defaults. That
+-- left the canonical shape spread across four migrations and the `id` column as
+-- text rather than uuid.
+--
+-- This single idempotent migration asserts the canonical shape in one place so a
+-- deployment that somehow missed a patch self-heals on apply, and normalizes
+-- `id` to uuid when it's safe to do so. pushSnapshot never sends an id (the
+-- column default supplies one via gen_random_uuid()), so in practice every value
+-- is already a uuid string — but we verify before casting so a stray non-uuid
+-- value can never fail the deploy.
+do $$
+declare
+  v_bad integer;
+begin
+  -- Guarantee the (user, course, engine) uniqueness the upsert targets, even on
+  -- a deployment that never ran 20260530010000.
+  if not exists (
+    select 1 from pg_indexes
+     where schemaname = 'public'
+       and indexname = 'lap_snapshots_user_course_engine_uidx'
+  ) then
+    create unique index lap_snapshots_user_course_engine_uidx
+      on public.lap_snapshots (user_id, course_key, engine_key);
+  end if;
+
+  -- Guarantee the column defaults (also missed if 20260530020000 never ran).
+  alter table public.lap_snapshots alter column id set default gen_random_uuid();
+  alter table public.lap_snapshots alter column updated_at set default now();
+
+  -- Normalize id text -> uuid, but only when every existing value is a valid
+  -- uuid (so the cast can't error and block the migration).
+  if exists (
+    select 1 from information_schema.columns
+     where table_schema = 'public' and table_name = 'lap_snapshots'
+       and column_name = 'id' and data_type = 'text'
+  ) then
+    select count(*) into v_bad
+      from public.lap_snapshots
+     where id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+    if v_bad = 0 then
+      alter table public.lap_snapshots alter column id drop default;
+      alter table public.lap_snapshots alter column id type uuid using id::uuid;
+      alter table public.lap_snapshots alter column id set default gen_random_uuid();
+    else
+      raise notice 'lap_snapshots.id left as text: % non-uuid value(s) present', v_bad;
+    end if;
+  end if;
+end $$;
+
+notify pgrst, 'reload schema';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,16 +35,18 @@ const PUBLIC_BACKEND_FALLBACKS = {
   VITE_SUPABASE_PUBLISHABLE_KEY:
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN2amxpZW92cHlpZmZicXdodGdrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEwMDQ1MzcsImV4cCI6MjA4NjU4MDUzN30.-LnwDsiT1vmWxfoLiHlK9hHqCzN9ToHeB6qkH5-A2I4",
   VITE_SUPABASE_URL: "https://svjlieovpyiffbqwhtgk.supabase.co",
-  // Admin + registration default OFF in fallbacks. The production deploy
-  // enables them via Lovable Cloud env injection ("true"). A new contributor
-  // cloning the repo without a .env should see the public app, not admin UI
-  // pointing at a backend they don't control.
-  VITE_ENABLE_ADMIN: "true",
+  // Admin + cloud default OFF in fallbacks. The production deploy enables them
+  // via Lovable Cloud env injection ("true") / committed `.env` / HTT_* build
+  // secrets. A new contributor cloning the repo without a .env must see the
+  // public, offline-first app — NOT the admin UI or live cloud-sync pointing at
+  // a backend they don't control. Anyone who hosts that build would otherwise
+  // expose admin surfaces and account features for an upstream backend.
+  VITE_ENABLE_ADMIN: "false",
   // Cloud auth + sync (public user accounts, Google sign-in, Cloud Sync Labs
-  // panel). Defaulted ON so fresh builds (including Lovable preview rebuilds
-  // without injected env) ship with the full feature set. Set to "false"
-  // explicitly via VITE_*/HTT_* if you want an offline-only build.
-  VITE_ENABLE_CLOUD: "true",
+  // panel). Defaulted OFF for the same reason — a fresh build is offline-only
+  // until the operator explicitly opts in via VITE_*/HTT_* env. The production
+  // deploy sets this to "true".
+  VITE_ENABLE_CLOUD: "false",
 } as const;
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
Fixes a batch of 15 reported security and data-integrity bugs on BETA. All four CI gates pass locally (lint, typecheck, **743 tests**, build). Three focused commits.

## Auth / account security
- **ResetPassword** now gates the password update on a real `PASSWORD_RECOVERY` session — a merely signed-in/stolen session can't change the account password without proving control of the email.
- **request-account-deletion** verifies the email OTP **server-side** (caller must supply the emailed code); a stolen JWT alone can no longer schedule deletion. The UI passes the code through instead of consuming it client-side.
- **process-account-deletions** deletes the auth user **before** wiping Storage blobs, so a transient auth-delete failure can't leave a half-deleted account whose files are gone but rows/cancellation window survive.

## Billing
- **create-checkout-session** rejects a new checkout when a subscription is already active; **`pricingCta`** routes paid→paid changes to the billing portal (new `manage` CTA / "Change plan" button) instead of creating a duplicate, double-billed subscription.
- **stripe-webhook** is now replay- and ordering-safe: events are de-duplicated by id (new `stripe_events` table), and a `subscription.deleted` for a *superseded* subscription is ignored so an out-of-order delivery can't demote an active entitlement.

## Cloud-sync data integrity
- Pending changes, snapshot tombstones, and per-file sync selections are **partitioned per user** (`activeUser.ts`), eliminating the A→B cross-account bleed on sign-out/sign-in.
- **cleanupOrphanBlobs** only reaps objects older than a grace window (closes the TOCTOU race where a concurrent upload was deleted as a false orphan).
- **pullAll** keeps a strictly-newer local document instead of downgrading it, and no longer auto-opts pulled files into ongoing sync; confirmation copy updated.

## Snapshots / pace / plugins
- Lap snapshots are **direction-aware** — a reverse lap no longer overwrites the forward "fastest lap" (forward/undefined keep the legacy key for back-compat); direction flows from auto-detection into the selection.
- Manual "Save current lap as snapshot" **confirms before clobbering a faster** stored snapshot.
- **lapDelta** detects a reference recorded in the opposite direction and returns null deltas (with a `reversed` flag) instead of emitting nonsense pace.
- Plugin panel/mount lookups are **reactive** (`useSyncExternalStore` over the registry), so tabs whose panels are contributed by an async plugin `setup` (the external coach) appear without a page reload.

## Build / migrations
- `VITE_ENABLE_ADMIN` / `VITE_ENABLE_CLOUD` build fallbacks default to **`false`** so a fresh clone ships the offline-first public app, not admin/cloud UI pointed at an upstream backend.
- Restored the documented `purge_expired_personal_data` retention predicates that a later Lovable migration had loosened (GDPR window).
- Added an idempotent `lap_snapshots` canonical migration (unique index + defaults + guarded `id`→`uuid`) so partial-migration deployments self-heal.

## Tests / docs
- Added regression tests: billing `manage` CTA, snapshot direction keys, reverse-reference pace.
- Updated `CHANGELOG.md` (Security + Fixed) and `README.md` env defaults.

### New migrations (operator note)
`20260531000000_stripe_event_dedup.sql`, `20260531010000_purge_predicate_fix.sql`, `20260531020000_lap_snapshots_canonical.sql` — all idempotent and safe to re-run.

https://claude.ai/code/session_01EwjjEY3KdLATXyB4aaqLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwjjEY3KdLATXyB4aaqLLS)_