### PR TITLE
feat(auth): gate Google sign-in behind a flag (off by default) until native Supabase OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,15 @@ VITE_SUPABASE_URL="https://your-project.supabase.co"
 # HTT_SUPABASE_URL=""
 
 # --- Feature flags -----------------------------------------------------------
-# Set to "true" to enable public user accounts (Cloud Sync, Google sign-in,
+# Set to "true" to enable public user accounts (Cloud Sync, email sign-in,
 # /register, /forgot-password, /reset-password, /auth/callback).
 VITE_ENABLE_CLOUD="true"
 # HTT_ENABLE_CLOUD="true"
+
+# Set to "true" to show the "Continue with Google" buttons. Requires
+# VITE_ENABLE_CLOUD. Left off until native Supabase Google OAuth is configured —
+# Google sign-in currently routes through Lovable's hosted OAuth broker.
+# VITE_ENABLE_GOOGLE_AUTH="true"
 
 # Set to "true" to enable the admin panel (/admin route, login UI).
 # Defaults ON so fresh builds get the full feature set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you save** versus paying monthly (prices fetched live from Stripe).
 
 ### Changed
+- **Google sign-in temporarily hidden.** The "Continue with Google" buttons (login,
+  register, Profile) are now gated behind a new `VITE_ENABLE_GOOGLE_AUTH` flag,
+  off by default. Google sign-in still routes through Lovable's hosted OAuth broker,
+  so it stays hidden until native Supabase Google OAuth is configured. Email
+  sign-in/registration is unaffected. Flip the flag back on once the Supabase Google
+  provider + Google Cloud OAuth client are set up.
 - **Simpler sign-up.** The display-name field is gone — accounts get a random name
   you can change (and reserve) later from your profile. Display names now pass a
   **basic profanity filter**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,7 +600,8 @@ existing user data keeps resolving without a destructive migration.
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | Client | Backend anon key (auto-set) |
 | `VITE_SUPABASE_PROJECT_ID` | Client | Backend project ID (auto-set) |
 | `VITE_ENABLE_ADMIN` | Client | `"true"` to enable admin UI + `/admin` route. `/login` is also mounted when this OR `VITE_ENABLE_CLOUD` is on. |
