### PR TITLE
Bump @perchwerks/eye-in-the-sky 0.4.0 → 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
-  `0.3.0` to `0.4.0`.**
+  `0.3.0` to `0.4.1`.**
 - **Profile moved into the file-manager drawer.** The Profile panel (account,
   storage, lap snapshots, data export) is no longer a tab in the main data view.
   It now lives as a third top-level tab in the slide-out drawer, sitting between

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.4.0",
+        "@perchwerks/eye-in-the-sky": "0.4.1",
       },
     },
   },
@@ -369,7 +369,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
-    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.4.0", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0" } }, "sha512-OlW/CyTKkd7HM1+meweDV1uDEg4v4VmWKvW1RO/2xpJdiilvlOyLvzjWLjga+3N9HAvddk9mmoFGBC9+/H+bWQ=="],
+    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.4.1", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0" } }, "sha512-SKjiObU+r+fKe28+B0oUEGmASpIG6ZDKRTERRqjFJ1LWmXNs7A2J1BtQE3cx2SI4wURI+H0ie0KeXUXfAYS8yg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.4.0"
+        "@perchwerks/eye-in-the-sky": "0.4.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@perchwerks/eye-in-the-sky": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.4.0.tgz",
-      "integrity": "sha512-OlW/CyTKkd7HM1+meweDV1uDEg4v4VmWKvW1RO/2xpJdiilvlOyLvzjWLjga+3N9HAvddk9mmoFGBC9+/H+bWQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@perchwerks/eye-in-the-sky/-/eye-in-the-sky-0.4.1.tgz",
+      "integrity": "sha512-SKjiObU+r+fKe28+B0oUEGmASpIG6ZDKRTERRqjFJ1LWmXNs7A2J1BtQE3cx2SI4wURI+H0ie0KeXUXfAYS8yg==",
       "license": "GPL-3.0-or-later",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.4.0"
+    "@perchwerks/eye-in-the-sky": "0.4.1"
   }
 }


### PR DESCRIPTION
## What

Bumps the optional AI coach plugin **`@perchwerks/eye-in-the-sky`** from `0.4.0` → `0.4.1` (follow-up to #112, now merged).

- `package.json` (`optionalDependencies`)
- Regenerated **both** lockfiles — `package-lock.json` (npm) and `bun.lock` (Cloudflare Workers frozen install).
- `CHANGELOG.md` — rolled the existing unreleased coach-bump entry forward to `0.4.1` (no second line, since `0.4.0` hasn't shipped yet).

## Verification

All green locally with 0.4.1 installed:
- `typecheck` (`tsc -b`) ✅
- `build` with the coach plugin loaded (`DOVE_PLUGIN_PACKAGES=@perchwerks/eye-in-the-sky`) ✅
- `test:run` — 50 files, 801 tests ✅

https://claude.ai/code/session_01K6tZ3oNt7nNZ6SKJHNH8qj

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6tZ3oNt7nNZ6SKJHNH8qj)_