### PR TITLE
Make documents + snapshots always free to sync; cap notes at 128 KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,9 +201,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unless the experimental setting is on or a plugin contributes to it.
 - Landing-page and About copy now reflect **optional cloud storage** (instead of
   "files never leave your device"), since cloud sync is available when signed in.
-- When local garage data exceeds the cloud **documents** limit, sync now does a
-  **partial push** — it saves everything that fits and tells you how many items
-  didn't — instead of rejecting the whole batch and syncing nothing.
+- **Garage data and lap snapshots now always sync, even when you're over your
+  storage cap.** They still count toward your pooled storage (shrinking the room
+  left for logs), but they're never blocked — only logs (and, later, videos) stop
+  syncing once the cap is reached. Garage and snapshot data is small and valuable,
+  so it shouldn't get locked out by a pool full of logs. The Profile storage panel
+  notes this beneath the usage bar.
+- Session notes are now capped at **128 KB each** to keep them from being used as
+  bulk document storage (they count toward your cloud document storage).
 - Cloud document sync is now **offline-aware and conflict-safe**. Garage records
   (vehicles, setups, templates, notes) carry an edit timestamp, and sync uses
   last-write-wins, so a newer change is never overwritten by an older copy.

--- a/src/components/drawer/NotesTab.tsx
+++ b/src/components/drawer/NotesTab.tsx
@@ -3,7 +3,7 @@ import { Pencil, Trash2, NotebookPen, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Note } from "@/lib/noteStorage";
+import { Note, MAX_NOTE_BYTES } from "@/lib/noteStorage";
 import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
 
