### PR TITLE
Unify cloud storage into one pooled per-tier budget + segmented bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Unified cloud storage — one budget, one bar.** Documents, synced logs, and
+  lap snapshots now share a **single per-tier cloud-storage allowance** instead of
+  three separate quotas: **Free 50 MB · Plus 10 GB · Premium 100 GB · Pro 500 GB**.
+  The Profile tab shows it as **one stacked, phone-style progress bar** — logs,
+  snapshots, and garage data as coloured segments filling the same limit — with a
+  per-segment breakdown. Snapshots are now measured by size (not a fixed count),
+  and `subscription_tiers.total_bytes` is the single source of truth the
+  server-side quota triggers and the meter both read.
 - **Lap snapshots — frozen "course fastest lap" per engine.** Capture a single
   lap (its GPS samples plus a 5-second buffer on each side, the course geometry,
   the engine, and a copy of the vehicle/setup) as an immutable baseline you can
@@ -34,12 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     and `PluginPanelProps.sessionSetup` (the setup the driver is currently
     running), so the AI coach can compare the current session and setup against a
     frozen course-fastest-lap baseline.
-  - **Local-first & unlimited on-device; cloud-synced with per-tier COUNT limits**
-    (free 5 / plus 10 / premium 20 / pro 50) via a dedicated `lap_snapshots`
-    table — not byte document storage. Snapshots always push on save, but a local
-    delete never removes the cloud copy (like the log menu); the cloud copy is
-    removed only explicitly from **Profile → Lap snapshots**, which also lists
-    on-device snapshots when signed out.
+  - **Local-first & unlimited on-device; cloud-synced** via a dedicated
+    `lap_snapshots` table whose size counts toward the same pooled per-tier cloud
+    storage budget as documents + logs (see *Unified cloud storage* below).
+    Snapshots always push on save, but a local delete never removes the cloud copy
+    (like the log menu); the cloud copy is removed only explicitly from
+    **Profile → Lap snapshots**, which also lists on-device snapshots when signed
+    out.
 - **GDPR self-service data tools** (Profile → **Data & privacy**, cloud builds):
   - **Download my data** — exports everything we hold about you as a single ZIP:
     your account data (profile, subscription, roles, synced garage records,
@@ -81,11 +90,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sign-up now states the **16+ age requirement** and links both documents
   (under-16 users use the app offline only). AI coaching is documented as
   informational only — not safety or professional advice.
-- **Paid subscription tiers**: Stripe-backed `Plus` ($1/mo, 500 MB logs),
-  `Premium` ($3/mo, 1 GB logs), and `Pro` ($10/mo, 1 GB logs + AI coaching)
-  plans on top of the free 20 MB tier. Plan limits are
-  data-driven (`subscription_tiers` table) and the cloud-sync storage quota is
-  enforced per the user's tier. Backed by `create-checkout-session`,
+- **Paid subscription tiers**: Stripe-backed `Plus` ($1/mo), `Premium` ($3/mo),
+  and `Pro` ($10/mo + AI coaching) plans that scale your pooled cloud-storage
+  budget (10 GB / 100 GB / 500 GB) on top of the free 50 MB tier — see *Unified
+  cloud storage* above. Plan limits are data-driven (`subscription_tiers` table)
+  and the cloud-sync storage quota is enforced per the user's tier. Backed by
+  `create-checkout-session`,
   `stripe-webhook`, and `create-portal-session` edge functions; entitlements are
   granted solely by the verified Stripe webhook. The **Plans & pricing** cards
   now show live **Upgrade** / **Current plan** actions for signed-in users (a
@@ -110,19 +120,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   webhook grants whatever tier the price maps to). Gated by a single
   `COMING_SOON_TIERS` set in `lib/billing.ts`.
 - **Cancellation grace + log trimming**: cancelling ends service at the period
-  boundary and drops you to the free tier's limits, but your cloud logs are kept
+  boundary and drops you to the free tier's limit, but your cloud logs are kept
   for a **60-day grace window** to re-subscribe or download. After it expires, a
   daily `pg_cron` job (`trim_expired_logs()`) trims synced logs **newest-first**
-  to the free allowance. The Profile tab surfaces the cancellation/grace date.
-- Document storage + **auto-sync**: when you're signed in, your garage
-  (vehicles, setups, setup templates, notes) now backs up to the cloud
-  automatically as you change it — no manual push. The "documents" storage type
-  is free with a **5 MB** limit; raw session **logs** are a separate **20 MB**
-  storage type. Limits are enforced server-side.
+  until your pooled total fits the free budget (snapshots + garage docs are never
+  auto-deleted). The Profile tab surfaces the cancellation/grace date.
+- Garage **auto-sync**: when you're signed in, your garage (vehicles, setups,
+  setup templates, notes) now backs up to the cloud automatically as you change
+  it — no manual push. Garage documents, synced logs, and snapshots all count
+  against one pooled per-tier storage budget (free 50 MB), enforced server-side.
 - **Propagation deletes**: deleting a vehicle or setup while signed in removes it
   from **every device and the cloud**, with a clear warning before you confirm.
