### PR TITLE
Reorganize file browser into a Track → Course → logs hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Organized file browser — Track → Course → logs, with filters.** The Files tab
+  is now a folder hierarchy instead of a flat list. Sessions are filed under their
+  **track**, then **course**; the final list can be grouped by **Engine** or
+  **Kart** (logs with neither shown below the groups). Each log is now labelled by
+  its **session date/time** — the time of its first GPS fix, e.g. "2/12/2026
+  11:15 AM" — instead of the raw filename, so logs read clearly. To keep clicking
+  to a minimum, folder levels only appear when there's an actual choice: a single
+  track or course is skipped automatically, with a **breadcrumb** always showing
+  where you are. Untagged logs get their own "Untagged" bucket. Opening the file
+  manager **jumps straight to the current session's track/course**.
 - **Setup revisions — frozen setup history per session.** Assigning a setup to a
   session now freezes an **immutable, content-addressed copy** of that setup, so
   the session keeps the exact setup it ran even if you edit the live setup later.
@@ -210,6 +220,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejects **disposable / temporary email** addresses.
 
 ### Changed
+- File metadata writes now go through a single read-merge helper, fixing cases
+  where tagging a track or saving a setup could drop other saved details (kart,
+  setup, fastest lap, weather).
 - Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
   `0.2.5` to `0.3.0`.
 - **Registration page** now shows the **Plans & pricing** cards above the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pointed at an upstream backend. Production enables them explicitly.
 
 ### Fixed