-| `VITE_ENABLE_CLOUD` | Client | `"true"` to enable public user accounts (Cloud Sync + Google sign-in + `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`). Default `"false"` — preserves offline-first invariant. |
+| `VITE_ENABLE_CLOUD` | Client | `"true"` to enable public user accounts (Cloud Sync + email sign-in + `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`). Default `"false"` — preserves offline-first invariant. |
+| `VITE_ENABLE_GOOGLE_AUTH` | Client | `"true"` to show the "Continue with Google" buttons (Login/Register/Profile). Requires `VITE_ENABLE_CLOUD`. Default `"false"`: Google sign-in still routes through Lovable's OAuth broker (`src/integrations/lovable/`), so it's gated off until native Supabase Google OAuth is wired up. |
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `DOVE_PLUGIN_PACKAGES` | Build | Comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`) when set |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ The app includes an optional admin system for managing a community track databas
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | Yes (if using Cloud) | Backend public/anon key (auto-set by Lovable Cloud) |
 | `VITE_SUPABASE_PROJECT_ID` | Yes (if using Cloud) | Backend project ID (auto-set by Lovable Cloud) |
 | `VITE_ENABLE_ADMIN` | No | Set to `true` to enable admin UI and `/admin` route. `/login` mounts when admin OR cloud is enabled. Default `false` — a fresh clone ships the public, offline-first app, not admin UI pointed at an upstream backend. |
-| `VITE_ENABLE_CLOUD` | No | Set to `true` to enable public user accounts: Cloud Sync Labs panel, Google sign-in, `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`. Default `false` — flag-off builds ship zero cloud auth code (offline-first invariant). |
+| `VITE_ENABLE_CLOUD` | No | Set to `true` to enable public user accounts: Cloud Sync Labs panel, email sign-in/registration, `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`. Default `false` — flag-off builds ship zero cloud auth code (offline-first invariant). |
+| `VITE_ENABLE_GOOGLE_AUTH` | No | Set to `true` to show the "Continue with Google" buttons (login, register, Profile). Requires `VITE_ENABLE_CLOUD`. Default `false`: Google sign-in currently routes through Lovable's hosted OAuth broker, so it stays hidden until native Supabase Google OAuth is configured (Google Cloud OAuth client + Supabase provider). |
 | `VITE_TURNSTILE_SITE_KEY` | No | Cloudflare Turnstile site key for track submission CAPTCHA |
 | `TURNSTILE_SECRET_KEY` | No | Cloudflare Turnstile secret key (edge function secret — `???`) |
 | `STRIPE_SECRET_KEY` | No (required for paid tiers) | Stripe secret key used by the `create-checkout-session`, `stripe-webhook`, and `create-portal-session` edge functions (edge function secret — `???`) |

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,6 +10,9 @@ import { Gauge, ArrowLeft } from 'lucide-react';
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
+// Google sign-in is gated separately: it currently routes through Lovable's OAuth
+// broker, so it stays off until native Supabase Google OAuth is configured.
+const enableGoogleAuth = import.meta.env.VITE_ENABLE_GOOGLE_AUTH === 'true';
 
 export default function Login() {
   useDocumentHead({
@@ -69,7 +72,7 @@ export default function Login() {
         <div className="racing-card p-6 space-y-4">
           <h2 className="text-lg font-semibold text-foreground">Sign in</h2>
 
-          {enableCloud && (
+          {enableCloud && enableGoogleAuth && (
             <>
               <Button type="button" variant="outline" className="w-full" onClick={handleGoogle} disabled={isLoading}>
                 Continue with Google

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -15,6 +15,10 @@ import { isDisposableEmail, looksLikeEmail } from '@/lib/emailValidation';
 import { isPaidTier } from '@/lib/billing';
 import { setPendingCheckout } from '@/lib/pendingCheckout';
 
+// Google sign-in is gated separately: it currently routes through Lovable's OAuth
+// broker, so it stays off until native Supabase Google OAuth is configured.
+const enableGoogleAuth = import.meta.env.VITE_ENABLE_GOOGLE_AUTH === 'true';
+
 export default function Register() {
   useDocumentHead({
     title: 'Create account — HackTheTrack',
@@ -145,14 +149,18 @@ export default function Register() {
             </div>
           </form>
 
-          <div className="relative flex items-center">
-            <div className="flex-grow border-t border-border" />
-            <span className="mx-3 text-xs text-muted-foreground">or</span>
-            <div className="flex-grow border-t border-border" />
-          </div>
-          <Button type="button" variant="outline" className="w-full" onClick={handleGoogle} disabled={isLoading}>
-            Continue with Google
-          </Button>
+          {enableGoogleAuth && (
+            <>
+              <div className="relative flex items-center">
+                <div className="flex-grow border-t border-border" />
+                <span className="mx-3 text-xs text-muted-foreground">or</span>
+                <div className="flex-grow border-t border-border" />
+              </div>
+              <Button type="button" variant="outline" className="w-full" onClick={handleGoogle} disabled={isLoading}>
+                Continue with Google
+              </Button>
+            </>
+          )}
 
           <p className="text-sm text-muted-foreground text-center">
             Already have an account?{' '}

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -31,6 +31,10 @@ const SEGMENTS: { key: StorageType; label: string; color: string }[] = [
   { key: "documents", label: "Garage", color: "bg-emerald-500" },
 ];
 
+// Google sign-in is gated separately: it currently routes through Lovable's OAuth
+// broker, so it stays off until native Supabase Google OAuth is configured.
+const enableGoogleAuth = import.meta.env.VITE_ENABLE_GOOGLE_AUTH === "true";
+
 // Merged account + profile panel: your display name + (when signed in) sign-out,
 // plan, and cloud storage usage; signed out it offers sign-in and still shows the
 // storage bar measured against this device's local storage. Everything here works
@@ -137,9 +141,11 @@ function SignInPrompt() {
         Everything here still works offline against this device — Cloud Sync is optional.
       </p>
       <div className="flex flex-col gap-2">
-        <Button variant="outline" onClick={handleGoogle} disabled={busy || !online}>
-          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Continue with Google"}
-        </Button>
+        {enableGoogleAuth && (
+          <Button variant="outline" onClick={handleGoogle} disabled={busy || !online}>
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Continue with Google"}
+          </Button>
+        )}
         <div className="grid grid-cols-2 gap-2">
           <Button asChild variant="secondary"><Link to="/login?next=/">Sign in</Link></Button>
           <Button asChild><Link to="/register">Create account</Link></Button>


### PR DESCRIPTION
## Why

Google sign-in still routes through **Lovable's hosted OAuth broker** (`@lovable.dev/cloud-auth-js` → `createLovableAuth`), where the Google OAuth app lives on Lovable's side. It can't stand on its own once the project moves off Lovable until native Supabase Google OAuth is configured (Google Cloud OAuth client + Supabase Google provider + redirect-URL allowlist) — and that setup needs Google's verification/approval steps.

Rather than do the native cutover under time pressure, this **hides Google sign-in for now** and keeps the wiring intact for a slow rollout.

## What

- New client flag **`VITE_ENABLE_GOOGLE_AUTH`** (default **off**), matching the existing `VITE_ENABLE_CLOUD` / `VITE_ENABLE_ADMIN` convention.
- Gates the three "Continue with Google" buttons:
  - `src/pages/Login.tsx` (now `enableCloud && enableGoogleAuth`)
  - `src/pages/Register.tsx` (button + "or" divider)
  - `src/plugins/cloud-sync/StoragePanel.tsx` (Profile sign-in prompt)
- **No code removed** — `signInWithGoogle` and the Lovable integration stay in place, so re-enabling is a one-line config change. The native-Supabase swap is a clean follow-up.
- **Email sign-in/registration is unaffected** — it's already native Supabase with no Lovable dependency.
- Docs: README + CLAUDE.md env tables, `.env.example`, CHANGELOG.

## Re-enabling later (the rollout)
1. Google Cloud Console: OAuth client → redirect URI `https://<project-ref>.supabase.co/auth/v1/callback`
2. Supabase → Auth → Providers → Google: enable + paste client id/secret
3. Supabase → Auth → URL Configuration: add real redirect URLs
4. Set `VITE_ENABLE_GOOGLE_AUTH=true`, and (recommended) swap `signInWithGoogle` from the Lovable wrapper to native `supabase.auth.signInWithOAuth({ provider: 'google' })`, then drop `@lovable.dev/cloud-auth-js`.

## Testing
`npm run lint`, `npm run typecheck`, `npm run test:run` (799 passing), and `npm run build` all green. Changes are view-layer feature gating (excluded from coverage scope), so no new tests.

https://claude.ai/code/session_01Ez7kiYzdK1gZJh61te1NkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ez7kiYzdK1gZJh61te1NkH)_