### PR TITLE
Relocate Profile into the file-manager drawer + widen drawer to half screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Profile moved into the file-manager drawer.** The Profile panel (account,
+  storage, lap snapshots, data export) is no longer a tab in the main data view.
+  It now lives as a third top-level tab in the slide-out drawer, sitting between
+  **Garage** and **Device**, so the main view tab bar stays focused on
+  visualizing the session. The drawer also opens at half the screen width (on
+  both mobile and desktop) for a bit more breathing room.
 - **Settings menu is now a two-column layout with collapsible sections.** The
   compact toggle settings (units, theme, G-force, lap delta, etc.) lay out in a
   responsive 2-column grid from the tablet breakpoint up (single column on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 ├── components/
 │   ├── ui/                # shadcn/ui primitives
 │   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, BannedIps, Tools, Messages)
-│   ├── tabs/              # Main view tabs (GraphView, RaceLine, LapTimes, Labs, Coach, Profile)
+│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach; Profile is mounted in the drawer)
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Notes, Setups, Device*)
 │   ├── track-editor/      # Track editor sub-components (VisualEditor is lazy — see Bundle Splitting)
@@ -192,9 +192,11 @@ first-party panel targets it now — it shows only when the experimental
 `enableLabs` setting is on or another plugin contributes), `PanelSlot.Coach`
 (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home for the
 `@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
-(rendered by `ProfileTab.tsx`, far-right — cloud-sync contributes the merged
-Account panel (sign-in/out + display name + plan + storage, working signed out
-against local storage), lap-snapshot management, and cloud-log management). All render contributed
+(rendered by `ProfileTab.tsx` — mounted as a tab **inside the file-manager
+drawer**, between Garage and Device, not in the main view tab bar; cloud-sync
+contributes the merged Account panel (sign-in/out + display name + plan +
+storage, working signed out against local storage), lap-snapshot management, and
+cloud-log management). All render contributed
 panels via `PluginPanelHost` and are
 **self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showProfile`
 from `getPanelsForSlot`, so a tab appears only when a
@@ -557,8 +559,16 @@ Profile **Cloud logs** panel reuses `SessionBrowser` with its own rows.
 
 ## Device Manager
 
-The slide-out drawer (`FileManagerDrawer.tsx`) has two top-level tabs:
+The slide-out drawer (`FileManagerDrawer.tsx`) opens at half the viewport width
+(`w-1/2`, both mobile and desktop) and has three top-level tabs:
 - **Garage** — Files, Karts, Setups, Notes (original functionality)
+- **Profile** — User account, storage, lap snapshots, data export. Renders the
+  `PanelSlot.Profile` plugin panels via `ProfileTab`; only shown when a plugin
+  (cloud-sync) contributes Profile panels (`showProfile` prop, computed in
+  `Index.tsx`). Sits between Garage and Device. `ProfileTab` reads session +
+  settings via the *optional* context hooks (`useOptionalSessionContext` /
+  `useOptionalSettingsContext`) so it also renders from the landing-page drawer
+  before any session is loaded.
 - **Device** — BLE device management, gated behind a "Connect to Logger" prompt
 
 Device sub-tabs:

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { X, Gauge, Cpu, Bluetooth, BluetoothOff, Loader2, Settings, MapPin, Battery, BatteryLow, BatteryMedium, BatteryFull, BatteryWarning } from "lucide-react";
+import { X, Gauge, Cpu, User, Bluetooth, BluetoothOff, Loader2, Settings, MapPin, Battery, BatteryLow, BatteryMedium, BatteryFull, BatteryWarning } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FileEntry, FileMetadata } from "@/lib/fileStorage";
 import { Vehicle } from "@/lib/vehicleStorage";
@@ -13,10 +13,11 @@ import { SetupsTab } from "./drawer/SetupsTab";
 import { NotesTab } from "./drawer/NotesTab";
 import { DeviceSettingsTab } from "./drawer/DeviceSettingsTab";
 import { DeviceTracksTab } from "./drawer/DeviceTracksTab";