@@ -155,7 +155,7 @@ export function NotesTab({
 
       {/* Add/Edit Form */}
       <div className="border-t border-border p-4 space-y-3 shrink-0">
-        <Textarea value={text} onChange={e => setText(e.target.value)} placeholder="Write a note…" className="min-h-[60px] text-sm resize-none" rows={3} />
+        <Textarea value={text} onChange={e => setText(e.target.value)} placeholder="Write a note…" className="min-h-[60px] text-sm resize-none" rows={3} maxLength={MAX_NOTE_BYTES} />
         <div className="flex items-center gap-2">
           <Button className="flex-1" size="sm" onClick={handleSubmit} disabled={!text.trim()}>
             {editingId ? "Update Note" : "Add Note"}

--- a/src/lib/noteStorage.test.ts
+++ b/src/lib/noteStorage.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { MAX_NOTE_BYTES, noteByteLength, exceedsNoteLimit } from "./noteStorage";
+
+describe("note size cap", () => {
+  it("measures UTF-8 byte length, not character count", () => {
+    expect(noteByteLength("abc")).toBe(3);
+    // "é" is 2 bytes in UTF-8, "😀" is 4 — bytes, not code units.
+    expect(noteByteLength("é")).toBe(2);
+    expect(noteByteLength("😀")).toBe(4);
+  });
+
+  it("allows notes at or under the cap", () => {
+    expect(exceedsNoteLimit("")).toBe(false);
+    expect(exceedsNoteLimit("a normal field note")).toBe(false);
+    expect(exceedsNoteLimit("a".repeat(MAX_NOTE_BYTES))).toBe(false);
+  });
+
+  it("rejects notes over the cap (the bulk-storage abuse case)", () => {
+    expect(exceedsNoteLimit("a".repeat(MAX_NOTE_BYTES + 1))).toBe(true);
+    // Multibyte content trips the byte cap below the character count.
+    expect(exceedsNoteLimit("😀".repeat(MAX_NOTE_BYTES / 4 + 1))).toBe(true);
+  });
+});

--- a/src/lib/noteStorage.ts
+++ b/src/lib/noteStorage.ts
@@ -15,6 +15,24 @@ export interface Note {
 
 const NOTES_STORE = STORE_NAMES.NOTES;
 
+/**
+ * Hard size cap per single note (128 KB of UTF-8 text). Notes are KB-sized field
+ * jottings; this guards against someone using a note as bulk document storage.
+ * Notes already count toward cloud document storage, so there's nothing to surface
+ * to the user — we just refuse to save anything pathologically large.
+ */
+export const MAX_NOTE_BYTES = 128 * 1024;
+
+/** UTF-8 byte length of a note's text. */
+export function noteByteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+/** True when the text is over the per-note size cap and must not be saved. */
+export function exceedsNoteLimit(text: string): boolean {
+  return noteByteLength(text) > MAX_NOTE_BYTES;
+}
+
 export async function listNotes(fileName: string): Promise<Note[]> {
   const db = await openDB();
   const tx = db.transaction(NOTES_STORE, "readonly");
@@ -29,6 +47,9 @@ export async function listNotes(fileName: string): Promise<Note[]> {
 }
 
 export async function saveNote(note: Note): Promise<void> {
+  if (exceedsNoteLimit(note.text)) {
+    throw new Error(`Note exceeds the ${MAX_NOTE_BYTES / 1024} KB limit.`);
+  }
   const stamped: Note = { ...note, updatedAt: Date.now() };
   const db = await openDB();
   const tx = db.transaction(NOTES_STORE, "readwrite");

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -281,6 +281,11 @@ function StorageBar({ usage }: { usage: StorageUsage }) {
         ))}
       </div>
 
+      <p className="text-[11px] text-muted-foreground">
+        Garage data and snapshots always sync, even when you're full — they still
+        count toward your storage, but only logs stop syncing when the cap is reached.
+      </p>
+
       {over && (
         <p className="text-[11px] text-destructive">
           You're over your plan's storage. New cloud syncs are saved locally until you free up space or upgrade.

--- a/supabase/migrations/20260602000000_free_documents_snapshots.sql
+++ b/supabase/migrations/20260602000000_free_documents_snapshots.sql
@@ -1,0 +1,58 @@
+-- Documents + snapshots are ALWAYS free to sync.
+--
+-- They still COUNT toward the pooled per-tier budget (so they shrink the headroom
+-- left for logs), but a write of a document or snapshot is never itself rejected
+-- for being over the cap. Only logs (and, later, videos) are blocked once the pool
+-- is full.
+--
+-- Supersedes the enforcement in 20260601000000_unified_storage_quota.sql, where all
+-- three kinds were rejected at the limit. Documents are KB-sized garage data and
+-- snapshots are user-curated baselines — silently dropping either because the pool
+-- is full of logs is a worse failure than letting them nudge slightly past. Ordered
+-- after the unified-quota migration; idempotent + self-healing.
+
+-- ── sync_records: enforce ONLY for log blobs (store = 'files') ────────────────
+-- Document upserts (every non-'files' store) return early, so they always commit
+-- regardless of the pooled total. A log is still blocked when the WHOLE pool —
+-- free docs/snapshots included — would exceed the tier limit. SECURITY DEFINER so
+-- the usage sum is exact regardless of the caller's RLS context.
+create or replace function public.enforce_sync_quota()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_limit bigint;
+  v_new   bigint;
+  v_used  bigint;
+begin
+  -- Documents are always free to sync (they still count toward the pool below).
+  if public.sync_storage_type(NEW.store) <> 'logs' then
+    return NEW;
+  end if;
+
+  v_limit := public.tier_total_limit(NEW.user_id);
+  if v_limit is null then return NEW; end if;
+  v_new := public.sync_record_size(NEW.store, NEW.data);
+
+  -- Pooled usage (docs + other logs + snapshots), excluding the log row being
+  -- upserted (it's replaced).
+  select
+      coalesce((select sum(public.sync_record_size(store, data))
+                  from public.sync_records
+                 where user_id = NEW.user_id
+                   and not (store = NEW.store and record_key = NEW.record_key)), 0)
+    + coalesce((select sum(octet_length(data::text))
+                  from public.lap_snapshots where user_id = NEW.user_id), 0)
+    into v_used;
+
+  if v_used + v_new > v_limit then
+    raise exception 'quota_exceeded: storage over limit (% bytes used + % new > % limit)',
+      v_used, v_new, v_limit using errcode = 'check_violation';
+  end if;
+  return NEW;
+end;
+$$;
+
+-- ── lap_snapshots: snapshots are always free now — drop the byte-quota gate ────
+-- Their serialized size still counts via total_storage_used / sync_storage_usage
+-- (the meter), they're just never rejected on write.
+drop trigger if exists lap_snapshots_quota on public.lap_snapshots;
+drop function if exists public.enforce_snapshot_quota();


### PR DESCRIPTION
## Summary

Back-pedals the unified pooled quota so **documents (garage data) and lap snapshots always sync**, even when a user is over their cloud-storage cap. They still **count** toward the pooled budget (shrinking the headroom left for logs), but they're never rejected on write. Only **logs** (and, later, videos) are blocked once the cap is reached.

Rationale: garage/snapshot data is KB-sized and user-curated — it shouldn't get locked out by a pool full of logs.

## Changes

**Server-side quota (the authoritative change)** — `supabase/migrations/20260602000000_free_documents_snapshots.sql`
- `enforce_sync_quota()` now returns early for document stores and only enforces the pooled limit for **log blobs** (`store = 'files'`). A log is still blocked when the *whole* pool (docs + snapshots + logs) would exceed the tier limit.
- Drops the `lap_snapshots_quota` trigger + `enforce_snapshot_quota()` — snapshot size still counts via `total_storage_used` / `sync_storage_usage` (the meter), it just never blocks.

**Profile storage panel** — `StoragePanel.tsx`
- Adds a note beneath the usage bar: garage data and snapshots always sync but still count toward the cap; only logs stop syncing when full.

**Session notes — 128 KB cap each** — `noteStorage.ts`, `NotesTab.tsx`
- `saveNote()` refuses to save a note over 128 KB of UTF-8 text (guards against using notes as bulk document storage — they count toward cloud document storage). Enforced via pure, tested helpers (`noteByteLength` / `exceedsNoteLimit`); the notes textarea gets a matching `maxLength` as a silent UI guard. No user-facing limit messaging, as requested.

## Tests / checks
- New regression test `src/lib/noteStorage.test.ts` (byte-length measurement + cap).
- `npm run lint`, `npm run typecheck`, `npm run test:run` (750 passed), `npm run build` — all green.

## Deployment note
The new SQL migration must be applied to Supabase for the server-side behavior to take effect. The client-side quota-error handling stays in place as a harmless fallback for environments where it hasn't run yet.

https://claude.ai/code/session_01Xkuh8ef3wR8JJrdZZpsrT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkuh8ef3wR8JJrdZZpsrT4)_