-- New **Profile** tab (far right) showing your cloud storage usage against the
-  document and log limits.
+- New **Profile** tab (far right) showing your cloud storage usage as a single
+  segmented bar against your pooled tier budget.
 - **Cloud log management** (Profile tab): see the session log files stored in your
   cloud — with upload date and size — and delete them. Deleting removes the
   **cloud copy only** (other devices keep what they've already downloaded), with
@@ -173,8 +183,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timestamp merge. Only your user-created tracks/courses sync; built-in tracks
   stay local.
 - **Plans & pricing** cards on the landing page (below the sample) and on the
-  registration page — Free offline, Free online (20 MB cloud logs), and paid
-  tiers (marked "Coming soon" until billing is wired up).
+  registration page — Free offline, Free online (50 MB pooled cloud storage), and
+  paid tiers (marked "Coming soon" until billing is wired up).
 - **"Download all cloud logs"** button at the bottom of the file manager:
   one-click bulk pull of every cloud log not already on this device.
 - Registration now supports a **Cloudflare Turnstile captcha** when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,9 +330,8 @@ cross-session comparison (and future AI coaching).
 
 - **Identity = (course + engine).** Engine is the layman's "primary key"; the
   chassis travels inside the frozen `setup`. Exactly one snapshot per pair — a
-  faster lap upserts in place (same deterministic `id`), so the count never
-  inflates. `engine` is the free-text `Vehicle.engine` string, matched via
-  `engineKey` (trimmed + lowercased).
+  faster lap upserts in place (same deterministic `id`). `engine` is the free-text
+  `Vehicle.engine` string, matched via `engineKey` (trimmed + lowercased).
 - **What's frozen:** the lap's GPS samples **± a 5s buffer** on each side (so a
   later start/finish nudge still fits), `lapStartMs`/`lapEndMs` markers, the
   `Course` geometry, lap time, source file/lap, and a copy of the vehicle/setup.
@@ -346,12 +345,12 @@ cross-session comparison (and future AI coaching).
   samples into the **external-reference slot** (`externalRefSamples`), so it
   renders like a reference lap and is **excluded from playback + the video
   player** — it is never an appended lap. Engine is shown in the overlay label.
-- **Sync (cloud-sync plugin):** a **dedicated `lap_snapshots` table** with a
-  per-tier **COUNT** quota (free 5 / plus 10 / premium 20 / pro 50 via
-  `subscription_tiers.snapshot_count`), enforced by a trigger — NOT byte document
-  storage. Always pushes on save; a local delete **never** propagates to the
-  cloud (the cloud copy is removed only explicitly from **Profile → Lap
-  snapshots**, like the log menu). Cloud deletes are tombstoned
+- **Sync (cloud-sync plugin):** a **dedicated `lap_snapshots` table**, but its
+  serialized payload size counts toward the **same unified per-tier byte budget**
+  as documents + logs (`subscription_tiers.total_bytes`), enforced by a trigger —
+  no separate count quota. Always pushes on save; a local delete **never**
+  propagates to the cloud (the cloud copy is removed only explicitly from
+  **Profile → Lap snapshots**, like the log menu). Cloud deletes are tombstoned
   (`snapshotTombstones.ts`) so reconcile won't resurrect a surviving local copy.
   `reconcileSnapshots()` pulls cloud→local additively and pushes local-only up.
   Local storage is always unlimited.
@@ -368,17 +367,19 @@ before working on:
 
 - **Cloud Sync** (`src/plugins/cloud-sync/`) — per-user backup/sync of the
   IndexedDB garage + log blobs: auto-sync off `garageEvents`, conflict resolution
-  (pending-wins + last-write-wins), storage-type quotas, orphan-safety, and
-  opt-in per-file logs.
-- **Subscriptions / Stripe** — paid tiers that scale the logs quota; tiers are
-  data (`subscription_tiers`), prices resolve by Stripe lookup_key, and
-  entitlements are written only by the webhook. Operator setup (Products/Prices,
-  secrets, `pg_cron`) is in the README.
+  (pending-wins + last-write-wins), the unified pooled byte quota, orphan-safety,
+  and opt-in per-file logs.
+- **Subscriptions / Stripe** — paid tiers that scale one pooled storage budget;
+  tiers are data (`subscription_tiers.total_bytes`), prices resolve by Stripe
+  lookup_key, and entitlements are written only by the webhook. Operator setup
+  (Products/Prices, secrets, `pg_cron`) is in the README.
 - **Data Rights & Retention / GDPR** — self-service export/erasure, the 7-day
   deletion window, and automatic IP minimisation.
 
-Lap-snapshot sync is separate — its own `lap_snapshots` table with a COUNT quota
-(see the Lap Snapshots section above and `docs/backend.md`).
+Documents, logs, and lap snapshots all draw from **one pooled per-tier byte
+budget** (`subscription_tiers.total_bytes`: free 50 MB / plus 10 GB / premium
+100 GB / pro 500 GB), shown as a single segmented bar on the Profile tab — see
+`docs/backend.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ The app includes an optional admin system for managing a community track databas
 > `COMING_SOON_TIERS` sets to open self-service purchase.
 >
 > **Cancellation grace + log trimming:** a cancelled subscription ends at the
-> period boundary and drops to the free tier's limits immediately, but the
+> period boundary and drops to the free tier's limit immediately, but the
 > user's cloud logs are kept for a 60-day grace window (`grace_until`). After it
-> expires, the `trim_expired_logs()` function (scheduled daily via `pg_cron` in
-> the `subscription_grace_trim` migration) deletes their synced log files
-> newest-first down to the free `logs_bytes` allowance. If `pg_cron` isn't
-> enabled on the project, enable it (Dashboard → Database → Extensions) or invoke
+> expires, the `trim_expired_logs()` function (scheduled daily via `pg_cron`)
+> deletes their synced log files newest-first until their pooled total (docs +
+> remaining logs + snapshots) fits the free `total_bytes` allowance; snapshots
+> and garage docs are never auto-deleted. If `pg_cron` isn't enabled on the
+> project, enable it (Dashboard → Database → Extensions) or invoke
 > `select public.trim_expired_logs();` from an external scheduler.
 
 > **Note:** `DOVE_PLUGIN_PACKAGES` is build-time only (read by `vite.config.ts`), not a client `VITE_` variable. It overrides which external plugin packages the build loads; by default the build pulls in the public AI coach (`@perchwerks/eye-in-the-sky`) from npm as an optional dependency — see `src/plugins/README.md`.
@@ -170,9 +171,8 @@ The admin system uses Lovable Cloud (Supabase) for the database. The schema is c
 - **user_roles** — Admin/user role assignments (uses `has_role()` security definer)
 - **sync_records** — Per-user cloud-sync documents (files/garage data), RLS-scoped to the owner
 - **user-files** (Storage bucket) — Private per-user session file blobs for cloud sync
-- **quota_limits** — Baseline per-storage-type byte limits (documents/logs)
-- **lap_snapshots** — Per-user frozen "course fastest lap" captures (one per course+engine), RLS-scoped; a dedicated, count-quota'd data type (not byte storage)
-- **subscription_tiers** — Data-driven plan catalogue (free/plus/premium/pro): label, price, per-type byte limits, and lap-snapshot count limit (`snapshot_count`: 5/10/20/50)
+- **lap_snapshots** — Per-user frozen "course fastest lap" captures (one per course+engine), RLS-scoped; its own table, but its size counts toward the unified storage pool (below)
+- **subscription_tiers** — Data-driven plan catalogue (free/plus/premium/pro): label, price, and a single pooled cloud-storage budget (`total_bytes`: 50 MB / 10 GB / 100 GB / 500 GB) shared by documents + logs + snapshots
 - **user_subscriptions** — Per-user tier + Stripe customer/subscription state, status, renewal date, cancellation grace (service-role-written only)
 - **profiles** — Per-user unique, editable display name
 - **account_deletions** — Pending self-service account-deletion requests (7-day, reversible grace window)

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -38,22 +38,27 @@ that fits and reports a `skipped` count (surfaced as a toast) rather than failin
 wholesale. `autoSync` tracks `navigator.onLine` + window online/offline events;
 the Profile-tab `StoragePanel` flags offline state + the pending count.
 
-**Storage types** (`storageTypes.ts`, enforced server-side) — distinct from
-future *subscription tiers*: **documents** = all structured stores (5 MB, free,
-auto-synced) and **logs** = file blobs (20 MB, opt-in). Limits live in the
-`quota_limits` table (one source of truth for the enforcing trigger + the client
-meter); `sync_storage_usage()` returns per-type usage for the Profile-tab meters.
-Client checks are advisory — the DB trigger is the real gate.
+**Unified storage pool** (`storageTypes.ts`, enforced server-side) — there is
+**one per-tier byte budget** that three data kinds share: **documents** (all
+structured stores — auto-synced), **logs** (file blobs — opt-in), and
+**snapshots** (`lap_snapshots` rows, by serialized size). The limit is
+`subscription_tiers.total_bytes` (the single source of truth for the enforcing
+triggers + the client meter); `sync_storage_usage()` returns the per-segment
+breakdown + the one pooled limit for the Profile-tab segmented bar. Client checks
+are advisory — the DB triggers are the real gate.
 
-Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`):
+Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`,
+`..._unified_storage_quota.sql`):
 
 | Object | Type | Notes |
 |--------|------|-------|
 | `sync_records` | table | One jsonb document per record: `(user_id, store, record_key, data, updated_at)`, unique on `(user_id, store, record_key)`. RLS: `auth.uid() = user_id`. `store`/`record_key` mirror the IndexedDB store name + key path. |
 | `user-files` | Storage bucket | Private. Raw session blobs at `{user_id}/{encodeURIComponent(name)}`. RLS scopes objects to the owner's folder. |
-| `quota_limits` | table | `(storage_type, max_bytes)` seeded `documents`=5 MB, `logs`=20 MB. Legacy baseline/fallback once tiers exist (see below). |
-| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects writes that push a storage type over the **caller's tier** limit (`tier_limit()`), falling back to `quota_limits` (`quota_exceeded`). |
-| `sync_storage_usage()` | RPC | Per-type `(used_bytes, limit_bytes)` for the caller — `limit_bytes` reflects the caller's tier. |
+| `total_storage_used(uuid)` | fn (SECURITY DEFINER) | Bytes a user occupies across `sync_records` + `lap_snapshots`. Used by the quota triggers + the trim job. |
+| `tier_total_limit(uuid)` | fn (SECURITY DEFINER) | The user's single pooled byte budget from their tier `total_bytes`, falling back to free, then a hard 50 MB. |
+| `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects a write that pushes the caller's **pooled total** (this table + all `lap_snapshots`, minus the upserted row) over `tier_total_limit()` (`quota_exceeded`). |
+| `enforce_snapshot_quota` | trigger | BEFORE INSERT/UPDATE on `lap_snapshots`: same pooled check keyed off the snapshot's serialized size (`quota_exceeded`). |
+| `sync_storage_usage()` | RPC | Single row `(documents_bytes, logs_bytes, snapshots_bytes, total_limit_bytes)` for the caller — the limit reflects the caller's tier. |
 | `profiles` | table | `(user_id PK→auth.users, display_name unique, …)`. RLS: authenticated read-all, update/insert own. Display name is unique but **not** a key — user-editable. |
 | `handle_new_user` | trigger | On `auth.users` insert: creates a profile, using the sign-up `display_name` or a generated silly name (`SpeedyRac3r-546`). `unique_display_name()` auto-suffixes a taken name at creation; user edits get an explicit "taken" error instead. |
 
@@ -98,27 +103,28 @@ After a migration, Lovable regenerates `integrations/supabase/types.ts`. Until
 then `cloudClient.ts` accesses the new table/bucket through a narrowly-typed
 escape hatch confined to that one module.
 
