### PR TITLE
fix(auth): stop spurious sign-out on refresh (auth-lock deadlock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Spurious sign-out on page refresh (and the paid plan card vanishing with
+  it).** The auth bootstrap awaited a Supabase RPC (`has_role`) *inside* the
+  `onAuthStateChange` callback. supabase-js holds the GoTrue cross-tab Web Lock
+  for the duration of that callback, so the awaited call deadlocked token
+  refresh on reload — signing the user out and, downstream, collapsing the
+  subscription to the free tier (hiding the paid plan card). The admin-role
+  lookup is now deferred out of the callback; session/user state is set
+  synchronously. (Symptom only cleared on a full browser restart, since the
+  contended Web Lock survives reloads.)
+
 ### Changed
 - **Bumped the optional AI coach plugin (`@perchwerks/eye-in-the-sky`) from
   `0.3.0` to `0.4.1`, and pinned it to a tilde patch range (`~0.4.1`)** so coach

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -26,27 +26,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     let initialResolved = false;
 
-    const updateAuth = async (s: Session | null) => {
-      if (cancelled) return;
+    // Resolve the admin role. MUST run outside the onAuthStateChange callback:
+    // supabase-js holds the GoTrue Web Lock (navigator.locks) for the duration
+    // of that callback, and any awaited Supabase call inside it needs the same
+    // lock — which deadlocks token refresh and spuriously signs the user out on
+    // reload. So updateAuth sets session/user synchronously and defers this.
+    const resolveRole = async (s: Session | null) => {
+      if (!s?.user) {
+        if (!cancelled) setIsAdmin(false);
+        return;
+      }
       try {
-        setSession(s);
-        setUser(s?.user ?? null);
-        if (s?.user) {
-          const { data } = await supabase.rpc('has_role', {
-            _user_id: s.user.id,
-            _role: 'admin',
-          });
-          if (!cancelled) setIsAdmin(!!data);
-        } else {
-          setIsAdmin(false);
-        }
+        const { data } = await supabase.rpc('has_role', {
+          _user_id: s.user.id,
+          _role: 'admin',
+        });
+        if (!cancelled) setIsAdmin(!!data);
       } catch {
         if (!cancelled) setIsAdmin(false);
       }
-      if (!cancelled) {
-        initialResolved = true;
-        setLoading(false);
-      }
+    };
+
+    const updateAuth = (s: Session | null) => {
+      if (cancelled) return;
+      setSession(s);
+      setUser(s?.user ?? null);
+      if (!s?.user) setIsAdmin(false);
+      initialResolved = true;
+      setLoading(false);
+      // Deferred so we never await a Supabase call while the auth lock is held.
+      setTimeout(() => { void resolveRole(s); }, 0);
     };
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(


### PR DESCRIPTION
## What

The auth bootstrap awaited `supabase.rpc('has_role')` **inside** the `onAuthStateChange` callback. supabase-js v2 holds the GoTrue cross-tab **Web Lock** (`navigator.locks`) for the duration of that callback, so awaiting another auth-dependent call inside it deadlocks token refresh on reload — the SDK then signs the user out.

This fixes two symptoms that were actually **one bug**:

1. **Logged out on refresh.** On reload the SDK tries to acquire the lock to refresh the persisted token; the awaited `has_role` RPC is holding it → refresh hangs → SDK emits `SIGNED_OUT` → `user` is wiped.
2. **Paid plan card disappears.** Downstream of #1: when `user` goes `null`, `useSubscription` clears the subscription → effective tier falls back to `free` → the `PlanSection` / paid `PricingCards` collapse to the free view.

### Why it looked like a caching issue
- **Incognito worked** because there's no persisted token to refresh, so the initial event is a clean `null` session — no deadlock.
- **Only a full browser restart cleared it** because a contended Web Lock survives page reloads but is reset on browser restart. That's the fingerprint of a lock/session issue, not HTTP/service-worker caching.

## Fix

`src/contexts/AuthContext.tsx`: set `session`/`user` state **synchronously** in the `onAuthStateChange` callback and **defer** the admin-role RPC via `setTimeout(0)`, so no Supabase call is ever awaited while the auth lock is held. Added a guard comment to prevent reintroduction.

The other `onAuthStateChange` listeners were audited and are already safe (`autoSync.ts` `void`s its reconcile; `AuthCallback.tsx` only navigates synchronously).

## Testing
- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test:run` — 801 passed ✓
- `npm run build` ✓

No automated regression test: the bug lives in a React context `useEffect`, the repo has no React render test infra (vitest env is `node`, no testing-library), and `contexts/**` is excluded from coverage. Standing that up was judged disproportionate for this fix — happy to add it as a follow-up if desired.

## Follow-ups (not in this PR)
- `useStripePrices` only re-fetches on connectivity change, not sign-in/out (mostly moot once the spurious logout is gone).
- `supabase/client.ts` omits `storageKey`/`detectSessionInUrl` — defaults are fine but worth pinning if multiple Supabase projects ever share an origin.

https://claude.ai/code/session_01R4MvBAJSBCs13thbkZEXTS

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4MvBAJSBCs13thbkZEXTS)_