### PR TITLE
Make "Submit to DB" track button a prominent CTA with help tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **"Submit to DB" track button now stands out.** In the track manager, the
+  button for contributing a user-created track/course to the shared database is
+  now a primary-styled call-to-action with a subtle pulsing glow, and sits next
+  to a help (`?`) tooltip explaining that sharing track configurations helps the
+  project grow for the whole community.
 - **Settings menu is now a two-column layout with collapsible sections.** The
   compact toggle settings (units, theme, G-force, lap delta, etc.) lay out in a
   responsive 2-column grid from the tablet breakpoint up (single column on

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useContext, lazy, Suspense } from 'react';
-import { Plus, Trash2, Edit2, Check, X, Settings, Code, Copy } from 'lucide-react';
+import { Plus, Trash2, Edit2, Check, X, Settings, Code, Copy, HelpCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { Label } from '@/components/ui/label';
@@ -42,6 +42,7 @@ import { CourseForm } from '@/components/track-editor/CourseForm';
 import { AddCourseDialog } from '@/components/track-editor/AddCourseDialog';
 import { AddTrackDialog } from '@/components/track-editor/AddTrackDialog';
 import { SubmitTrackDialog } from '@/components/SubmitTrackDialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Send } from 'lucide-react';
 
 import type { Lap, GpsSample } from '@/types/racing';
@@ -460,9 +461,10 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
             <Code className="w-4 h-4 mr-2" />View JSON
           </Button>
           {selectedTrack && (selectedTrack.isUserDefined || selectedTrack.courses.some(c => c.isUserDefined)) && (
+            <div className="flex items-center gap-1">
             <SubmitTrackDialog
               trigger={
-                <Button variant="outline">
+                <Button className="animate-attention-glow">
                   <Send className="w-4 h-4 mr-2" />Submit to DB
                 </Button>
               }
@@ -479,6 +481,23 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
                 };
               })()}
             />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Why submit to the database?"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <HelpCircle className="w-4 h-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>Sharing your track configurations to the database helps the
+                project grow — your tracks become available to everyone, so the
+                community spends less time mapping and more time driving.</p>
+              </TooltipContent>
+            </Tooltip>
+            </div>
           )}
         </div>
         <Button variant="outline" onClick={() => setIsManageMode(false)}>Back to Selection</Button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -89,12 +89,19 @@ export default {
           from: { transform: "translateY(-10px)", opacity: "0" },
           to: { transform: "translateY(0)", opacity: "1" },
         },
+        // Subtle expanding ring used to draw attention to a call-to-action
+        // (e.g. the "Submit to DB" button) without being distracting.
+        "attention-glow": {
+          "0%, 100%": { boxShadow: "0 0 0 0 hsl(var(--primary) / 0.45)" },
+          "70%": { boxShadow: "0 0 0 7px hsl(var(--primary) / 0)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "pulse-glow": "pulse-glow 2s ease-in-out infinite",
         "slide-in": "slide-in 0.3s ease-out",
+        "attention-glow": "attention-glow 2.4s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## Why

On the track management screen, once a user creates a track/course we surface a **"Submit to DB"** button so they can contribute it to the shared database. It was a plain outline button that blended in next to the other actions, so people rarely noticed it — and these submissions are exactly what grows the community track database.

## What changed

- **Prominent CTA**: the button is now primary-styled with a subtle, infinitely looping `attention-glow` ring (new Tailwind keyframe) — eye-catching but not distracting.
- **Help tooltip**: added a `?` (`HelpCircle`) icon beside the button with a tooltip explaining that sharing track configurations helps the project grow for the whole community.
- Updated `CHANGELOG.md` under `[Unreleased]`.

## Notes

- Visual/UX-only change; no logic touched. Tooltip uses the global `TooltipProvider` already mounted in `App.tsx`.
- Gates all green locally: `lint`, `typecheck` (`tsc -b`), `test:run` (801 passed), and `build`.

https://claude.ai/code/session_01K6tZ3oNt7nNZ6SKJHNH8qj

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6tZ3oNt7nNZ6SKJHNH8qj)_