### PR TITLE
fix(supabase): align 20260528001943 function signatures to applied schema

### DIFF
--- a/supabase/migrations/20260528001943_16457d28-551f-4461-8d65-5b560a70e018.sql
+++ b/supabase/migrations/20260528001943_16457d28-551f-4461-8d65-5b560a70e018.sql
@@ -272,22 +272,22 @@ grant all on public.user_subscriptions to service_role;
 drop policy if exists "Users read own subscription" on public.user_subscriptions;
 create policy "Users read own subscription" on public.user_subscriptions for select to authenticated using (auth.uid() = user_id);
 
-create or replace function public.user_tier(p_user_id uuid)
+create or replace function public.user_tier(p_user uuid)
 returns text language sql stable security definer set search_path = public as $$
   select coalesce(
     (select tier from public.user_subscriptions
-      where user_id = p_user_id
+      where user_id = p_user
         and status in ('active','trialing','past_due')),
     'free');
 $$;
 
 grant execute on function public.user_tier(uuid) to authenticated;
 
-create or replace function public.tier_limit(p_user_id uuid, p_type text)
+create or replace function public.tier_limit(p_user uuid, p_type text)
 returns bigint language sql stable security definer set search_path = public as $$
   select coalesce(
     (select case p_type when 'logs' then logs_bytes when 'documents' then doc_bytes end
-       from public.subscription_tiers where tier = public.user_tier(p_user_id)),
+       from public.subscription_tiers where tier = public.user_tier(p_user)),
     (select case p_type when 'logs' then logs_bytes when 'documents' then doc_bytes end
        from public.subscription_tiers where tier = 'free'),
     (select max_bytes from public.quota_limits where storage_type = p_type));
@@ -363,13 +363,13 @@ create policy "Users read own deletion" on public.account_deletions for select t
 drop policy if exists "Users cancel own deletion" on public.account_deletions;
 create policy "Users cancel own deletion" on public.account_deletions for delete to authenticated using (auth.uid() = user_id);
 
-create or replace function public.encode_uri_component(p text)
+create or replace function public.encode_uri_component(p_text text)
 returns text language sql immutable as $$
   select string_agg(
     case when c ~ '[A-Za-z0-9\-_.!~*''()]' then c
          else regexp_replace(encode(convert_to(c,'UTF8'),'hex'),'(..)','%\1','g') end,
     '')
-  from regexp_split_to_table(p, '') as c;
+  from regexp_split_to_table(p_text, '') as c;
 $$;
 
 create or replace function public.purge_expired_personal_data()
@@ -387,7 +387,7 @@ end;
 $$;
 
 create or replace function public.due_account_deletions()
-returns table(user_id uuid) language sql stable security definer set search_path = public as $$
+returns setof uuid language sql stable security definer set search_path = public as $$
   select user_id from public.account_deletions where scheduled_for <= now();
 $$;
 
@@ -398,6 +398,10 @@ alter table public.user_subscriptions
   add column if not exists grace_until timestamptz,
   add column if not exists logs_trimmed_at timestamptz;
 
+-- Drop first: the incremental 20260528000000 migration already created this
+-- with `returns integer`, and create-or-replace cannot change a return type.
+-- A later migration (20260529105524) re-establishes the integer-returning form.
+drop function if exists public.trim_expired_logs();
 create or replace function public.trim_expired_logs()
 returns void language plpgsql security definer set search_path = public as $$
 declare


### PR DESCRIPTION
## What

Second deploy-blocker in the same migration. After the policy fix (#103) let the replay get further, it now dies on:

```
ERROR: cannot change name of input parameter "p_user" (SQLSTATE 42P13)
At statement: 51
create or replace function public.user_tier(p_user_id uuid) ...
```

## Root cause

`20260528001943` is a full-schema **snapshot** migration applied *on top of* the incremental migrations that already created these functions. `create or replace function` **cannot change a parameter name or a return type**, so every signature drift is a hard error. I found and fixed all of them in this migration:

| Function | Conflict | Fix |
|---|---|---|
| `user_tier` | param `p_user` → `p_user_id` | revert to `p_user` (matches `20260526000000`) |
| `tier_limit` | param `p_user` → `p_user_id` | revert to `p_user` (matches `20260526000000`) |
| `encode_uri_component` | param `p_text` → `p` | revert to `p_text` (matches `20260528000000`) |
| `due_account_deletions` | `returns setof uuid` → `returns table(user_id uuid)` | revert to `setof uuid` |
| `trim_expired_logs` | `returns integer` → `returns void` | `drop function if exists` before create |

## ⚠️ Notable: `due_account_deletions` would have broken account deletion

The `process-account-deletions` edge function reads the RPC result as a **`string[]` of UUIDs**:

```ts
const userIds = (due ?? []) as string[];
for (const userId of userIds) { await admin.auth.admin.deleteUser(userId); }
```

That's the `returns setof uuid` shape. The snapshot's `returns table(user_id uuid)` would make PostgREST return `[{ user_id: … }]` objects, so `deleteUser(userId)` would receive an object and the deletion worker would silently fail. Reverting to `setof uuid` both unblocks the deploy **and** keeps the edge function correct.

## Final schema unchanged

- `user_tier` / `encode_uri_component` / `due_account_deletions` settle on the signatures already in the DB.
- `tier_limit` is dropped later (`20260601000000`); `trim_expired_logs` is re-established as `returns integer` by `20260529105524`.

I also swept the rest of the migration set for other replay hazards — `create type`, triggers, indexes, `add column` — and they're all either guarded (`if not exists` / `drop … if exists`) or single-occurrence. No further conflicts found.

https://claude.ai/code/session_01LNAofcjhRmFv51ZYJoCX9k

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNAofcjhRmFv51ZYJoCX9k)_