### PR TITLE
feat(charts): distance/time X-axis toggle, default to distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   analysis works. A new **Chart Scale** toggle in Settings switches between
   Distance and Time; **Distance is the default**. Distance tick labels follow
   the speed unit (MPH → ft/mi, KPH → m/km).
+  - The X-axis is **anchored at the start-finish line**: tick labels read in
+    *absolute* distance/time from the lap start (e.g. 450 m → 780 m), not from
+    the cropped window — `0` is always the start line. Cropping with the range
+    handles still zooms the graph; the handles themselves are now labelled in
+    the same distance/time scale.
 
 ## [2.0.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Distance vs. time chart scale.** The analysis charts (simple-mode telemetry
+  chart and pro-mode graphs) can now plot against **track distance** instead of
+  elapsed time, so laps line up corner-for-corner — the way Race Studio / MoTeC
+  analysis works. A new **Chart Scale** toggle in Settings switches between
+  Distance and Time; **Distance is the default**. Distance tick labels follow
+  the speed unit (MPH → ft/mi, KPH → m/km).
+
 ## [2.0.0] - 2026-06-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,6 +598,14 @@ MPH→ft/mi, KPH→m/km), and an `indexAt` inverse for scrubbing. Distance is th
 default so laps line up by track position; the reference/pace overlays already
 align by distance, so they sit correctly on either axis.
 
