### PR TITLE
Bump @perchwerks/eye-in-the-sky 0.3.0 → 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
+  `0.3.0` to `0.4.0`.**
 - **"Submit to DB" track button now stands out.** In the track manager, the
   button for contributing a user-created track/course to the shared database is
   now a primary-styled call-to-action with a subtle pulsing glow, and sits next

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.3.0",
+        "@perchwerks/eye-in-the-sky": "0.4.0",
       },
     },
   },
@@ -369,7 +369,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
-    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.3.0", "https://europe-west4-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.3.0.tgz", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0" } }, "sha512-XJ6Riez1x5A210Kj0Vxt+NU8P+QZGHo7ZYgqN684uBWaB/JjY9sjWEAp5nxxtZrNN17NzHYM/NsOK/xN3AyHfA=="],
+    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.4.0", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0" } }, "sha512-OlW/CyTKkd7HM1+meweDV1uDEg4v4VmWKvW1RO/2xpJdiilvlOyLvzjWLjga+3N9HAvddk9mmoFGBC9+/H+bWQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1525,8 +1525,6 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/eslintrc/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
@@ -1536,8 +1534,6 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
-    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -1571,8 +1567,6 @@
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
@@ -1598,8 +1592,6 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.3.0"
+        "@perchwerks/eye-in-the-sky": "0.4.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.3.0.tgz",
-      "integrity": "sha512-XJ6Riez1x5A210Kj0Vxt+NU8P+QZGHo7ZYgqN684uBWaB/JjY9sjWEAp5nxxtZrNN17NzHYM/NsOK/xN3AyHfA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.4.0.tgz",
+      "integrity": "sha512-OlW/CyTKkd7HM1+meweDV1uDEg4v4VmWKvW1RO/2xpJdiilvlOyLvzjWLjga+3N9HAvddk9mmoFGBC9+/H+bWQ==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.3.0"
+    "@perchwerks/eye-in-the-sky": "0.4.0"
   }
 }


### PR DESCRIPTION
## What

Bumps the optional AI coach plugin **`@perchwerks/eye-in-the-sky`** from `0.3.0` → `0.4.0`.

- `package.json` (`optionalDependencies`)
- Regenerated **both** lockfiles — `package-lock.json` (npm) and `bun.lock` (used by the Cloudflare Workers build's frozen install). The bun re-resolve also dropped the stale Lovable-sandbox cache URL on the package entry and tidied a few unused transitive dedupe entries.
- `CHANGELOG.md` `[Unreleased]` updated.

## Verification

All green locally with 0.4.0 installed:
- `typecheck` (`tsc -b`) ✅
- `build` with the coach plugin loaded (`DOVE_PLUGIN_PACKAGES=@perchwerks/eye-in-the-sky`) ✅
- `test:run` — 50 files, 801 tests ✅

https://claude.ai/code/session_01K6tZ3oNt7nNZ6SKJHNH8qj

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6tZ3oNt7nNZ6SKJHNH8qj)_