### PR TITLE
Clarify paid plans only cover cloud backups on pricing cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contended Web Lock survives reloads.)
 
 ### Changed
+- **Pricing cards now clarify that paid plans only cover cloud backups.** Every
+  storage line on the plan cards (home + sign-up) carries an asterisk to a new
+  footnote spelling out that storage on your own device is always unlimited and
+  free — paid tiers only back your datalogs up to the cloud (and help support
+  development). Removes the common confusion that you have to pay to keep using
+  the app or to store logs locally.
 - **Coverage badge now publishes to a GitHub Gist instead of a `badges` branch.**
   The orphan `badges` branch caused Cloudflare Workers Builds to repeatedly try
   (and fail) to deploy a branch with no app in it. The `coverage.yml` workflow

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -81,7 +81,7 @@ function onlineCard(variant: Variant): FreeTier {
     price: "$0",
     slug: "free",
     inherits: variant === "register" ? "Everything included with offline mode" : "Everything in Free, plus",
-    features: [CLOUD_SYNC_FEATURE, "Fastest laps & synced setups — always free", "50 MB cloud storage"],
+    features: [CLOUD_SYNC_FEATURE, "Fastest laps & synced setups — always free", "50 MB cloud storage*"],
   };
 }
 
@@ -96,7 +96,7 @@ const PAID_TIERS: PaidTier[] = [
     highlight: true,
     inherits: "Everything in Free online, plus",
     features: [
-      "10 GB cloud storage",
+      "10 GB cloud storage*",
       "Video uploads & sharing (coming soon)",
       "You're helping support the project ❤️",
     ],
@@ -106,14 +106,14 @@ const PAID_TIERS: PaidTier[] = [
     blurb: "Max storage",
     slug: "premium",
     inherits: "Everything in Plus, plus",
-    features: ["100 GB cloud storage"],
+    features: ["100 GB cloud storage*"],
   },
   {
     name: "Pro",
     blurb: "With AI coaching",
     slug: "pro",
     inherits: "Everything in Premium, plus",
-    features: ["500 GB cloud storage", "AI coaching (coming soon)"],
+    features: ["500 GB cloud storage*", "AI coaching (coming soon)"],
   },
 ];
 
@@ -364,6 +364,12 @@ export function PricingCards({ className, variant = "home" }: { className?: stri
             );
           })}
       </div>
+      <p className="mt-4 text-center text-xs text-muted-foreground">
+        * Storage on your own device is always <span className="font-medium text-foreground">unlimited and free</span>.
+        Paid plans only cover <span className="font-medium text-foreground">cloud backups of your datalogs</span> —
+        so you can dump as many logs as you like and keep them synced across devices. Upgrading mostly just helps
+        support development ❤️
+      </p>
     </section>
   );
 }


### PR DESCRIPTION
## Why

People keep reading the plan cards as "you have to pay to use the app / to store logs." In reality the app is fully offline and local storage on your device is always unlimited — paid tiers only buy **cloud backup** of your datalogs (and help support development). This is a small copy/visual change to remove that confusion.

## What

In `src/components/PricingCards.tsx` (the single component that renders the cards on **both** the landing/home page and the sign-up page):

- Added an asterisk to every cloud-storage feature line — `50 MB cloud storage*`, `10 GB cloud storage*`, `100 GB cloud storage*`, `500 GB cloud storage*`.
- Added a footnote beneath the grid:

  > \* Storage on your own device is always **unlimited and free**. Paid plans only cover **cloud backups of your datalogs** — so you can dump as many logs as you like and keep them synced across devices. Upgrading mostly just helps support development ❤️

Plus a `CHANGELOG.md` `[Unreleased]` entry.

## Notes

- No tier limits or storage values were changed — this is purely messaging.
- Cloud/log backups currently bill against the pooled Supabase byte budget (`subscription_tiers.total_bytes`), not Cloudflare. Raising the free tier later is a one-value change in the storage-quota migration + `TIER_STORAGE_LABEL` — left untouched here.

## Checks

`npm run lint`, `npm run typecheck`, `npm run test:run` (801 passing), and `npm run build` all green.

https://claude.ai/code/session_01UCEoj5PWSHdGdyjpfN6C13

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEoj5PWSHdGdyjpfN6C13)_