### PR TITLE
ci(coverage): publish badge to a gist, not the badges branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,10 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# contents: write       -> publish the badge JSON to the `badges` branch (main only)
 # pull-requests: write  -> post/update the per-PR coverage summary comment
+# The live % badge is pushed to a GitHub Gist (see the gist step below) with a
+# dedicated GIST_TOKEN secret, so this workflow no longer needs `contents: write`
+# and no longer publishes a `badges` branch (which Cloudflare kept trying to deploy).
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:
@@ -68,22 +69,23 @@ jobs:
               core.warning(`Could not post coverage comment: ${e.message}`);
             }
 
-      # ---- Live % badge: publish shields.io endpoint JSON to `badges` branch ----
-      - name: Generate badge JSON
+      # ---- Live % badge: push shields.io endpoint fields to a GitHub Gist ----
+      # No Git branch is created, so Cloudflare Workers Builds has nothing extra
+      # to deploy. coverage-badge.mjs computes the message + color and hands them
+      # over as step outputs. Requires repo secret GIST_TOKEN (PAT with `gist`
+      # scope) and repo variable COVERAGE_GIST_ID (see README → Coverage badge).
+      - name: Generate badge fields
+        id: badge
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: npm run coverage:badge
 
-      - name: Stage badge for publish
+      - name: Push badge to coverage gist
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: |
-          mkdir -p badge-publish
-          cp coverage/coverage-badge.json badge-publish/
-
-      - name: Publish badge to the `badges` branch
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: Schneegans/dynamic-badges-action@v1.7.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: badges
-          publish_dir: ./badge-publish
-          force_orphan: true
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: coverage-badge.json
+          label: coverage
+          message: ${{ steps.badge.outputs.message }}
+          color: ${{ steps.badge.outputs.color }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Coverage badge now publishes to a GitHub Gist instead of a `badges` branch.**
+  The orphan `badges` branch caused Cloudflare Workers Builds to repeatedly try
+  (and fail) to deploy a branch with no app in it. The `coverage.yml` workflow
+  now pushes the badge `%`/color to a gist via `Schneegans/dynamic-badges-action`
+  (repo secret `GIST_TOKEN` + variable `COVERAGE_GIST_ID`), drops its
+  `contents: write` permission, and no longer creates a Git branch. See the
+  README "Coverage badge" section for setup.
 - **Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
   `0.3.0` to `0.4.1`, and pinned it to a tilde patch range (`~0.4.1`)** so coach
   `0.4.x` patch releases are picked up automatically on the next install, while a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,7 +659,10 @@ CI is split into five parallel workflows under `.github/workflows/`
 (`lint.yml`, `typecheck.yml`, `test.yml`, `build.yml`, `coverage.yml`). Each
 runs on every PR and push to `main` and shows up as its own status check +
 README badge. `coverage.yml` also enforces the thresholds in `vitest.config.ts`,
-posts a per-PR summary comment, and publishes the % badge JSON.
+posts a per-PR summary comment, and pushes the % badge fields to a **GitHub Gist**
+(repo secret `GIST_TOKEN` + repo variable `COVERAGE_GIST_ID`) — not a Git branch,
+so Cloudflare Workers Builds has no badge-only branch to try to deploy. See the
+README "Coverage badge" section for the gist wiring.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Typecheck](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/typecheck.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/typecheck.yml)
 [![Test](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/test.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/test.yml)
 [![Build](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/build.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/build.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TheAngryRaven/COVERAGE_GIST_ID/raw/coverage-badge.json)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TheAngryRaven/9c0c31f9c333c565804b26643a2e3aec/raw/coverage-badge.json)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/coverage.yml)
 
 🌐 **Live Demo:** [HackTheTrack.net](https://hackthetrack.net)  
 🔧 **Hardware Project:** [DovesDataLogger on GitHub](https://github.com/TheAngryRaven/DovesDataLogger)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Typecheck](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/typecheck.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/typecheck.yml)
 [![Test](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/test.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/test.yml)
 [![Build](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/build.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/build.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/TheAngryRaven/DovesDataViewer/badges/coverage-badge.json)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TheAngryRaven/COVERAGE_GIST_ID/raw/coverage-badge.json)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/coverage.yml)
 
 🌐 **Live Demo:** [HackTheTrack.net](https://hackthetrack.net)  
 🔧 **Hardware Project:** [DovesDataLogger on GitHub](https://github.com/TheAngryRaven/DovesDataLogger)
@@ -283,6 +283,24 @@ Open [http://localhost:8080](http://localhost:8080) in your browser.
 | `npm run typecheck` | Type-check via `tsc -b` (build mode — follows project references) |
 | `npm test` | Run Vitest in watch mode |
 | `npm run test:run` | Run Vitest once (CI-style) |
+
+### Coverage badge
+
+The live coverage badge is a [shields.io endpoint](https://shields.io/badges/endpoint-badge)
+backed by a **GitHub Gist** (not a Git branch — that kept Cloudflare Workers
+Builds trying to deploy a badge-only branch). The `coverage.yml` workflow runs
+`npm run coverage:badge` (which computes the `%` + color from the Vitest summary)
+and pushes those fields to the gist on every push to `main`. To wire it up on a
+fork:
+
+1. Create a **public** gist with a single file named `coverage-badge.json`
+   (any placeholder contents) and copy its ID from the URL
+   (`gist.github.com/<user>/<THIS_IS_THE_ID>`).
+2. Create a fine-grained/classic **PAT with the `gist` scope** and add it as the
+   repo secret **`GIST_TOKEN`** (Settings → Secrets and variables → Actions).
+3. Add the gist ID as the repo **variable `COVERAGE_GIST_ID`** (same page → Variables).
+4. Replace `COVERAGE_GIST_ID` in the Coverage badge URL at the top of this README
+   with your gist ID.
 
 ---
 

--- a/scripts/coverage-badge.mjs
+++ b/scripts/coverage-badge.mjs
@@ -1,7 +1,10 @@
 // Reads the Vitest json-summary and emits a shields.io endpoint badge JSON.
-// No third-party service involved — the JSON is published to the `badges`
-// branch by the Coverage workflow and rendered by img.shields.io/endpoint.
-import { readFileSync, writeFileSync } from "node:fs";
+// The Coverage workflow pushes this badge's fields to a GitHub Gist (rendered
+// by img.shields.io/endpoint), so it never touches a Git branch — keeping
+// Cloudflare Workers Builds from trying to deploy a badge-only branch.
+// This script stays the single source of truth for the color thresholds: it
+// also exports `message`/`color` as GitHub Actions step outputs when run in CI.
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
 const summary = JSON.parse(
   readFileSync("coverage/coverage-summary.json", "utf8"),
@@ -26,3 +29,11 @@ const badge = {
 
 writeFileSync("coverage/coverage-badge.json", JSON.stringify(badge) + "\n");
 console.log("coverage badge:", JSON.stringify(badge));
+
+// Hand the rendered fields to the Coverage workflow's gist-update step.
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `message=${badge.message}\ncolor=${badge.color}\n`,
+  );
+}


### PR DESCRIPTION
## Why

The `coverage.yml` workflow force-pushed the shields.io coverage badge JSON to an orphan **`badges` branch** on every push to `main`. Cloudflare Workers Builds, wired to build on branch pushes, then repeatedly tried (and failed) to deploy that branch — it has no `package.json`/`wrangler.jsonc`, so `npm run build` errors out. There is no repo-side setting that filters which branches Workers Builds deploys, so the fix is to stop creating the branch at all.

## What changed

- **`coverage.yml`** — replaced the three `peaceiris/actions-gh-pages` "publish to `badges`" steps with a single `Schneegans/dynamic-badges-action` step that pushes the badge `%`/color to a **GitHub Gist**. No Git branch is created, so Cloudflare has nothing extra to grab. Also drops the now-unneeded `contents: write` permission (least privilege).
- **`scripts/coverage-badge.mjs`** — stays the single source of truth for the `%`/color thresholds; now also exports `message`/`color` as workflow step outputs for the gist step.
- **`README.md`** — badge URL now points at the gist; added a "Coverage badge" setup section documenting the `GIST_TOKEN` secret + `COVERAGE_GIST_ID` variable.
- **`CHANGELOG.md`** / **`CLAUDE.md`** — documented the move.

## Operator setup (already done)

- Repo secret **`GIST_TOKEN`** (PAT with `gist` scope)
- Repo variable **`COVERAGE_GIST_ID`** = `9c0c31f9c333c565804b26643a2e3aec`
- Gist contains a `coverage-badge.json` file

## Follow-up after merge

Once this is on `main`, the workflow will no longer recreate the `badges` branch — it can be deleted (`git push origin --delete badges`). It's safe to delete only *after* merge, otherwise the current `main` workflow would just recreate it on the next push.

https://claude.ai/code/session_0186CDgYgD2dNPrrtmLQmPtY

---
_Generated by [Claude Code](https://claude.ai/code/session_0186CDgYgD2dNPrrtmLQmPtY)_