+- **Auto-detected track/course is now saved automatically.** When a loaded log's
+  track and course are recognised, the session is filed under them in the browser
+  immediately — previously the detection only applied in-memory and the log stayed
+  "Untagged" until some later manual action (e.g. saving a track) happened to
+  persist it.
 - **Lap snapshots are now direction-aware.** A course driven in reverse keeps a
   separate "fastest lap" snapshot from the forward direction instead of
   overwriting it (and the position-based pace overlay refuses to compare against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ src/
 │   ├── courseDetection.ts # ★ Auto track/course/direction detection + waypoint mode
 │   ├── lapCalculation.ts  # Start/finish crossing detection → Lap[]
 │   ├── lapDelta.ts        # ★ Position-based lap delta (arc-length resample + segment-projected gap)
+│   ├── fileBrowserTree.ts # ★ Pure file-browser hierarchy: Track→Course→logs, engine/kart filter, breadcrumbs, smart collapse
 │   ├── lapSnapshot.ts     # ★ Pure snapshot types/keying/buffer (course+engine identity)
 │   ├── lapSnapshotStorage.ts # ★ IndexedDB CRUD for lap snapshots (emits garageEvents)
 │   ├── setupRevision.ts  # ★ Pure content-addressed setup history: hash + freeze (immutable revisions)
@@ -267,7 +268,7 @@ Detection order matters: binary formats first (MoTeC LD → UBX), then text form
 | `CourseDetectionResult` | `track`, `course`, `direction?`, `laps[]`, `isWaypointMode`, `waypointNotice?` |
 | `CourseDirection` | `'forward' \| 'reverse'` |
 | `FieldMapping` | `index`, `name` (canonical ChannelId or `custom:` slug — the extraFields key), `label?` (display), `unit?`, `enabled` |
-| `FileMetadata` | `fileName`, `trackName`, `courseName`, `weatherStation*?`, `sessionKartId?`, `sessionSetupId?` (live setup), `sessionSetupRev?` (frozen setup-revision content hash), `fastestLapMs?`, `fastestLapNumber?` |
+| `FileMetadata` | `fileName`, `trackName`, `courseName`, `weatherStation*?`, `sessionKartId?`, `sessionSetupId?` (live setup), `sessionSetupRev?` (frozen setup-revision content hash), `sessionEngine?` (engine snapshot for browser grouping), `sessionStartTime?` (first-sample epoch ms → browser display name), `fastestLapMs?`, `fastestLapNumber?`. Partial updates go through `updateFileMetadata(fileName, patch)` (read-merge-write — never clobbers untouched tags). |
 
 ---
 
@@ -497,6 +498,33 @@ Pure comparison/conversion logic for merging app tracks with device track files:
 - `buildTrackJsonForUpload()` — serializes app Track to device JSON format (flat course array, includes `lengthFt`)
 - `deviceCourseToAppCourse()` / `appCourseToDeviceJson()` — format converters (both include `lengthFt`)
 - `DeviceCourseJson` includes `lengthFt?: number` for hardware course detection by lap distance
+
+---
+
+## File Browser (`FilesTab.tsx` + `lib/fileBrowserTree.ts`)
+
+The Garage → **Files** tab is a folder hierarchy, not a flat list: **Track → Course
+→ logs**, with an optional **Engine/Kart** grouping on the final list. All the tree
++ navigation math is pure in `fileBrowserTree.ts` (unit-tested); `FilesTab` just
+renders the computed `BrowserView` (breadcrumb + folders + log rows).
+
+- **Display name = the session's date/time**, derived from `sessionStartTime` (the
+  first valid sample), e.g. "2/12/2026 11:15 AM" — *not* the upload time or raw
+  filename (filename is the row's `title`/tooltip + the stable IndexedDB key).
+- **Smart collapse:** a folder level is only rendered when there's more than one
+  entry — a single track and/or single course auto-descends straight to the logs
+  (the breadcrumb still records the collapsed segments so date names read in
+  context). The explicit Engine/Kart filter, by contrast, **always** shows its
+  folder(s); logs with no engine/kart sit loose **below** the filter folders.
+- **Untagged bucket:** logs missing a track/course land in an "Untagged" folder
+  after the real tracks (collapsing to a flat list when it's the only group).
+- **Opens at the current session.** `Index.tsx` passes the loaded session's
+  `currentTrackName`/`currentCourseName`; `FilesTab` re-homes there (`defaultNav`)
+  on every drawer open and whenever a different session loads.
+- **Grouping data** rides `FileMetadata`: `sessionEngine` (snapshotted from the
+  kart at assign time, so grouping survives vehicle edits), `sessionKartId`
+  (→ vehicle name), and `sessionStartTime`. Engine resolves to the snapshot first,
+  then the live `Vehicle.engine`.
 
 ---
 

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -52,6 +52,9 @@ interface FileManagerDrawerProps {
   onAddVehicle: (vehicle: Omit<Vehicle, "id">) => Promise<void>;
   onUpdateVehicle: (vehicle: Vehicle) => Promise<void>;
   onRemoveVehicle: (id: string) => Promise<void>;
+  // Current session context (the browser opens at this track/course)
+  currentTrackName: string | null;
+  currentCourseName: string | null;
   // Note props
   currentFileName: string | null;
   notes: Note[];
@@ -78,6 +81,7 @@ export function FileManagerDrawer({
   onClose, onLoadFile, onDeleteFile, onExportFile, onSaveFile, onDataLoaded, autoSave,
   vehicles, vehicleTypes, templates,
   onAddVehicle, onUpdateVehicle, onRemoveVehicle,
+  currentTrackName, currentCourseName,
   currentFileName, notes, onAddNote, onUpdateNote, onRemoveNote,
   sessionKartId, sessionSetupId, sessionSetupRev, onSaveSessionSetup,
   setups, onAddSetup, onUpdateSetup, onRemoveSetup, onGetLatestSetupForVehicle,
@@ -178,7 +182,7 @@ export function FileManagerDrawer({
             </div>
 
             {garageTab === "files" && (
-              <FilesTab files={files} fileMetadataMap={fileMetadataMap} storageUsed={storageUsed} storageQuota={storageQuota} onLoadFile={onLoadFile} onDeleteFile={onDeleteFile} onExportFile={onExportFile} onSaveFile={onSaveFile} onDataLoaded={onDataLoaded} onClose={onClose} autoSave={autoSave} />
+              <FilesTab files={files} fileMetadataMap={fileMetadataMap} vehicles={vehicles} currentTrackName={currentTrackName} currentCourseName={currentCourseName} isOpen={isOpen} storageUsed={storageUsed} storageQuota={storageQuota} onLoadFile={onLoadFile} onDeleteFile={onDeleteFile} onExportFile={onExportFile} onSaveFile={onSaveFile} onDataLoaded={onDataLoaded} onClose={onClose} autoSave={autoSave} />
             )}
             {garageTab === "vehicles" && (
               <VehiclesTab vehicles={vehicles} vehicleTypes={vehicleTypes} onAdd={onAddVehicle} onUpdate={onUpdateVehicle} onRemove={onRemoveVehicle} />

--- a/src/components/drawer/FilesTab.tsx
+++ b/src/components/drawer/FilesTab.tsx
@@ -1,14 +1,19 @@
-import { useCallback, useRef, useState, useEffect, lazy, Suspense } from "react";
-import { Trash2, Download, Upload, FolderOpen, Loader2, Video, X } from "lucide-react";
+import { useCallback, useRef, useState, useEffect, useMemo, lazy, Suspense, Fragment } from "react";
+import { Trash2, Download, Upload, FolderOpen, Folder, Loader2, Video, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FileEntry, FileMetadata } from "@/lib/fileStorage";
+import { Vehicle } from "@/lib/vehicleStorage";
 import { parseDatalogFile } from "@/lib/datalogParser";
 import { ParsedData } from "@/types/racing";
+import {
+  buildBrowserSessions, computeBrowserView, defaultNav,
+  type FilterMode, type NavState,
+} from "@/lib/fileBrowserTree";
 // Lazy — keeps the BLE module in its own chunk, loaded only on device use.
 const DataloggerDownload = lazy(() =>
   import("@/components/DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
 );
-import { listSessionVideos, deleteSessionVideo, StoredVideoMeta } from "@/lib/videoFileStorage";
+import { listSessionVideos, StoredVideoMeta } from "@/lib/videoFileStorage";
 import { PluginMount } from "@/plugins/PluginMount";
 import { MountSlot } from "@/plugins/mounts";
 
@@ -28,9 +33,17 @@ function formatLapTime(ms: number): string {
     : secs.toFixed(3);
 }
 
+const FILTER_LABELS: Record<FilterMode, string> = { none: "None", engine: "Engine", kart: "Kart" };
+
 interface FilesTabProps {
   files: FileEntry[];
   fileMetadataMap: Map<string, FileMetadata>;
+  vehicles: Vehicle[];
+  /** Track/course of the currently-loaded session — the browser opens here. */
+  currentTrackName: string | null;
+  currentCourseName: string | null;
+  /** Drawer open flag — re-homes the browser to the current session on each open. */
+  isOpen: boolean;
   storageUsed: number;
   storageQuota: number;
   onLoadFile: (name: string) => Promise<Blob | null>;
@@ -45,6 +58,10 @@ interface FilesTabProps {
 export function FilesTab({
   files,
   fileMetadataMap,
+  vehicles,
+  currentTrackName,
+  currentCourseName,
+  isOpen,
   storageUsed,
   storageQuota,
   onLoadFile,
@@ -61,21 +78,26 @@ export function FilesTab({
   const [loading, setLoading] = useState(false);
   const [videoFiles, setVideoFiles] = useState<Map<string, StoredVideoMeta>>(new Map());
 
+  // Folder navigation. Opens at the current session's track/course, and re-homes
+  // there whenever the drawer is (re)opened or a different session is loaded.
+  const [nav, setNav] = useState<NavState>(() => defaultNav(currentTrackName, currentCourseName));
+  useEffect(() => {
+    if (isOpen) setNav(defaultNav(currentTrackName, currentCourseName));
+  }, [isOpen, currentTrackName, currentCourseName]);
+
+  const sessions = useMemo(
+    () => buildBrowserSessions(files, fileMetadataMap, vehicles),
+    [files, fileMetadataMap, vehicles],
+  );
+  const view = useMemo(() => computeBrowserView(sessions, nav), [sessions, nav]);
+  const filesByName = useMemo(() => new Map(files.map((f) => [f.name, f])), [files]);
+
   // Load stored video metadata to show video icons
   useEffect(() => {
     listSessionVideos().then(videos => {
       setVideoFiles(new Map(videos.map(v => [v.sessionFileName, v])));
     }).catch(() => {});
   }, [files]);
-
-  const handleDeleteVideo = useCallback(async (sessionFileName: string) => {
-    await deleteSessionVideo(sessionFileName);
-    setVideoFiles(prev => {
-      const next = new Map(prev);
-      next.delete(sessionFileName);
-      return next;
-    });
-  }, []);
 
   const handleLoadConfirm = useCallback(async () => {
     if (!confirmLoad) return;
@@ -144,7 +166,74 @@ export function FilesTab({
     [onDataLoaded, onClose],
   );
 
+  const setFilter = useCallback((filter: FilterMode) => {
+    // Keep the resolved track/course; clear any drilled-in folder.
+    setNav((prev) => ({ track: prev.track, course: prev.course, filter }));
+  }, []);
+
   const storagePercent = storageQuota > 0 ? Math.min((storageUsed / storageQuota) * 100, 100) : 0;
+
+  const renderLog = (fileName: string, displayName: string, fastestLapMs?: number) => {
+    const file = filesByName.get(fileName);
+    if (!file) return null;
+    const metadata = fileMetadataMap.get(fileName);
+    return (
+      <div
+        key={fileName}
+        className="flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors group"
+      >
+        <button
+          className="flex-1 text-left min-w-0 cursor-pointer"
+          onClick={() => setConfirmLoad(fileName)}
+        >
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium truncate text-foreground" title={fileName}>{displayName}</span>
+            {videoFiles.has(fileName) && (
+              <span title={(() => {
+                const m = videoFiles.get(fileName)!;
+                const parts = [m.exportType === "lap" && m.lapNumber != null ? `Lap ${m.lapNumber}` : m.exportType === "session" ? "Session" : "Source"];
+                if (m.hasOverlays) parts.push("w/ overlays");
+                parts.push(`(${formatSize(m.size)})`);
+                return parts.join(" ");
+              })()}>
+                <Video className="w-3.5 h-3.5 text-primary shrink-0" />
+              </span>
+            )}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {formatSize(file.size)} · {new Date(file.savedAt).toLocaleDateString()}
+            {fastestLapMs != null && (
+              <span className="ml-1.5 text-primary font-medium">
+                ⚡ {formatLapTime(fastestLapMs)}
+              </span>
+            )}
+          </div>
+        </button>
+        <PluginMount
+          slot={MountSlot.FileRow}
+          ctx={{ file, metadata }}
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100"
+          onClick={() => onExportFile(fileName)}
+          title="Export / Download"
+        >
+          <Download className="w-3.5 h-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100 hover:text-destructive"
+          onClick={() => setConfirmDelete(fileName)}
+          title="Delete"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+    );
+  };
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -198,62 +287,74 @@ export function FilesTab({
             <p className="text-xs">Upload or import files to get started</p>
           </div>
         ) : (
-          files.map((file) => (
-            <div
-              key={file.name}
-              className="flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors group"
-            >
-              <button
-                className="flex-1 text-left min-w-0 cursor-pointer"
-                onClick={() => setConfirmLoad(file.name)}
-              >
-                <div className="flex items-center gap-1.5">
-                  <span className="text-sm font-mono truncate text-foreground">{file.name}</span>
-                  {videoFiles.has(file.name) && (
-                    <span title={(() => {
-                      const m = videoFiles.get(file.name)!;
-                      const parts = [m.exportType === "lap" && m.lapNumber != null ? `Lap ${m.lapNumber}` : m.exportType === "session" ? "Session" : "Source"];
-                      if (m.hasOverlays) parts.push("w/ overlays");
-                      parts.push(`(${formatSize(m.size)})`);
-                      return parts.join(" ");
-                    })()}>
-                      <Video className="w-3.5 h-3.5 text-primary shrink-0" />
-                    </span>
-                  )}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {formatSize(file.size)} · {new Date(file.savedAt).toLocaleDateString()}
-                  {fileMetadataMap.get(file.name)?.fastestLapMs != null && (
-                    <span className="ml-1.5 text-primary font-medium">
-                      ⚡ {formatLapTime(fileMetadataMap.get(file.name)!.fastestLapMs!)}
-                    </span>
-                  )}
-                </div>
-              </button>
-              <PluginMount
-                slot={MountSlot.FileRow}
-                ctx={{ file, metadata: fileMetadataMap.get(file.name) }}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100"
-                onClick={() => onExportFile(file.name)}
-                title="Export / Download"
-              >
-                <Download className="w-3.5 h-3.5" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100 hover:text-destructive"
-                onClick={() => setConfirmDelete(file.name)}
-                title="Delete"
-              >
-                <Trash2 className="w-3.5 h-3.5" />
-              </Button>
+          <div className="space-y-1">
+            {/* Breadcrumb — always shown so date-named logs read in context. */}
+            <div className="flex items-center flex-wrap gap-0.5 px-1 pb-1 text-sm">
+              {view.breadcrumb.map((seg, i) => {
+                const isLast = i === view.breadcrumb.length - 1;
+                return (
+                  <Fragment key={`${seg.label}-${i}`}>
+                    {i > 0 && <ChevronRight className="w-3.5 h-3.5 text-muted-foreground shrink-0" />}
+                    <button
+                      type="button"
+                      disabled={isLast}
+                      onClick={() => setNav(seg.nav)}
+                      className={isLast
+                        ? "font-semibold text-foreground truncate"
+                        : "text-muted-foreground hover:text-foreground truncate"}
+                    >
+                      {seg.label}
+                    </button>
+                  </Fragment>
+                );
+              })}
             </div>
-          ))
+
+            {/* Engine/Kart filter — only on the final log level. */}
+            {view.showFilter && (
+              <div className="flex items-center gap-2 px-1 pb-1">
+                <span className="text-xs text-muted-foreground">Group by</span>
+                <div className="flex gap-0.5 bg-muted/50 rounded-md p-0.5">
+                  {(["none", "engine", "kart"] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => setFilter(mode)}
+                      className={`px-2.5 py-0.5 text-xs font-medium rounded transition-colors ${
+                        view.filterMode === mode
+                          ? "bg-primary text-primary-foreground"
+                          : "text-muted-foreground hover:text-foreground"
+                      }`}
+                    >
+                      {FILTER_LABELS[mode]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Folders */}
+            {view.folders.map((folder) => (
+              <button
+                key={`${folder.kind}-${folder.key}`}
+                type="button"
+                onClick={() => setNav(folder.nav)}
+                className="w-full flex items-center gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors text-left"
+              >
+                <Folder className="w-4 h-4 text-muted-foreground shrink-0" />
+                <span className="flex-1 text-sm font-medium text-foreground truncate">{folder.label}</span>
+                <span className="text-xs text-muted-foreground shrink-0">{folder.count}</span>
+                <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
+              </button>
+            ))}
+
+            {/* Logs (final list, or unconfigured logs below filter folders) */}
+            {view.sessions.map((s) => renderLog(s.fileName, s.displayName, s.fastestLapMs))}
+
+            {view.folders.length === 0 && view.sessions.length === 0 && (
+              <p className="text-xs text-muted-foreground text-center py-6">No sessions here</p>
+            )}
+          </div>
         )}
       </div>
 

--- a/src/hooks/useDataLoader.test.ts
+++ b/src/hooks/useDataLoader.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { detectionMetadataPatch } from "./useDataLoader";
+
+const laps = [
+  { lapNumber: 1, lapTimeMs: 65000 },
+  { lapNumber: 2, lapTimeMs: 62000 },
+  { lapNumber: 3, lapTimeMs: 63000 },
+];
+
+describe("detectionMetadataPatch (auto-detect tagging)", () => {
+  it("tags track + course with the start time and fastest lap", () => {
+    const start = new Date(2026, 1, 12, 11, 15);
+    expect(detectionMetadataPatch("OKC", "CW", laps, start)).toEqual({
+      trackName: "OKC",
+      courseName: "CW",
+      sessionStartTime: start.getTime(),
+      fastestLapMs: 62000,
+      fastestLapNumber: 2,
+    });
+  });
+
+  it("omits the start time when the parser gave no date", () => {
+    const patch = detectionMetadataPatch("OKC", "CW", laps, undefined);
+    expect(patch.sessionStartTime).toBeUndefined();
+    expect(patch).toMatchObject({ trackName: "OKC", courseName: "CW", fastestLapMs: 62000 });
+  });
+
+  it("omits fastest-lap fields when there are no laps", () => {
+    const patch = detectionMetadataPatch("OKC", "CW", [], new Date(0));
+    expect(patch.fastestLapMs).toBeUndefined();
+    expect(patch.fastestLapNumber).toBeUndefined();
+    expect(patch).toMatchObject({ trackName: "OKC", courseName: "CW", sessionStartTime: 0 });
+  });
+});

--- a/src/hooks/useDataLoader.ts
+++ b/src/hooks/useDataLoader.ts
@@ -5,7 +5,7 @@ import {
   TrackCourseSelection,
   CourseDetectionResult,
 } from "@/types/racing";
-import { getFileMetadata } from "@/lib/fileStorage";
+import { getFileMetadata, updateFileMetadata } from "@/lib/fileStorage";
 import { loadTracks } from "@/lib/trackStorage";
 import { findNearestTrack } from "@/lib/trackUtils";
 import { autoDetectCourse } from "@/lib/courseDetection";
@@ -80,6 +80,11 @@ export function useDataLoader({
       if (fileName) {
         const meta = await getFileMetadata(fileName);
         if (meta) {
+          // Backfill the session start time for files saved before this existed,
+          // so the browser's date/time display name works on older logs too.
+          if (meta.sessionStartTime == null && parsedData.startDate) {
+            updateFileMetadata(fileName, { sessionStartTime: parsedData.startDate.getTime() });
+          }
           const tracks = await loadTracks();
           const track = tracks.find((t) => t.name === meta.trackName);
           const course = track?.courses.find((c) => c.name === meta.courseName);

--- a/src/hooks/useDataLoader.ts
+++ b/src/hooks/useDataLoader.ts
@@ -5,7 +5,7 @@ import {
   TrackCourseSelection,
   CourseDetectionResult,
 } from "@/types/racing";
-import { getFileMetadata, updateFileMetadata } from "@/lib/fileStorage";
+import { getFileMetadata, updateFileMetadata, type FileMetadata } from "@/lib/fileStorage";
 import { loadTracks } from "@/lib/trackStorage";
 import { findNearestTrack } from "@/lib/trackUtils";
 import { autoDetectCourse } from "@/lib/courseDetection";
@@ -41,13 +41,40 @@ export interface UseDataLoaderReturn {
 const DEFAULT_SAMPLE_FILE_NAME = "okc-tillotson-data.dovex";
 
 /** Pick the lap with the lowest lapTimeMs (linear, no Math.min spread). */
-function pickFastestLapNumber(laps: { lapNumber: number; lapTimeMs: number }[]): number | null {
+function pickFastestLap<T extends { lapTimeMs: number }>(laps: T[]): T | null {
   if (laps.length === 0) return null;
   let fastest = laps[0];
   for (let i = 1; i < laps.length; i++) {
     if (laps[i].lapTimeMs < fastest.lapTimeMs) fastest = laps[i];
   }
-  return fastest.lapNumber;
+  return fastest;
+}
+
+/** Pick the lap number with the lowest lapTimeMs. */
+function pickFastestLapNumber(laps: { lapNumber: number; lapTimeMs: number }[]): number | null {
+  return pickFastestLap(laps)?.lapNumber ?? null;
+}
+
+/**
+ * The metadata patch to persist when auto-detection resolves a real course, so a
+ * freshly-loaded session is filed under its track/course in the browser without
+ * any manual save — including the session start time (display name) and fastest
+ * lap (the browser badge). Pure so the tag-on-detect behaviour stays testable.
+ */
+export function detectionMetadataPatch(
+  trackName: string,
+  courseName: string,
+  laps: { lapNumber: number; lapTimeMs: number }[],
+  startDate?: Date,
+): Partial<Omit<FileMetadata, "fileName">> {
+  const patch: Partial<Omit<FileMetadata, "fileName">> = { trackName, courseName };
+  if (startDate) patch.sessionStartTime = startDate.getTime();
+  const fastest = pickFastestLap(laps);
+  if (fastest) {
+    patch.fastestLapMs = fastest.lapTimeMs;
+    patch.fastestLapNumber = fastest.lapNumber;
+  }
+  return patch;
 }
 
 /**
@@ -139,6 +166,21 @@ export function useDataLoader({
         });
         lapMgmt.setLaps(detection.laps);
         lapMgmt.setSelectedLapNumber(pickFastestLapNumber(detection.laps));
+        // setSelection is the raw setter and does NOT persist — so write the
+        // detected tag straight to metadata here, otherwise a confidently
+        // auto-detected session would stay "Untagged" until some later manual
+        // selection happened to save it.
+        if (fileName) {
+          updateFileMetadata(
+            fileName,
+            detectionMetadataPatch(
+              detection.track.name,
+              detection.course.name,
+              detection.laps,
+              parsedData.startDate,
+            ),
+          );
+        }
         return;
       }
 

--- a/src/hooks/useLapManagement.ts
+++ b/src/hooks/useLapManagement.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { ParsedData, Lap, GpsSample, TrackCourseSelection, Course } from "@/types/racing";
 import { calculateLaps } from "@/lib/lapCalculation";
-import { saveFileMetadata, getFileMetadata } from "@/lib/fileStorage";
+import { updateFileMetadata } from "@/lib/fileStorage";
 
 /**
  * Manages track/course selection, lap calculation, lap/reference selection,
@@ -70,22 +70,12 @@ export function useLapManagement(data: ParsedData | null, currentFileName: strin
         );
         setSelectedLapNumber(fastest.lapNumber);
 
-        // Persist fastest lap into metadata
+        // Persist fastest lap into metadata (preserving all other tags).
         const targetFileName = fileNameOverride ?? currentFileName;
         if (targetFileName) {
-          getFileMetadata(targetFileName).then((existing) => {
-            saveFileMetadata({
-              fileName: targetFileName,
-              trackName: existing?.trackName ?? "",
-              courseName: existing?.courseName ?? "",
-              weatherStationId: existing?.weatherStationId,
-              weatherStationName: existing?.weatherStationName,
-              weatherStationDistanceKm: existing?.weatherStationDistanceKm,
-              sessionKartId: existing?.sessionKartId,
-              sessionSetupId: existing?.sessionSetupId,
-              fastestLapMs: fastest.lapTimeMs,
-              fastestLapNumber: fastest.lapNumber,
-            });
+          updateFileMetadata(targetFileName, {
+            fastestLapMs: fastest.lapTimeMs,
+            fastestLapNumber: fastest.lapNumber,
           });
         }
       }
@@ -98,17 +88,14 @@ export function useLapManagement(data: ParsedData | null, currentFileName: strin
     (newSelection: TrackCourseSelection | null) => {
       setSelection(newSelection);
 
-      // Persist track/course association for current file
+      // Persist track/course association for current file (preserving all other
+      // tags), and stamp the session's true start time from the first sample so
+      // the browser can show a date/time display name.
       if (currentFileName && newSelection) {
-        getFileMetadata(currentFileName).then((existing) => {
-          saveFileMetadata({
-            fileName: currentFileName,
-            trackName: newSelection.trackName,
-            courseName: newSelection.courseName,
-            weatherStationId: existing?.weatherStationId,
-            weatherStationName: existing?.weatherStationName,
-            weatherStationDistanceKm: existing?.weatherStationDistanceKm,
-          });
+        updateFileMetadata(currentFileName, {
+          trackName: newSelection.trackName,
+          courseName: newSelection.courseName,
+          ...(data?.startDate ? { sessionStartTime: data.startDate.getTime() } : {}),
         });
       }
 

--- a/src/hooks/useSessionMetadata.ts
+++ b/src/hooks/useSessionMetadata.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { WeatherStation } from "@/lib/weatherService";
-import { saveFileMetadata, getFileMetadata, FileMetadata } from "@/lib/fileStorage";
+import { updateFileMetadata, FileMetadata } from "@/lib/fileStorage";
 import { freezeSetupRevision } from "@/lib/setupRevisionStorage";
 
 /**
@@ -39,15 +39,10 @@ export function useSessionMetadata(currentFileName: string | null) {
     (station: WeatherStation) => {
       setCachedWeatherStation(station);
       if (currentFileName) {
-        getFileMetadata(currentFileName).then((existing) => {
-          saveFileMetadata({
-            fileName: currentFileName,
-            trackName: existing?.trackName || "",
-            courseName: existing?.courseName || "",
-            weatherStationId: station.stationId,
-            weatherStationName: station.name,
-            weatherStationDistanceKm: station.distanceKm,
-          });
+        updateFileMetadata(currentFileName, {
+          weatherStationId: station.stationId,
+          weatherStationName: station.name,
+          weatherStationDistanceKm: station.distanceKm,
         });
       }
     },
@@ -55,23 +50,19 @@ export function useSessionMetadata(currentFileName: string | null) {
   );
 
   const handleSaveSessionSetup = useCallback(
-    async (kartId: string | null, setupId: string | null) => {
+    async (kartId: string | null, setupId: string | null, engine?: string | null) => {
       if (!currentFileName) return;
-      const existing = await getFileMetadata(currentFileName);
       // Freeze the assigned setup into an immutable, content-addressed revision
       // so this session keeps the exact setup it ran even if the live setup is
       // edited later. Idempotent: an unchanged setup re-uses its existing hash.
       const rev = setupId ? await freezeSetupRevision(setupId) : null;
-      // Spread existing first so unrelated cached fields (track/course, weather,
-      // fastest-lap) survive a setup change.
-      await saveFileMetadata({
-        ...(existing ?? {}),
-        fileName: currentFileName,
-        trackName: existing?.trackName || "",
-        courseName: existing?.courseName || "",
+      // updateFileMetadata preserves every other tag (track/course, weather,
+      // fastest-lap, start time). Engine is snapshotted for browser grouping.
+      await updateFileMetadata(currentFileName, {
         sessionKartId: kartId ?? undefined,
         sessionSetupId: setupId ?? undefined,
         sessionSetupRev: rev ?? undefined,
+        sessionEngine: engine?.trim() || undefined,
       });
       setSessionKartId(kartId);
       setSessionSetupId(setupId);

--- a/src/lib/fileBrowserTree.test.ts
+++ b/src/lib/fileBrowserTree.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import type { FileEntry, FileMetadata } from "./fileStorage";
+import type { Vehicle } from "./vehicleStorage";
+import {
+  buildBrowserSessions,
+  computeBrowserView,
+  defaultNav,
+  formatSessionDisplayName,
+  ROOT_NAV,
+  UNTAGGED_TRACK,
+  type BrowserSession,
+} from "./fileBrowserTree";
+
+// ── Helpers ──
+
+function session(over: Partial<BrowserSession>): BrowserSession {
+  return {
+    fileName: over.fileName ?? "f",
+    displayName: over.displayName ?? "name",
+    savedAt: over.savedAt ?? 0,
+    startTime: over.startTime,
+    trackName: over.trackName,
+    courseName: over.courseName,
+    engine: over.engine,
+    kartId: over.kartId,
+    kartName: over.kartName,
+    fastestLapMs: over.fastestLapMs,
+  };
+}
+
+describe("formatSessionDisplayName", () => {
+  it("formats a start time as date + 12h time", () => {
+    const t = new Date(2026, 1, 12, 11, 15).getTime(); // Feb 12 2026 11:15 local
+    expect(formatSessionDisplayName(t, "raw.dove")).toBe("2/12/2026 11:15 AM");
+  });
+
+  it("handles midnight and noon", () => {
+    expect(formatSessionDisplayName(new Date(2026, 0, 1, 0, 5).getTime(), "x")).toBe("1/1/2026 12:05 AM");
+    expect(formatSessionDisplayName(new Date(2026, 0, 1, 12, 0).getTime(), "x")).toBe("1/1/2026 12:00 PM");
+    expect(formatSessionDisplayName(new Date(2026, 0, 1, 23, 59).getTime(), "x")).toBe("1/1/2026 11:59 PM");
+  });
+
+  it("falls back to the file name with no start time", () => {
+    expect(formatSessionDisplayName(undefined, "raw.dove")).toBe("raw.dove");
+  });
+});
+
+describe("buildBrowserSessions", () => {
+  const files: FileEntry[] = [
+    { name: "a.dove", size: 1, savedAt: 100 },
+    { name: "b.dove", size: 1, savedAt: 200 },
+  ];
+  const vehicles: Vehicle[] = [
+    { id: "v1", name: "Kart 7", vehicleTypeId: "t", engine: "Rotax", number: 7, weight: 0, weightUnit: "lb" },
+  ];
+
+  it("resolves engine from the snapshot, then the live vehicle", () => {
+    const metaMap = new Map<string, FileMetadata>([
+      ["a.dove", { fileName: "a.dove", trackName: "OKC", courseName: "CW", sessionKartId: "v1", sessionStartTime: 1 }],
+      ["b.dove", { fileName: "b.dove", trackName: "OKC", courseName: "CW", sessionKartId: "v1", sessionEngine: "IAME" }],
+    ]);
+    const [a, b] = buildBrowserSessions(files, metaMap, vehicles);
+    expect(a.engine).toBe("Rotax");  // from live vehicle
+    expect(a.kartName).toBe("Kart 7");
+    expect(b.engine).toBe("IAME");   // frozen snapshot wins
+  });
+
+  it("leaves track/course/engine undefined when unset", () => {
+    const [a] = buildBrowserSessions([files[0]], new Map(), vehicles);
+    expect(a.trackName).toBeUndefined();
+    expect(a.engine).toBeUndefined();
+    expect(a.displayName).toBe("a.dove");
+  });
+});
+
+describe("computeBrowserView — collapsing", () => {
+  it("collapses a single track and single course straight to the log list", () => {
+    const sessions = [
+      session({ fileName: "1", trackName: "OKC", courseName: "CW", startTime: 2 }),
+      session({ fileName: "2", trackName: "OKC", courseName: "CW", startTime: 1 }),
+    ];
+    const view = computeBrowserView(sessions, ROOT_NAV);
+    expect(view.folders).toEqual([]);
+    expect(view.sessions.map((s) => s.fileName)).toEqual(["1", "2"]); // newest first
+    // Breadcrumb still records the collapsed track + course.
+    expect(view.breadcrumb.map((b) => b.label)).toEqual(["All sessions", "OKC", "CW"]);
+    expect(view.showFilter).toBe(true);
+  });
+
+  it("shows track folders when there is more than one track", () => {
+    const sessions = [
+      session({ fileName: "1", trackName: "OKC", courseName: "CW" }),
+      session({ fileName: "2", trackName: "Daytona", courseName: "Nat" }),
+    ];
+    const view = computeBrowserView(sessions, ROOT_NAV);
+    expect(view.folders.map((f) => f.label)).toEqual(["Daytona", "OKC"]); // alpha
+    expect(view.folders.every((f) => f.kind === "track")).toBe(true);
+    expect(view.sessions).toEqual([]);
+  });
+
+  it("shows course folders when a track has more than one course", () => {
+    const sessions = [
+      session({ fileName: "1", trackName: "OKC", courseName: "CW" }),
+      session({ fileName: "2", trackName: "OKC", courseName: "CCW" }),
+    ];
+    const view = computeBrowserView(sessions, { track: "OKC", filter: "none" });
+    expect(view.folders.map((f) => f.label)).toEqual(["CCW", "CW"]);
+    expect(view.folders.every((f) => f.kind === "course")).toBe(true);
+  });
+});
+
+describe("computeBrowserView — untagged bucket", () => {
+  it("buckets untagged logs after real tracks", () => {
+    const sessions = [
+      session({ fileName: "1", trackName: "OKC", courseName: "CW" }),
+      session({ fileName: "2" }), // untagged
+    ];
+    const view = computeBrowserView(sessions, ROOT_NAV);
+    expect(view.folders.map((f) => f.label)).toEqual(["OKC", "Untagged"]);
+    expect(view.folders[1].key).toBe(UNTAGGED_TRACK);
+  });
+
+  it("opens the untagged bucket straight to its logs (no course level)", () => {
+    const sessions = [
+      session({ fileName: "1", trackName: "OKC", courseName: "CW" }),
+      session({ fileName: "2", startTime: 5 }),
+      session({ fileName: "3", startTime: 9 }),
+    ];
+    const view = computeBrowserView(sessions, { track: UNTAGGED_TRACK, filter: "none" });
+    expect(view.breadcrumb.map((b) => b.label)).toEqual(["All sessions", "Untagged"]);
+    expect(view.sessions.map((s) => s.fileName)).toEqual(["3", "2"]);
+  });
+
+  it("collapses to a flat list when untagged is the only group", () => {
+    const sessions = [session({ fileName: "1" }), session({ fileName: "2" })];
+    const view = computeBrowserView(sessions, ROOT_NAV);
+    expect(view.folders).toEqual([]);
+    expect(view.sessions).toHaveLength(2);
+    expect(view.breadcrumb.map((b) => b.label)).toEqual(["All sessions", "Untagged"]);
+  });
+});
+
+describe("computeBrowserView — engine/kart filter", () => {
+  const sessions = [
+    session({ fileName: "1", trackName: "OKC", courseName: "CW", engine: "Rotax", kartId: "k1", kartName: "Kart 1" }),
+    session({ fileName: "2", trackName: "OKC", courseName: "CW", engine: "IAME", kartId: "k2", kartName: "Kart 2" }),
+    session({ fileName: "3", trackName: "OKC", courseName: "CW" }), // unconfigured
+  ];
+
+  it("builds a folder per engine with unconfigured logs below", () => {
+    const view = computeBrowserView(sessions, { track: "OKC", course: "CW", filter: "engine" });
+    expect(view.folders.map((f) => f.label)).toEqual(["IAME", "Rotax"]);
+    expect(view.folders.every((f) => f.kind === "engine")).toBe(true);
+    expect(view.sessions.map((s) => s.fileName)).toEqual(["3"]); // unconfigured loose
+    expect(view.filterMode).toBe("engine");
+  });
+
+  it("always shows the folder even with a single engine group", () => {
+    const single = [sessions[0], sessions[2]];
+    const view = computeBrowserView(single, { track: "OKC", course: "CW", filter: "engine" });
+    expect(view.folders.map((f) => f.label)).toEqual(["Rotax"]);
+    expect(view.sessions.map((s) => s.fileName)).toEqual(["3"]);
+  });
+
+  it("drills into one engine folder and shows just its logs", () => {
+    const view = computeBrowserView(sessions, {
+      track: "OKC", course: "CW", filter: "engine", filterValue: "Rotax",
+    });
+    expect(view.folders).toEqual([]);
+    expect(view.sessions.map((s) => s.fileName)).toEqual(["1"]);
+    expect(view.breadcrumb.at(-1)?.label).toBe("Rotax");
+  });
+
+  it("labels kart folders by name but keys by id", () => {
+    const view = computeBrowserView(sessions, { track: "OKC", course: "CW", filter: "kart" });
+    expect(view.folders.map((f) => f.label)).toEqual(["Kart 1", "Kart 2"]);
+    expect(view.folders.map((f) => f.key)).toEqual(["k1", "k2"]);
+  });
+});
+
+describe("computeBrowserView — stale nav", () => {
+  it("falls back to root when the track no longer exists", () => {
+    const sessions = [
+      session({ fileName: "1", trackName: "OKC", courseName: "CW" }),
+      session({ fileName: "2", trackName: "Daytona", courseName: "Nat" }),
+    ];
+    const view = computeBrowserView(sessions, { track: "Ghost", filter: "none" });
+    expect(view.folders.map((f) => f.label)).toEqual(["Daytona", "OKC"]);
+  });
+});
+
+describe("defaultNav", () => {
+  it("seeds from the current track/course", () => {
+    expect(defaultNav("OKC", "CW")).toEqual({ track: "OKC", course: "CW", filter: "none" });
+    expect(defaultNav("OKC", null)).toEqual({ track: "OKC", course: undefined, filter: "none" });
+    expect(defaultNav(null, null)).toEqual(ROOT_NAV);
+  });
+});

--- a/src/lib/fileBrowserTree.ts
+++ b/src/lib/fileBrowserTree.ts
@@ -1,0 +1,277 @@
+// Pure logic for the hierarchical file browser: Track → Course → logs, with an
+// optional Engine/Kart filter on the final list, breadcrumbs, and smart folder
+// collapsing ("clicking sucks" — only build a folder level when there's more
+// than one thing in it). No React / no IndexedDB so the tree + navigation math
+// stays unit-testable; the UI (FilesTab) just renders the computed view.
+
+import type { FileEntry, FileMetadata } from "./fileStorage";
+import type { Vehicle } from "./vehicleStorage";
+
+export type FilterMode = "none" | "engine" | "kart";
+
+/** Sentinel track key for the bucket of sessions with no track/course tag. */
+export const UNTAGGED_TRACK = "__UNTAGGED__";
+
+/** One log, flattened with everything the browser needs to group + label it. */
+export interface BrowserSession {
+  fileName: string;
+  /** Date/time label derived from the session's first valid sample. */
+  displayName: string;
+  savedAt: number;
+  startTime?: number;
+  trackName?: string;
+  courseName?: string;
+  /** Resolved engine string (frozen `sessionEngine`, else the live vehicle's). */
+  engine?: string;
+  kartId?: string;
+  kartName?: string;
+  fastestLapMs?: number;
+}
+
+/** Where the browser is currently pointing. */
+export interface NavState {
+  /** Track name, or UNTAGGED_TRACK, or undefined for the root. */
+  track?: string;
+  course?: string;
+  filter: FilterMode;
+  /** Selected engine string / kart id when drilled into a filter folder. */
+  filterValue?: string;
+}
+
+export const ROOT_NAV: NavState = { filter: "none" };
+
+export interface BrowserFolder {
+  kind: "track" | "course" | "engine" | "kart";
+  /** Raw grouping value (track/course name, engine string, or kart id). */
+  key: string;
+  label: string;
+  count: number;
+  /** Nav to apply when this folder is opened. */
+  nav: NavState;
+}
+
+export interface BreadcrumbSegment {
+  label: string;
+  /** Nav to apply when this crumb is clicked. */
+  nav: NavState;
+}
+
+export interface BrowserView {
+  breadcrumb: BreadcrumbSegment[];
+  /** Folders to render at the current level (may be empty). */
+  folders: BrowserFolder[];
+  /** Loose logs to render below the folders (the final list, or "unconfigured"). */
+  sessions: BrowserSession[];
+  /** Current filter — only meaningful (and `showFilter` true) at the log level. */
+  filterMode: FilterMode;
+  showFilter: boolean;
+}
+
+// ── Display name ─────────────────────────────────────────────────────────────
+
+/**
+ * The browser label for a session: the date + time of its first valid sample
+ * (e.g. "2/12/2026 11:15 AM"), independent of upload time. Falls back to the raw
+ * file name when no start time is known (older logs, before backfill).
+ */
+export function formatSessionDisplayName(
+  startTime: number | undefined,
+  fileName: string,
+): string {
+  if (startTime == null || !Number.isFinite(startTime)) return fileName;
+  const d = new Date(startTime);
+  const date = `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+  let h = d.getHours();
+  const ampm = h < 12 ? "AM" : "PM";
+  h = h % 12;
+  if (h === 0) h = 12;
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${date} ${h}:${mm} ${ampm}`;
+}
+
+// ── Building the session list ────────────────────────────────────────────────
+
+/** Flatten stored files + their metadata + the vehicle list into BrowserSessions. */
+export function buildBrowserSessions(
+  files: FileEntry[],
+  metaMap: Map<string, FileMetadata>,
+  vehicles: Vehicle[],
+): BrowserSession[] {
+  const vehiclesById = new Map(vehicles.map((v) => [v.id, v]));
+  return files.map((f) => {
+    const meta = metaMap.get(f.name);
+    const vehicle = meta?.sessionKartId ? vehiclesById.get(meta.sessionKartId) : undefined;
+    // Prefer the frozen engine snapshot; fall back to the live vehicle's engine.
+    const engineRaw = meta?.sessionEngine ?? vehicle?.engine;
+    const engine = engineRaw?.trim() || undefined;
+    return {
+      fileName: f.name,
+      displayName: formatSessionDisplayName(meta?.sessionStartTime, f.name),
+      savedAt: f.savedAt,
+      startTime: meta?.sessionStartTime,
+      trackName: meta?.trackName?.trim() || undefined,
+      courseName: meta?.courseName?.trim() || undefined,
+      engine,
+      kartId: meta?.sessionKartId || undefined,
+      kartName: vehicle?.name,
+      fastestLapMs: meta?.fastestLapMs,
+    };
+  });
+}
+
+// ── Navigation / view computation ────────────────────────────────────────────
+
+/** Newest first (by session start, falling back to save time). */
+function sortLogs(sessions: BrowserSession[]): BrowserSession[] {
+  return [...sessions].sort((a, b) => (b.startTime ?? b.savedAt) - (a.startTime ?? a.savedAt));
+}
+
+/** A session belongs in the tree only when it has both a track and a course. */
+function isTagged(s: BrowserSession): boolean {
+  return !!s.trackName && !!s.courseName;
+}
+
+function distinctSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+interface TopGroup {
+  key: string;
+  label: string;
+  sessions: BrowserSession[];
+}
+
+/** Top-level groups: one per track (alpha), then an "Untagged" bucket if needed. */
+function topLevelGroups(sessions: BrowserSession[]): TopGroup[] {
+  const tagged = sessions.filter(isTagged);
+  const untagged = sessions.filter((s) => !isTagged(s));
+  const groups: TopGroup[] = distinctSorted(tagged.map((s) => s.trackName!)).map((track) => ({
+    key: track,
+    label: track,
+    sessions: tagged.filter((s) => s.trackName === track),
+  }));
+  if (untagged.length > 0) {
+    groups.push({ key: UNTAGGED_TRACK, label: "Untagged", sessions: untagged });
+  }
+  return groups;
+}
+
+/** Build the log-level view (final list or engine/kart filter folders). */
+function logsView(
+  set: BrowserSession[],
+  nav: NavState,
+  breadcrumb: BreadcrumbSegment[],
+): BrowserView {
+  const filterMode = nav.filter;
+  if (filterMode === "none") {
+    return { breadcrumb, folders: [], sessions: sortLogs(set), filterMode, showFilter: true };
+  }
+
+  const keyOf = (s: BrowserSession) => (filterMode === "engine" ? s.engine : s.kartId);
+  const labelOf = (s: BrowserSession) =>
+    filterMode === "engine" ? s.engine! : s.kartName || s.kartId!;
+
+  // Drilled into one specific engine/kart folder → show just its logs.
+  if (nav.filterValue != null) {
+    const inside = set.filter((s) => keyOf(s) === nav.filterValue);
+    const label = inside[0] ? labelOf(inside[0]) : nav.filterValue;
+    return {
+      breadcrumb: [...breadcrumb, { label, nav }],
+      folders: [],
+      sessions: sortLogs(inside),
+      filterMode,
+      showFilter: true,
+    };
+  }
+
+  // Group configured logs into folders (always shown, even a single group), with
+  // unconfigured logs (no engine/kart) listed loosely below.
+  const configured = set.filter((s) => keyOf(s));
+  const unconfigured = set.filter((s) => !keyOf(s));
+  const keys = distinctSorted(configured.map((s) => keyOf(s)!));
+  const folders: BrowserFolder[] = keys.map((key) => {
+    const group = configured.filter((s) => keyOf(s) === key);
+    return {
+      kind: filterMode,
+      key,
+      label: labelOf(group[0]),
+      count: group.length,
+      nav: { ...nav, filterValue: key },
+    };
+  });
+  return { breadcrumb, folders, sessions: sortLogs(unconfigured), filterMode, showFilter: true };
+}
+
+/**
+ * Resolve the current navigation into a renderable view. Levels with a single
+ * entry auto-collapse (we descend through them, still recording the breadcrumb),
+ * so the user only sees folders where there's a real choice to make. Stale nav
+ * (a track/course that no longer exists) gracefully falls back toward the root.
+ */
+export function computeBrowserView(sessions: BrowserSession[], nav: NavState): BrowserView {
+  const groups = topLevelGroups(sessions);
+  const breadcrumb: BreadcrumbSegment[] = [{ label: "All sessions", nav: ROOT_NAV }];
+
+  // ── Track level ──
+  let effTrack = nav.track;
+  let group = effTrack ? groups.find((g) => g.key === effTrack) : undefined;
+  if (effTrack && !group) effTrack = undefined; // stale → behave as root
+
+  if (!effTrack) {
+    if (groups.length === 0) {
+      return { breadcrumb, folders: [], sessions: [], filterMode: "none", showFilter: false };
+    }
+    if (groups.length > 1) {
+      const folders: BrowserFolder[] = groups.map((g) => ({
+        kind: "track",
+        key: g.key,
+        label: g.label,
+        count: g.sessions.length,
+        nav: { track: g.key, filter: "none" },
+      }));
+      return { breadcrumb, folders, sessions: [], filterMode: "none", showFilter: false };
+    }
+    effTrack = groups[0].key; // single track → collapse into it
+    group = groups[0];
+  }
+  group = group ?? groups.find((g) => g.key === effTrack)!;
+  breadcrumb.push({ label: group.label, nav: { track: effTrack, filter: "none" } });
+
+  // Untagged bucket has no course level → straight to logs.
+  if (effTrack === UNTAGGED_TRACK) {
+    return logsView(group.sessions, nav, breadcrumb);
+  }
+
+  // ── Course level ──
+  const courses = distinctSorted(group.sessions.map((s) => s.courseName!));
+  let effCourse = nav.course;
+  if (effCourse && !courses.includes(effCourse)) effCourse = undefined; // stale
+
+  if (!effCourse) {
+    if (courses.length > 1) {
+      const folders: BrowserFolder[] = courses.map((c) => ({
+        kind: "course",
+        key: c,
+        label: c,
+        count: group!.sessions.filter((s) => s.courseName === c).length,
+        nav: { track: effTrack, course: c, filter: "none" },
+      }));
+      return { breadcrumb, folders, sessions: [], filterMode: "none", showFilter: false };
+    }
+    if (courses.length === 0) return logsView(group.sessions, nav, breadcrumb);
+    effCourse = courses[0]; // single course → collapse into it
+  }
+  // Clicking this crumb returns to the course's folder grid, keeping the filter.
+  breadcrumb.push({
+    label: effCourse,
+    nav: { track: effTrack, course: effCourse, filter: nav.filter },
+  });
+  const courseSessions = group.sessions.filter((s) => s.courseName === effCourse);
+  return logsView(courseSessions, nav, breadcrumb);
+}
+
+/** Seed nav from the currently-loaded session's track/course (compute collapses). */
+export function defaultNav(currentTrack?: string | null, currentCourse?: string | null): NavState {
+  if (!currentTrack) return ROOT_NAV;
+  return { track: currentTrack, course: currentCourse ?? undefined, filter: "none" };
+}

--- a/src/lib/fileStorage.ts
+++ b/src/lib/fileStorage.ts
@@ -24,6 +24,12 @@ export interface FileMetadata {
   // Immutable revision (content hash) of the setup as it was when assigned, so
   // this session keeps the exact setup it ran even if the live one is edited.
   sessionSetupRev?: string;
+  // Engine string snapshot (resolved from the kart at assign time), so the file
+  // browser can group by engine even if the vehicle is later edited or deleted.
+  sessionEngine?: string;
+  // Epoch ms of the first valid GPS sample (the session's true start), used for
+  // the browser's date/time display name — independent of when it was uploaded.
+  sessionStartTime?: number;
   // Fastest lap cache
   fastestLapMs?: number;
   fastestLapNumber?: number;
@@ -125,6 +131,28 @@ export async function saveFileMetadata(meta: FileMetadata): Promise<void> {
   } catch (e) {
     console.warn("Failed to save file metadata:", e);
   }
+}
+
+/**
+ * Read-merge-write one file's metadata: applies `patch` over the existing record
+ * (or a fresh one), preserving every untouched field. Use this for all partial
+ * updates so a write that only cares about, say, the fastest lap can't clobber
+ * the track/course/kart/setup tags. Returns the merged record.
+ */
+export async function updateFileMetadata(
+  fileName: string,
+  patch: Partial<Omit<FileMetadata, "fileName">>,
+): Promise<FileMetadata> {
+  const existing = await getFileMetadata(fileName);
+  const merged: FileMetadata = {
+    ...(existing ?? {}),
+    ...patch,
+    fileName,
+    trackName: patch.trackName ?? existing?.trackName ?? "",
+    courseName: patch.courseName ?? existing?.courseName ?? "",
+  };
+  await saveFileMetadata(merged);
+  return merged;
 }
 
 export async function getFileMetadata(fileName: string): Promise<FileMetadata | null> {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -194,9 +194,12 @@ export default function Index() {
 
   // Assigning an engine/setup may set a new course fastest lap → prompt to save.
   const handleSaveSessionSetupWithSnapshot = useCallback(async (kartId: string | null, setupId: string | null) => {
-    await sessionMeta.handleSaveSessionSetup(kartId, setupId);
+    // Snapshot the engine string for the file browser's engine grouping, so it
+    // survives later edits/deletes of the vehicle.
+    const engine = kartId ? vehicleManager.vehicles.find((v) => v.id === kartId)?.engine ?? null : null;
+    await sessionMeta.handleSaveSessionSetup(kartId, setupId, engine);
     snapshots.maybePromptOnAssignment(kartId, setupId);
-  }, [sessionMeta, snapshots]);
+  }, [sessionMeta, snapshots, vehicleManager.vehicles]);
 
   // Clearing the shared reference slot (e.g. the ExternalRefBar X) must also drop
   // the active snapshot, since a loaded snapshot rides that same slot.
@@ -391,6 +394,8 @@ export default function Index() {
     onGetLatestSetupForVehicle: setupManager.getLatestForVehicle,
     onAddVehicleType: templateManager.addVehicleType,
     onRemoveVehicleType: templateManager.removeVehicleType,
+    currentTrackName: lapMgmt.selection?.trackName ?? null,
+    currentCourseName: lapMgmt.selection?.courseName ?? null,
     sessionKartId,
     sessionSetupId,
     sessionSetupRev,
@@ -404,7 +409,7 @@ export default function Index() {
     currentFileName,
     noteManager.notes, noteManager.addNote, noteManager.updateNote, noteManager.removeNote,
     setupManager.setups, setupManager.addSetup, setupManager.updateSetup, setupManager.removeSetup, setupManager.getLatestForVehicle,
-    sessionKartId, sessionSetupId, sessionSetupRev, handleSaveSessionSetupWithSnapshot,
+    lapMgmt.selection, sessionKartId, sessionSetupId, sessionSetupRev, handleSaveSessionSetupWithSnapshot,
   ]);
 
   // No data loaded - show import UI


### PR DESCRIPTION
## Why

The Files tab was a flat list of raw filenames sorted by upload time — hard to navigate and impossible to tell sessions apart. This reorganizes it into a folder hierarchy with friendly date/time names, so logs are actually findable.

## What

**Track → Course → logs**, with breadcrumbs and an Engine/Kart filter on the final list.

- **Display name = session date/time.** Derived from the *first valid GPS sample* (e.g. "2/12/2026 11:15 AM"), independent of upload time. The raw filename stays as the row tooltip + the stable IndexedDB key (no risky key rename).
- **Smart collapse.** A folder level only renders when there's a real choice — a single track and/or single course auto-descends straight to the logs, with a **breadcrumb** always recording the path so date-named rows read in context.
- **Engine/Kart filter** (None/Engine/Kart) on the final list. The filter folder is **always shown when active** (even a single group), with **unconfigured logs loose below** the folders.
- **"Untagged" bucket** for logs with no track/course (waypoint-mode / never-confirmed), after the real tracks (collapses to a flat list when it's the only group).
- **Opens at the current session.** The browser re-homes to the loaded session's track/course on every drawer open and whenever a different session loads.

## How

- **`lib/fileBrowserTree.ts`** — all the tree + navigation math, pure (no React / IndexedDB) and **fully unit-tested** (17 cases): build sessions, compute the view, collapse, filter folders, breadcrumbs, untagged bucket, display-name formatting, engine/kart resolution, stale-nav fallback.
- **`FilesTab.tsx`** — rewritten to render the computed `BrowserView`. All existing plugin mount points (cloud-sync per-row toggle, delete-confirm hook, footer, section) preserved.
- **`FileMetadata`** gained `sessionStartTime` (→ display name; backfilled on load for older logs) and `sessionEngine` (engine snapshot taken at kart-assign, so grouping survives later vehicle edits/deletes).
- **`fileStorage.updateFileMetadata(fileName, patch)`** — one read-merge-write helper. Routing the scattered metadata writers (track/course tag, fastest lap, weather, kart/setup) through it **fixes a latent bug** where a partial write could silently drop other saved tags.
- `useDataLoader` backfills `sessionStartTime` for logs saved before this existed.

## Notes / possible follow-ups

- Display names use the **device's local time**, not the track's timezone.
- Names are **computed**, not editable — a manual "rename session" is an easy follow-up if wanted.
- Session **tagging by setup `#hash`** in the browser (from the earlier setup-revisions work) is now straightforward to add on top of this.

## Verification

All green: `lint`, `typecheck`, `test:run` (**785** pass, 48 files, +17 new), `build`, and coverage thresholds (which ticked up).

https://claude.ai/code/session_01L2F5uU88qyMDBz9dCHVFjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2F5uU88qyMDBz9dCHVFjx)_