### PR TITLE
Landing page: PerchWerks footer, datalogger CTA, and Coach Plugin link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscription to free (it keeps the existing paid tier instead).
 
 ### Added
-- **Homepage "Build your own datalogger" call-to-action.** A new banner under the
-  pricing cards links to the open-source [DovesDataLogger](https://github.com/TheAngryRaven/DovesDataLogger)
-  hardware/firmware repo.
+- **Homepage "Build your own datalogger" call-to-action.** A banner below the
+  page heading links to the open-source [DovesDataLogger](https://github.com/TheAngryRaven/DovesDataLogger)
+  hardware/firmware repo (replacing the old supported-formats subtext).
 - **"Coach Plugin" GitHub link** added to the landing page's GitHub link row,
   pointing at the [DataViewer_coach](https://github.com/TheAngryRaven/DataViewer_coach) repo.
 - **"Operated by PerchWerks LLC" footer** at the bottom of the landing page,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscription to free (it keeps the existing paid tier instead).
 
 ### Added
+- **Homepage "Build your own datalogger" call-to-action.** A new banner under the
+  pricing cards links to the open-source [DovesDataLogger](https://github.com/TheAngryRaven/DovesDataLogger)
+  hardware/firmware repo.
+- **"Coach Plugin" GitHub link** added to the landing page's GitHub link row,
+  pointing at the [DataViewer_coach](https://github.com/TheAngryRaven/DataViewer_coach) repo.
+- **"Operated by PerchWerks LLC" footer** at the bottom of the landing page,
+  linking to [PerchWerks.com](https://PerchWerks.com).
 - **More fields in Settings → field defaults.** The show/hide field list now
   includes **horizontal accuracy** (`H Accuracy`, under GPS Data) and the **raw
   IMU accelerometer axes** (`Accel X/Y/Z`) under a new **Motion (IMU)** category,

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -100,14 +100,30 @@ export function LandingPage({
             <LocalWeatherDialog />
           </div>
 
-          <div className="text-center space-y-2">
+          <div className="text-center">
             <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
               Free Online VBO, MoTeC, AiM &amp; NMEA Telemetry Viewer
             </h1>
-            <p className="text-sm text-muted-foreground">
-              Open any Racelogic VBO, MoTeC i2 (LD/CSV), AiM MyChron, Alfano, u-blox UBX, NMEA or Dove datalog right in your browser. Offline-first — with optional cloud storage to sync across your devices.
-            </p>
           </div>
+
+          <a
+            href="https://github.com/TheAngryRaven/DovesDataLogger"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-col items-center gap-3 rounded-xl border border-primary/30 bg-primary/5 px-6 py-6 text-center transition-colors hover:border-primary hover:bg-primary/10 sm:flex-row sm:text-left"
+          >
+            <Cpu className="h-8 w-8 shrink-0 text-primary" />
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold text-foreground">Build your own datalogger</h3>
+              <p className="text-sm text-muted-foreground">
+                The DovesDataLogger is fully open source — grab the hardware design and firmware to build your own GPS telemetry logger.
+              </p>
+            </div>
+            <Button variant="default" size="sm" className="mt-2 shrink-0 gap-2 sm:ml-auto sm:mt-0">
+              <Github className="h-4 w-4" />
+              Get Started
+            </Button>
+          </a>
 
           <FileImport
             onDataLoaded={onDataLoaded}
@@ -133,27 +149,6 @@ export function LandingPage({
         </div>
 
         <PricingCards className="mx-auto w-full max-w-5xl" />
-
-        <div className="mx-auto w-full max-w-2xl">
-          <a
-            href="https://github.com/TheAngryRaven/DovesDataLogger"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex flex-col items-center gap-3 rounded-xl border border-primary/30 bg-primary/5 px-6 py-6 text-center transition-colors hover:border-primary hover:bg-primary/10 sm:flex-row sm:text-left"
-          >
-            <Cpu className="h-8 w-8 shrink-0 text-primary" />
-            <div className="space-y-1">
-              <h3 className="text-base font-semibold text-foreground">Build your own datalogger</h3>
-              <p className="text-sm text-muted-foreground">
-                The DovesDataLogger is fully open source — grab the hardware design and firmware to build your own GPS telemetry logger.
-              </p>
-            </div>
-            <Button variant="default" size="sm" className="mt-2 shrink-0 gap-2 sm:ml-auto sm:mt-0">
-              <Github className="h-4 w-4" />
-              Get Started
-            </Button>
-          </a>
-        </div>
 
         <div className="mx-auto w-full max-w-xl space-y-4">
           <div className="flex justify-center">

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Gauge, Github, Heart, Shield, BookOpen, Play, Loader2, LogIn, LogOut, FileText } from "lucide-react";
+import { Gauge, Github, Heart, Shield, BookOpen, Play, Loader2, LogIn, LogOut, FileText, Cpu } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { FileImport } from "@/components/FileImport";
@@ -27,6 +27,7 @@ const GITHUB_LINKS: Array<{ href: string; label: string }> = [
   { href: "https://github.com/TheAngryRaven/DovesDataViewer", label: "View on GitHub" },
   { href: "https://github.com/TheAngryRaven/DovesDataLogger", label: "View Datalogger" },
   { href: "https://github.com/TheAngryRaven/DovesLapTimer", label: "View Timer Library" },
+  { href: "https://github.com/TheAngryRaven/DataViewer_coach", label: "Coach Plugin" },
 ];
 
 /**
@@ -133,6 +134,27 @@ export function LandingPage({
 
         <PricingCards className="mx-auto w-full max-w-5xl" />
 
+        <div className="mx-auto w-full max-w-2xl">
+          <a
+            href="https://github.com/TheAngryRaven/DovesDataLogger"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-col items-center gap-3 rounded-xl border border-primary/30 bg-primary/5 px-6 py-6 text-center transition-colors hover:border-primary hover:bg-primary/10 sm:flex-row sm:text-left"
+          >
+            <Cpu className="h-8 w-8 shrink-0 text-primary" />
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold text-foreground">Build your own datalogger</h3>
+              <p className="text-sm text-muted-foreground">
+                The DovesDataLogger is fully open source — grab the hardware design and firmware to build your own GPS telemetry logger.
+              </p>
+            </div>
+            <Button variant="default" size="sm" className="mt-2 shrink-0 gap-2 sm:ml-auto sm:mt-0">
+              <Github className="h-4 w-4" />
+              Get Started
+            </Button>
+          </a>
+        </div>
+
         <div className="mx-auto w-full max-w-xl space-y-4">
           <div className="flex justify-center">
             <BrowserCompatDialog />
@@ -176,6 +198,20 @@ export function LandingPage({
           </div>
         </div>
       </main>
+
+      <footer className="border-t border-border px-6 py-4">
+        <p className="text-center text-xs text-muted-foreground">
+          Operated by{" "}
+          <a
+            href="https://PerchWerks.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+          >
+            PerchWerks LLC
+          </a>
+        </p>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three small additions to the landing page (`src/components/LandingPage.tsx`):

1. **Footer** — "Operated by PerchWerks LLC" at the bottom of the homepage, linking to https://PerchWerks.com.
2. **"Build your own datalogger" CTA** — a medium-sized banner placed directly under the pricing cards, linking to https://github.com/TheAngryRaven/DovesDataLogger.
3. **"Coach Plugin" GitHub link** — added to the existing GitHub link row, pointing at https://github.com/TheAngryRaven/DataViewer_coach.

All use existing Tailwind semantic tokens (no hardcoded colors) and `lucide-react` icons. External links open in a new tab with `rel="noopener noreferrer"`.

## Notes
- `CHANGELOG.md` updated under `[Unreleased] → Added`.

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run build` ✅

https://claude.ai/code/session_01HgoTpWkmZaDGVjjvtG9zhw

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgoTpWkmZaDGVjjvtG9zhw)_