-> **Lap-snapshot sync** uses its own dedicated `lap_snapshots` table with a
-> per-tier COUNT quota (not byte document storage) — see CLAUDE.md → Lap
-> Snapshots for the client model and the snapshot-specific sync rules.
+> **Lap-snapshot sync** uses its own dedicated `lap_snapshots` table, but its
+> serialized size counts toward the **same pooled per-tier byte budget** as
+> documents + logs — see CLAUDE.md → Lap Snapshots for the client model and the
+> snapshot-specific sync rules.
 
 ---
 
 ## Subscriptions / Stripe (`..._stripe_subscriptions.sql`, `..._subscription_grace_trim.sql` + 4 edge functions)
 
-Paid tiers scale the cloud-sync **logs** quota (`free` 20 MB → `plus` $1 500 MB
-→ `premium` $3 1 GB → `pro` $10 1 GB; docs stay 5 MB). `premium` matches `pro`'s
-storage but carries no AI credits. Each paid tier bills **monthly or annual**.
-Tiers are **data**, not code (numbers are provisional):
+Paid tiers scale **one pooled cloud-storage budget** that documents + logs +
+snapshots all share (`free` 50 MB → `plus` $1 10 GB → `premium` $3 100 GB →
+`pro` $10 500 GB). `premium` carries no AI credits. Each paid tier bills
+**monthly or annual**. Tiers are **data**, not code (numbers are provisional):
 
 | Object | Type | Notes |
 |--------|------|-------|
-| `subscription_tiers` | table | One row per plan: `(tier PK, label, price_cents, logs_bytes, doc_bytes, ai_credits, stripe_price_id, sort_order)`. Authenticated read-all. Change a limit = UPDATE here. (`stripe_price_id` is a legacy fallback only — prices now resolve by lookup_key, see below.) |
+| `subscription_tiers` | table | One row per plan: `(tier PK, label, price_cents, total_bytes, ai_credits, stripe_price_id, sort_order)`. `total_bytes` is the single pooled storage budget. Authenticated read-all. Change a limit = UPDATE here. (`stripe_price_id` is a legacy fallback only — prices now resolve by lookup_key, see below.) |
 | `user_subscriptions` | table | `(user_id PK→auth.users, tier→subscription_tiers, status, stripe_customer_id, stripe_subscription_id, current_period_end, cancel_at_period_end, billing_interval, grace_until, logs_trimmed_at, updated_at)`. RLS: owner **read-only** — only the service role (webhook) writes, so no one can self-grant a tier. |
 | `user_tier(uuid)` | fn (SECURITY DEFINER) | Effective tier: the subscription tier when `status in (active, trialing, past_due)`, else `free`. |
-| `tier_limit(uuid, type)` | fn (SECURITY DEFINER) | Byte limit for a user + storage type from their tier; falls back to `free`, then `quota_limits`. Used by the quota trigger + usage RPC. |
+| `tier_total_limit(uuid)` | fn (SECURITY DEFINER) | The user's single pooled byte budget from their tier `total_bytes`; falls back to `free`, then a hard 50 MB. Used by both quota triggers + the usage RPC. |
 | `encode_uri_component(text)` | fn | SQL parity with JS `encodeURIComponent`, so the trim job can address the right `user-files` bucket object (`{user_id}/{encoded name}`). |
-| `trim_expired_logs()` | fn (SECURITY DEFINER) | For users past their `grace_until`, deletes synced **log** files newest-first (index row + bucket object) down to the free `logs_bytes`. Scheduled daily via `pg_cron` (guarded; enable the extension or run externally). Not granted to `authenticated`. |
+| `trim_expired_logs()` | fn (SECURITY DEFINER) | For users past their `grace_until`, deletes synced **log** files newest-first (index row + bucket object) until their **pooled total** (docs + remaining logs + snapshots) fits the free `total_bytes`; snapshots + docs are never auto-deleted. Scheduled daily via `pg_cron` (guarded; enable the extension or run externally). Not granted to `authenticated`. |
 
 **Prices via lookup_key (no Price ids in code):** each (tier × interval) has a
 Stripe Price tagged with a lookup_key `${tier}_${interval}` (`plus_monthly`,

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -63,7 +63,7 @@ const FREE_TIERS: FreeTier[] = [
     features: [
       "Setup info synced across all your devices",
       "Sync your personal tracks",
-      "20 MB cloud log storage",
+      "50 MB cloud storage",
     ],
   },
 ];
@@ -76,21 +76,21 @@ const PAID_TIERS: PaidTier[] = [
     blurb: "For bigger garages",
     slug: "plus",
     inherits: "Everything in Free online, plus",
-    features: ["500 MB cloud log storage"],
+    features: ["10 GB cloud storage"],
   },
   {
     name: "Premium",
     blurb: "Max storage",
     slug: "premium",
     inherits: "Everything in Plus, plus",
-    features: ["1 GB cloud log storage"],
+    features: ["100 GB cloud storage"],
   },
   {
     name: "Pro",
     blurb: "With AI coaching",
     slug: "pro",
     inherits: "Everything in Premium, plus",
-    features: ["AI coaching (coming soon)"],
+    features: ["500 GB cloud storage", "AI coaching (coming soon)"],
   },
 ];
 

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -6,11 +6,9 @@ export interface SubscriptionTierRow {
   tier: string;
   label: string;
   price_cents: number;
-  logs_bytes: number;
-  doc_bytes: number;
+  /** The tier's single pooled cloud-storage budget in bytes (docs + logs + snapshots). */
+  total_bytes: number;
   ai_credits: number;
-  /** Max cloud lap snapshots for the tier (count, not bytes). */
-  snapshot_count: number;
   stripe_price_id: string | null;
   sort_order: number;
 }

--- a/src/plugins/cloud-sync/LapSnapshotsPanel.tsx
+++ b/src/plugins/cloud-sync/LapSnapshotsPanel.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useAuth } from "@/contexts/AuthContext";
-import { useSubscription } from "@/hooks/useSubscription";
 import { STORE_NAMES } from "@/lib/dbUtils";
 import { onGarageChange } from "@/lib/garageEvents";
 import { formatLapTime } from "@/lib/lapCalculation";
