### PR TITLE
Auto-save sector lines on drag release in visual track editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Track editor sector lines now save the moment you release a drag marker.**
+  In the visual editor, adjusting the Start/Finish, Sector 2, or Sector 3 line no
+  longer requires a separate "Done" click to commit — each line is written to the
+  form as soon as you let go of a marker. The footer button is relabeled "Close"
+  for line tools (it just dismisses the editor; your edits are already saved) and
+  stays "Done" for the layout Draw tool, which still finalizes the drawing on
+  click. Removes a confusing extra step where dragging a line and switching tools
+  silently discarded the change.
+
 ### Fixed
 - **Spurious sign-out on page refresh (and the paid plan card vanishing with
   it).** The auth bootstrap awaited a Supabase RPC (`has_role`) *inside* the

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -194,7 +194,7 @@ function VisualEditorToolbar({ activeTool, onToolChange, onDone, showDrawTool, i
           onClick={handleDone}
         >
           <Check className="w-3.5 h-3.5" />
-          Done
+          {activeTool === 'draw' ? 'Done' : 'Close'}
         </Button>
       </div>
       {showLapPicker && laps && laps.length > 0 && (
@@ -501,12 +501,18 @@ export function VisualEditor({
         const newA = isPointA ? newPoint : otherPoint;
         const newB = isPointA ? otherPoint : newPoint;
 
+        // Save immediately on release — no separate "Done" step needed. The
+        // pending state keeps the active markers consistent; the parent
+        // callback commits the line straight into the form.
         if (tool === 'startFinish') {
           setPendingStartFinish({ a: newA, b: newB });
+          onStartFinishChange?.(newA, newB);
         } else if (tool === 'sector2') {
           setPendingSector2({ a: newA, b: newB });
+          onSector2Change?.({ a: newA, b: newB });
         } else if (tool === 'sector3') {
           setPendingSector3({ a: newA, b: newB });
+          onSector3Change?.({ a: newA, b: newB });
         }
       });
 
@@ -811,7 +817,7 @@ export function VisualEditor({
       return `No ${activeTool === 'startFinish' ? 'Start/Finish' : activeTool === 'sector2' ? 'Sector 2' : 'Sector 3'} line defined`;
     }
     const toolName = activeTool === 'startFinish' ? 'Start/Finish' : activeTool === 'sector2' ? 'Sector 2' : 'Sector 3';
-    return `Drag the markers to adjust the ${toolName} line`;
+    return `Drag the markers to adjust the ${toolName} line — changes save automatically when you release`;
   };
 
   return (


### PR DESCRIPTION
## What

In the visual track/course editor, adjusting the **Start/Finish**, **Sector 2**, or **Sector 3** line now saves the moment you release a drag marker. No more separate "Done" click to commit a line.

## Why

Dragging a marker only updated local *pending* state — the change wasn't written to the form until you clicked **Done**. Switching tools (or closing) without clicking Done **silently discarded** the edit. Users reported the "Done" step as very confusing, since the line visibly moved but didn't stick.

## Changes

- `VisualEditor.tsx` `dragend` handler now commits the line straight into the form via the parent callback (`onStartFinishChange` / `onSector2Change` / `onSector3Change`) on release, in addition to keeping the pending state that drives the live markers.
- The footer button is relabeled **"Close"** for the line tools (edits are already saved; it just dismisses the editor) and stays **"Done"** for the layout **Draw** tool, which still finalizes its drawing on click.
- Helper text notes that line edits save automatically on release.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Verification

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test:run` — 801 passed ✓
- `npm run build` ✓

No new unit test: this is Leaflet marker interaction in the excluded view layer (`components/**/*.tsx`), with no pure function to target.

https://claude.ai/code/session_01JRXQjuRKccev5JjUjHThAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRXQjuRKccev5JjUjHThAv)_