### PR TITLE
security(supabase): explicit deny-all RLS policy on stripe_events + full security sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Explicit deny-all RLS policy on `stripe_events`.** The Stripe webhook
+  idempotency ledger had row-level security enabled but no policy. Direct client
+  access was already denied (only the service role, which bypasses RLS, writes to
+  it), but Supabase's database linter flagged it as `rls_enabled_no_policy`. It now
+  carries an explicit `FOR ALL ... USING (false)` deny-all policy plus a table
+  comment, matching the existing `login_attempts` service-role-only pattern —
+  self-documenting defense-in-depth, no behavioural change. A full sweep confirmed
+  every table has RLS enabled with appropriate policies, every `SECURITY DEFINER`
+  function pins `search_path`, and each edge function enforces its own auth.
+
 ### Fixed
 - **Active subscription no longer reads as "Free".** The Stripe webhook could
   resolve an entitling subscription (active/trialing/past_due) down to the free

--- a/supabase/migrations/20260603000000_stripe_events_deny_policy.sql
+++ b/supabase/migrations/20260603000000_stripe_events_deny_policy.sql
@@ -1,0 +1,26 @@
+-- Make stripe_events' "service-role only" posture explicit.
+--
+-- stripe_events (the webhook idempotency / replay-protection ledger) has RLS
+-- enabled but no policy. That is already deny-all for every non-service role —
+-- the service role bypasses RLS, so the stripe-webhook function still works —
+-- but Supabase's database linter flags it as `rls_enabled_no_policy`, and an
+-- empty policy list reads as "someone forgot to add policies" rather than
+-- "this is intentional".
+--
+-- This mirrors the existing login_attempts pattern (20260213210008): an explicit
+-- FOR ALL ... USING (false) WITH CHECK (false) policy for authenticated + anon,
+-- plus a table comment. No behavioural change — direct client access was already
+-- denied — but the intent is now self-documenting and the linter warning clears.
+
+drop policy if exists "Deny all direct access to stripe_events" on public.stripe_events;
+create policy "Deny all direct access to stripe_events"
+  on public.stripe_events
+  for all
+  to authenticated, anon
+  using (false)
+  with check (false);
+
+comment on table public.stripe_events is
+  'Service role only - written exclusively by the stripe-webhook edge function for event idempotency. RLS enabled with an explicit deny-all policy as defense-in-depth.';
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Addresses the Supabase advisory that the Stripe table "has no policies" and documents a full RLS / edge-function security sweep.

The flagged table is **`stripe_events`** (the webhook idempotency ledger). It had RLS *enabled* but *no policy* — which is already deny-all to clients (the service role used by the webhook bypasses RLS), so this was a documentation/linter gap, not an exploit. Supabase's database linter reports it as `rls_enabled_no_policy`, and an empty policy list reads as an oversight rather than intent.

## Change

New migration `20260603000000_stripe_events_deny_policy.sql` adds an explicit `FOR ALL ... USING (false) WITH CHECK (false)` deny-all policy for `authenticated` + `anon` plus a table comment — mirroring the existing `login_attempts` service-role-only pattern (`20260213210008`). **No behavioural change**; the linter warning clears and the intent is self-documenting.

## Full sweep results — clean

| Area | Finding |
|------|---------|
| **RLS coverage** | All 16 `public` tables have RLS enabled |
| **Policies** | User tables scoped `auth.uid() = user_id`; admin tables gated on `has_role(..., 'admin')`; service-role-only tables (`login_attempts`, `stripe_events`) deny-all |
| **`SECURITY DEFINER` fns** | All pin `set search_path` — no search-path hijack vector |
| **Stripe webhook** | Verifies Stripe signature via `constructEventAsync` before any work; dedups on `stripe_events`; releases claim on failure |
| **Edge functions** | `verify_jwt=false` globally, but each enforces its own auth: user fns validate JWT via `getUser()`; `admin-build-zip` also checks the admin role (403); `process-account-deletions` is cron-only via `x-cron-secret` (403) |
| **`profiles` public read** | Intentional and safe — only holds a display name |

### Minor observation (not addressed, no behaviour change)
`subscription_tiers` carries two overlapping SELECT policies from different migrations ("Anyone authenticated reads tiers" and "Tiers readable by all"). They're permissive/OR'd and the net effect — public pricing readable by all — is intended. Left alone; can consolidate to a single policy on request.

## Testing
SQL migration + CHANGELOG only — no TypeScript or build paths touched.

https://claude.ai/code/session_01Ez7kiYzdK1gZJh61te1NkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ez7kiYzdK1gZJh61te1NkH)_