+The axis is **anchored at the start-finish line**: the charts draw the cropped
+visible window stretched to fill the canvas (zoom preserved), but pass the full
+lap (`allSamples`) + the window's `rangeStart` so `buildChartAxis` labels ticks
+in *absolute* distance/time from the lap origin (`0` = start-finish) rather than
+window-relative. The range-slider crop handles (`formatRangeLabel`, built in
+`Index.tsx`) follow the same scale — cumulative distance from the lap start in
+distance mode, elapsed time otherwise.
+
 Channels are normalized to canonical ids at parse time (`channels.ts` →
 `normalizeChannels()`), so `extraFields` keys and `FieldMapping.name` are uniform
 across formats (e.g. every parser's lateral-g lands on `lat_g`, with display

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,11 +583,20 @@ Global BLE connection state is managed by `DeviceContext.tsx`, wrapping the app 
 
 `useSettings` hook (persists to localStorage) → `SettingsContext` for tree-wide access.
 
-Key settings: `useKph`, `gForceSmoothing`, `gForceSmoothingStrength`, `brakingZoneSettings` (thresholds, duration, smoothing, color, width), `enableLabs` (hidden when no labs features), `darkMode`, `deltaMethod` (`'position'` default | `'distance'` legacy), `deltaSampleMeters` (arc-length resample spacing for position delta, default 2).
+Key settings: `useKph`, `gForceSmoothing`, `gForceSmoothingStrength`, `brakingZoneSettings` (thresholds, duration, smoothing, color, width), `enableLabs` (hidden when no labs features), `darkMode`, `deltaMethod` (`'position'` default | `'distance'` legacy), `deltaSampleMeters` (arc-length resample spacing for position delta, default 2), `chartXAxis` (`'distance'` default | `'time'`) — the analysis-chart X-axis scale.
 
 `useReferenceLap.ts` routes pace through `computeLapPace` (`lapDelta.ts`), which
 switches on `deltaMethod`. The position method is the issue #29 port; `distance`
 falls back to the legacy `calculatePace` in `referenceUtils.ts`.
+
+`chartXAxis` is plumbed through `SettingsContext` and consumed by both analysis
+charts (`TelemetryChart`, `SingleSeriesChart`) via `lib/chartAxis.ts`
+(`buildChartAxis`): a pure, unit-tested helper that maps each sample to an
+x-fraction (elapsed-time fraction, or cumulative-distance fraction via
+`calculateDistanceArray`), supplies tick labels (distance unit follows `useKph`:
+MPH→ft/mi, KPH→m/km), and an `indexAt` inverse for scrubbing. Distance is the
+default so laps line up by track position; the reference/pace overlays already
+align by distance, so they sit correctly on either axis.
 
 Channels are normalized to canonical ids at parse time (`channels.ts` →
 `normalizeChannels()`), so `extraFields` keys and `FieldMapping.name` are uniform

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Settings, Eye, EyeOff, Gauge, Activity, Circle, HardDrive, FlaskConical, Sun, Moon, RefreshCw, Timer, ChevronDown } from "lucide-react";
+import { Settings, Eye, EyeOff, Gauge, Activity, Circle, HardDrive, FlaskConical, Sun, Moon, RefreshCw, Timer, Ruler, ChevronDown } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -214,6 +214,38 @@ export function SettingsModal({
                 />
                 <span className={`text-xs ${settings.deltaMethod === 'position' ? "text-foreground font-medium" : "text-muted-foreground"}`}>
                   Position
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Chart X-Axis Scale */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Ruler className="w-4 h-4 text-muted-foreground" />
+              <h3 className="font-medium">Chart Scale</h3>
+            </div>
+            <div className="flex items-center justify-between pl-6">
+              <div>
+                <Label htmlFor="settings-chart-xaxis" className="text-sm text-muted-foreground">
+                  Telemetry chart X-axis
+                </Label>
+                <p className="text-xs text-muted-foreground/70 mt-0.5">
+                  Distance plots against track position so laps line up
+                  corner-for-corner; Time plots against elapsed lap time
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className={`text-xs ${settings.chartXAxis === 'time' ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                  Time
+                </span>
+                <Switch
+                  id="settings-chart-xaxis"
+                  checked={settings.chartXAxis === 'distance'}
+                  onCheckedChange={(checked) => onSettingsChange({ chartXAxis: checked ? 'distance' : 'time' })}
+                />
+                <span className={`text-xs ${settings.chartXAxis === 'distance' ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                  Distance
                 </span>
               </div>
             </div>

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -14,6 +14,10 @@ interface TelemetryChartProps {
   paceData?: (number | null)[];
   referenceSpeedData?: (number | null)[];
   hasReference?: boolean;
+  /** Full lap samples + the visible window's start index, for absolute
+   *  (start-finish-anchored) X-axis labels while the window stays zoomed. */
+  allSamples?: GpsSample[];
+  rangeStart?: number;
 }
 
 const COLORS = [
@@ -39,10 +43,15 @@ export function TelemetryChart({
   paceData = [],
   referenceSpeedData = [],
   hasReference = false,
+  allSamples,
+  rangeStart,
 }: TelemetryChartProps) {
   const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, gForceSource, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
-  const axis = useMemo(() => buildChartAxis(samples, chartXAxis, { useKph }), [samples, chartXAxis, useKph]);
+  const axis = useMemo(
+    () => buildChartAxis(samples, chartXAxis, { useKph, fullSamples: allSamples, rangeStart }),
+    [samples, chartXAxis, useKph, allSamples, rangeStart],
+  );
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -3,6 +3,7 @@ import { GpsSample, FieldMapping } from '@/types/racing';
 import { G_FORCE_FIELDS, G_FORCE_FIELDS_GPS, G_FORCE_FIELDS_HW, applySmoothingToValues, computeSmoothingWindowSize, detectSpeedGlitchIndices, interpolateGlitchSpeed } from '@/lib/chartUtils';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
+import { buildChartAxis } from '@/lib/chartAxis';
 
 interface TelemetryChartProps {
   samples: GpsSample[];
@@ -39,8 +40,9 @@ export function TelemetryChart({
   referenceSpeedData = [],
   hasReference = false,
 }: TelemetryChartProps) {
-  const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, gForceSource } = useSettingsContext();
+  const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, gForceSource, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
+  const axis = useMemo(() => buildChartAxis(samples, chartXAxis, { useKph }), [samples, chartXAxis, useKph]);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -154,7 +156,7 @@ export function TelemetryChart({
           continue;
         }
 
-        const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+        const x = padding.left + axis.fracAt(i) * chartWidth;
         const y = padding.top + (1 - (refSpeed - minSpeed) / (maxSpeed - minSpeed)) * chartHeight;
 
         if (!isDrawing) {
@@ -180,7 +182,7 @@ export function TelemetryChart({
     let lastValidIndex = 0;
 
     for (let i = 0; i < samples.length; i++) {
-      const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+      const x = padding.left + axis.fracAt(i) * chartWidth;
       let speed = allSpeeds[i];
 
       if (interpolateIndices.has(i) && i > 0 && i < samples.length - 1) {
@@ -234,7 +236,7 @@ export function TelemetryChart({
           continue;
         }
         
-        const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+        const x = padding.left + axis.fracAt(i) * chartWidth;
         const y = padding.top + (1 - (val - minVal) / range) * chartHeight;
         
         if (!isDrawing) {
@@ -281,7 +283,7 @@ export function TelemetryChart({
             continue;
           }
           
-          const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+          const x = padding.left + axis.fracAt(i) * chartWidth;
           // Pace: positive = slower (below zero line), negative = faster (above zero line)
           // Normalize to use full chart height
           const normalizedPace = pace / paceExtent; // -1 to 1
@@ -307,7 +309,7 @@ export function TelemetryChart({
           const pace = paceData[i];
           if (pace === null) continue;
           
-          const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+          const x = padding.left + axis.fracAt(i) * chartWidth;
           const normalizedPace = pace / paceExtent;
           const y = padding.top + ((1 - (-normalizedPace)) / 2) * chartHeight;
           
@@ -346,23 +348,16 @@ export function TelemetryChart({
     ctx.fillText(speedUnit, 0, 0);
     ctx.restore();
 
-    // Draw X axis labels (time)
+    // Draw X axis labels (time or distance, per chartXAxis setting)
     ctx.textAlign = 'center';
-    const startTime = samples[0].t / 1000;
-    const endTime = samples[samples.length - 1].t / 1000;
-    const duration = endTime - startTime;
-    
     for (let i = 0; i <= timeGridCount; i++) {
-      const time = (duration / timeGridCount) * i;
       const x = padding.left + (chartWidth / timeGridCount) * i;
-      const minutes = Math.floor(time / 60);
-      const seconds = (time % 60).toFixed(0).padStart(2, '0');
-      ctx.fillText(`${minutes}:${seconds}`, x, dimensions.height - 8);
+      ctx.fillText(axis.label(i / timeGridCount), x, dimensions.height - 8);
     }
 
     // Draw scrub cursor
     if (currentIndex >= 0 && currentIndex < samples.length) {
-      const x = padding.left + (currentIndex / (samples.length - 1)) * chartWidth;
+      const x = padding.left + axis.fracAt(currentIndex) * chartWidth;
       
       ctx.beginPath();
       ctx.moveTo(x, padding.top);
@@ -432,7 +427,7 @@ export function TelemetryChart({
       });
     }
 
-  }, [samples, currentIndex, dimensions, enabledFields, useKph, speedUnit, paceData, referenceSpeedData, hasReference, showReferenceSpeed, showPace, smoothedGForceData, chartColors, fieldMappings, getSpeed]);
+  }, [samples, currentIndex, dimensions, enabledFields, useKph, speedUnit, paceData, referenceSpeedData, hasReference, showReferenceSpeed, showPace, smoothedGForceData, chartColors, fieldMappings, getSpeed, axis]);
 
   // Scrub handling
   const handleScrub = useCallback((clientX: number) => {
@@ -444,9 +439,8 @@ export function TelemetryChart({
     const chartWidth = rect.width - padding.left - padding.right;
     const x = clientX - rect.left - padding.left;
     const ratio = Math.max(0, Math.min(1, x / chartWidth));
-    const index = Math.round(ratio * (samples.length - 1));
-    onScrub(index);
-  }, [samples, onScrub]);
+    onScrub(axis.indexAt(ratio));
+  }, [samples, onScrub, axis]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     setIsDragging(true);

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -225,6 +225,8 @@ export function GraphPanel({
                 onDelete={() => removeGraph(key)}
                 referenceValues={referenceValuesByKey[key]?.slice(visibleRange[0], visibleRange[1] + 1) ?? null}
                 brakingGValues={key === '__braking_g__' ? brakingGFull.slice(visibleRange[0], visibleRange[1] + 1) : undefined}
+                allSamples={filteredSamples}
+                rangeStart={visibleRange[0]}
               />
             ))}
             {/* Add more button */}

--- a/src/components/graphview/SingleSeriesChart.tsx
+++ b/src/components/graphview/SingleSeriesChart.tsx
@@ -16,16 +16,24 @@ interface SingleSeriesChartProps {
   onDelete: () => void;
   referenceValues?: (number | null)[] | null;
   brakingGValues?: number[];
+  /** Full lap samples + the visible window's start index, for absolute
+   *  (start-finish-anchored) X-axis labels while the window stays zoomed. */
+  allSamples?: GpsSample[];
+  rangeStart?: number;
 }
 
 export function SingleSeriesChart({
   samples, seriesKey, currentIndex, onScrub,
   color, label, onDelete,
   referenceValues = null, brakingGValues,
+  allSamples, rangeStart,
 }: SingleSeriesChartProps) {
   const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
-  const axis = useMemo(() => buildChartAxis(samples, chartXAxis, { useKph }), [samples, chartXAxis, useKph]);
+  const axis = useMemo(
+    () => buildChartAxis(samples, chartXAxis, { useKph, fullSamples: allSamples, rangeStart }),
+    [samples, chartXAxis, useKph, allSamples, rangeStart],
+  );
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });

--- a/src/components/graphview/SingleSeriesChart.tsx
+++ b/src/components/graphview/SingleSeriesChart.tsx
@@ -4,6 +4,7 @@ import { GpsSample } from '@/types/racing';
 import { G_FORCE_FIELDS, applySmoothingToValues, computeSmoothingWindowSize, detectSpeedGlitchIndices, interpolateGlitchSpeed } from '@/lib/chartUtils';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
+import { buildChartAxis } from '@/lib/chartAxis';
 
 interface SingleSeriesChartProps {
   samples: GpsSample[];
@@ -22,8 +23,9 @@ export function SingleSeriesChart({
   color, label, onDelete,
   referenceValues = null, brakingGValues,
 }: SingleSeriesChartProps) {
-  const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode } = useSettingsContext();
+  const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
+  const axis = useMemo(() => buildChartAxis(samples, chartXAxis, { useKph }), [samples, chartXAxis, useKph]);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -149,7 +151,7 @@ export function SingleSeriesChart({
       for (let i = 0; i < samples.length; i++) {
         const rv = referenceValues[i];
         if (rv === null || rv === undefined) { refDrawing = false; continue; }
-        const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+        const x = padding.left + axis.fracAt(i) * chartWidth;
         const y = padding.top + (1 - (rv - minVal) / range) * chartHeight;
         if (!refDrawing) { ctx.moveTo(x, y); refDrawing = true; }
         else { ctx.lineTo(x, y); }
@@ -193,7 +195,7 @@ export function SingleSeriesChart({
         lastValidIndex = i;
       }
 
-      const x = padding.left + (i / (samples.length - 1)) * chartWidth;
+      const x = padding.left + axis.fracAt(i) * chartWidth;
       const y = padding.top + (1 - (val - minVal) / range) * chartHeight;
 
       if (!isDrawing) { ctx.moveTo(x, y); isDrawing = true; }
@@ -212,22 +214,16 @@ export function SingleSeriesChart({
       ctx.fillText(fmt, padding.left - 6, y + 3);
     }
 
-    // X axis labels (time)
+    // X axis labels (time or distance, per chartXAxis setting)
     ctx.textAlign = 'center';
-    const startTime = samples[0].t / 1000;
-    const endTime = samples[samples.length - 1].t / 1000;
-    const duration = endTime - startTime;
     for (let i = 0; i <= timeGridCount; i += 2) {
-      const time = (duration / timeGridCount) * i;
       const x = padding.left + (chartWidth / timeGridCount) * i;
-      const mins = Math.floor(time / 60);
-      const secs = (time % 60).toFixed(0).padStart(2, '0');
-      ctx.fillText(`${mins}:${secs}`, x, dimensions.height - 6);
+      ctx.fillText(axis.label(i / timeGridCount), x, dimensions.height - 6);
     }
 
     // Scrub cursor
     if (currentIndex >= 0 && currentIndex < samples.length) {
-      const x = padding.left + (currentIndex / (samples.length - 1)) * chartWidth;
+      const x = padding.left + axis.fracAt(currentIndex) * chartWidth;
       ctx.beginPath();
       ctx.moveTo(x, padding.top);
       ctx.lineTo(x, padding.top + chartHeight);
@@ -278,7 +274,7 @@ export function SingleSeriesChart({
         }
       }
     }
-  }, [samples, values, currentIndex, dimensions, color, isSpeed, isPace, isBrakingG, useKph, interpolateIndices, referenceValues, chartColors]);
+  }, [samples, values, currentIndex, dimensions, color, isSpeed, isPace, isBrakingG, useKph, interpolateIndices, referenceValues, chartColors, axis]);
 
   // Scrub handling
   const handleScrub = useCallback((clientX: number) => {
@@ -289,8 +285,8 @@ export function SingleSeriesChart({
     const chartWidth = rect.width - padding.left - padding.right;
     const x = clientX - rect.left - padding.left;
     const ratio = Math.max(0, Math.min(1, x / chartWidth));
-    onScrub(Math.round(ratio * (samples.length - 1)));
-  }, [samples, onScrub]);
+    onScrub(axis.indexAt(ratio));
+  }, [samples, onScrub, axis]);
 
   const handleMouseDown = (e: React.MouseEvent) => { setIsDragging(true); handleScrub(e.clientX); };
   const handleMouseMove = (e: React.MouseEvent) => { if (isDragging) handleScrub(e.clientX); };

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -52,6 +52,8 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
               paceData={s.paceData}
               referenceSpeedData={s.referenceSpeedData}
               hasReference={s.hasReference}
+              allSamples={s.filteredSamples}
+              rangeStart={s.visibleRange[0]}
             />
           </div>
           {s.filteredSamples.length > 0 && (

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -19,6 +19,7 @@ export interface SettingsContextValue {
   enableLabs: boolean;
   darkMode: boolean;
   gForceSource: 'gps' | 'hw';
+  chartXAxis: 'time' | 'distance';
 }
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -21,6 +21,7 @@ export interface AppSettings {
   gForceSource: 'gps' | 'hw';      // Which G-force source to show in simple mode (default: 'hw')
   deltaMethod: 'position' | 'distance'; // Lap delta algorithm (default: 'position')
   deltaSampleMeters: number;        // Arc-length resample spacing for position delta (default: 2)
+  chartXAxis: 'time' | 'distance';  // Analysis chart X-axis scale (default: 'distance')
 }
 
 const SETTINGS_KEY = "dove-dataviewer-settings";
@@ -45,6 +46,7 @@ const defaultSettings: AppSettings = {
   gForceSource: 'hw',
   deltaMethod: 'position',
   deltaSampleMeters: 2,
+  chartXAxis: 'distance',
 };
 
 export function useSettings() {

--- a/src/lib/chartAxis.test.ts
+++ b/src/lib/chartAxis.test.ts
@@ -110,6 +110,37 @@ describe("buildChartAxis.label", () => {
   });
 });
 
+describe("buildChartAxis absolute labels (fullSamples + rangeStart)", () => {
+  // Full lap: 11 points, 10 m apart (0..100 m), 1 s apart (0..10 s).
+  const fullLap = Array.from({ length: 11 }, (_, i) => makeSample(i * 10, i * 1000));
+
+  it("labels a cropped window in absolute distance from the lap start", () => {
+    const window = fullLap.slice(3, 7); // 30 m .. 60 m
+    const axis = buildChartAxis(window, "distance", { useKph: true, fullSamples: fullLap, rangeStart: 3 });
+    // Window still fills the canvas (data fractions span 0..1)...
+    expect(axis.fracAt(0)).toBe(0);
+    expect(axis.fracAt(3)).toBeCloseTo(1, 6);
+    // ...but tick labels are anchored at the start-finish line.
+    expect(axis.label(0)).toBe("30 m");
+    expect(axis.label(1)).toBe("60 m");
+    expect(axis.label(0.5)).toBe("45 m");
+  });
+
+  it("labels a cropped window in absolute time from the lap start", () => {
+    const window = fullLap.slice(4, 9); // 4 s .. 8 s
+    const axis = buildChartAxis(window, "time", { useKph: false, fullSamples: fullLap, rangeStart: 4 });
+    expect(axis.label(0)).toBe("0:04");
+    expect(axis.label(1)).toBe("0:08");
+  });
+
+  it("anchors at 0 when the window starts at the lap origin", () => {
+    const window = fullLap.slice(0, 5); // 0 m .. 40 m
+    const axis = buildChartAxis(window, "distance", { useKph: true, fullSamples: fullLap, rangeStart: 0 });
+    expect(axis.label(0)).toBe("0 m");
+    expect(axis.label(1)).toBe("40 m");
+  });
+});
+
 describe("format helpers", () => {
   it("formats time as m:ss", () => {
     expect(formatAxisTime(0)).toBe("0:00");

--- a/src/lib/chartAxis.test.ts
+++ b/src/lib/chartAxis.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { EARTH_RADIUS_M } from "./parserUtils";
+import {
+  buildChartAxis,
+  computeAxisPositions,
+  formatAxisDistance,
+  formatAxisTime,
+} from "./chartAxis";
+import type { GpsSample } from "@/types/racing";
+
+const BASE_LAT = 45;
+const BASE_LON = 9;
+const M_PER_DEG_LAT = (Math.PI / 180) * EARTH_RADIUS_M;
+
+// Sample whose planar distance from the origin equals `distM` (lat-only shift),
+// timestamped at `t` ms — so both axis quantities are exactly known.
+function makeSample(distM: number, t: number): GpsSample {
+  return {
+    t,
+    lat: BASE_LAT + distM / M_PER_DEG_LAT,
+    lon: BASE_LON,
+    speedMps: 0,
+    speedMph: 0,
+    speedKph: 0,
+    extraFields: {},
+  };
+}
+
+describe("computeAxisPositions", () => {
+  it("returns elapsed-time fractions in time mode", () => {
+    // Non-uniform timestamps: 0, 100, 400 ms.
+    const samples = [makeSample(0, 0), makeSample(10, 100), makeSample(20, 400)];
+    const pos = computeAxisPositions(samples, "time");
+    expect(pos[0]).toBe(0);
+    expect(pos[1]).toBeCloseTo(0.25, 6);
+    expect(pos[2]).toBe(1);
+  });
+
+  it("returns cumulative-distance fractions in distance mode", () => {
+    // Distances 0, 10, 40 m but evenly timed — distance axis must follow space.
+    const samples = [makeSample(0, 0), makeSample(10, 100), makeSample(40, 200)];
+    const pos = computeAxisPositions(samples, "distance");
+    expect(pos[0]).toBe(0);
+    expect(pos[1]).toBeCloseTo(0.25, 4);
+    expect(pos[2]).toBeCloseTo(1, 6);
+  });
+
+  it("is monotonic non-decreasing and bounded to [0,1]", () => {
+    const samples = Array.from({ length: 50 }, (_, i) => makeSample(i * i, i * 17));
+    for (const mode of ["time", "distance"] as const) {
+      const pos = computeAxisPositions(samples, mode);
+      expect(pos[0]).toBe(0);
+      expect(pos[pos.length - 1]).toBeCloseTo(1, 6);
+      for (let i = 1; i < pos.length; i++) {
+        expect(pos[i]).toBeGreaterThanOrEqual(pos[i - 1]);
+        expect(pos[i]).toBeLessThanOrEqual(1 + 1e-9);
+      }
+    }
+  });
+
+  it("falls back to a linear index ramp when the quantity has no span", () => {
+    // Stationary trace (zero distance) and identical timestamps (zero duration).
+    const stationary = [makeSample(0, 0), makeSample(0, 0), makeSample(0, 0)];
+    expect(computeAxisPositions(stationary, "distance")).toEqual([0, 0.5, 1]);
+    expect(computeAxisPositions(stationary, "time")).toEqual([0, 0.5, 1]);
+  });
+
+  it("handles empty and single-sample inputs", () => {
+    expect(computeAxisPositions([], "time")).toEqual([]);
+    expect(computeAxisPositions([makeSample(0, 0)], "distance")).toEqual([0]);
+  });
+});
+
+describe("buildChartAxis.indexAt", () => {
+  it("inverts fracAt to the nearest sample", () => {
+    const samples = [makeSample(0, 0), makeSample(10, 100), makeSample(40, 200)];
+    const axis = buildChartAxis(samples, "distance", { useKph: true });
+    // Round-trip every sample's own fraction back to its index.
+    samples.forEach((_, i) => expect(axis.indexAt(axis.fracAt(i))).toBe(i));
+    // A fraction just past the midpoint snaps to the closer endpoint sample.
+    expect(axis.indexAt(0.24)).toBe(1);
+    expect(axis.indexAt(0)).toBe(0);
+    expect(axis.indexAt(1)).toBe(2);
+  });
+
+  it("clamps out-of-range fractions", () => {
+    const samples = [makeSample(0, 0), makeSample(10, 100)];
+    const axis = buildChartAxis(samples, "time", { useKph: false });
+    expect(axis.indexAt(-5)).toBe(0);
+    expect(axis.indexAt(5)).toBe(1);
+  });
+});
+
+describe("buildChartAxis.label", () => {
+  it("labels time mode as m:ss across the axis", () => {
+    const samples = [makeSample(0, 0), makeSample(10, 90_000)]; // 90 s span
+    const axis = buildChartAxis(samples, "time", { useKph: false });
+    expect(axis.label(0)).toBe("0:00");
+    expect(axis.label(1)).toBe("1:30");
+  });
+
+  it("labels distance mode in the speed-unit family", () => {
+    const samples = [makeSample(0, 0), makeSample(100, 1000)]; // 100 m span
+    const metric = buildChartAxis(samples, "distance", { useKph: true });
+    expect(metric.label(0)).toBe("0 m");
+    expect(metric.label(1)).toBe("100 m");
+
+    const imperial = buildChartAxis(samples, "distance", { useKph: false });
+    expect(imperial.label(1)).toBe("328 ft");
+  });
+});
+
+describe("format helpers", () => {
+  it("formats time as m:ss", () => {
+    expect(formatAxisTime(0)).toBe("0:00");
+    expect(formatAxisTime(65)).toBe("1:05");
+  });
+
+  it("switches distance units past a full km / mile", () => {
+    expect(formatAxisDistance(500, true)).toBe("500 m");
+    expect(formatAxisDistance(1500, true)).toBe("1.50 km");
+    expect(formatAxisDistance(304.8, false)).toBe("1000 ft");
+    expect(formatAxisDistance(1609.344, false)).toBe("1.00 mi");
+  });
+});

--- a/src/lib/chartAxis.ts
+++ b/src/lib/chartAxis.ts
@@ -110,32 +110,52 @@ function nearestIndex(positions: number[], frac: number): number {
 /**
  * Build the axis helper for a sample set. `useKph` only affects distance-mode
  * tick labels (the unit family); positions are unit-agnostic fractions.
+ *
+ * Pass `fullSamples` + `rangeStart` to label **absolutely** from the full
+ * series' origin (the lap start / start-finish line): the drawn fractions still
+ * span [0..1] across `samples` so a cropped window fills the chart (zoom
+ * preserved), but tick labels read in absolute distance/time (e.g. 450 m →
+ * 780 m) instead of resetting to 0. Omit them to label window-relative.
  */
 export function buildChartAxis(
   samples: GpsSample[],
   mode: ChartXAxisMode,
-  opts: { useKph: boolean },
+  opts: { useKph: boolean; fullSamples?: GpsSample[]; rangeStart?: number },
 ): ChartAxis {
   const positions = computeAxisPositions(samples, mode);
   const n = samples.length;
 
-  let total = 0;
+  // Axis quantity spanned by the visible window (seconds or meters).
+  let extent = 0;
   if (mode === 'distance') {
     const dist = calculateDistanceArray(samples);
-    total = dist.length > 0 ? dist[dist.length - 1] : 0;
+    extent = dist.length > 0 ? dist[dist.length - 1] : 0;
   } else if (n > 1) {
-    total = (samples[n - 1].t - samples[0].t) / 1000; // seconds
+    extent = (samples[n - 1].t - samples[0].t) / 1000;
+  }
+
+  // Absolute offset of the window start from the full-series origin.
+  let offset = 0;
+  const { fullSamples, rangeStart } = opts;
+  const rs = rangeStart ?? 0;
+  if (fullSamples && rs > 0 && rs < fullSamples.length) {
+    if (mode === 'distance') {
+      const lead = calculateDistanceArray(fullSamples.slice(0, rs + 1));
+      offset = lead.length > 0 ? lead[lead.length - 1] : 0;
+    } else {
+      offset = (fullSamples[rs].t - fullSamples[0].t) / 1000;
+    }
   }
 
   return {
     mode,
     positions,
-    total,
+    total: extent,
     fracAt: (i: number) => positions[i] ?? 0,
     indexAt: (frac: number) => nearestIndex(positions, frac),
     label: (frac: number) =>
       mode === 'distance'
-        ? formatAxisDistance(total * frac, opts.useKph)
-        : formatAxisTime(total * frac),
+        ? formatAxisDistance(offset + extent * frac, opts.useKph)
+        : formatAxisTime(offset + extent * frac),
   };
 }

--- a/src/lib/chartAxis.ts
+++ b/src/lib/chartAxis.ts
@@ -1,0 +1,141 @@
+/**
+ * Chart X-axis abstraction shared by the analysis charts (TelemetryChart,
+ * SingleSeriesChart).
+ *
+ * Charts historically plotted each sample at a linear index fraction
+ * (`i / (n - 1)`) and labelled the axis as time. Serious telemetry tools plot
+ * against **distance** so two laps line up corner-for-corner. This module turns
+ * a sample array + a mode into:
+ *  - `positions[i]` — the sample's fraction [0..1] along the chosen quantity
+ *    (elapsed time or cumulative distance). The pixel axis is linear in that
+ *    quantity, so data points sit at `fracAt(i) * chartWidth`.
+ *  - `label(frac)` — the tick label for an axis fraction (mm:ss or a distance).
+ *  - `indexAt(frac)` — inverse lookup for scrubbing (axis fraction → sample).
+ *
+ * Everything here is pure and React-free so it can be unit-tested directly.
+ */
+
+import { GpsSample } from '@/types/racing';
+import { calculateDistanceArray } from './referenceUtils';
+
+export type ChartXAxisMode = 'time' | 'distance';
+
+const METERS_PER_FOOT = 0.3048;
+const FEET_PER_MILE = 5280;
+
+export interface ChartAxis {
+  mode: ChartXAxisMode;
+  /** Per-sample fraction [0..1] along the axis quantity (monotonic). */
+  positions: number[];
+  /** Total axis quantity — seconds (time) or meters (distance). */
+  total: number;
+  /** Fraction [0..1] for a sample index. */
+  fracAt(i: number): number;
+  /** Nearest sample index for an axis fraction [0..1]. */
+  indexAt(frac: number): number;
+  /** Tick label for an axis fraction [0..1]. */
+  label(frac: number): string;
+}
+
+/** Format elapsed seconds as `m:ss`. */
+export function formatAxisTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.abs(seconds % 60).toFixed(0).padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+/**
+ * Format a distance (in meters) using the unit family implied by the speed
+ * unit: KPH → meters/km, MPH → feet/miles. Switches to the larger unit once
+ * past a full km / mile so long sessions stay readable.
+ */
+export function formatAxisDistance(meters: number, useKph: boolean): string {
+  if (useKph) {
+    return meters >= 1000 ? `${(meters / 1000).toFixed(2)} km` : `${Math.round(meters)} m`;
+  }
+  const feet = meters / METERS_PER_FOOT;
+  return feet >= FEET_PER_MILE ? `${(feet / FEET_PER_MILE).toFixed(2)} mi` : `${Math.round(feet)} ft`;
+}
+
+/**
+ * Compute the per-sample axis fraction [0..1] for a mode. Falls back to a
+ * linear index fraction whenever the chosen quantity has no span (single
+ * sample, zero duration, or a stationary trace in distance mode) so the chart
+ * always renders something sensible.
+ */
+export function computeAxisPositions(samples: GpsSample[], mode: ChartXAxisMode): number[] {
+  const n = samples.length;
+  if (n === 0) return [];
+  if (n === 1) return [0];
+
+  const indexFallback = () => samples.map((_, i) => i / (n - 1));
+
+  if (mode === 'distance') {
+    const dist = calculateDistanceArray(samples);
+    const total = dist[dist.length - 1];
+    if (!(total > 0)) return indexFallback();
+    return dist.map((d) => d / total);
+  }
+
+  // time
+  const t0 = samples[0].t;
+  const total = samples[n - 1].t - t0;
+  if (!(total > 0)) return indexFallback();
+  return samples.map((s) => (s.t - t0) / total);
+}
+
+/** Nearest sample index whose position is closest to `frac` (positions monotonic). */
+function nearestIndex(positions: number[], frac: number): number {
+  const n = positions.length;
+  if (n === 0) return 0;
+  if (n === 1) return 0;
+  const target = Math.max(0, Math.min(1, frac));
+
+  // Binary search for the first index with position >= target.
+  let lo = 0;
+  let hi = n - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (positions[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+
+  // Compare the bracketing candidate to its predecessor and pick the closer one.
+  if (lo > 0 && Math.abs(positions[lo - 1] - target) <= Math.abs(positions[lo] - target)) {
+    return lo - 1;
+  }
+  return lo;
+}
+
+/**
+ * Build the axis helper for a sample set. `useKph` only affects distance-mode
+ * tick labels (the unit family); positions are unit-agnostic fractions.
+ */
+export function buildChartAxis(
+  samples: GpsSample[],
+  mode: ChartXAxisMode,
+  opts: { useKph: boolean },
+): ChartAxis {
+  const positions = computeAxisPositions(samples, mode);
+  const n = samples.length;
+
+  let total = 0;
+  if (mode === 'distance') {
+    const dist = calculateDistanceArray(samples);
+    total = dist.length > 0 ? dist[dist.length - 1] : 0;
+  } else if (n > 1) {
+    total = (samples[n - 1].t - samples[0].t) / 1000; // seconds
+  }
+
+  return {
+    mode,
+    positions,
+    total,
+    fracAt: (i: number) => positions[i] ?? 0,
+    indexAt: (frac: number) => nearestIndex(positions, frac),
+    label: (frac: number) =>
+      mode === 'distance'
+        ? formatAxisDistance(total * frac, opts.useKph)
+        : formatAxisTime(total * frac),
+  };
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,6 +29,8 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ParsedData } from "@/types/racing";
+import { calculateDistanceArray } from "@/lib/referenceUtils";
+import { formatAxisDistance } from "@/lib/chartAxis";
 import { usePanelsForSlot, PanelSlot } from "@/plugins/panels";
 import { TrackPromptDialog } from "@/components/TrackPromptDialog";
 import { useSettings } from "@/hooks/useSettings";
@@ -85,7 +87,7 @@ export default function Index() {
     filteredSamples, visibleSamples, visibleRange, currentIndex, filteredBounds,
     setSelectedLapNumber, setReferenceLapNumber, setCurrentIndex,
     handleSelectionChange, handleLapSelect, handleLapDropdownChange,
-    handleSetReference, handleScrub, handleRangeChange, formatRangeLabel,
+    handleSetReference, handleScrub, handleRangeChange, formatRangeLabel: formatRangeLabelTime,
   } = lapMgmt;
 
   // External reference
@@ -224,6 +226,23 @@ export default function Index() {
 
   const isAllLaps = selectedLapNumber === null;
   const minRange = Math.min(10, Math.floor(filteredSamples.length / 10));
+
+  // Crop-handle labels follow the chart X-axis scale: cumulative distance from
+  // the lap start (start-finish line) in distance mode, elapsed time otherwise.
+  const filteredDistances = useMemo(
+    () => (settings.chartXAxis === 'distance' ? calculateDistanceArray(filteredSamples) : null),
+    [settings.chartXAxis, filteredSamples],
+  );
+  const formatRangeLabel = useCallback(
+    (idx: number) => {
+      if (filteredDistances) {
+        const d = filteredDistances[idx];
+        return d === undefined ? "" : formatAxisDistance(d, useKph);
+      }
+      return formatRangeLabelTime(idx);
+    },
+    [filteredDistances, useKph, formatRangeLabelTime],
+  );
 
   const settingsContextValue = useMemo(() => ({
     useKph,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -233,7 +233,8 @@ export default function Index() {
     enableLabs: settings.enableLabs,
     darkMode: settings.darkMode,
     gForceSource: settings.gForceSource,
-  }), [useKph, settings.gForceSmoothing, settings.gForceSmoothingStrength, brakingZoneSettings, settings.enableLabs, settings.darkMode, settings.gForceSource]);
+    chartXAxis: settings.chartXAxis,
+  }), [useKph, settings.gForceSmoothing, settings.gForceSmoothingStrength, brakingZoneSettings, settings.enableLabs, settings.darkMode, settings.gForceSource, settings.chartXAxis]);
 
   // Memoize sliced data arrays to avoid recreating on every render
   const slicedPaceData = useMemo(


### PR DESCRIPTION
## What & why

First step in the "real race-data analysis" arc. The analysis charts plotted against **elapsed time**, which is exactly what makes a Race Studio / MoTeC user say "this doesn't give me the metrics I'd expect" — you can't compare two laps corner-for-corner on a time axis. This adds a **distance** X-axis (the pro default) and makes it the app-wide default, with a toggle back to time.

## Changes

- **New pure helper `src/lib/chartAxis.ts` (`buildChartAxis`)** — maps each sample to an x-fraction along the chosen quantity:
  - `time`: elapsed-time fraction `(t[i]-t0)/(t[n-1]-t0)`
  - `distance`: cumulative-distance fraction via the existing `calculateDistanceArray`
  - Supplies tick labels (distance unit follows the speed unit: **MPH → ft/mi, KPH → m/km**) and an `indexAt` inverse so scrub clicks still map to the right sample.
  - Falls back to a linear index ramp when the quantity has no span (single sample, zero duration, stationary trace). Unit-tested (`chartAxis.test.ts`, 11 cases).
- **New setting `chartXAxis: 'time' | 'distance'`** (default `'distance'`), plumbed `useSettings → SettingsContext → Index`, with a **Chart Scale** Time|Distance toggle in `SettingsModal`.
- **`TelemetryChart` (simple mode) + `SingleSeriesChart` (pro mode)** now plot at the axis fraction, relabel the X axis, and invert scrubbing through the axis. The reference/pace overlays already align by distance, so they sit correctly on either axis — no change to the comparison math.
- CHANGELOG + CLAUDE.md updated.

## Verification

`npm run lint` · `npm run typecheck` · `npm run test:run` (812 pass, +11 new) · `npm run build` — all green.

## Notes / follow-ups

Scoped to the on-screen analysis charts. The video-export overlay timeline stays time-based (it's tied to playback). Multi-lap line overlay + spatial map alignment and the G-G diagram are the planned next steps.

https://claude.ai/code/session_01Bv71GkEnPEfHki9RSYR7aq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv71GkEnPEfHki9RSYR7aq)_