### PR TITLE
Pin coach plugin to ~0.4.1 for automatic patch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
-  `0.3.0` to `0.4.1`.**
+  `0.3.0` to `0.4.1`, and pinned it to a tilde patch range (`~0.4.1`)** so coach
+  `0.4.x` patch releases are picked up automatically on the next install, while a
+  minor/major bump (`0.5.0`+) stays an explicit, reviewed change.
 - **Profile moved into the file-manager drawer.** The Profile panel (account,
   storage, lap snapshots, data export) is no longer a tab in the main data view.
   It now lives as a third top-level tab in the slide-out drawer, sitting between

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.4.1",
+        "@perchwerks/eye-in-the-sky": "~0.4.1",
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^4.1.6"
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.4.1"
+        "@perchwerks/eye-in-the-sky": "~0.4.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.4.1"
+    "@perchwerks/eye-in-the-sky": "~0.4.1"
   }
 }

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -174,7 +174,11 @@ automated in the coach repo via a GitHub Actions workflow that runs
 
 1. List the package in `optionalDependencies` in the app's `package.json` and
    run `npm install` to refresh the lockfile, then commit both. No `.npmrc` or
-   token is needed — it's the default public registry.
+   token is needed — it's the default public registry. The version is pinned to
+   a **tilde patch range** (e.g. `~0.4.1`) so coach **patch** releases (`0.4.x`)
+   are picked up automatically on the next install, while a minor/major bump
+   (`0.5.0`+) stays an explicit, reviewed change — bump the tilde base when you
+   intend to adopt a new minor.
 2. The loader in `vite.config.ts` defaults to `@perchwerks/eye-in-the-sky`, so
    the standard build picks it up with no env configuration. Override the
    candidate list via the `DOVE_PLUGIN_PACKAGES` env var (comma-separated) if


### PR DESCRIPTION
## What

Loosen the AI coach optional dependency from an **exact** pin to a **tilde patch range** so coach patch releases are adopted automatically.

```diff
- "@perchwerks/eye-in-the-sky": "0.4.1"
+ "@perchwerks/eye-in-the-sky": "~0.4.1"
```

BETA already bumped the coach to `0.4.1` (#113); this PR only changes *how* it's pinned.

## Behavior
`~0.4.1` resolves to `>=0.4.1 <0.5.0`, so coach **patch** releases (`0.4.2`, `0.4.3`, …) flow in on the next unlocked install / fresh CI install. A **minor or major** bump (`0.5.0`+) stays an explicit, reviewed change — bump the tilde base when you want to adopt a new minor.

> Note: npm won't re-resolve a committed lockfile on its own; the range makes patches *eligible* (picked up by `npm update` / a fresh CI install / contributor reinstall). If you ever want truly hands-off updates, that'd be a Renovate/Dependabot job — happy to wire one scoped to just this package.

## Changes
- `package.json` — `0.4.1` → `~0.4.1`.
- `package-lock.json` + `bun.lock` — regenerated (both still resolve to `0.4.1`, the current latest).
- `CHANGELOG.md` — extended the existing `[Unreleased]` coach entry to note the patch-range pin.
- `src/plugins/README.md` — documented the tilde-range policy in the "wire it into the app" step.

## Checks
`npm run typecheck` and `npm run build` green. Diff vs BETA is the 5 files above and nothing else.

https://claude.ai/code/session_011E5fUNUYD46fCeZbCys8W9

---
_Generated by [Claude Code](https://claude.ai/code/session_011E5fUNUYD46fCeZbCys8W9)_