@@ -28,7 +27,6 @@ function formatDate(ms?: number): string {
 // do with them until you sign in to sync.
 export default function LapSnapshotsPanel(_props: PluginPanelProps) {
   const { user, loading } = useAuth();
-  const { tiers, currentTier } = useSubscription();
   const [items, setItems] = useState<LapSnapshot[] | null>(null);
   const [localIds, setLocalIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
@@ -52,10 +50,6 @@ export default function LapSnapshotsPanel(_props: PluginPanelProps) {
       setError(e instanceof Error ? e.message : "Failed to load snapshots");
     }
   }, [user]);
-
-  // Used + limit derived client-side from the cloud list + tier catalogue (the
-  // snapshot_usage RPC has been flaky in production schema caches).
-  const snapshotLimit = tiers.find((t) => t.tier === currentTier)?.snapshot_count ?? null;
 
   // Auto-detect local-only snapshots and upload them when signed in (the same
   // reconcile autoSync runs on sign-in, re-triggered here so opening the panel
@@ -118,7 +112,7 @@ export default function LapSnapshotsPanel(_props: PluginPanelProps) {
     setSyncing(true);
     try {
       const { pushed, skipped } = await reconcileSnapshots(user.id);
-      if (skipped > 0) toast.error(`${skipped} snapshot${skipped === 1 ? "" : "s"} didn't fit your plan's limit.`);
+      if (skipped > 0) toast.error(`${skipped} snapshot${skipped === 1 ? "" : "s"} didn't fit your cloud storage.`);
       else if (pushed > 0) toast.success(`Synced ${pushed} snapshot${pushed === 1 ? "" : "s"}.`);
       else toast("Everything is already synced.");
       await refresh();
@@ -139,9 +133,7 @@ export default function LapSnapshotsPanel(_props: PluginPanelProps) {
       {user ? (
         <div className="flex items-center justify-between">
           <p className="text-xs text-muted-foreground">
-            {snapshotLimit !== null
-              ? `${items.length} of ${snapshotLimit} synced`
-              : "Synced snapshots"}
+            {items.length} synced
           </p>
           {unsyncedLocal && (
             <Button size="sm" variant="outline" className="h-7 text-xs" disabled={syncing} onClick={() => void handleSyncLocal()}>

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -10,25 +10,27 @@ import { useSubscription } from "@/hooks/useSubscription";
 import { isPaidTier } from "@/lib/billing";
 import { createPortal } from "@/lib/billingClient";
 import { getStorageUsage } from "./syncEngine";
-import { listCloudSnapshots } from "./snapshotSync";
 import { getMyProfile, updateDisplayName } from "./profile";
 import { pendingCount } from "./pendingSync";
-import { formatBytes, usageFraction, type StorageTypeUsage } from "./storageTypes";
+import {
+  formatBytes, segmentFractions, totalUsed, usageFraction,
+  type StorageType, type StorageUsage,
+} from "./storageTypes";
 
-const TYPE_LABEL: Record<string, string> = { documents: "Documents", logs: "Logs" };
-const TYPE_HINT: Record<string, string> = {
-  documents: "Vehicles, setups, templates & notes — free, auto-synced.",
-  logs: "Session log files you've chosen to sync.",
-};
+// The three segments of the one storage bar, in stacked order (logs first). Each
+// draws from the same pooled per-tier limit; the dot + bar share a colour.
+const SEGMENTS: { key: StorageType; label: string; color: string }[] = [
+  { key: "logs", label: "Logs", color: "bg-primary" },
+  { key: "snapshots", label: "Snapshots", color: "bg-amber-500" },
+  { key: "documents", label: "Garage", color: "bg-emerald-500" },
+];
 
 // Scratch-pad profile panel: your (editable, unique) display name + cloud storage
-// usage against the document/log storage limits.
+// usage against the single pooled per-tier budget (documents + logs + snapshots).
 export default function StoragePanel(_props: PluginPanelProps) {
   const { user, loading } = useAuth();
   const online = useOnlineStatus();
-  const { tiers, currentTier } = useSubscription();
-  const [usage, setUsage] = useState<StorageTypeUsage[] | null>(null);
-  const [snapshotCount, setSnapshotCount] = useState<number | null>(null);
+  const [usage, setUsage] = useState<StorageUsage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(0);
 
@@ -41,18 +43,7 @@ export default function StoragePanel(_props: PluginPanelProps) {
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load storage usage");
     }
-    // Snapshot count: derive client-side from the cloud list (the RPC has been
-    // flaky in production schema caches). The limit comes from the tier
-    // catalogue (snapshot_count). Best-effort — a failure must not hide the
-    // documents/logs meters above.
-    try {
-      setSnapshotCount((await listCloudSnapshots(user.id)).length);
-    } catch {
-      setSnapshotCount(null);
-    }
   }, [user]);
-
-  const snapshotLimit = tiers.find((t) => t.tier === currentTier)?.snapshot_count ?? null;
 
   // Re-read on mount and whenever connectivity flips (pending changes flush on
   // reconnect, so the count + usage should refresh then).
@@ -103,17 +94,7 @@ export default function StoragePanel(_props: PluginPanelProps) {
         </div>
         {error && <p className="text-xs text-destructive">{error}</p>}
         {!usage && !error && <p className="text-xs text-muted-foreground">Loading usage…</p>}
-        {usage?.map((u) => (
-          <Meter key={u.storageType} usage={u} />
-        ))}
-        {snapshotCount !== null && snapshotLimit !== null && (
-          <CountMeter
-            label="Lap snapshots"
-            hint="Frozen course-fastest-lap captures."
-            used={snapshotCount}
-            limit={snapshotLimit}
-          />
-        )}
+        {usage && <StorageBar usage={usage} />}
       </div>
     </div>
   );
@@ -263,48 +244,48 @@ function PlanSection() {
   );
 }
 
-function Meter({ usage }: { usage: StorageTypeUsage }) {
-  const pct = Math.round(usageFraction(usage) * 100);
-  const over = usage.usedBytes > usage.limitBytes;
-  return (
-    <div className="space-y-1">
-      <div className="flex items-baseline justify-between text-sm">
-        <span className="text-foreground">{TYPE_LABEL[usage.storageType] ?? usage.storageType}</span>
-        <span className={`text-xs tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
-          {formatBytes(usage.usedBytes)} / {formatBytes(usage.limitBytes)}
-        </span>
-      </div>
-      <div className="h-2 overflow-hidden rounded-full bg-muted">
-        <div
-          className={`h-full rounded-full ${over ? "bg-destructive" : "bg-primary"}`}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <p className="text-[11px] text-muted-foreground">{TYPE_HINT[usage.storageType]}</p>
-    </div>
-  );
-}
+// One pooled byte budget, drawn as a single stacked bar: logs + snapshots + garage
+// data share the tier limit (like a phone's storage screen). Segments are coloured;
+// the empty remainder is muted. Over the limit, segments fill the whole bar and the
+// readout turns destructive.
+function StorageBar({ usage }: { usage: StorageUsage }) {
+  const used = totalUsed(usage);
+  const over = used > usage.totalLimit;
+  const fractions = segmentFractions(usage);
+  const pct = Math.round(usageFraction(used, usage.totalLimit) * 100);
 
-// Snapshots are a count-based quota (not bytes), so they need their own meter
-// rather than the byte-aware one above.
-function CountMeter({ label, hint, used, limit }: { label: string; hint: string; used: number; limit: number }) {
-  const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
-  const over = used > limit;
   return (
-    <div className="space-y-1">
+    <div className="space-y-2">
       <div className="flex items-baseline justify-between text-sm">
-        <span className="text-foreground">{label}</span>
+        <span className="text-foreground">{pct}% used</span>
         <span className={`text-xs tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
-          {used} / {limit}
+          {formatBytes(used)} / {formatBytes(usage.totalLimit)}
         </span>
       </div>
-      <div className="h-2 overflow-hidden rounded-full bg-muted">
-        <div
-          className={`h-full rounded-full ${over ? "bg-destructive" : "bg-primary"}`}
-          style={{ width: `${pct}%` }}
-        />
+
+      <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted" role="presentation">
+        {SEGMENTS.map((seg) => {
+          const width = fractions[seg.key] * 100;
+          if (width <= 0) return null;
+          return <div key={seg.key} className={`h-full ${seg.color}`} style={{ width: `${width}%` }} />;
+        })}
       </div>
-      <p className="text-[11px] text-muted-foreground">{hint}</p>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {SEGMENTS.map((seg) => (
+          <div key={seg.key} className="flex items-center gap-1.5 text-[11px]">
+            <span className={`inline-block h-2 w-2 shrink-0 rounded-full ${seg.color}`} />
+            <span className="text-foreground">{seg.label}</span>
+            <span className="tabular-nums text-muted-foreground">{formatBytes(usage[seg.key])}</span>
+          </div>
+        ))}
+      </div>
+
+      {over && (
+        <p className="text-[11px] text-destructive">
+          You're over your plan's storage. New cloud syncs are saved locally until you free up space or upgrade.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -6,20 +6,19 @@
 //   • Offline (or a failed push): the change is recorded as *pending* so it isn't
 //     lost; on reconnect the pending set flushes first as priority-1 (replacing
 //     the cloud state), then a timestamp-aware reconcile merges the rest.
-// On sign-in it reconciles too. Only the free "documents" storage type syncs
-// here; log blobs stay manual/opt-in.
+// On sign-in it reconciles too. Garage documents + lap snapshots auto-sync here;
+// log blobs stay manual/opt-in. All three share one pooled per-tier byte budget.
 
 import { supabase } from "@/integrations/supabase/client";
 import { STORE_NAMES } from "@/lib/dbUtils";
 import { onGarageChange, type GarageChange } from "@/lib/garageEvents";
-import { isQuotaError, isSnapshotQuotaError } from "./cloudClient";
+import { isQuotaError } from "./cloudClient";
 import { deleteCloudFile, deleteRecord, pushRecord, reconcileDocs } from "./syncEngine";
 import { clearSnapshotTombstone, pushSnapshot, reconcileSnapshots } from "./snapshotSync";
 import { clearPending, listPending, markPending, pendingKeySet } from "./pendingSync";
 import { unselectFile } from "./fileSync";
 import { setActiveUserId } from "./activeUser";
 import { pendingId } from "./merge";
-import { storageTypeForStore } from "./storageTypes";
 import { FILE_STORE } from "./syncStores";
 
 const DEBOUNCE_MS = 800;
@@ -72,13 +71,8 @@ async function flush(change: GarageChange): Promise<void> {
     await pushOne(userId, change);
     await clearPending(change.store, change.key);
   } catch (err) {
-    if (isSnapshotQuotaError(err)) {
-      notify("Cloud snapshot limit reached — saved locally. Delete one in Profile to sync.", "error");
-    } else if (isQuotaError(err)) {
-      notify(
-        `Cloud ${storageTypeForStore(change.store)} storage is full — saved locally, not synced.`,
-        "error",
-      );
+    if (isQuotaError(err)) {
+      notify("Cloud storage is full — saved locally, not synced. Free up space or upgrade in Profile.", "error");
     } else {
       // Network/other failure → keep it as a pending change to retry on reconnect.
       await markPending(change);
@@ -111,13 +105,8 @@ async function flushPending(userId: string): Promise<void> {
       await pushOne(userId, change);
       await clearPending(change.store, change.key);
     } catch (err) {
-      if (isSnapshotQuotaError(err)) {
-        notify("Cloud snapshot limit reached — delete one in Profile to sync.", "error");
-      } else if (isQuotaError(err)) {
-        notify(
-          `Cloud ${storageTypeForStore(change.store)} storage is full — some changes didn't sync.`,
-          "error",
-        );
+      if (isQuotaError(err)) {
+        notify("Cloud storage is full — some changes didn't sync. Free up space or upgrade in Profile.", "error");
       }
       // otherwise leave it pending for the next reconnect
     }
@@ -132,13 +121,13 @@ async function runReconcile(userId: string): Promise<void> {
     const { skipped } = await reconcileDocs(userId, await pendingKeySet());
     if (skipped > 0) {
       notify(
-        `Cloud document storage is full — ${skipped} item${skipped === 1 ? "" : "s"} didn't sync.`,
+        `Cloud storage is full — ${skipped} item${skipped === 1 ? "" : "s"} didn't sync.`,
         "error",
       );
     }
   } catch (err) {
     if (isQuotaError(err)) {
-      notify("Cloud document storage is full — some items didn't sync.", "error");
+      notify("Cloud storage is full — some items didn't sync.", "error");
     } else {
       console.error("auto-sync document reconcile failed", err);
     }
@@ -148,7 +137,7 @@ async function runReconcile(userId: string): Promise<void> {
     const snap = await reconcileSnapshots(userId);
     if (snap.skipped > 0) {
       notify(
-        `Cloud snapshot limit reached — ${snap.skipped} snapshot${snap.skipped === 1 ? "" : "s"} didn't sync. Delete one in Profile.`,
+        `Cloud storage is full — ${snap.skipped} snapshot${snap.skipped === 1 ? "" : "s"} didn't sync. Free up space or upgrade in Profile.`,
         "error",
       );
     }

--- a/src/plugins/cloud-sync/cloudClient.ts
+++ b/src/plugins/cloud-sync/cloudClient.ts
@@ -40,22 +40,9 @@ export interface LapSnapshotRow {
   updated_at?: string;
 }
 
-/** Query builder for the lap_snapshots table (a dedicated, count-quota'd type). */
+/** Query builder for the lap_snapshots table (snapshots count toward the byte pool). */
 export function lapSnapshotsTable() {
   return untyped.from("lap_snapshots");
-}
-
-/** Current user's snapshot usage: how many of the tier's count limit are used. */
-export async function fetchSnapshotUsage(): Promise<{ usedCount: number; limitCount: number }> {
-  const { data, error } = await untyped.rpc("snapshot_usage");
-  if (error) throw new Error(`Failed to read snapshot usage: ${error.message}`);
-  const row = ((data ?? []) as { used_count?: number; limit_count?: number }[])[0];
-  return { usedCount: row?.used_count ?? 0, limitCount: row?.limit_count ?? 0 };
-}
-
-/** True when an error is the server's snapshot count-quota rejection. */
-export function isSnapshotQuotaError(err: unknown): boolean {
-  return err instanceof Error && /snapshot_quota_exceeded/i.test(err.message);
 }
 
 /** Storage API for the private per-user file bucket. */
@@ -63,21 +50,25 @@ export function userFiles() {
   return untyped.storage.from(SYNC_BUCKET);
 }
 
-/** One storage type's usage as returned by the server's sync_storage_usage() RPC. */
+/** The single-row pooled-usage shape returned by the server's sync_storage_usage() RPC. */
 export interface StorageUsageRow {
-  storage_type: string;
-  used_bytes: number;
-  limit_bytes: number;
+  documents_bytes: number;
+  logs_bytes: number;
+  snapshots_bytes: number;
+  total_limit_bytes: number;
 }
 
-/** Per-type storage usage for the current user (authoritative, server-computed). */
-export async function fetchStorageUsage(): Promise<StorageUsageRow[]> {
+/** Pooled storage usage for the current user (authoritative, server-computed). */
+export async function fetchStorageUsage(): Promise<StorageUsageRow | null> {
   const { data, error } = await untyped.rpc("sync_storage_usage");
   if (error) throw new Error(`Failed to read storage usage: ${error.message}`);
-  return (data ?? []) as StorageUsageRow[];
+  return ((data ?? []) as StorageUsageRow[])[0] ?? null;
 }
 
-/** True when an error from a sync_records write is the server quota rejection. */
+/**
+ * True when an error from a sync_records or lap_snapshots write is the server's
+ * pooled-quota rejection. Both tables now raise the same `quota_exceeded` code.
+ */
 export function isQuotaError(err: unknown): boolean {
   return err instanceof Error && /quota_exceeded/i.test(err.message);
 }

--- a/src/plugins/cloud-sync/snapshotSync.ts
+++ b/src/plugins/cloud-sync/snapshotSync.ts
@@ -1,5 +1,5 @@
-// Cloud sync for lap snapshots — a dedicated data type (NOT byte document
-// storage), enforced by a per-tier COUNT quota server-side.
+// Cloud sync for lap snapshots — their own table, but their serialized size counts
+// toward the same pooled per-tier byte budget as documents + logs (server-enforced).
 //
 // Sync model (deliberately a hybrid of garage docs and log files):
 //   • Always push on local save (like garage docs) — snapshots are valuable.
@@ -11,7 +11,7 @@
 
 import type { LapSnapshot } from "@/lib/lapSnapshot";
 import { getSnapshot, listSnapshots, putSnapshotRaw } from "@/lib/lapSnapshotStorage";
-import { isSnapshotQuotaError, lapSnapshotsTable } from "./cloudClient";
+import { isQuotaError, lapSnapshotsTable } from "./cloudClient";
 import {
   addSnapshotTombstone, clearSnapshotTombstone, snapshotTombstoneSet,
 } from "./snapshotTombstones";
@@ -68,7 +68,7 @@ export async function deleteCloudSnapshot(userId: string, snap: LapSnapshot): Pr
 export interface SnapshotReconcileResult {
   pulled: number;
   pushed: number;
-  /** Local snapshots that didn't fit under the tier's count limit. */
+  /** Local snapshots that didn't fit under the tier's storage limit. */
   skipped: number;
 }
 
@@ -107,7 +107,7 @@ export async function reconcileSnapshots(userId: string): Promise<SnapshotReconc
       await pushSnapshot(userId, s.id);
       pushed++;
     } catch (err) {
-      if (isSnapshotQuotaError(err)) skipped++;
+      if (isQuotaError(err)) skipped++;
       else throw err;
     }
   }

--- a/src/plugins/cloud-sync/storageTypes.test.ts
+++ b/src/plugins/cloud-sync/storageTypes.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from "vitest";
 import {
-  DEFAULT_LIMITS,
-  docByteSize,
+  DEFAULT_TOTAL_LIMIT,
   formatBytes,
-  isOverLimit,
+  segmentFractions,
   storageTypeForStore,
+  totalUsed,
   usageFraction,
-  wouldExceed,
+  type StorageUsage,
 } from "./storageTypes";
 
-describe("storage types", () => {
+describe("storage types (single pool)", () => {
   it("classifies the files store as logs, everything else as documents", () => {
     expect(storageTypeForStore("files")).toBe("logs");
     expect(storageTypeForStore("setups")).toBe("documents");
@@ -17,33 +17,70 @@ describe("storage types", () => {
     expect(storageTypeForStore("graph-prefs")).toBe("documents");
   });
 
-  it("has the agreed default limits (5 MB docs / 20 MB logs)", () => {
-    expect(DEFAULT_LIMITS.documents).toBe(5 * 1024 * 1024);
-    expect(DEFAULT_LIMITS.logs).toBe(20 * 1024 * 1024);
+  it("uses the free 50 MB budget as the advisory fallback", () => {
+    expect(DEFAULT_TOTAL_LIMIT).toBe(50 * 1024 * 1024);
   });
 
-  it("measures document byte size from serialized JSON", () => {
-    expect(docByteSize({ a: 1 })).toBe(new TextEncoder().encode('{"a":1}').length);
-    expect(docByteSize(null)).toBe(4); // "null"
+  it("sums the three segments", () => {
+    expect(totalUsed({ documents: 1, logs: 2, snapshots: 3 })).toBe(6);
   });
 
   it("computes a clamped usage fraction", () => {
-    expect(usageFraction({ usedBytes: 0, limitBytes: 100 })).toBe(0);
-    expect(usageFraction({ usedBytes: 50, limitBytes: 100 })).toBe(0.5);
-    expect(usageFraction({ usedBytes: 200, limitBytes: 100 })).toBe(1);
-    expect(usageFraction({ usedBytes: 5, limitBytes: 0 })).toBe(0);
+    expect(usageFraction(0, 100)).toBe(0);
+    expect(usageFraction(50, 100)).toBe(0.5);
+    expect(usageFraction(200, 100)).toBe(1); // clamped
+    expect(usageFraction(5, 0)).toBe(0); // no limit
   });
 
-  it("detects over-limit and projected overflow", () => {
-    expect(isOverLimit(101, 100)).toBe(true);
-    expect(isOverLimit(100, 100)).toBe(false);
-    expect(wouldExceed(90, 20, 100)).toBe(true);
-    expect(wouldExceed(90, 10, 100)).toBe(false);
-  });
-
-  it("formats byte sizes", () => {
+  it("formats byte sizes up to GB", () => {
     expect(formatBytes(512)).toBe("512 B");
     expect(formatBytes(2048)).toBe("2 KB");
     expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+    expect(formatBytes(50 * 1024 * 1024)).toBe("50.0 MB");
+    expect(formatBytes(10 * 1024 * 1024 * 1024)).toBe("10.0 GB");
+    expect(formatBytes(100 * 1024 * 1024 * 1024)).toBe("100.0 GB");
+    expect(formatBytes(500 * 1024 * 1024 * 1024)).toBe("500.0 GB");
+  });
+
+  it("rolls over at unit boundaries instead of showing 1024 KB / 1024.0 MB", () => {
+    expect(formatBytes(1024 * 1024 - 1)).toBe("1.0 MB"); // not "1024 KB"
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe("1.0 GB"); // not "1024.0 MB"
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0 GB");
+  });
+
+  describe("segmentFractions", () => {
+    it("leaves empty space when under the limit", () => {
+      const u: StorageUsage = { documents: 10, logs: 20, snapshots: 30, totalLimit: 100 };
+      const f = segmentFractions(u);
+      expect(f.documents).toBeCloseTo(0.1);
+      expect(f.logs).toBeCloseTo(0.2);
+      expect(f.snapshots).toBeCloseTo(0.3);
+      expect(f.documents + f.logs + f.snapshots).toBeCloseTo(0.6); // 0.4 left empty
+    });
+
+    it("fills the whole bar exactly at the limit", () => {
+      const u: StorageUsage = { documents: 50, logs: 30, snapshots: 20, totalLimit: 100 };
+      const f = segmentFractions(u);
+      expect(f.documents + f.logs + f.snapshots).toBeCloseTo(1);
+    });
+
+    it("normalises to a full bar (keeping proportions) when over the limit", () => {
+      const u: StorageUsage = { documents: 40, logs: 40, snapshots: 40, totalLimit: 100 };
+      const f = segmentFractions(u);
+      // 1.2 raw → each scaled to 0.4/1.2 ≈ 1/3, summing to 1 (full, no empty space).
+      expect(f.documents).toBeCloseTo(1 / 3);
+      expect(f.logs).toBeCloseTo(1 / 3);
+      expect(f.snapshots).toBeCloseTo(1 / 3);
+      expect(f.documents + f.logs + f.snapshots).toBeCloseTo(1);
+    });
+
+    it("clamps negatives and guards a zero limit", () => {
+      const u: StorageUsage = { documents: -5, logs: 0, snapshots: 0, totalLimit: 0 };
+      const f = segmentFractions(u);
+      expect(f.documents).toBe(0);
+      expect(f.logs).toBe(0);
+      expect(f.snapshots).toBe(0);
+    });
   });
 });

--- a/src/plugins/cloud-sync/storageTypes.ts
+++ b/src/plugins/cloud-sync/storageTypes.ts
@@ -1,57 +1,72 @@
-// Storage types + limits for cloud sync.
+// Cloud storage accounting for the unified, single-pool quota.
 //
-// Two storage *types* (not to be confused with subscription tiers, which will
-// scale these limits later): "documents" (garage data — vehicles, setups,
-// templates, types, notes, metadata, graph prefs) and "logs" (raw session file
-// blobs). The real limits + enforcement live server-side (the quota_limits
-// table + trigger in the storage-quotas migration); these client values are the
-// offline/advisory fallback for the meter and the pre-push check.
-// sync_storage_usage() on the server is the source of truth the UI reads online.
+// There is ONE per-tier byte budget. Three kinds of data draw from it — they're
+// segments of one bar, not separate quotas:
+//   • documents — garage data (vehicles, setups, templates, types, notes, tracks,
+//     metadata, graph prefs), stored as sync_records jsonb docs
+//   • logs      — raw session file blobs (sync_records "files" index rows)
+//   • snapshots — frozen course-fastest-lap captures (lap_snapshots rows)
+//
+// The real limit + enforcement live server-side (subscription_tiers.total_bytes +
+// the pooled quota triggers); sync_storage_usage() is the authoritative readout the
+// meter reads online. These client values are the offline/advisory fallback.
 
 import { FILE_STORE } from "./syncStores";
 
-export type StorageType = "documents" | "logs";
+/** A segment of the storage bar (also the document/log split for sync_records). */
+export type StorageType = "documents" | "logs" | "snapshots";
 
-/** Advisory fallback limits (bytes). Mirror of the server `quota_limits` seed. */
-export const DEFAULT_LIMITS: Record<StorageType, number> = {
-  documents: 5 * 1024 * 1024, // 5 MB
-  logs: 20 * 1024 * 1024, // 20 MB
-};
+/** Advisory fallback for the pooled limit (bytes) — the free tier's 50 MB budget. */
+export const DEFAULT_TOTAL_LIMIT = 50 * 1024 * 1024;
 
-/** Which storage type a sync store belongs to. */
-export function storageTypeForStore(store: string): StorageType {
+/** Which sync_records segment a store belongs to (snapshots have their own table). */
+export function storageTypeForStore(store: string): "documents" | "logs" {
   return store === FILE_STORE ? "logs" : "documents";
 }
 
-/** Approximate serialized byte size of a structured (document) record. */
-export function docByteSize(record: unknown): number {
-  return new TextEncoder().encode(JSON.stringify(record ?? null)).length;
+/** Per-segment used bytes + the single pooled limit they all share. */
+export interface StorageUsage {
+  documents: number;
+  logs: number;
+  snapshots: number;
+  totalLimit: number;
 }
 
-export interface StorageTypeUsage {
-  storageType: StorageType;
-  usedBytes: number;
-  limitBytes: number;
+/** Total bytes used across all three segments. */
+export function totalUsed(u: Pick<StorageUsage, "documents" | "logs" | "snapshots">): number {
+  return u.documents + u.logs + u.snapshots;
 }
 
-/** Fraction of the limit used, clamped to [0, 1]. */
-export function usageFraction(u: Pick<StorageTypeUsage, "usedBytes" | "limitBytes">): number {
-  if (u.limitBytes <= 0) return 0;
-  return Math.min(1, u.usedBytes / u.limitBytes);
+/** Fraction of the pooled limit used, clamped to [0, 1]. */
+export function usageFraction(used: number, limit: number): number {
+  if (limit <= 0) return 0;
+  return Math.min(1, used / limit);
 }
 
-export function isOverLimit(usedBytes: number, limitBytes: number): boolean {
-  return usedBytes > limitBytes;
+/**
+ * Widths (as fractions of the bar) for the three stacked segments. Under the limit
+ * the segments leave empty space; at/over the limit they're normalised to fill the
+ * whole bar while keeping their relative proportions (a full bar = "you're maxed").
+ */
+export function segmentFractions(u: StorageUsage): Record<StorageType, number> {
+  const limit = u.totalLimit > 0 ? u.totalLimit : 1;
+  const raw: Record<StorageType, number> = {
+    documents: Math.max(0, u.documents) / limit,
+    logs: Math.max(0, u.logs) / limit,
+    snapshots: Math.max(0, u.snapshots) / limit,
+  };
+  const sum = raw.documents + raw.logs + raw.snapshots;
+  if (sum <= 1) return raw;
+  return { documents: raw.documents / sum, logs: raw.logs / sum, snapshots: raw.snapshots / sum };
 }
 
-/** Would adding `addBytes` to the current usage exceed the limit? */
-export function wouldExceed(usedBytes: number, addBytes: number, limitBytes: number): boolean {
-  return usedBytes + addBytes > limitBytes;
-}
-
-/** Human-readable byte size (KB/MB), 1 decimal for MB. */
+/** Human-readable byte size (B / KB / MB / GB). Rolls over at the rounded display
+ *  value, so e.g. 1048575 reads "1.0 MB" rather than "1024 KB". */
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  const kb = Math.round(bytes / 1024);
+  if (kb < 1024) return `${kb} KB`;
+  const mb = bytes / (1024 * 1024);
+  if (Math.round(mb * 10) / 10 < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }

--- a/src/plugins/cloud-sync/syncEngine.ts
+++ b/src/plugins/cloud-sync/syncEngine.ts
@@ -16,7 +16,7 @@ import { getAccessor } from "./storeAccessors";
 import { fetchStorageUsage, isQuotaError, syncRecords, userFiles, type SyncRecordRow } from "./cloudClient";
 import { DOC_STORES, FILE_STORE, extractKey, type SyncSummary } from "./syncStores";
 import { listSelectedFiles, markPushed, orphanedObjectNames } from "./fileSync";
-import { DEFAULT_LIMITS, type StorageType, type StorageTypeUsage } from "./storageTypes";
+import { DEFAULT_TOTAL_LIMIT, type StorageUsage } from "./storageTypes";
 import { decideSync, pendingId, recordUpdatedAt } from "./merge";
 
 export type { SyncSummary };
@@ -338,17 +338,13 @@ export async function reconcileDocs(
   return { pulled, pushed, skipped };
 }
 
-/** Per-type storage usage from the server, with the advisory limits as fallback. */
-export async function getStorageUsage(): Promise<StorageTypeUsage[]> {
-  const rows = await fetchStorageUsage();
-  const byType = new Map(rows.map((r) => [r.storage_type, r]));
-  const types: StorageType[] = ["documents", "logs"];
-  return types.map((storageType) => {
-    const row = byType.get(storageType);
-    return {
-      storageType,
-      usedBytes: row?.used_bytes ?? 0,
-      limitBytes: row?.limit_bytes ?? DEFAULT_LIMITS[storageType],
-    };
-  });
+/** Pooled storage usage from the server, with the advisory free limit as fallback. */
+export async function getStorageUsage(): Promise<StorageUsage> {
+  const row = await fetchStorageUsage();
+  return {
+    documents: row?.documents_bytes ?? 0,
+    logs: row?.logs_bytes ?? 0,
+    snapshots: row?.snapshots_bytes ?? 0,
+    totalLimit: row?.total_limit_bytes || DEFAULT_TOTAL_LIMIT,
+  };
 }

--- a/supabase/migrations/20260601000000_unified_storage_quota.sql
+++ b/supabase/migrations/20260601000000_unified_storage_quota.sql
@@ -1,0 +1,238 @@
+-- Unified cloud-storage quota: ONE pooled byte budget per tier.
+--
+-- Supersedes the previous split model — two byte quotas (documents / logs) plus a
+-- separate snapshot COUNT quota — with a single per-tier byte limit that ALL three
+-- data kinds draw from:
+--
+--     documents (sync_records, non-files)
+--   + logs      (sync_records, files — counted by their index row's size)
+--   + snapshots (lap_snapshots, counted by serialized jsonb length)
+--   ────────────────────────────────────────────────────────────────────
+--   ≤ subscription_tiers.total_bytes   (free 50 MB / plus 10 GB / premium 100 GB / pro 500 GB)
+--
+-- `subscription_tiers.total_bytes` becomes the single source of truth for capacity.
+-- The legacy per-type columns (logs_bytes / doc_bytes), the snapshot_count column,
+-- and the quota_limits baseline table are all removed, along with the helper
+-- functions that read them.
+--
+-- This migration is idempotent + self-healing and ordered last, so it overrides the
+-- function/column drift left by the earlier hand-written + Lovable-batch migrations.
+-- ORDERING NOTE: every function below is redefined to stop referencing the old
+-- columns / quota_limits BEFORE those objects are dropped at the end (SQL-language
+-- function bodies are validated at creation time).
+
+-- ── 1. Single capacity column (data-driven, the one source of truth) ──────────
+alter table public.subscription_tiers
+  add column if not exists total_bytes bigint;
+
+update public.subscription_tiers set total_bytes =     52428800 where tier = 'free';     --  50 MB
+update public.subscription_tiers set total_bytes =  10737418240 where tier = 'plus';     --  10 GB
+update public.subscription_tiers set total_bytes = 107374182400 where tier = 'premium';  -- 100 GB
+update public.subscription_tiers set total_bytes = 536870912000 where tier = 'pro';      -- 500 GB
+-- Backfill any unknown/custom tier rows so NOT NULL can be enforced (free baseline).
+update public.subscription_tiers set total_bytes = 52428800 where total_bytes is null;
+
+alter table public.subscription_tiers alter column total_bytes set not null;
+
+-- ── 2. Pooled-usage + limit helpers ──────────────────────────────────────────
+-- Total bytes a user occupies across BOTH backing tables. SECURITY DEFINER so the
+-- count is exact regardless of the calling RLS context (the quota triggers + the
+-- usage RPC rely on it).
+create or replace function public.total_storage_used(p_user uuid)
+returns bigint language sql stable security definer set search_path = public as $$
+  select
+      coalesce((select sum(public.sync_record_size(store, data))
+                  from public.sync_records where user_id = p_user), 0)
+    + coalesce((select sum(octet_length(data::text))
+                  from public.lap_snapshots where user_id = p_user), 0);
+$$;
+grant execute on function public.total_storage_used(uuid) to authenticated;
+
+-- The single pooled byte limit for a user, from their effective tier. Falls back to
+-- the free tier, then to a hard 50 MB default.
+create or replace function public.tier_total_limit(p_user uuid)
+returns bigint language sql stable security definer set search_path = public as $$
+  select coalesce(
+    (select total_bytes from public.subscription_tiers where tier = public.user_tier(p_user)),
+    (select total_bytes from public.subscription_tiers where tier = 'free'),
+    52428800);
+$$;
+grant execute on function public.tier_total_limit(uuid) to authenticated;
+
+-- ── 3. Quota enforcement: sync_records (documents + logs) ─────────────────────
+-- Rejects a write that would push the user's POOLED total (this table + all
+-- lap_snapshots) over their tier limit. SECURITY DEFINER so the usage sum is exact.
+-- The trigger sync_records_quota is already bound to this function name.
+create or replace function public.enforce_sync_quota()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_limit bigint := public.tier_total_limit(NEW.user_id);
+  v_new   bigint := public.sync_record_size(NEW.store, NEW.data);
+  v_used  bigint;
+begin
+  if v_limit is null then return NEW; end if;
+
+  -- Pooled usage, excluding the sync_records row being upserted (it's replaced).
+  select
+      coalesce((select sum(public.sync_record_size(store, data))
+                  from public.sync_records
+                 where user_id = NEW.user_id
+                   and not (store = NEW.store and record_key = NEW.record_key)), 0)
+    + coalesce((select sum(octet_length(data::text))
+                  from public.lap_snapshots where user_id = NEW.user_id), 0)
+    into v_used;
+
+  if v_used + v_new > v_limit then
+    raise exception 'quota_exceeded: storage over limit (% bytes used + % new > % limit)',
+      v_used, v_new, v_limit using errcode = 'check_violation';
+  end if;
+  return NEW;
+end;
+$$;
+
+-- ── 4. Quota enforcement: lap_snapshots (now BYTE-pooled, not a count) ─────────
+-- Same pooled check, keyed off the snapshot payload size. Fires on INSERT *and*
+-- UPDATE (a faster lap upserts in place and can change the payload size), excluding
+-- the row being replaced — matched on the upsert conflict key (course_key, engine_key).
+create or replace function public.enforce_snapshot_quota()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_limit bigint := public.tier_total_limit(NEW.user_id);
+  v_new   bigint := octet_length(NEW.data::text);
+  v_used  bigint;
+begin
+  if v_limit is null then return NEW; end if;
+
+  select
+      coalesce((select sum(public.sync_record_size(store, data))
+                  from public.sync_records where user_id = NEW.user_id), 0)
+    + coalesce((select sum(octet_length(data::text))
+                  from public.lap_snapshots
+                 where user_id = NEW.user_id
+                   and not (course_key = NEW.course_key and engine_key = NEW.engine_key)), 0)
+    into v_used;
+
+  if v_used + v_new > v_limit then
+    raise exception 'quota_exceeded: storage over limit (% bytes used + % new > % limit)',
+      v_used, v_new, v_limit using errcode = 'check_violation';
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists lap_snapshots_quota on public.lap_snapshots;
+create trigger lap_snapshots_quota
+  before insert or update on public.lap_snapshots
+  for each row execute function public.enforce_snapshot_quota();
+
+-- ── 5. Usage readout for the segmented meter ─────────────────────────────────
+-- One row with the three segment sizes + the single pooled limit, for auth.uid().
+-- Return type changes (was per-type rows), so drop before recreate.
+drop function if exists public.sync_storage_usage();
+create or replace function public.sync_storage_usage()
+returns table(documents_bytes bigint, logs_bytes bigint, snapshots_bytes bigint, total_limit_bytes bigint)
+language sql stable security definer set search_path = public as $$
+  select
+    coalesce((select sum(public.sync_record_size(store, data))
+                from public.sync_records
+               where user_id = auth.uid()
+                 and public.sync_storage_type(store) = 'documents'), 0)::bigint,
+    coalesce((select sum(public.sync_record_size(store, data))
+                from public.sync_records
+               where user_id = auth.uid()
+                 and public.sync_storage_type(store) = 'logs'), 0)::bigint,
+    coalesce((select sum(octet_length(data::text))
+                from public.lap_snapshots where user_id = auth.uid()), 0)::bigint,
+    public.tier_total_limit(auth.uid());
+$$;
+grant execute on function public.sync_storage_usage() to authenticated;
+
+-- ── 6. Grace trim: target the free POOLED total, logs only ────────────────────
+-- For a user past their grace window, delete their synced LOGS newest-first until
+-- their pooled total (docs + remaining logs + snapshots) fits the free total_bytes,
+-- keeping the OLDEST logs that fit. Snapshots + docs are never auto-deleted, so if
+-- those alone already exceed the free total, trimming logs can't make the pool fit —
+-- we skip rather than pointlessly wipe every log (the user stays over until they
+-- free up snapshots/docs themselves). Return type changes (void -> integer), so drop
+-- first. The existing pg_cron schedule keeps calling it by name.
+drop function if exists public.trim_expired_logs();
+create or replace function public.trim_expired_logs()
+returns integer language plpgsql security definer set search_path = public, storage as $$
+declare
+  v_free_total bigint;
+  v_user       uuid;
+  v_logs       bigint;
+  v_nonlog     bigint;
+  v_allowance  bigint;
+  v_deleted    int := 0;
+  r            record;
+begin
+  select total_bytes into v_free_total from public.subscription_tiers where tier = 'free';
+  if v_free_total is null then return 0; end if;
+
+  for v_user in
+    select user_id
+      from public.user_subscriptions
+     where status not in ('active', 'trialing', 'past_due')
+       and grace_until is not null
+       and grace_until < now()
+       and (logs_trimmed_at is null or logs_trimmed_at < grace_until)
+  loop
+    -- Split the pool: logs (trimmable) vs everything else (docs + snapshots, kept).
+    select coalesce(sum(public.sync_record_size(store, data)), 0)
+      into v_logs
+      from public.sync_records
+     where user_id = v_user and public.sync_storage_type(store) = 'logs';
+    v_nonlog := public.total_storage_used(v_user) - v_logs;
+
+    -- How many log bytes may remain so the POOLED total fits the free budget. If the
+    -- kept data alone already exceeds it, deleting logs is futile → allowance 0 only
+    -- when that headroom is gone; otherwise keep the oldest logs up to the headroom.
+    v_allowance := greatest(0, v_free_total - v_nonlog);
+
+    -- Skip the (futile, destructive) full wipe when logs can't get the pool under.
+    if v_nonlog < v_free_total then
+      for r in
+        select record_key, data
+          from public.sync_records
+         where user_id = v_user
+           and public.sync_storage_type(store) = 'logs'
+         order by updated_at desc, record_key desc
+      loop
+        exit when v_logs <= v_allowance;
+        delete from storage.objects
+         where bucket_id = 'user-files'
+           and name = v_user::text || '/' || public.encode_uri_component(r.record_key);
+        delete from public.sync_records
+         where user_id = v_user and store = 'files' and record_key = r.record_key;
+        v_logs := v_logs - public.sync_record_size('files', r.data);
+        v_deleted := v_deleted + 1;
+      end loop;
+    end if;
+
+    update public.user_subscriptions set logs_trimmed_at = now() where user_id = v_user;
+  end loop;
+
+  return v_deleted;
+end;
+$$;
+
+-- ── 7. Drop the superseded per-type / count-quota machinery ───────────────────
+-- (Done last: the functions above no longer reference any of these.)
+drop function if exists public.tier_limit(uuid, text);
+drop function if exists public.snapshot_limit(uuid);
+drop function if exists public.tier_snapshot_count(uuid);
+drop function if exists public.snapshot_usage();
+drop function if exists public.enforce_lap_snapshot_quota();
+
+alter table public.subscription_tiers
+  drop column if exists logs_bytes,
+  drop column if exists doc_bytes,
+  drop column if exists snapshot_count;
+
+-- quota_limits was the legacy per-type baseline; the pool makes it redundant.
+-- DROP TABLE removes its RLS policies with it.
+drop table if exists public.quota_limits;
+
+-- Refresh PostgREST so the new sync_storage_usage() shape is served immediately.
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## What & why

Collapses the **three separate cloud-storage quotas** — documents (byte), logs (byte), and snapshots (COUNT) — into **one pooled per-tier byte budget** that all three draw from, and renders it as a single phone-style stacked progress bar on the Profile tab.

New per-tier limits (single source of truth = `subscription_tiers.total_bytes`):

| Tier | Pooled storage |
|------|----------------|
| Free | 50 MB |
| Plus | 10 GB |
| Premium | 100 GB |
| Pro | 500 GB |

Billing per data-type meant three sources of truth and three meters. Pooling to one number makes capacity data-driven and simplifies every storage check.

## Backend — `supabase/migrations/20260601000000_unified_storage_quota.sql`

Idempotent, ordered last to override the prior function/column drift.

- `subscription_tiers.total_bytes` is the only capacity column. Legacy `logs_bytes`/`doc_bytes`/`snapshot_count`, the `quota_limits` table, and the count-quota functions (`tier_limit`, `snapshot_limit`, `snapshot_usage`, …) are dropped.
- `enforce_sync_quota` + `enforce_snapshot_quota` now check the **pooled** total across `sync_records` + `lap_snapshots`, each excluding the row being upserted. Snapshots are byte-counted (`octet_length`), and the snapshot trigger now fires on `INSERT OR UPDATE`.
- `sync_storage_usage()` returns one row `(documents_bytes, logs_bytes, snapshots_bytes, total_limit_bytes)`.
- `trim_expired_logs()` trims logs newest-first toward the free total, keeping the oldest that fit — and **skips the futile full-wipe** when docs+snapshots alone already exceed the budget.

Stripe edge functions are untouched (they only reference `tier`; limits stay data).

## Frontend

One `StorageBar` in `StoragePanel.tsx` (logs → snapshots → garage segments, legend, `% used`, `used / limit`, over-limit note). `storageTypes.ts` carries the pooled `StorageUsage` + `segmentFractions` bar math + GB-aware `formatBytes` with boundary rollover. `cloudClient`/`syncEngine` adopt the new RPC shape; `autoSync`/`snapshotSync` collapse to one `quota_exceeded` path; `LapSnapshotsPanel` drops the count limit; `billing.ts` gains `total_bytes`; `PricingCards` copy updated.

## Verification

- `npm run lint`, `typecheck`, `test:run` (**747 pass**, incl. new bar-math + `formatBytes`-boundary tests), and `build` — all green.
- Reviewed by a multi-agent adversarial pass (SQL / frontend / docs, each finding independently verified). The migration + frontend logic got a clean correctness bill; the surfaced edge cases (trim full-wipe, `formatBytes` boundary, stale changelog/comment copy) are fixed in this PR.

## Behavior note

Documents lose their protected always-free allowance (**pure pool**, as requested): a free user who fills the budget with logs can block garage auto-sync. Garage docs are KB-sized, so this is a corner case — flagging it as an intentional change from the old model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)