+import { ProfileTab } from "./tabs/ProfileTab";
 import { useDeviceContext } from "@/contexts/DeviceContext";
 import { isBleSupported, requestBatteryLevel, type BatteryInfo } from "@/lib/bleDatalogger";
 
-type TopTab = "garage" | "device";
+type TopTab = "garage" | "profile" | "device";
 type GarageTab = "files" | "vehicles" | "setups" | "notes";
 type DeviceTab = "settings" | "tracks";
 
@@ -45,6 +46,8 @@ interface FileManagerDrawerProps {
   onSaveFile: (name: string, blob: Blob) => Promise<void>;
   onDataLoaded: (data: ParsedData, fileName?: string) => void;
   autoSave: boolean;
+  // Profile tab is gated on a plugin (cloud-sync) contributing a Profile panel.
+  showProfile: boolean;
   // Vehicle props
   vehicles: Vehicle[];
   vehicleTypes: VehicleType[];
@@ -79,6 +82,7 @@ interface FileManagerDrawerProps {
 export function FileManagerDrawer({
   isOpen, files, fileMetadataMap, storageUsed, storageQuota,
   onClose, onLoadFile, onDeleteFile, onExportFile, onSaveFile, onDataLoaded, autoSave,
+  showProfile,
   vehicles, vehicleTypes, templates,
   onAddVehicle, onUpdateVehicle, onRemoveVehicle,
   currentTrackName, currentCourseName,
@@ -127,12 +131,12 @@ export function FileManagerDrawer({
   return (
     <>
       <div className="fixed inset-0 z-[10000] bg-black/40" onClick={onClose} />
-      <div className="fixed inset-y-0 right-0 z-[10001] w-full md:w-[28vw] md:min-w-[320px] bg-background border-l border-border flex flex-col shadow-2xl animate-in slide-in-from-right duration-200">
+      <div className="fixed inset-y-0 right-0 z-[10001] w-1/2 min-w-[320px] bg-background border-l border-border flex flex-col shadow-2xl animate-in slide-in-from-right duration-200">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
           <div className="flex items-center gap-2">
-            {topTab === "garage" ? <Gauge className="w-5 h-5 text-primary" /> : <Cpu className="w-5 h-5 text-primary" />}
-            <h2 className="font-semibold text-foreground">{topTab === "garage" ? "Garage" : "Device"}</h2>
+            {topTab === "garage" ? <Gauge className="w-5 h-5 text-primary" /> : topTab === "profile" ? <User className="w-5 h-5 text-primary" /> : <Cpu className="w-5 h-5 text-primary" />}
+            <h2 className="font-semibold text-foreground">{topTab === "garage" ? "Garage" : topTab === "profile" ? "Profile" : "Device"}</h2>
             {topTab === "device" && device.deviceName && (
               <span className="text-xs text-muted-foreground truncate max-w-[120px]">— {device.deviceName}</span>
             )}
@@ -165,6 +169,11 @@ export function FileManagerDrawer({
           <button onClick={() => setTopTab("garage")} className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors ${topTab === "garage" ? "text-primary border-b-2 border-primary bg-primary/5" : "text-muted-foreground hover:text-foreground"}`}>
             <Gauge className="w-4 h-4" /> Garage
           </button>
+          {showProfile && (
+            <button onClick={() => setTopTab("profile")} className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors ${topTab === "profile" ? "text-primary border-b-2 border-primary bg-primary/5" : "text-muted-foreground hover:text-foreground"}`}>
+              <User className="w-4 h-4" /> Profile
+            </button>
+          )}
           <button onClick={() => setTopTab("device")} className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors ${topTab === "device" ? "text-primary border-b-2 border-primary bg-primary/5" : "text-muted-foreground hover:text-foreground"}`}>
             <Cpu className="w-4 h-4" /> Device
           </button>
@@ -217,6 +226,13 @@ export function FileManagerDrawer({
               />
             )}
           </>
+        )}
+
+        {/* Profile Panel — relocated from the main view's tab bar. */}
+        {topTab === "profile" && showProfile && (
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <ProfileTab />
+          </div>
         )}
 
         {/* Device Panel */}

--- a/src/components/tabs/ProfileTab.tsx
+++ b/src/components/tabs/ProfileTab.tsx
@@ -1,24 +1,27 @@
 import { memo } from "react";
 import { User } from "lucide-react";
-import { useSessionContext } from "@/contexts/SessionContext";
-import { useSettingsContext } from "@/contexts/SettingsContext";
+import { useOptionalSessionContext } from "@/contexts/SessionContext";
+import { useOptionalSettingsContext } from "@/contexts/SettingsContext";
 import { PluginPanelHost } from "@/plugins/PluginPanelHost";
 import { PanelSlot } from "@/plugins/panels";
 
 export const ProfileTab = memo(function ProfileTab() {
-  const { data, laps, selectedLapNumber, course, activeSnapshot, sessionSetup } = useSessionContext();
-  const { useKph } = useSettingsContext();
+  // Profile lives in the file-manager drawer, which also opens from the landing
+  // page before any session exists — read both contexts optionally and fall
+  // back to empty/default values so the account & storage panels still render.
+  const session = useOptionalSessionContext();
+  const settings = useOptionalSettingsContext();
 
   return (
     <PluginPanelHost
       slot={PanelSlot.Profile}
-      data={data}
-      laps={laps}
-      selectedLapNumber={selectedLapNumber}
-      course={course}
-      useKph={useKph}
-      sessionSetup={sessionSetup}
-      activeSnapshot={activeSnapshot}
+      data={session?.data ?? null}
+      laps={session?.laps ?? []}
+      selectedLapNumber={session?.selectedLapNumber ?? null}
+      course={session?.course ?? null}
+      useKph={settings?.useKph ?? false}
+      sessionSetup={session?.sessionSetup ?? null}
+      activeSnapshot={session?.activeSnapshot ?? null}
       fallback={<ProfileEmpty />}
     />
   );

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -123,3 +123,11 @@ export function useSessionContext(): SessionContextValue {
   if (!ctx) throw new Error('useSessionContext must be used within SessionProvider');
   return ctx;
 }
+
+// Non-throwing variant for surfaces that may render outside a session (e.g. the
+// Profile drawer tab, which is also reachable from the landing page before any
+// file is loaded). Returns null when no SessionProvider is mounted.
+// eslint-disable-next-line react-refresh/only-export-components -- co-located with SessionProvider
+export function useOptionalSessionContext(): SessionContextValue | null {
+  return useContext(SessionContext);
+}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -33,3 +33,10 @@ export function useSettingsContext(): SettingsContextValue {
   if (!ctx) throw new Error('useSettingsContext must be used within SettingsProvider');
   return ctx;
 }
+
+// Non-throwing variant for surfaces that may render outside the provider (e.g.
+// the Profile drawer tab on the landing page). Returns null when unmounted.
+// eslint-disable-next-line react-refresh/only-export-components -- co-located with SettingsProvider
+export function useOptionalSettingsContext(): SettingsContextValue | null {
+  return useContext(SettingsContext);
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, User } from "lucide-react";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical } from "lucide-react";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { RaceLineTab } from "@/components/tabs/RaceLineTab";
@@ -16,9 +16,6 @@ const LabsTab = lazy(() =>
 );
 const CoachTab = lazy(() =>
   import("@/components/tabs/CoachTab").then((m) => ({ default: m.CoachTab })),
-);
-const ProfileTab = lazy(() =>
-  import("@/components/tabs/ProfileTab").then((m) => ({ default: m.ProfileTab })),
 );
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SettingsModal } from "@/components/SettingsModal";
@@ -57,7 +54,7 @@ import { snapshotLapSamples } from "@/lib/lapSnapshot";
 import type { PluginSnapshot } from "@/plugins/panels";
 
 
-type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach" | "profile";
+type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
@@ -376,6 +373,7 @@ export default function Index() {
     onSaveFile: fileManager.saveFile,
     onDataLoaded: handleDataLoaded,
     autoSave: settings.autoSaveFiles,
+    showProfile,
     vehicles: vehicleManager.vehicles,
     vehicleTypes: templateManager.vehicleTypes,
     templates: templateManager.templates,
@@ -403,7 +401,7 @@ export default function Index() {
   }), [
     fileManager.isOpen, fileManager.files, fileManager.fileMetadataMap, fileManager.storageUsed, fileManager.storageQuota,
     fileManager.close, fileManager.loadFile, fileManager.removeFile, fileManager.exportFile, fileManager.saveFile,
-    handleDataLoaded, settings.autoSaveFiles,
+    handleDataLoaded, settings.autoSaveFiles, showProfile,
     vehicleManager.vehicles, vehicleManager.addVehicle, vehicleManager.updateVehicle, vehicleManager.removeVehicle,
     templateManager.vehicleTypes, templateManager.templates, templateManager.addVehicleType, templateManager.removeVehicleType,
     currentFileName,
@@ -499,7 +497,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} showProfile={showProfile} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -509,7 +507,6 @@ export default function Index() {
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "labs" && showLabs && <LabsTab />}
             {topPanelView === "coach" && showCoach && <CoachTab />}
-            {topPanelView === "profile" && showProfile && <ProfileTab />}
           </Suspense>
         </div>
       </main>
@@ -539,7 +536,7 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, showProfile }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
@@ -547,7 +544,6 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   onToggleOverlays: () => void;
   showLabs: boolean;
   showCoach: boolean;
-  showProfile: boolean;
 }) {
   const tabClass = (view: TopPanelView) =>
     `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
@@ -587,11 +583,6 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
             <span className="text-xs">Overlay</span>
           </Button>
         </div>
-      )}
-      {showProfile && (
-        <button onClick={() => setTopPanelView("profile")} className={`${tabClass("profile")} ${topPanelView === "raceline" ? "" : "ml-auto"}`}>
-          <User className="w-4 h-4" /> <span className="hidden sm:inline">Profile</span>
-        </button>
       )}
     </div>
   );

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -23,7 +23,7 @@ export const PanelSlot = {
   Labs: "labs",
   /** The dedicated AI Coach tab in the main view. */
   Coach: "coach",
-  /** The user profile tab (storage usage, account) in the main view. */
+  /** The user profile tab (storage usage, account) in the file-manager drawer. */
   Profile: "profile",
 } as const;
 export type PanelSlot = (typeof PanelSlot)[keyof typeof PanelSlot];


### PR DESCRIPTION
## What

Two related drawer changes:

1. **Drawer is now half the viewport width** (`w-1/2`, both mobile and desktop), replacing the old `w-full md:w-[28vw]`, for a bit more breathing room.
2. **Profile moved into the drawer as a third top-level tab**, sitting between **Garage** and **Device**. It's no longer a tab in the main data view's tab bar, so that bar stays focused on visualizing the session.

```
Drawer tabs:  [ Garage ] [ Profile ] [ Device ]
```

## How

- `FileManagerDrawer.tsx` — added the middle **Profile** tab (gated on the new `showProfile` prop), header icon/title, and the panel render. Width changed to `w-1/2 min-w-[320px]`.
- `Index.tsx` — removed Profile from `TopPanelView`, the main `TabBar`, and the main-view panel render; `showProfile` (already computed from `getPanelsForSlot(PanelSlot.Profile)`) is now threaded into the drawer props instead.
- `ProfileTab.tsx` — now reads session + settings via **non-throwing** optional context hooks so it renders correctly even from the landing-page drawer (which mounts before any `SessionProvider`/`SettingsProvider`). The account/storage/snapshot panels don't need session data, so falling back to `null`/defaults is safe.
- New `useOptionalSessionContext` / `useOptionalSettingsContext` hooks in the respective contexts.
- Profile remains **self-gating**: the tab only appears when the cloud-sync plugin contributes `PanelSlot.Profile` panels.

## Docs
- `CHANGELOG.md` — `[Unreleased]` entry.
- `CLAUDE.md` — Device Manager + plugin panels + architecture map updated to reflect Profile living in the drawer.

## Checks
`npm run lint`, `npm run typecheck`, `npm run test:run` (801 passing), and `npm run build` all green.

https://claude.ai/code/session_011E5fUNUYD46fCeZbCys8W9

---
_Generated by [Claude Code](https://claude.ai/code/session_011E5fUNUYD46fCeZbCys8W9)_