### PR TITLE
fix(supabase): make cloud-sync policy migrations idempotent

### DIFF
--- a/supabase/migrations/20260524120000_cloud_sync.sql
+++ b/supabase/migrations/20260524120000_cloud_sync.sql
@@ -23,19 +23,23 @@ create index if not exists sync_records_user_store_idx
 
 alter table public.sync_records enable row level security;
 
+drop policy if exists "Users read own sync records" on public.sync_records;
 create policy "Users read own sync records"
   on public.sync_records for select to authenticated
   using (auth.uid() = user_id);
 
+drop policy if exists "Users insert own sync records" on public.sync_records;
 create policy "Users insert own sync records"
   on public.sync_records for insert to authenticated
   with check (auth.uid() = user_id);
 
+drop policy if exists "Users update own sync records" on public.sync_records;
 create policy "Users update own sync records"
   on public.sync_records for update to authenticated
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
 
+drop policy if exists "Users delete own sync records" on public.sync_records;
 create policy "Users delete own sync records"
   on public.sync_records for delete to authenticated
   using (auth.uid() = user_id);
@@ -45,6 +49,7 @@ insert into storage.buckets (id, name, public)
 values ('user-files', 'user-files', false)
 on conflict (id) do nothing;
 
+drop policy if exists "Users read own files" on storage.objects;
 create policy "Users read own files"
   on storage.objects for select to authenticated
   using (
@@ -52,6 +57,7 @@ create policy "Users read own files"
     and (storage.foldername(name))[1] = auth.uid()::text
   );
 
+drop policy if exists "Users upload own files" on storage.objects;
 create policy "Users upload own files"
   on storage.objects for insert to authenticated
   with check (
@@ -59,6 +65,7 @@ create policy "Users upload own files"
     and (storage.foldername(name))[1] = auth.uid()::text
   );
 
+drop policy if exists "Users update own files" on storage.objects;
 create policy "Users update own files"
   on storage.objects for update to authenticated
   using (
@@ -66,6 +73,7 @@ create policy "Users update own files"
     and (storage.foldername(name))[1] = auth.uid()::text
   );
 
+drop policy if exists "Users delete own files" on storage.objects;
 create policy "Users delete own files"
   on storage.objects for delete to authenticated
   using (

--- a/supabase/migrations/20260524185344_7111be94-4e12-476e-abfb-5f3716a856cb.sql
+++ b/supabase/migrations/20260524185344_7111be94-4e12-476e-abfb-5f3716a856cb.sql
@@ -14,19 +14,23 @@ create index if not exists sync_records_user_store_idx
 
 alter table public.sync_records enable row level security;
 
+drop policy if exists "Users read own sync records" on public.sync_records;
 create policy "Users read own sync records"
   on public.sync_records for select to authenticated
   using (auth.uid() = user_id);
 
+drop policy if exists "Users insert own sync records" on public.sync_records;
 create policy "Users insert own sync records"
   on public.sync_records for insert to authenticated
   with check (auth.uid() = user_id);
 
+drop policy if exists "Users update own sync records" on public.sync_records;
 create policy "Users update own sync records"
   on public.sync_records for update to authenticated
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
 
+drop policy if exists "Users delete own sync records" on public.sync_records;
 create policy "Users delete own sync records"
   on public.sync_records for delete to authenticated
   using (auth.uid() = user_id);
@@ -36,6 +40,7 @@ insert into storage.buckets (id, name, public)
 values ('user-files', 'user-files', false)
 on conflict (id) do nothing;
 
+drop policy if exists "Users read own files" on storage.objects;
 create policy "Users read own files"
   on storage.objects for select to authenticated
   using (
@@ -43,6 +48,7 @@ create policy "Users read own files"
     and (storage.foldername(name))[1] = auth.uid()::text
   );
 
+drop policy if exists "Users upload own files" on storage.objects;
 create policy "Users upload own files"
   on storage.objects for insert to authenticated
   with check (
@@ -50,6 +56,7 @@ create policy "Users upload own files"
     and (storage.foldername(name))[1] = auth.uid()::text
   );
 
+drop policy if exists "Users update own files" on storage.objects;
 create policy "Users update own files"
   on storage.objects for update to authenticated
   using (
@@ -57,6 +64,7 @@ create policy "Users update own files"
     and (storage.foldername(name))[1] = auth.uid()::text
   );
 
+drop policy if exists "Users delete own files" on storage.objects;
 create policy "Users delete own files"
   on storage.objects for delete to authenticated
   using (


### PR DESCRIPTION
## What

Fixes the Supabase auto-deploy failure:

```
ERROR: policy "Users read own sync records" for table "sync_records" already exists (SQLSTATE 42710)
At statement: 3
```

## Root cause

Two cloud-sync migrations are near-identical duplicates and both issued **bare** `create policy` for the same 8 policies (4 on `public.sync_records`, 4 on `storage.objects`):

- `20260524120000_cloud_sync.sql`
- `20260524185344_7111be94-…sql`

On a fresh replay, the first migration creates the policies and the second fails at statement 3 with `42710 (already exists)`. The later rollup `20260528001943` already guards these with `if not exists`, but these two earlier files did not.

## Fix

Added `drop policy if exists …` before each `create policy` in both files (8 guards each), matching the idempotent pattern the `20260528001943` rollup already uses. The two migrations are now self-idempotent and replay cleanly. **No change to the resulting policy set.**

## RLS audit (context)

This branch was also used for a full RLS audit of the migration set. Summary:

- ✅ All **16** created tables have `ENABLE ROW LEVEL SECURITY` — no unprotected table.
- ✅ All user-scoped tables (`sync_records`, `profiles`, `user_subscriptions`, `account_deletions`, `lap_snapshots`) are owner-scoped via `auth.uid() = user_id`, with matching `WITH CHECK` on UPDATE.
- ✅ Every surviving `SECURITY DEFINER` function pins `search_path`. The only unpinned survivor (`touch_lap_snapshot`) is not `SECURITY DEFINER` and references no schema objects.
- ℹ️ `profiles` / `subscription_tiers` broad reads are intentional (public display names / public pricing catalog).
- ℹ️ GDPR `purge_expired_personal_data` predicate drift was introduced in `20260528001943` and already corrected in `20260531010000` — noted, no action needed.

No RLS gaps found in the final schema; this PR only resolves the deploy blocker.

https://claude.ai/code/session_01LNAofcjhRmFv51ZYJoCX9k

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNAofcjhRmFv51ZYJoCX9k)_