### PR TITLE
feat(settings): add Accel X/Y/Z + horizontal accuracy to field-default list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscription to free (it keeps the existing paid tier instead).
 
 ### Added
+- **More fields in Settings → field defaults.** The show/hide field list now
+  includes **horizontal accuracy** (`H Accuracy`, under GPS Data) and the **raw
+  IMU accelerometer axes** (`Accel X/Y/Z`) under a new **Motion (IMU)** category,
+  so you can default-show or default-hide them like any other channel.
 - **Change your plan from your profile.** Subscribers now get a **Change plan**
   button alongside **Manage subscription** in **Profile → Plan**. It deep-links
   straight into Stripe's change-plan screen (swapping your storage tier / billing

--- a/src/lib/fieldResolver.test.ts
+++ b/src/lib/fieldResolver.test.ts
@@ -94,7 +94,19 @@ describe("getFieldAliases", () => {
 describe("FIELD_CATEGORIES", () => {
   it("groups fields under named categories", () => {
     const names = FIELD_CATEGORIES.map((c) => c.category);
-    expect(names).toEqual(["GPS Data", "Computed", "Sensors"]);
+    expect(names).toEqual(["GPS Data", "Computed", "Motion (IMU)", "Sensors"]);
+  });
+
+  it("exposes horizontal accuracy under GPS Data", () => {
+    const gps = FIELD_CATEGORIES.find((c) => c.category === "GPS Data");
+    const ids = gps?.fields.map((f) => f.canonicalId) ?? [];
+    expect(ids).toContain("h_acc");
+  });
+
+  it("places the raw accelerometer axes in the Motion (IMU) category", () => {
+    const imu = FIELD_CATEGORIES.find((c) => c.category === "Motion (IMU)");
+    const ids = imu?.fields.map((f) => f.canonicalId) ?? [];
+    expect(ids).toEqual(["accel_x", "accel_y", "accel_z"]);
   });
 
   it("every field references a real canonical id resolvable back to itself", () => {

--- a/src/lib/fieldResolver.ts
+++ b/src/lib/fieldResolver.ts
@@ -63,6 +63,7 @@ export const FIELD_CATEGORIES: FieldCategory[] = [
       { canonicalId: 'altitude', label: "Altitude", description: "GPS altitude in meters" },
       { canonicalId: 'satellites', label: "Satellites", description: "Number of GPS satellites" },
       { canonicalId: 'hdop', label: "HDOP", description: "Horizontal dilution of precision" },
+      { canonicalId: 'h_acc', label: "H Accuracy", description: "Estimated horizontal position accuracy (m)" },
     ],
   },
   {
@@ -71,6 +72,15 @@ export const FIELD_CATEGORIES: FieldCategory[] = [
     fields: [
       { canonicalId: 'lat_g', label: "Lateral G", description: "Lateral acceleration (computed)" },
       { canonicalId: 'lon_g', label: "Longitudinal G", description: "Longitudinal acceleration (computed)" },
+    ],
+  },
+  {
+    category: "Motion (IMU)",
+    description: "Raw accelerometer data from the device's IMU",
+    fields: [
+      { canonicalId: 'accel_x', label: "Accel X", description: "Raw IMU acceleration, X axis" },
+      { canonicalId: 'accel_y', label: "Accel Y", description: "Raw IMU acceleration, Y axis" },
+      { canonicalId: 'accel_z', label: "Accel Z", description: "Raw IMU acceleration, Z axis" },
     ],
   },
   {


### PR DESCRIPTION
## What

Adds the **raw accelerometer axes** and **horizontal accuracy** to the **Settings → field defaults** show/hide list.

The channel registry (`channels.ts`) already defined `accel_x/y/z` (raw IMU) and `h_acc` (horizontal accuracy), but they were never surfaced in `FIELD_CATEGORIES` (`fieldResolver.ts`), so users couldn't default-toggle them.

- `h_acc` → **GPS Data** category ("H Accuracy")
- `accel_x` / `accel_y` / `accel_z` → new **Motion (IMU)** category

Kept the IMU axes distinct from the GPS-derived **Computed** g-forces (`lat_g`/`lon_g`) and from external **Sensors**, matching how the registry already models IMU data as its own group. `SettingsModal` renders the list straight from `FIELD_CATEGORIES`, so no UI change was needed — the new rows appear automatically.

## Tests
Updated `fieldResolver.test.ts` for the new category ordering and added assertions that `h_acc` lands under GPS Data and the three axes under Motion (IMU). Full suite green (801 passing, +2).

`npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run build` all pass.

https://claude.ai/code/session_01Ez7kiYzdK1gZJh61te1NkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ez7kiYzdK1gZJh61te1NkH)_