### PR TITLE
Replace track submission form with bulk community-DB contribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **"Submit to DB" is now a one-tap bulk contribution instead of a coordinate
+  form.** The old flow made you hand-fill latitudes/longitudes for one course at
+  a time. Now the app diffs everything you've created locally against the
+  community track list and shows a review screen of exactly what will be sent —
+  each track flagged **New** or **Edited**, each course flagged **New track**,
+  **New course**, or **Modified** — and sends the whole thing as a single upload.
+  Courses identical to the built-in ones are skipped automatically, and the app
+  remembers what you've already submitted so unchanged courses aren't re-sent
+  (editing a course later re-flags it). Adding a course to a built-in track shows
+  that track as **Edited** (it adds the course; it never overwrites the track).
+- **Bulk submissions are grouped for admin review.** The `submit-track` edge
+  function now accepts many courses in one request and tags them with a shared
+  `batch_id`; the admin Submissions tab groups a user's upload together with
+  **Approve all / Deny all** for the batch. Each course is still its own row, so
+  the existing per-submission review/approve flow is unchanged. (Legacy
+  single-course submissions still work.)
+
 ## [2.0.0] - 2026-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remembers what you've already submitted so unchanged courses aren't re-sent
   (editing a course later re-flags it). Adding a course to a built-in track shows
   that track as **Edited** (it adds the course; it never overwrites the track).
+- **Track creation now captures a short name, auto-filled from the long name.**
+  The "Add Track" form has a **Short Name** field (max 8 chars) that fills in
+  live as you type the track name (e.g. "Orlando Kart Center" → "OKC") until you
+  edit it yourself. Tracks created before this — or otherwise missing a short
+  name — get one auto-derived at submit time, so contributing them is never
+  blocked.
 - **Bulk submissions are grouped for admin review.** The `submit-track` edge
   function now accepts many courses in one request and tags them with a shared
   `batch_id`; the admin Submissions tab groups a user's upload together with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ src/
 │   ├── lapSnapshotStorage.ts # ★ IndexedDB CRUD for lap snapshots (emits garageEvents)
 │   ├── setupRevision.ts  # ★ Pure content-addressed setup history: hash + freeze (immutable revisions)
 │   ├── setupRevisionStorage.ts # ★ IndexedDB CRUD for setup revisions (freezeSetupRevision; emits garageEvents)
+│   ├── trackSubmission.ts # ★ Pure community-DB upload plan: diff local tracks vs built-ins → new/edited, geometry hash + dedupe
+│   ├── submittedTracksStorage.ts # localStorage record of already-submitted course hashes (dedupe)
 │   ├── dbUtils.ts         # ★ Shared IndexedDB: DB_NAME, DB_VERSION, openDB(), tx helpers
 │   ├── garageEvents.ts    # ★ Host pub/sub: storage emits {store,key,put|delete}; cloud-sync syncs off it
 │   ├── *Storage.ts        # IDB stores: file, kart(compat), vehicle, engine, template, note, setup,
@@ -474,6 +476,34 @@ The `course_layouts` table stores polyline drawings of track layouts (1:1 with c
 **Submissions**: The `submissions` table has `has_layout` (bool) and `layout_data` (jsonb) columns to carry drawing data through the submission workflow.
 
 **Public drawings**: Admin exports drawings to `public/drawings.json` (keyed by `shortName/courseName` → `[{lat, lon}, ...]`). Loaded by `trackStorage.ts:loadCourseDrawings()` (cached). Rendered on the race line map as a dashed polyline outline when a course is selected. Helper: `getDrawingForCourse(shortName, courseName)`.
+
+---
+
+## Community Track Submission (`SubmitTrackDialog` + `lib/trackSubmission.ts`)
+
+The "Submit to DB" flow (track editor) is a **bulk, form-free contribution**:
+`buildSubmissionPlan(merged, defaults, submitted)` (pure, unit-tested) diffs the
+user's local tracks against the built-in list (`loadDefaultTracks()`) and
+classifies each user course as **new_track** (wholly new track —
+`Track.isUserDefined`), **new_course** (a course added to a built-in track), or
+**course_modification** (an edited built-in course). A user "edit" that is
+byte-identical to the built-in course is skipped. The track-level rollup reads
+**New** vs **Edited** (adding a course never overwrites the track). A geometry
+**content hash** (`courseContentHash`, rounded to ~1cm) drives both the
+identical-skip and dedupe: `submittedTracksStorage.ts` (localStorage key
+`racing-datalog-submitted-v1`) remembers each submitted course's hash, so
+unchanged courses aren't re-sent and a later edit re-flags the course.
+
+The review dialog sends all selected courses in **one** `submit-track` call
+(`{ submissions: [...], turnstile_token }`); the edge function validates each,
+caps batch size, rate-limits by rows/hour/IP, and inserts one `submissions` row
+per course sharing a generated **`batch_id`** (migration
+`20260603120000_submissions_batch_id.sql`). The admin **Submissions** tab groups
+a batch together with **Approve all / Deny all**; each row is still reviewed/
+approved individually (approval is still manual — it flips status; the admin then
+builds/imports `tracks.json` as before). The single-submission body shape stays
+supported for back-compat. `DbSubmission.batch_id` carries the group id client-
+side (the generated Supabase types are untouched — `getSubmissions` casts).
 
 ---
 

--- a/src/components/SubmitTrackDialog.tsx
+++ b/src/components/SubmitTrackDialog.tsx
@@ -1,54 +1,73 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from '@/components/ui/dialog';
 import { toast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
-import { Send, ShieldCheck, ArrowRight, ArrowLeft } from 'lucide-react';
-import type { Course } from '@/types/racing';
+import { Send, ShieldCheck, ArrowRight, ArrowLeft, Loader2, CheckCircle2, AlertTriangle, Check } from 'lucide-react';
+import { loadTracks, loadDefaultTracks } from '@/lib/trackStorage';
+import { buildSubmissionPlan, type SubmissionPlan, type SubmissionCourse } from '@/lib/trackSubmission';
+import { loadSubmittedRecords, markCoursesSubmitted } from '@/lib/submittedTracksStorage';
 
 const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY;
 
 interface SubmitTrackDialogProps {
   trigger: React.ReactNode;
-  prefill?: {
-    type: 'new_track' | 'new_course' | 'course_modification';
-    trackName: string;
-    trackShortName?: string;
-    courseName: string;
-    course?: Course;
-  };
+  /** Notified after a successful upload (e.g. to refresh a count badge). */
+  onSubmitted?: () => void;
 }
 
-type Step = 'confirm' | 'form';
+type Step = 'confirm' | 'review';
 
-export function SubmitTrackDialog({ trigger, prefill }: SubmitTrackDialogProps) {
+/** A new track can only go up if it has the short name the DB requires. */
+function isBlocked(course: SubmissionCourse): boolean {
+  return course.type === 'new_track' && !course.trackShortName?.trim();
+}
+
+const CHANGE_LABEL: Record<SubmissionCourse['change'], string> = {
+  'new-track': 'New track',
+  'new-course': 'New course',
+  modified: 'Modified',
+};
+
+const CHANGE_STYLE: Record<SubmissionCourse['change'], string> = {
+  'new-track': 'bg-primary/20 text-primary',
+  'new-course': 'bg-primary/20 text-primary',
+  modified: 'bg-amber-500/20 text-amber-400',
+};
+
+export function SubmitTrackDialog({ trigger, onSubmitted }: SubmitTrackDialogProps) {
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<Step>('confirm');
-  const [type, setType] = useState<string>('new_track');
-  const [trackName, setTrackName] = useState('');
-  const [trackShortName, setTrackShortName] = useState('');
-  const [courseName, setCourseName] = useState('');
-  const [startALat, setStartALat] = useState('');
-  const [startALng, setStartALng] = useState('');
-  const [startBLat, setStartBLat] = useState('');
-  const [startBLng, setStartBLng] = useState('');
-  const [s2aLat, setS2aLat] = useState('');
-  const [s2aLng, setS2aLng] = useState('');
-  const [s2bLat, setS2bLat] = useState('');
-  const [s2bLng, setS2bLng] = useState('');
-  const [s3aLat, setS3aLat] = useState('');
-  const [s3aLng, setS3aLng] = useState('');
-  const [s3bLat, setS3bLat] = useState('');
-  const [s3bLng, setS3bLng] = useState('');
+  const [plan, setPlan] = useState<SubmissionPlan | null>(null);
+  const [planLoading, setPlanLoading] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const turnstileRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
 
-  // Load Turnstile script
+  // Build the upload plan from everything the user currently has locally.
+  const buildPlan = useCallback(async () => {
+    setPlanLoading(true);
+    try {
+      const [merged, defaults] = await Promise.all([loadTracks(), loadDefaultTracks()]);
+      const p = buildSubmissionPlan(merged, defaults, loadSubmittedRecords());
+      setPlan(p);
+      // Default-select everything still pending and submittable.
+      const next = new Set<string>();
+      for (const g of p.groups) {
+        for (const c of g.courses) {
+          if (!c.alreadySubmitted && !isBlocked(c)) next.add(c.key);
+        }
+      }
+      setSelected(next);
+    } catch (e) {
+      toast({ title: 'Could not read your tracks', description: (e as Error).message, variant: 'destructive' });
+    }
+    setPlanLoading(false);
+  }, []);
+
+  // Load Turnstile script once.
   useEffect(() => {
     if (!TURNSTILE_SITE_KEY) return;
     if (document.getElementById('cf-turnstile-script')) return;
@@ -59,18 +78,14 @@ export function SubmitTrackDialog({ trigger, prefill }: SubmitTrackDialogProps) 
     document.head.appendChild(script);
   }, []);
 
-  // Render Turnstile widget when form step is shown
   const renderTurnstile = useCallback(() => {
     if (!TURNSTILE_SITE_KEY || !turnstileRef.current) return;
-    const win = window as unknown as { turnstile?: { render: (el: HTMLElement, opts: Record<string, unknown>) => string; remove: (id: string) => void; reset: (id: string) => void } };
+    const win = window as unknown as { turnstile?: { render: (el: HTMLElement, opts: Record<string, unknown>) => string; remove: (id: string) => void } };
     if (!win.turnstile) return;
-    
-    // Remove previous widget
     if (widgetIdRef.current) {
-      try { win.turnstile.remove(widgetIdRef.current); } catch { /* widget may already be removed */ }
+      try { win.turnstile.remove(widgetIdRef.current); } catch { /* already removed */ }
       widgetIdRef.current = null;
     }
-
     setTurnstileToken(null);
     widgetIdRef.current = win.turnstile.render(turnstileRef.current, {
       sitekey: TURNSTILE_SITE_KEY,
@@ -81,54 +96,35 @@ export function SubmitTrackDialog({ trigger, prefill }: SubmitTrackDialogProps) 
   }, []);
 
   useEffect(() => {
-    if (step === 'form' && open) {
-      // Small delay to ensure DOM is ready
+    if (step === 'review' && open) {
       const timer = setTimeout(renderTurnstile, 200);
       return () => clearTimeout(timer);
     }
   }, [step, open, renderTurnstile]);
 
-  // Pre-fill form when dialog opens
+  // Reset + (re)build the plan each time the dialog opens.
   useEffect(() => {
-    if (open && prefill) {
-      setType(prefill.type);
-      setTrackName(prefill.trackName);
-      setTrackShortName(prefill.trackShortName || '');
-      setCourseName(prefill.courseName);
-      if (prefill.course) {
-        setStartALat(String(prefill.course.startFinishA.lat));
-        setStartALng(String(prefill.course.startFinishA.lon));
-        setStartBLat(String(prefill.course.startFinishB.lat));
-        setStartBLng(String(prefill.course.startFinishB.lon));
-        if (prefill.course.sector2) {
-          setS2aLat(String(prefill.course.sector2.a.lat));
-          setS2aLng(String(prefill.course.sector2.a.lon));
-          setS2bLat(String(prefill.course.sector2.b.lat));
-          setS2bLng(String(prefill.course.sector2.b.lon));
-        }
-        if (prefill.course.sector3) {
-          setS3aLat(String(prefill.course.sector3.a.lat));
-          setS3aLng(String(prefill.course.sector3.a.lon));
-          setS3bLat(String(prefill.course.sector3.b.lat));
-          setS3bLng(String(prefill.course.sector3.b.lon));
-        }
-      }
-    }
     if (open) {
       setStep('confirm');
       setTurnstileToken(null);
+      buildPlan();
     }
-  }, [open, prefill]);
+  }, [open, buildPlan]);
 
-  const parseOpt = (v: string) => { const n = parseFloat(v); return isNaN(n) ? undefined : n; };
+  const toggle = (key: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const selectedCourses: SubmissionCourse[] =
+    plan?.groups.flatMap(g => g.courses).filter(c => selected.has(c.key)) ?? [];
 
   const handleSubmit = async () => {
-    if (!trackName.trim() || !courseName.trim()) {
-      toast({ title: 'Track name and course name are required', variant: 'destructive' });
-      return;
-    }
-    if (type === 'new_track' && !trackShortName.trim()) {
-      toast({ title: 'Short name is required for new tracks', variant: 'destructive' });
+    if (selectedCourses.length === 0) {
+      toast({ title: 'Nothing selected to submit', variant: 'destructive' });
       return;
     }
     if (TURNSTILE_SITE_KEY && !turnstileToken) {
@@ -138,53 +134,36 @@ export function SubmitTrackDialog({ trigger, prefill }: SubmitTrackDialogProps) 
 
     setLoading(true);
     try {
-      const courseData: Record<string, number | undefined> = {
-        start_a_lat: parseFloat(startALat),
-        start_a_lng: parseFloat(startALng),
-        start_b_lat: parseFloat(startBLat),
-        start_b_lng: parseFloat(startBLng),
-        sector_2_a_lat: parseOpt(s2aLat),
-        sector_2_a_lng: parseOpt(s2aLng),
-        sector_2_b_lat: parseOpt(s2bLat),
-        sector_2_b_lng: parseOpt(s2bLng),
-        sector_3_a_lat: parseOpt(s3aLat),
-        sector_3_a_lng: parseOpt(s3aLng),
-        sector_3_b_lat: parseOpt(s3bLat),
-        sector_3_b_lng: parseOpt(s3bLng),
-      };
-      for (const key of Object.keys(courseData)) {
-        if (courseData[key] === undefined) delete courseData[key];
-      }
+      const submissions = selectedCourses.map(c => ({
+        type: c.type,
+        track_name: c.trackName,
+        track_short_name: c.type === 'new_track' ? c.trackShortName : undefined,
+        course_name: c.courseName,
+        course_data: c.courseData,
+      }));
 
-      const { error } = await supabase.functions.invoke('submit-track', {
-        body: {
-          type,
-          track_name: trackName.trim(),
-          track_short_name: type === 'new_track' ? trackShortName.trim() : undefined,
-          course_name: courseName.trim(),
-          course_data: courseData,
-          turnstile_token: turnstileToken,
-        },
+      const { data, error } = await supabase.functions.invoke('submit-track', {
+        body: { submissions, turnstile_token: turnstileToken },
       });
       if (error) throw error;
-      toast({ title: 'Submission sent!', description: 'An admin will review your submission.' });
+
+      const batchId = (data as { batch_id?: string } | null)?.batch_id ?? `local-${Date.now()}`;
+      markCoursesSubmitted(selectedCourses, batchId);
+
+      toast({
+        title: 'Submission sent!',
+        description: `${selectedCourses.length} course${selectedCourses.length !== 1 ? 's' : ''} sent for review. Thank you for contributing!`,
+      });
+      onSubmitted?.();
       setOpen(false);
-      resetForm();
     } catch (e: unknown) {
       toast({ title: 'Submission failed', description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
   };
 
-  const resetForm = () => {
-    setType('new_track');
-    setTrackName(''); setTrackShortName(''); setCourseName('');
-    setStartALat(''); setStartALng(''); setStartBLat(''); setStartBLng('');
-    setS2aLat(''); setS2aLng(''); setS2bLat(''); setS2bLng('');
-    setS3aLat(''); setS3aLng(''); setS3bLat(''); setS3bLng('');
-    setTurnstileToken(null);
-    setStep('confirm');
-  };
+  const pendingCount = plan?.pendingCount ?? 0;
+  const hasAnything = (plan?.groups.length ?? 0) > 0;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -195,95 +174,96 @@ export function SubmitTrackDialog({ trigger, prefill }: SubmitTrackDialogProps) 
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 <ShieldCheck className="w-5 h-5 text-primary" />
-                Submit Track to Database
+                Share your tracks with the community
               </DialogTitle>
               <DialogDescription>
-                You're about to submit track/course data for review.
+                Contribute the tracks and courses you've created to the shared database.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-4 py-2">
               <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3 text-sm text-muted-foreground">
                 <p className="text-foreground font-medium">What happens when you submit:</p>
                 <ul className="list-disc list-inside space-y-1.5">
-                  <li>Your track/course coordinates will be sent to the <strong className="text-foreground">HackTheTrack database</strong> for review.</li>
-                  <li>An admin will review and approve or reject your submission.</li>
+                  <li>We figure out which of your tracks/courses aren't in the community database yet and send only those.</li>
+                  <li>An admin reviews each one and approves or rejects it.</li>
                   <li>If approved, your track data becomes available to <strong className="text-foreground">all users</strong> in future updates.</li>
-                  <li>Your IP address is logged for anti-spam purposes.</li>
+                  <li>Your IP address is logged for anti-spam purposes — nothing else personal is stored.</li>
                 </ul>
-                <p className="text-xs mt-2">Submissions are rate-limited to 5 per hour. No personal information beyond your IP is stored.</p>
               </div>
-              <Button onClick={() => setStep('form')} className="w-full">
-                <ArrowRight className="w-4 h-4 mr-2" /> Continue to Submission Form
+              <Button onClick={() => setStep('review')} className="w-full" disabled={planLoading}>
+                {planLoading
+                  ? (<><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Checking your tracks…</>)
+                  : (<><ArrowRight className="w-4 h-4 mr-2" /> Review what you'll send{pendingCount > 0 ? ` (${pendingCount})` : ''}</>)}
               </Button>
             </div>
           </>
         ) : (
           <>
             <DialogHeader>
-              <DialogTitle>Submit Track / Course</DialogTitle>
+              <DialogTitle>Review your contribution</DialogTitle>
+              <DialogDescription>
+                These are the tracks and courses that will be sent to the community database.
+              </DialogDescription>
             </DialogHeader>
+
             <div className="space-y-4">
-              <div>
-                <Label>Submission Type</Label>
-                <Select value={type} onValueChange={setType}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="new_track">New Track</SelectItem>
-                    <SelectItem value="new_course">New Course</SelectItem>
-                    <SelectItem value="course_modification">Course Modification</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label>Track Name</Label>
-                <Input value={trackName} onChange={e => setTrackName(e.target.value)} placeholder="Orlando Kart Center" />
-              </div>
-              {type === 'new_track' && (
-                <div>
-                  <Label>Short Name (max 8 chars)</Label>
-                  <Input value={trackShortName} onChange={e => setTrackShortName(e.target.value.slice(0, 8))} placeholder="OKC" maxLength={8} />
+              {!hasAnything ? (
+                <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+                  <CheckCircle2 className="w-5 h-5 text-primary shrink-0" />
+                  Everything you've created is already in the community database. Nothing new to send.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {plan!.groups.map(group => (
+                    <div key={group.trackName} className="rounded-lg border border-border p-3 space-y-2">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium text-foreground">{group.trackName}</span>
+                        {group.shortName && <span className="text-xs text-muted-foreground">({group.shortName})</span>}
+                        <span className={`text-xs px-2 py-0.5 rounded ${group.trackStatus === 'new' ? 'bg-primary/20 text-primary' : 'bg-amber-500/20 text-amber-400'}`}>
+                          {group.trackStatus === 'new' ? 'New' : 'Edited'}
+                        </span>
+                      </div>
+                      <div className="space-y-1.5">
+                        {group.courses.map(course => {
+                          const blocked = isBlocked(course);
+                          const checked = selected.has(course.key);
+                          return (
+                            <button
+                              key={course.key}
+                              type="button"
+                              role="checkbox"
+                              aria-checked={checked}
+                              disabled={blocked}
+                              onClick={() => toggle(course.key)}
+                              className={`w-full flex items-center gap-2 text-sm text-left ${blocked ? 'opacity-60 cursor-not-allowed' : ''}`}
+                            >
+                              <span className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${checked ? 'bg-primary border-primary text-primary-foreground' : 'border-input'}`}>
+                                {checked && <Check className="w-3 h-3" />}
+                              </span>
+                              <span className="flex-1 flex items-center gap-2 flex-wrap">
+                                <span className="text-foreground">{course.courseName}</span>
+                                <span className={`text-xs px-1.5 py-0.5 rounded ${CHANGE_STYLE[course.change]}`}>
+                                  {CHANGE_LABEL[course.change]}
+                                </span>
+                                {course.alreadySubmitted && (
+                                  <span className="text-xs text-muted-foreground">already submitted</span>
+                                )}
+                                {blocked && (
+                                  <span className="flex items-center gap-1 text-xs text-amber-400">
+                                    <AlertTriangle className="w-3 h-3" /> needs a short name
+                                  </span>
+                                )}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               )}
-              <div>
-                <Label>Course Name</Label>
-                <Input value={courseName} onChange={e => setCourseName(e.target.value)} placeholder="Normal" />
-              </div>
 
-              {/* Start/Finish */}
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-green-400">Start/Finish Line</p>
-                <div className="grid grid-cols-2 gap-2">
-                  <div><Label className="text-xs">A Lat</Label><Input type="number" step="any" value={startALat} onChange={e => setStartALat(e.target.value)} /></div>
-                  <div><Label className="text-xs">A Lng</Label><Input type="number" step="any" value={startALng} onChange={e => setStartALng(e.target.value)} /></div>
-                  <div><Label className="text-xs">B Lat</Label><Input type="number" step="any" value={startBLat} onChange={e => setStartBLat(e.target.value)} /></div>
-                  <div><Label className="text-xs">B Lng</Label><Input type="number" step="any" value={startBLng} onChange={e => setStartBLng(e.target.value)} /></div>
-                </div>
-              </div>
-
-              {/* Sector 2 */}
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-purple-400">Sector 2 Line (optional)</p>
-                <div className="grid grid-cols-2 gap-2">
-                  <div><Label className="text-xs">A Lat</Label><Input type="number" step="any" value={s2aLat} onChange={e => setS2aLat(e.target.value)} /></div>
-                  <div><Label className="text-xs">A Lng</Label><Input type="number" step="any" value={s2aLng} onChange={e => setS2aLng(e.target.value)} /></div>
-                  <div><Label className="text-xs">B Lat</Label><Input type="number" step="any" value={s2bLat} onChange={e => setS2bLat(e.target.value)} /></div>
-                  <div><Label className="text-xs">B Lng</Label><Input type="number" step="any" value={s2bLng} onChange={e => setS2bLng(e.target.value)} /></div>
-                </div>
-              </div>
-
-              {/* Sector 3 */}
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-purple-400">Sector 3 Line (optional)</p>
-                <div className="grid grid-cols-2 gap-2">
-                  <div><Label className="text-xs">A Lat</Label><Input type="number" step="any" value={s3aLat} onChange={e => setS3aLat(e.target.value)} /></div>
-                  <div><Label className="text-xs">A Lng</Label><Input type="number" step="any" value={s3aLng} onChange={e => setS3aLng(e.target.value)} /></div>
-                  <div><Label className="text-xs">B Lat</Label><Input type="number" step="any" value={s3bLat} onChange={e => setS3bLat(e.target.value)} /></div>
-                  <div><Label className="text-xs">B Lng</Label><Input type="number" step="any" value={s3bLng} onChange={e => setS3bLng(e.target.value)} /></div>
-                </div>
-              </div>
-
-              {/* Turnstile widget */}
-              {TURNSTILE_SITE_KEY && (
+              {TURNSTILE_SITE_KEY && hasAnything && (
                 <div className="flex justify-center">
                   <div ref={turnstileRef} />
                 </div>
@@ -295,10 +275,13 @@ export function SubmitTrackDialog({ trigger, prefill }: SubmitTrackDialogProps) 
                 </Button>
                 <Button
                   onClick={handleSubmit}
-                  disabled={loading || (!!TURNSTILE_SITE_KEY && !turnstileToken)}
+                  disabled={loading || selectedCourses.length === 0 || (!!TURNSTILE_SITE_KEY && !turnstileToken)}
                   className="flex-1"
                 >
-                  <Send className="w-4 h-4 mr-2" /> {loading ? 'Submitting...' : 'Submit to DB'}
+                  <Send className="w-4 h-4 mr-2" />
+                  {loading
+                    ? 'Submitting…'
+                    : `Submit ${selectedCourses.length} course${selectedCourses.length !== 1 ? 's' : ''}`}
                 </Button>
               </div>
             </div>

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -460,7 +460,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
           <Button variant="outline" onClick={() => setIsJsonViewOpen(true)} disabled={!selectedTrack}>
             <Code className="w-4 h-4 mr-2" />View JSON
           </Button>
-          {selectedTrack && (selectedTrack.isUserDefined || selectedTrack.courses.some(c => c.isUserDefined)) && (
+          {tracks.some(t => t.isUserDefined || t.courses.some(c => c.isUserDefined)) && (
             <div className="flex items-center gap-1">
             <SubmitTrackDialog
               trigger={
@@ -468,18 +468,6 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
                   <Send className="w-4 h-4 mr-2" />Submit to DB
                 </Button>
               }
-              prefill={(() => {
-                const userCourse = selectedTrack.courses.find(c => c.isUserDefined && c.name === tempCourseName)
-                  || selectedTrack.courses.find(c => c.isUserDefined);
-                if (!userCourse) return undefined;
-                return {
-                  type: selectedTrack.isUserDefined ? 'new_track' as const : 'new_course' as const,
-                  trackName: selectedTrack.name,
-                  trackShortName: selectedTrack.shortName,
-                  courseName: userCourse.name,
-                  course: userCourse,
-                };
-              })()}
             />
             <Tooltip>
               <TooltipTrigger asChild>

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -244,7 +244,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
   const handleAddTrack = async () => {
     const course = form.buildCourse();
     if (!course || !form.formTrackName.trim()) return;
-    await addTrackToStorage(form.formTrackName.trim(), course);
+    await addTrackToStorage(form.formTrackName.trim(), course, form.formTrackShortName.trim() || undefined);
     await refreshTracks();
     setTempTrackName(form.formTrackName.trim());
     setTempCourseName(course.name);

--- a/src/components/admin/SubmissionsTab.tsx
+++ b/src/components/admin/SubmissionsTab.tsx
@@ -1,11 +1,37 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { toast } from '@/hooks/use-toast';
 import { getDatabase } from '@/lib/db';
 import type { DbSubmission } from '@/lib/db/types';
-import { Check, X } from 'lucide-react';
+import { Check, X, Layers } from 'lucide-react';
+
+/** A batch of submissions uploaded together, or a single legacy submission. */
+interface SubmissionGroup {
+  batchId: string | null;
+  items: DbSubmission[];
+}
+
+/** Group rows by batch_id, preserving the incoming (created_at desc) order. */
+function groupSubmissions(submissions: DbSubmission[]): SubmissionGroup[] {
+  const groups: SubmissionGroup[] = [];
+  const byBatch = new Map<string, SubmissionGroup>();
+  for (const sub of submissions) {
+    if (sub.batch_id) {
+      let g = byBatch.get(sub.batch_id);
+      if (!g) {
+        g = { batchId: sub.batch_id, items: [] };
+        byBatch.set(sub.batch_id, g);
+        groups.push(g);
+      }
+      g.items.push(sub);
+    } else {
+      groups.push({ batchId: null, items: [sub] });
+    }
+  }
+  return groups;
+}
 
 export function SubmissionsTab() {
   const [submissions, setSubmissions] = useState<DbSubmission[]>([]);
@@ -28,6 +54,8 @@ export function SubmissionsTab() {
 
   useEffect(() => { load(); }, [load]);
 
+  const groups = useMemo(() => groupSubmissions(submissions), [submissions]);
+
   const handleAction = async (id: string, status: 'approved' | 'denied') => {
     try {
       await db.updateSubmission(id, status, reviewNotes[id]);
@@ -36,6 +64,62 @@ export function SubmissionsTab() {
     } catch (e: unknown) {
       toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
     }
+  };
+
+  const handleBatchAction = async (items: DbSubmission[], status: 'approved' | 'denied') => {
+    const pending = items.filter(s => s.status === 'pending');
+    try {
+      await Promise.all(pending.map(s => db.updateSubmission(s.id, status, reviewNotes[s.id])));
+      toast({ title: `${pending.length} submission${pending.length !== 1 ? 's' : ''} ${status}` });
+      load();
+    } catch (e: unknown) {
+      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+    }
+  };
+
+  const renderCard = (sub: DbSubmission) => {
+    const hasLayout = (sub as unknown as { has_layout?: boolean }).has_layout;
+    return (
+      <div key={sub.id} className="racing-card p-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded">{sub.type}</span>
+            <span className="text-sm font-medium text-foreground">{sub.track_name}</span>
+            {sub.track_short_name && <span className="text-xs text-muted-foreground">({sub.track_short_name})</span>}
+            <span className="text-muted-foreground">→</span>
+            <span className="text-sm text-foreground">{sub.course_name}</span>
+            {hasLayout && (
+              <span className="text-xs bg-cyan-500/20 text-cyan-400 px-2 py-0.5 rounded">Drawing included</span>
+            )}
+          </div>
+          <span className={`text-xs px-2 py-0.5 rounded ${sub.status === 'pending' ? 'bg-accent text-accent-foreground' : sub.status === 'approved' ? 'bg-primary/20 text-primary' : 'bg-destructive/20 text-destructive'}`}>
+            {sub.status}
+          </span>
+        </div>
+        <pre className="text-xs font-mono bg-muted p-2 rounded overflow-x-auto max-h-32">
+          {JSON.stringify(sub.course_data, null, 2)}
+        </pre>
+        <p className="text-xs text-muted-foreground">
+          IP: {sub.submitted_by_ip || 'unknown'} • {new Date(sub.created_at).toLocaleString()}
+        </p>
+        {sub.status === 'pending' && (
+          <div className="flex items-center gap-2 pt-2">
+            <Input
+              placeholder="Review notes (optional)"
+              value={reviewNotes[sub.id] || ''}
+              onChange={e => setReviewNotes(prev => ({ ...prev, [sub.id]: e.target.value }))}
+              className="flex-1 text-sm"
+            />
+            <Button size="sm" onClick={() => handleAction(sub.id, 'approved')} className="gap-1">
+              <Check className="w-3 h-3" /> Approve
+            </Button>
+            <Button size="sm" variant="destructive" onClick={() => handleAction(sub.id, 'denied')} className="gap-1">
+              <X className="w-3 h-3" /> Deny
+            </Button>
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -58,49 +142,40 @@ export function SubmissionsTab() {
       ) : submissions.length === 0 ? (
         <p className="text-muted-foreground">No submissions found.</p>
       ) : (
-        <div className="space-y-3">
-          {submissions.map(sub => {
-            const hasLayout = (sub as unknown as { has_layout?: boolean }).has_layout;
+        <div className="space-y-4">
+          {groups.map(group => {
+            // A single, non-batched submission renders bare.
+            if (group.items.length === 1 && !group.batchId) {
+              return renderCard(group.items[0]);
+            }
+            const pendingCount = group.items.filter(s => s.status === 'pending').length;
+            const tracks = Array.from(new Set(group.items.map(s => s.track_name)));
             return (
-            <div key={sub.id} className="racing-card p-4 space-y-2">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded">{sub.type}</span>
-                  <span className="text-sm font-medium text-foreground">{sub.track_name}</span>
-                  {sub.track_short_name && <span className="text-xs text-muted-foreground">({sub.track_short_name})</span>}
-                  <span className="text-muted-foreground">→</span>
-                  <span className="text-sm text-foreground">{sub.course_name}</span>
-                  {hasLayout && (
-                    <span className="text-xs bg-cyan-500/20 text-cyan-400 px-2 py-0.5 rounded">Drawing included</span>
+              <div key={group.batchId!} className="rounded-lg border border-primary/30 bg-primary/5 p-3 space-y-3">
+                <div className="flex items-center justify-between gap-2 flex-wrap">
+                  <div className="flex items-center gap-2 text-sm">
+                    <Layers className="w-4 h-4 text-primary" />
+                    <span className="font-medium text-foreground">Bulk upload</span>
+                    <span className="text-muted-foreground">
+                      {group.items.length} course{group.items.length !== 1 ? 's' : ''} across {tracks.length} track{tracks.length !== 1 ? 's' : ''}
+                      {' • '}{new Date(group.items[0].created_at).toLocaleString()}
+                    </span>
+                  </div>
+                  {pendingCount > 0 && (
+                    <div className="flex items-center gap-2">
+                      <Button size="sm" onClick={() => handleBatchAction(group.items, 'approved')} className="gap-1">
+                        <Check className="w-3 h-3" /> Approve all ({pendingCount})
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => handleBatchAction(group.items, 'denied')} className="gap-1">
+                        <X className="w-3 h-3" /> Deny all
+                      </Button>
+                    </div>
                   )}
                 </div>
-                <span className={`text-xs px-2 py-0.5 rounded ${sub.status === 'pending' ? 'bg-accent text-accent-foreground' : sub.status === 'approved' ? 'bg-primary/20 text-primary' : 'bg-destructive/20 text-destructive'}`}>
-                  {sub.status}
-                </span>
-              </div>
-              <pre className="text-xs font-mono bg-muted p-2 rounded overflow-x-auto max-h-32">
-                {JSON.stringify(sub.course_data, null, 2)}
-              </pre>
-              <p className="text-xs text-muted-foreground">
-                IP: {sub.submitted_by_ip || 'unknown'} • {new Date(sub.created_at).toLocaleString()}
-              </p>
-              {sub.status === 'pending' && (
-                <div className="flex items-center gap-2 pt-2">
-                  <Input
-                    placeholder="Review notes (optional)"
-                    value={reviewNotes[sub.id] || ''}
-                    onChange={e => setReviewNotes(prev => ({ ...prev, [sub.id]: e.target.value }))}
-                    className="flex-1 text-sm"
-                  />
-                  <Button size="sm" onClick={() => handleAction(sub.id, 'approved')} className="gap-1">
-                    <Check className="w-3 h-3" /> Approve
-                  </Button>
-                  <Button size="sm" variant="destructive" onClick={() => handleAction(sub.id, 'denied')} className="gap-1">
-                    <X className="w-3 h-3" /> Deny
-                  </Button>
+                <div className="space-y-3">
+                  {group.items.map(renderCard)}
                 </div>
-              )}
-            </div>
+              </div>
             );
           })}
         </div>

--- a/src/components/track-editor/AddTrackDialog.tsx
+++ b/src/components/track-editor/AddTrackDialog.tsx
@@ -55,7 +55,7 @@ export function AddTrackDialog({
         </DialogHeader>
         <EditorModeToggle mode={editorMode} onModeChange={onEditorModeChange} />
         {editorMode === 'manual' ? (
-          <CourseForm {...courseFormProps} onSubmit={onSubmit} onCancel={onCancel} submitLabel="Create Track" />
+          <CourseForm {...courseFormProps} onSubmit={onSubmit} onCancel={onCancel} submitLabel="Create Track" showShortName />
         ) : (
           <div className="space-y-4">
             {/* Track/Course inputs above the map for better UX */}
@@ -63,6 +63,11 @@ export function AddTrackDialog({
               <div>
                 <Label htmlFor="newTrackName">Track Name</Label>
                 <Input id="newTrackName" value={courseFormProps.trackName} onChange={(e) => courseFormProps.onTrackNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., Orlando Kart Center" className="font-mono" />
+              </div>
+              <div>
+                <Label htmlFor="newTrackShortName">Short Name (max 8 chars)</Label>
+                <Input id="newTrackShortName" value={courseFormProps.trackShortName} onChange={(e) => courseFormProps.onTrackShortNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., OKC" maxLength={8} className="font-mono" />
+                <p className="text-xs text-muted-foreground mt-1">Auto-filled from the track name — edit it if you'd like.</p>
               </div>
               <div>
                 <Label htmlFor="newCourseName">Course Name</Label>

--- a/src/components/track-editor/CourseForm.tsx
+++ b/src/components/track-editor/CourseForm.tsx
@@ -7,13 +7,13 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import type { CourseFormProps } from '@/hooks/useTrackEditorForm';
 
 export function CourseForm({
-  trackName, courseName, latA, lonA, latB, lonB,
+  trackName, trackShortName, courseName, latA, lonA, latB, lonB,
   sector2, sector3,
-  onTrackNameChange, onCourseNameChange,
+  onTrackNameChange, onTrackShortNameChange, onCourseNameChange,
   onLatAChange, onLonAChange, onLatBChange, onLonBChange,
   onSector2Change, onSector3Change,
-  onSubmit, onCancel, submitLabel, showTrackName = true,
-}: CourseFormProps) {
+  onSubmit, onCancel, submitLabel, showTrackName = true, showShortName = false,
+}: CourseFormProps & { showShortName?: boolean }) {
   const [showSectors, setShowSectors] = useState(
     Boolean(sector2.aLat || sector2.aLon || sector3.aLat || sector3.aLon)
   );
@@ -25,6 +25,13 @@ export function CourseForm({
         <div>
           <Label htmlFor="trackName">Track Name</Label>
           <Input id="trackName" value={trackName} onChange={(e) => onTrackNameChange(e.target.value)} onKeyDownCapture={stopKeys} placeholder="e.g., Orlando Kart Center" className="font-mono" />
+        </div>
+      )}
+      {showShortName && (
+        <div>
+          <Label htmlFor="trackShortName">Short Name (max 8 chars)</Label>
+          <Input id="trackShortName" value={trackShortName} onChange={(e) => onTrackShortNameChange(e.target.value)} onKeyDownCapture={stopKeys} placeholder="e.g., OKC" maxLength={8} className="font-mono" />
+          <p className="text-xs text-muted-foreground mt-1">Auto-filled from the track name — edit it if you'd like.</p>
         </div>
       )}
       <div>

--- a/src/hooks/useTrackEditorForm.ts
+++ b/src/hooks/useTrackEditorForm.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Course, SectorLine } from '@/types/racing';
-import { parseSectorLine } from '@/lib/trackUtils';
+import { parseSectorLine, deriveShortName, MAX_SHORT_NAME_LENGTH } from '@/lib/trackUtils';
 import type { GpsPoint } from '@/components/track-editor/VisualEditor';
 
 export type SectorFormState = { aLat: string; aLon: string; bLat: string; bLon: string };
@@ -14,7 +14,9 @@ export interface CourseFormProps {
   lonB: string;
   sector2: SectorFormState;
   sector3: SectorFormState;
+  trackShortName: string;
   onTrackNameChange: (value: string) => void;
+  onTrackShortNameChange: (value: string) => void;
   onCourseNameChange: (value: string) => void;
   onLatAChange: (value: string) => void;
   onLonAChange: (value: string) => void;
@@ -30,6 +32,10 @@ export interface CourseFormProps {
 
 export function useTrackEditorForm() {
   const [formTrackName, setFormTrackName] = useState('');
+  const [formTrackShortName, setFormTrackShortName] = useState('');
+  // Once the user edits the short name themselves, stop auto-deriving it from
+  // the long name so we don't clobber their choice.
+  const [shortNameTouched, setShortNameTouched] = useState(false);
   const [formCourseName, setFormCourseName] = useState('');
   const [formLatA, setFormLatA] = useState('');
   const [formLonA, setFormLonA] = useState('');
@@ -41,10 +47,25 @@ export function useTrackEditorForm() {
   const [editorMode, setEditorMode] = useState<'manual' | 'visual'>('visual');
 
   const resetForm = useCallback(() => {
-    setFormTrackName(''); setFormCourseName('');
+    setFormTrackName(''); setFormTrackShortName(''); setShortNameTouched(false);
+    setFormCourseName('');
     setFormLatA(''); setFormLonA(''); setFormLatB(''); setFormLonB('');
     setFormSector2({ aLat: '', aLon: '', bLat: '', bLon: '' });
     setFormSector3({ aLat: '', aLon: '', bLat: '', bLon: '' });
+  }, []);
+
+  // Editing the long name auto-fills the short name (until the user overrides it).
+  const handleTrackNameChange = useCallback((value: string) => {
+    setFormTrackName(value);
+    setShortNameTouched((touched) => {
+      if (!touched) setFormTrackShortName(deriveShortName(value));
+      return touched;
+    });
+  }, []);
+
+  const handleTrackShortNameChange = useCallback((value: string) => {
+    setShortNameTouched(true);
+    setFormTrackShortName(value.slice(0, MAX_SHORT_NAME_LENGTH));
   }, []);
 
   const buildCourse = useCallback((): Course | null => {
@@ -122,10 +143,11 @@ export function useTrackEditorForm() {
   const visualEditorSector3 = parseSectorLine(formSector3);
 
   const courseFormProps = {
-    trackName: formTrackName, courseName: formCourseName,
+    trackName: formTrackName, trackShortName: formTrackShortName, courseName: formCourseName,
     latA: formLatA, lonA: formLonA, latB: formLatB, lonB: formLonB,
     sector2: formSector2, sector3: formSector3,
-    onTrackNameChange: setFormTrackName, onCourseNameChange: setFormCourseName,
+    onTrackNameChange: handleTrackNameChange, onTrackShortNameChange: handleTrackShortNameChange,
+    onCourseNameChange: setFormCourseName,
     onLatAChange: setFormLatA, onLonAChange: setFormLonA,
     onLatBChange: setFormLatB, onLonBChange: setFormLonB,
     onSector2Change: handleSector2Change, onSector3Change: handleSector3Change,
@@ -133,6 +155,7 @@ export function useTrackEditorForm() {
 
   return {
     formTrackName, setFormTrackName,
+    formTrackShortName,
     formCourseName, setFormCourseName,
     formLatA, formLonA, formLatB, formLonB,
     formSector2, formSector3,

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -42,6 +42,8 @@ export interface DbSubmission {
   course_data: Record<string, unknown>;
   status: 'pending' | 'approved' | 'denied';
   submitted_by_ip: string | null;
+  /** Ties courses uploaded together in one bulk submit. NULL for legacy rows. */
+  batch_id: string | null;
   created_at: string;
   reviewed_at: string | null;
   reviewed_by: string | null;

--- a/src/lib/submittedTracksStorage.ts
+++ b/src/lib/submittedTracksStorage.ts
@@ -1,0 +1,55 @@
+/**
+ * Local record of which course geometries the user has already submitted to the
+ * community database. Lets the contribute flow skip re-uploading unchanged
+ * courses, while re-flagging a course the user later edits.
+ *
+ * Thin localStorage wrapper — all the diff/merge logic is pure in
+ * `trackSubmission.ts`.
+ */
+
+import {
+  mergeSubmittedRecords,
+  type SubmissionCourse,
+  type SubmittedRecord,
+} from '@/lib/trackSubmission';
+
+const STORAGE_KEY = 'racing-datalog-submitted-v1';
+
+interface StoredShape {
+  records: Record<string, SubmittedRecord>;
+}
+
+/** Load the remembered submissions, keyed by `submissionKey`. */
+export function loadSubmittedRecords(): Record<string, SubmittedRecord> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredShape;
+    return parsed.records ?? {};
+  } catch (e) {
+    console.error('Failed to load submitted-tracks records:', e);
+    return {};
+  }
+}
+
+/** Remember a freshly-submitted batch of courses. */
+export function markCoursesSubmitted(
+  courses: Array<Pick<SubmissionCourse, 'key' | 'contentHash'>>,
+  batchId: string,
+): void {
+  try {
+    const next = mergeSubmittedRecords(loadSubmittedRecords(), courses, batchId);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ records: next } satisfies StoredShape));
+  } catch (e) {
+    console.error('Failed to persist submitted-tracks records:', e);
+  }
+}
+
+/** Clear the remembered set (e.g. a "re-submit everything" escape hatch). */
+export function clearSubmittedRecords(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.error('Failed to clear submitted-tracks records:', e);
+  }
+}

--- a/src/lib/trackStorage.ts
+++ b/src/lib/trackStorage.ts
@@ -302,11 +302,11 @@ function emitTrackChange(trackName: string): void {
 }
 
 /**
- * Add a new track with an optional initial course.
+ * Add a new track with an optional initial course and short name.
  */
-export async function addTrack(trackName: string, course?: Course): Promise<Track[]> {
+export async function addTrack(trackName: string, course?: Course, shortName?: string): Promise<Track[]> {
   const tracks = await loadTracks();
-  
+
   const existing = tracks.find(t => t.name === trackName);
   if (existing) {
     // Track exists, add course if provided
@@ -316,10 +316,15 @@ export async function addTrack(trackName: string, course?: Course): Promise<Trac
         existing.courses.push({ ...course, isUserDefined: true });
       }
     }
+    // Backfill a short name if the track never had one
+    if (shortName && !existing.shortName) {
+      existing.shortName = shortName;
+    }
   } else {
     // Create new track
     tracks.push({
       name: trackName,
+      shortName,
       courses: course ? [{ ...course, isUserDefined: true }] : [],
       isUserDefined: true,
     });

--- a/src/lib/trackSubmission.test.ts
+++ b/src/lib/trackSubmission.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import type { Course, Track } from '@/types/racing';
+import {
+  buildSubmissionPlan,
+  courseContentHash,
+  courseToSubmissionData,
+  mergeSubmittedRecords,
+  pendingCourses,
+  submissionKey,
+  type SubmittedRecord,
+} from './trackSubmission';
+
+function course(name: string, overrides: Partial<Course> = {}): Course {
+  return {
+    name,
+    startFinishA: { lat: 28.41, lon: -81.38 },
+    startFinishB: { lat: 28.42, lon: -81.39 },
+    ...overrides,
+  };
+}
+
+const sectors = {
+  sector2: { a: { lat: 28.411, lon: -81.381 }, b: { lat: 28.412, lon: -81.382 } },
+  sector3: { a: { lat: 28.413, lon: -81.383 }, b: { lat: 28.414, lon: -81.384 } },
+};
+
+describe('courseToSubmissionData', () => {
+  it('emits the flat start/finish payload without sectors', () => {
+    const d = courseToSubmissionData(course('A'));
+    expect(d).toEqual({
+      start_a_lat: 28.41, start_a_lng: -81.38,
+      start_b_lat: 28.42, start_b_lng: -81.39,
+    });
+    expect(d.sector_2_a_lat).toBeUndefined();
+  });
+
+  it('includes sector lines only when both sector2 and sector3 are present', () => {
+    const withBoth = courseToSubmissionData(course('A', sectors));
+    expect(withBoth.sector_2_a_lat).toBe(28.411);
+    expect(withBoth.sector_3_b_lng).toBe(-81.384);
+
+    // sector2 alone is dropped (matches the rest of the codebase's contract)
+    const withOne = courseToSubmissionData(course('A', { sector2: sectors.sector2 }));
+    expect(withOne.sector_2_a_lat).toBeUndefined();
+  });
+});
+
+describe('courseContentHash', () => {
+  it('is stable for identical geometry and ignores the course name', () => {
+    expect(courseContentHash(course('A'))).toBe(courseContentHash(course('B')));
+  });
+
+  it('changes when a coordinate moves beyond rounding precision', () => {
+    const moved = course('A', { startFinishA: { lat: 28.4105, lon: -81.38 } });
+    expect(courseContentHash(moved)).not.toBe(courseContentHash(course('A')));
+  });
+
+  it('is unaffected by sub-7th-decimal float noise', () => {
+    const noisy = course('A', { startFinishA: { lat: 28.41 + 1e-9, lon: -81.38 } });
+    expect(courseContentHash(noisy)).toBe(courseContentHash(course('A')));
+  });
+
+  it('changes when sectors are added', () => {
+    expect(courseContentHash(course('A', sectors))).not.toBe(courseContentHash(course('A')));
+  });
+});
+
+describe('buildSubmissionPlan', () => {
+  const builtin: Track[] = [
+    {
+      name: 'Orlando Kart Center',
+      shortName: 'OKC',
+      isUserDefined: false,
+      courses: [{ ...course('Normal'), isUserDefined: false }],
+    },
+  ];
+
+  it('classifies a wholly new user track as new_track', () => {
+    const merged: Track[] = [
+      ...builtin,
+      {
+        name: 'My Backyard',
+        shortName: 'YARD',
+        isUserDefined: true,
+        courses: [{ ...course('Loop'), isUserDefined: true }],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    const group = plan.groups.find((g) => g.trackName === 'My Backyard')!;
+    expect(group.trackStatus).toBe('new');
+    expect(group.courses[0].type).toBe('new_track');
+    expect(group.courses[0].change).toBe('new-track');
+    expect(group.courses[0].trackShortName).toBe('YARD');
+    expect(plan.pendingCount).toBe(1);
+  });
+
+  it('classifies a user course added to a built-in track as new_course (track "edited")', () => {
+    const merged: Track[] = [
+      {
+        ...builtin[0],
+        courses: [
+          { ...course('Normal'), isUserDefined: false },
+          { ...course('Reverse'), isUserDefined: true },
+        ],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    const group = plan.groups[0];
+    expect(group.trackStatus).toBe('edited');
+    expect(group.courses).toHaveLength(1);
+    expect(group.courses[0].courseName).toBe('Reverse');
+    expect(group.courses[0].type).toBe('new_course');
+    expect(group.courses[0].change).toBe('new-course');
+  });
+
+  it('classifies an edited built-in course as course_modification', () => {
+    const merged: Track[] = [
+      {
+        ...builtin[0],
+        courses: [
+          { ...course('Normal', { startFinishA: { lat: 28.5, lon: -81.4 } }), isUserDefined: true },
+        ],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    expect(plan.groups[0].courses[0].type).toBe('course_modification');
+    expect(plan.groups[0].courses[0].change).toBe('modified');
+  });
+
+  it('skips a user course whose geometry is identical to the built-in course', () => {
+    const merged: Track[] = [
+      {
+        ...builtin[0],
+        // marked user-defined but never actually moved
+        courses: [{ ...course('Normal'), isUserDefined: true }],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    expect(plan.groups).toHaveLength(0);
+    expect(plan.pendingCount).toBe(0);
+  });
+
+  it('never includes untouched built-in courses', () => {
+    const plan = buildSubmissionPlan(builtin, builtin);
+    expect(plan.groups).toHaveLength(0);
+  });
+
+  it('marks already-submitted unchanged courses and excludes them from pendingCount', () => {
+    const newTrack: Track = {
+      name: 'My Backyard', shortName: 'YARD', isUserDefined: true,
+      courses: [{ ...course('Loop'), isUserDefined: true }],
+    };
+    const merged = [...builtin, newTrack];
+    const hash = courseContentHash(newTrack.courses[0]);
+    const submitted: Record<string, SubmittedRecord> = {
+      [submissionKey('My Backyard', 'Loop')]: { hash, submittedAt: 1, batchId: 'b1' },
+    };
+    const plan = buildSubmissionPlan(merged, builtin, submitted);
+    const c = plan.groups[0].courses[0];
+    expect(c.alreadySubmitted).toBe(true);
+    expect(plan.pendingCount).toBe(0);
+    expect(pendingCourses(plan)).toHaveLength(0);
+  });
+
+  it('re-flags a previously-submitted course after it is edited', () => {
+    const newTrack: Track = {
+      name: 'My Backyard', shortName: 'YARD', isUserDefined: true,
+      courses: [{ ...course('Loop', { startFinishB: { lat: 29.0, lon: -82.0 } }), isUserDefined: true }],
+    };
+    const submitted: Record<string, SubmittedRecord> = {
+      // stale hash from the pre-edit geometry
+      [submissionKey('My Backyard', 'Loop')]: { hash: 'deadbeef', submittedAt: 1, batchId: 'b1' },
+    };
+    const plan = buildSubmissionPlan([...builtin, newTrack], builtin, submitted);
+    expect(plan.groups[0].courses[0].alreadySubmitted).toBe(false);
+    expect(plan.pendingCount).toBe(1);
+  });
+});
+
+describe('mergeSubmittedRecords', () => {
+  it('adds new records without dropping existing ones', () => {
+    const existing: Record<string, SubmittedRecord> = {
+      a: { hash: 'h1', submittedAt: 1, batchId: 'old' },
+    };
+    const merged = mergeSubmittedRecords(
+      existing,
+      [{ key: 'b', contentHash: 'h2' }],
+      'new-batch',
+      123,
+    );
+    expect(merged.a).toEqual(existing.a);
+    expect(merged.b).toEqual({ hash: 'h2', submittedAt: 123, batchId: 'new-batch' });
+    // pure — does not mutate the input
+    expect(existing.b).toBeUndefined();
+  });
+
+  it('overwrites the record for a re-submitted key', () => {
+    const merged = mergeSubmittedRecords(
+      { a: { hash: 'old', submittedAt: 1, batchId: 'b1' } },
+      [{ key: 'a', contentHash: 'fresh' }],
+      'b2',
+      999,
+    );
+    expect(merged.a).toEqual({ hash: 'fresh', submittedAt: 999, batchId: 'b2' });
+  });
+});

--- a/src/lib/trackSubmission.test.ts
+++ b/src/lib/trackSubmission.test.ts
@@ -94,6 +94,22 @@ describe('buildSubmissionPlan', () => {
     expect(plan.pendingCount).toBe(1);
   });
 
+  it('derives a short name for a new track that never got one', () => {
+    const merged: Track[] = [
+      ...builtin,
+      {
+        name: 'Sunshine Speed Park',
+        // no shortName set (e.g. created before short names were captured)
+        isUserDefined: true,
+        courses: [{ ...course('Loop'), isUserDefined: true }],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    const group = plan.groups.find((g) => g.trackName === 'Sunshine Speed Park')!;
+    expect(group.shortName).toBe('SSP');
+    expect(group.courses[0].trackShortName).toBe('SSP');
+  });
+
   it('classifies a user course added to a built-in track as new_course (track "edited")', () => {
     const merged: Track[] = [
       {

--- a/src/lib/trackSubmission.ts
+++ b/src/lib/trackSubmission.ts
@@ -1,0 +1,249 @@
+/**
+ * Track-submission planning — pure logic for the "contribute to the community
+ * database" flow.
+ *
+ * The old flow made the user hand-fill a coordinate form, one course at a time.
+ * Instead we diff everything they already have locally against the built-in
+ * (community) track list and produce a plan of exactly what is new or modified,
+ * so the whole contribution can go up as a single payload.
+ *
+ * Local storage already only persists user-defined content (see trackStorage),
+ * so the candidate set is small. `Track.isUserDefined` distinguishes a wholly
+ * new track from a built-in one the user merely added/edited a course on; the
+ * built-in `defaults` list tells us, for a course on a built-in track, whether
+ * it is a brand-new course or a modification of an existing one.
+ *
+ * A content hash of each course's geometry lets us (a) skip a "modified" course
+ * that is actually identical to the built-in one, and (b) remember what was
+ * already submitted so an unchanged course is not re-uploaded.
+ */
+
+import type { Course, Track } from '@/types/racing';
+
+/** Flat snake_case coordinate payload — the shape the edge fn + DB expect. */
+export interface CourseSubmissionData {
+  start_a_lat: number;
+  start_a_lng: number;
+  start_b_lat: number;
+  start_b_lng: number;
+  sector_2_a_lat?: number;
+  sector_2_a_lng?: number;
+  sector_2_b_lat?: number;
+  sector_2_b_lng?: number;
+  sector_3_a_lat?: number;
+  sector_3_a_lng?: number;
+  sector_3_b_lat?: number;
+  sector_3_b_lng?: number;
+}
+
+/** Submission type understood by the `submissions` table. */
+export type SubmissionType = 'new_track' | 'new_course' | 'course_modification';
+
+/** UI-facing classification of a single course in the plan. */
+export type CourseChange = 'new-track' | 'new-course' | 'modified';
+
+export interface SubmissionCourse {
+  trackName: string;
+  trackShortName?: string;
+  courseName: string;
+  type: SubmissionType;
+  change: CourseChange;
+  courseData: CourseSubmissionData;
+  /** Geometry hash — identity for dedupe against already-submitted content. */
+  contentHash: string;
+  /** Stable key (track + course) used by the already-submitted store. */
+  key: string;
+  /** True when this exact geometry was already submitted (unchanged since). */
+  alreadySubmitted: boolean;
+}
+
+/** Track-level rollup. Adding a course to a built-in track reads as "edited". */
+export type TrackStatus = 'new' | 'edited';
+
+export interface SubmissionTrackGroup {
+  trackName: string;
+  shortName?: string;
+  trackStatus: TrackStatus;
+  courses: SubmissionCourse[];
+}
+
+export interface SubmissionPlan {
+  groups: SubmissionTrackGroup[];
+  /** Total courses that still need uploading (excludes already-submitted). */
+  pendingCount: number;
+}
+
+/** One remembered submission: the geometry hash we last sent for a course. */
+export interface SubmittedRecord {
+  hash: string;
+  submittedAt: number;
+  batchId: string;
+}
+
+// ─── Keys & hashing ─────────────────────────────────────────────────────────
+
+const KEY_SEP = '␟'; // ␟ unit separator — safe inside track/course names
+
+/** Stable per-course key for the already-submitted store. */
+export function submissionKey(trackName: string, courseName: string): string {
+  return `${trackName}${KEY_SEP}${courseName}`;
+}
+
+// Round to 7 decimals (~1cm) so float noise below the coord epsilon doesn't
+// produce a spurious "modified" diff.
+function r(n: number): number {
+  return Math.round(n * 1e7) / 1e7;
+}
+
+/** Build the flat coordinate payload for a course (sectors only if both set). */
+export function courseToSubmissionData(course: Course): CourseSubmissionData {
+  const data: CourseSubmissionData = {
+    start_a_lat: course.startFinishA.lat,
+    start_a_lng: course.startFinishA.lon,
+    start_b_lat: course.startFinishB.lat,
+    start_b_lng: course.startFinishB.lon,
+  };
+  if (course.sector2 && course.sector3) {
+    data.sector_2_a_lat = course.sector2.a.lat;
+    data.sector_2_a_lng = course.sector2.a.lon;
+    data.sector_2_b_lat = course.sector2.b.lat;
+    data.sector_2_b_lng = course.sector2.b.lon;
+    data.sector_3_a_lat = course.sector3.a.lat;
+    data.sector_3_a_lng = course.sector3.a.lon;
+    data.sector_3_b_lat = course.sector3.b.lat;
+    data.sector_3_b_lng = course.sector3.b.lon;
+  }
+  return data;
+}
+
+// FNV-1a 32-bit → 8 hex chars. Not cryptographic — only change-detection.
+function fnv1a(str: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * Deterministic hash of a course's geometry (rounded). Name is intentionally
+ * excluded — identity is carried by the key; the hash detects geometry edits.
+ */
+export function courseContentHash(course: Course): string {
+  const d = courseToSubmissionData(course);
+  const parts = [
+    d.start_a_lat, d.start_a_lng, d.start_b_lat, d.start_b_lng,
+    d.sector_2_a_lat, d.sector_2_a_lng, d.sector_2_b_lat, d.sector_2_b_lng,
+    d.sector_3_a_lat, d.sector_3_a_lng, d.sector_3_b_lat, d.sector_3_b_lng,
+  ].map((n) => (n === undefined ? '' : String(r(n))));
+  return fnv1a(parts.join(','));
+}
+
+// ─── Plan ───────────────────────────────────────────────────────────────────
+
+/**
+ * Diff the user's local tracks against the built-in (community) list and build
+ * the upload plan.
+ *
+ * @param merged   The merged track list (built-ins + user overlay), as returned
+ *                 by `loadTracks()`. Only user-defined tracks/courses are
+ *                 candidates for submission.
+ * @param defaults The built-in track list (`loadDefaultTracks()`), used to tell
+ *                 a new course apart from a modified one and to skip user
+ *                 "edits" that are byte-identical to the built-in course.
+ * @param submitted Already-submitted records keyed by `submissionKey`.
+ */
+export function buildSubmissionPlan(
+  merged: Track[],
+  defaults: Track[],
+  submitted: Record<string, SubmittedRecord> = {},
+): SubmissionPlan {
+  // Built-in course geometry, looked up by "trackName / courseName".
+  const defaultCourseHash = new Map<string, string>();
+  for (const track of defaults) {
+    for (const course of track.courses) {
+      defaultCourseHash.set(submissionKey(track.name, course.name), courseContentHash(course));
+    }
+  }
+
+  const groups: SubmissionTrackGroup[] = [];
+  let pendingCount = 0;
+
+  for (const track of merged) {
+    const isNewTrack = !!track.isUserDefined;
+    const courses: SubmissionCourse[] = [];
+
+    for (const course of track.courses) {
+      // Only user-touched courses are ever candidates.
+      if (!course.isUserDefined) continue;
+
+      const key = submissionKey(track.name, course.name);
+      const hash = courseContentHash(course);
+      const builtinHash = isNewTrack ? undefined : defaultCourseHash.get(key);
+
+      // A user "edit" that is identical to the built-in course is a no-op.
+      if (builtinHash !== undefined && builtinHash === hash) continue;
+
+      let type: SubmissionType;
+      let change: CourseChange;
+      if (isNewTrack) {
+        type = 'new_track';
+        change = 'new-track';
+      } else if (builtinHash === undefined) {
+        type = 'new_course';
+        change = 'new-course';
+      } else {
+        type = 'course_modification';
+        change = 'modified';
+      }
+
+      const alreadySubmitted = submitted[key]?.hash === hash;
+      if (!alreadySubmitted) pendingCount++;
+
+      courses.push({
+        trackName: track.name,
+        trackShortName: track.shortName,
+        courseName: course.name,
+        type,
+        change,
+        courseData: courseToSubmissionData(course),
+        contentHash: hash,
+        key,
+        alreadySubmitted,
+      });
+    }
+
+    if (courses.length === 0) continue;
+    groups.push({
+      trackName: track.name,
+      shortName: track.shortName,
+      trackStatus: isNewTrack ? 'new' : 'edited',
+      courses,
+    });
+  }
+
+  return { groups, pendingCount };
+}
+
+/** Flatten a plan to the courses that still need uploading. */
+export function pendingCourses(plan: SubmissionPlan): SubmissionCourse[] {
+  return plan.groups.flatMap((g) => g.courses.filter((c) => !c.alreadySubmitted));
+}
+
+/**
+ * Merge freshly-submitted courses into the remembered set (pure). Returns a new
+ * record map; the caller persists it.
+ */
+export function mergeSubmittedRecords(
+  existing: Record<string, SubmittedRecord>,
+  submittedCourses: Array<Pick<SubmissionCourse, 'key' | 'contentHash'>>,
+  batchId: string,
+  now: number = Date.now(),
+): Record<string, SubmittedRecord> {
+  const next = { ...existing };
+  for (const c of submittedCourses) {
+    next[c.key] = { hash: c.contentHash, submittedAt: now, batchId };
+  }
+  return next;
+}

--- a/src/lib/trackSubmission.ts
+++ b/src/lib/trackSubmission.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Course, Track } from '@/types/racing';
+import { deriveShortName } from '@/lib/trackUtils';
 
 /** Flat snake_case coordinate payload — the shape the edge fn + DB expect. */
 export interface CourseSubmissionData {
@@ -172,6 +173,11 @@ export function buildSubmissionPlan(
 
   for (const track of merged) {
     const isNewTrack = !!track.isUserDefined;
+    // A new track needs a short name; auto-derive one if it never got set so the
+    // contribution isn't blocked (the create flow now fills this in up front).
+    const resolvedShortName = isNewTrack
+      ? (track.shortName?.trim() || deriveShortName(track.name) || undefined)
+      : track.shortName;
     const courses: SubmissionCourse[] = [];
 
     for (const course of track.courses) {
@@ -203,7 +209,7 @@ export function buildSubmissionPlan(
 
       courses.push({
         trackName: track.name,
-        trackShortName: track.shortName,
+        trackShortName: resolvedShortName,
         courseName: course.name,
         type,
         change,
@@ -217,7 +223,7 @@ export function buildSubmissionPlan(
     if (courses.length === 0) continue;
     groups.push({
       trackName: track.name,
-      shortName: track.shortName,
+      shortName: resolvedShortName,
       trackStatus: isNewTrack ? 'new' : 'edited',
       courses,
     });

--- a/src/lib/trackUtils.test.ts
+++ b/src/lib/trackUtils.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TRACK_SEARCH_RADIUS_M,
   parseSectorLine,
   abbreviateTrackName,
+  deriveShortName,
   getTrackDisplayName,
   findNearestTrack,
   calculatePolylineLength,
@@ -85,6 +86,28 @@ describe("abbreviateTrackName", () => {
 
   it("trims surrounding whitespace before abbreviating", () => {
     expect(abbreviateTrackName("  Sebring  ")).toBe("SEBR");
+  });
+});
+
+// ─── deriveShortName ───────────────────────────────────────────────────────────
+
+describe("deriveShortName", () => {
+  it("reuses the abbreviation for typical names", () => {
+    expect(deriveShortName("Orlando Kart Center")).toBe("OKC");
+    expect(deriveShortName("Bushnell")).toBe("BUSH");
+  });
+
+  it("caps the result at 8 characters", () => {
+    // 10 single-letter words → 10-letter abbreviation, capped to 8
+    expect(deriveShortName("a b c d e f g h i j")).toBe("ABCDEFGH");
+  });
+
+  it("strips punctuation from the abbreviation", () => {
+    expect(deriveShortName("St. Pete Karting")).toBe("SPK");
+  });
+
+  it("returns empty string when there is no alphanumeric content", () => {
+    expect(deriveShortName("!!! ---")).toBe("");
   });
 });
 

--- a/src/lib/trackUtils.ts
+++ b/src/lib/trackUtils.ts
@@ -51,6 +51,23 @@ export function getTrackDisplayName(track: { name: string; shortName?: string })
   return track.shortName || abbreviateTrackName(track.name);
 }
 
+/** Max length for a track short name (matches the `short_name VARCHAR(8)` column). */
+export const MAX_SHORT_NAME_LENGTH = 8;
+
+/**
+ * Derive a valid short name from a long track name: builds on
+ * `abbreviateTrackName`, then strips to alphanumerics and caps at
+ * `MAX_SHORT_NAME_LENGTH`. Used to auto-fill the short-name field during track
+ * creation and as a fallback when submitting a track that never got one.
+ * Returns '' only when the name has no alphanumeric content.
+ */
+export function deriveShortName(name: string): string {
+  const abbr = abbreviateTrackName(name).replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+  if (abbr) return abbr.slice(0, MAX_SHORT_NAME_LENGTH);
+  const raw = name.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+  return raw.slice(0, MAX_SHORT_NAME_LENGTH);
+}
+
 
 /**
  * Find the nearest track to a GPS point. Returns the track if within threshold (default 2km).

--- a/supabase/functions/submit-track/index.ts
+++ b/supabase/functions/submit-track/index.ts
@@ -5,6 +5,20 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
 };
 
+// A single bulk submit may carry many courses, but cap it so one request can't
+// flood the queue. Also cap how many rows one IP can add per rolling hour.
+const MAX_BATCH = 200;
+const MAX_ROWS_PER_HOUR = 300;
+
+interface SubmissionInput {
+  type?: string;
+  track_name?: string;
+  track_short_name?: string;
+  course_name?: string;
+  course_data?: Record<string, unknown>;
+  layout_data?: unknown;
+}
+
 async function verifyTurnstile(token: string, ip: string): Promise<boolean> {
   const secret = Deno.env.get('TURNSTILE_SECRET_KEY');
   if (!secret) {
@@ -22,80 +36,89 @@ async function verifyTurnstile(token: string, ip: string): Promise<boolean> {
   return result.success === true;
 }
 
+/** Validate one submission. Returns an error message, or null when valid. */
+function validateSubmission(s: SubmissionInput): string | null {
+  const { type, track_name, track_short_name, course_name, course_data } = s;
+
+  if (!type || !track_name || !course_name || !course_data) {
+    return 'Missing required fields';
+  }
+  if (!['new_track', 'new_course', 'course_modification'].includes(type)) {
+    return 'Invalid submission type';
+  }
+  if (type === 'new_track' && (!track_short_name || track_short_name.trim().length > 8)) {
+    return 'Short name required (max 8 chars) for new tracks';
+  }
+  if (track_name.trim().length > 100 || course_name.trim().length > 100) {
+    return 'Names must be under 100 characters';
+  }
+
+  const requiredCoords = ['start_a_lat', 'start_a_lng', 'start_b_lat', 'start_b_lng'];
+  for (const key of requiredCoords) {
+    const v = course_data[key];
+    if (typeof v !== 'number' || isNaN(v)) return `Invalid coordinate: ${key}`;
+  }
+
+  const optionalCoords = [
+    'sector_2_a_lat', 'sector_2_a_lng', 'sector_2_b_lat', 'sector_2_b_lng',
+    'sector_3_a_lat', 'sector_3_a_lng', 'sector_3_b_lat', 'sector_3_b_lng',
+  ];
+  for (const key of optionalCoords) {
+    const v = course_data[key];
+    if (v !== undefined && (typeof v !== 'number' || isNaN(v))) return `Invalid coordinate: ${key}`;
+  }
+
+  return null;
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
-    const { type, track_name, track_short_name, course_name, course_data, turnstile_token, layout_data } = await req.json();
+    const body = await req.json();
+    const { turnstile_token } = body;
 
-    // Validate required fields
-    if (!type || !track_name || !course_name || !course_data) {
-      return new Response(JSON.stringify({ error: 'Missing required fields' }), {
-        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+    // Accept either a bulk `submissions` array (new flow) or a single
+    // submission at the top level (legacy single-course flow).
+    const items: SubmissionInput[] = Array.isArray(body.submissions)
+      ? body.submissions
+      : [body];
+
+    if (items.length === 0) {
+      return jsonError('No submissions provided', 400);
+    }
+    if (items.length > MAX_BATCH) {
+      return jsonError(`Too many courses in one submission (max ${MAX_BATCH})`, 400);
     }
 
-    if (!['new_track', 'new_course', 'course_modification'].includes(type)) {
-      return new Response(JSON.stringify({ error: 'Invalid submission type' }), {
-        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
-    }
-
-    if (type === 'new_track' && (!track_short_name || track_short_name.trim().length > 8)) {
-      return new Response(JSON.stringify({ error: 'Short name required (max 8 chars) for new tracks' }), {
-        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
-    }
-
-    // Validate track/course name lengths
-    if (track_name.trim().length > 100 || course_name.trim().length > 100) {
-      return new Response(JSON.stringify({ error: 'Names must be under 100 characters' }), {
-        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
-    }
-
-    // Validate coordinate data
-    const requiredCoords = ['start_a_lat', 'start_a_lng', 'start_b_lat', 'start_b_lng'];
-    for (const key of requiredCoords) {
-      if (typeof course_data[key] !== 'number' || isNaN(course_data[key])) {
-        return new Response(JSON.stringify({ error: `Invalid coordinate: ${key}` }), {
-          status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
-      }
-    }
-
-    // Validate optional sector coordinates if present
-    const optionalCoords = [
-      'sector_2_a_lat', 'sector_2_a_lng', 'sector_2_b_lat', 'sector_2_b_lng',
-      'sector_3_a_lat', 'sector_3_a_lng', 'sector_3_b_lat', 'sector_3_b_lng',
-    ];
-    for (const key of optionalCoords) {
-      if (course_data[key] !== undefined && (typeof course_data[key] !== 'number' || isNaN(course_data[key]))) {
-        return new Response(JSON.stringify({ error: `Invalid coordinate: ${key}` }), {
-          status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+    // Validate every item up front — reject the whole batch on the first bad one.
+    for (let i = 0; i < items.length; i++) {
+      const err = validateSubmission(items[i]);
+      if (err) {
+        return jsonError(items.length > 1 ? `Submission ${i + 1}: ${err}` : err, 400);
       }
     }
 
     // Get submitter IP
-    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 
+    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
                req.headers.get('cf-connecting-ip') || 'unknown';
 
-    // Verify Turnstile token
+    // Verify Turnstile token (once for the whole batch)
     if (Deno.env.get('TURNSTILE_SECRET_KEY')) {
       if (!turnstile_token || typeof turnstile_token !== 'string') {
-        return new Response(JSON.stringify({ error: 'Verification required. Please complete the CAPTCHA.' }), {
-          status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+        return jsonError('Verification required. Please complete the CAPTCHA.', 400);
       }
-
       const valid = await verifyTurnstile(turnstile_token, ip);
       if (!valid) {
-        return new Response(JSON.stringify({ error: 'Verification failed. Please try again.' }), {
-          status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+        return jsonError('Verification failed. Please try again.', 403);
       }
     }
 
@@ -114,15 +137,13 @@ Deno.serve(async (req) => {
 
     if (banned) {
       if (!banned.expires_at || new Date(banned.expires_at) > new Date()) {
-        return new Response(JSON.stringify({ error: 'Your IP has been blocked from submissions.' }), {
-          status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
+        return jsonError('Your IP has been blocked from submissions.', 403);
       }
       // Ban expired, remove it
       await supabase.from('banned_ips').delete().eq('id', banned.id);
     }
 
-    // Rate limiting: max 5 submissions per hour per IP
+    // Rate limiting: cap total rows added per rolling hour per IP.
     const oneHourAgo = new Date(Date.now() - 3600000).toISOString();
     const { count } = await supabase
       .from('submissions')
@@ -130,37 +151,37 @@ Deno.serve(async (req) => {
       .eq('submitted_by_ip', ip)
       .gte('created_at', oneHourAgo);
 
-    if (count !== null && count >= 5) {
-      return new Response(JSON.stringify({ error: 'Too many submissions. Please try again later.' }), {
-        status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+    if (count !== null && count + items.length > MAX_ROWS_PER_HOUR) {
+      return jsonError('Too many submissions. Please try again later.', 429);
     }
 
-    // Determine if layout data is included
-    const hasLayout = Array.isArray(layout_data) && layout_data.length > 0;
+    // One batch id ties this upload together for admin review.
+    const batchId = crypto.randomUUID();
 
-    // Insert submission
-    const { error } = await supabase.from('submissions').insert({
-      type,
-      track_name: track_name.trim(),
-      track_short_name: track_short_name?.trim() || null,
-      course_name: course_name.trim(),
-      course_data,
-      status: 'pending',
-      submitted_by_ip: ip,
-      has_layout: hasLayout,
-      layout_data: hasLayout ? layout_data : null,
+    const rows = items.map((s) => {
+      const hasLayout = Array.isArray(s.layout_data) && s.layout_data.length > 0;
+      return {
+        type: s.type,
+        track_name: s.track_name!.trim(),
+        track_short_name: s.track_short_name?.trim() || null,
+        course_name: s.course_name!.trim(),
+        course_data: s.course_data,
+        status: 'pending',
+        submitted_by_ip: ip,
+        batch_id: batchId,
+        has_layout: hasLayout,
+        layout_data: hasLayout ? s.layout_data : null,
+      };
     });
 
+    const { error } = await supabase.from('submissions').insert(rows);
     if (error) throw error;
 
-    return new Response(JSON.stringify({ success: true }), {
+    return new Response(JSON.stringify({ success: true, batch_id: batchId, count: rows.length }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   } catch (e) {
     console.error('submit-track error:', e);
-    return new Response(JSON.stringify({ error: 'An error occurred. Please try again later.' }), {
-      status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    return jsonError('An error occurred. Please try again later.', 500);
   }
 });

--- a/supabase/migrations/20260603120000_submissions_batch_id.sql
+++ b/supabase/migrations/20260603120000_submissions_batch_id.sql
@@ -1,0 +1,10 @@
+-- Group the courses uploaded together in one bulk "contribute to the community
+-- database" submit. Each course is still its own `submissions` row (so the
+-- existing admin review/approve flow is unchanged); batch_id ties a user's
+-- one-shot upload together so the admin can review it as a unit.
+ALTER TABLE public.submissions ADD COLUMN IF NOT EXISTS batch_id uuid;
+
+CREATE INDEX IF NOT EXISTS submissions_batch_id_idx ON public.submissions (batch_id);
+
+COMMENT ON COLUMN public.submissions.batch_id IS
+  'Groups multiple course submissions uploaded together in a single bulk submit. NULL for legacy single-course submissions.';


### PR DESCRIPTION
## What

Replaces the one-course-at-a-time **"Submit to DB"** coordinate form with a **diff-and-review bulk contribution**. The app figures out locally what's actually new or modified versus the community track list and sends the whole thing as a single payload.

## Why

The old form made users hand-fill latitudes/longitudes for one course at a time — bad UX for contributing the tracks they've already drawn in the editor. Users should just be able to send everything they have and see what's going up.

## How it works

**Client (`lib/trackSubmission.ts`, pure + unit-tested):**
- Diffs the merged local track list against the built-in list (`loadDefaultTracks()`).
- Classifies each user-defined course as **new_track** (wholly new track), **new_course** (added to a built-in track), or **course_modification** (edited built-in course).
- Track-level rollup reads **New** vs **Edited** — adding a course to a built-in track shows it as *Edited*; it never overwrites the track.
- A geometry **content hash** (rounded ~1cm) skips "edits" identical to the built-in course and powers dedupe.

**Dedupe (`lib/submittedTracksStorage.ts`):** localStorage record (`racing-datalog-submitted-v1`) of submitted course hashes, so unchanged courses aren't re-sent; editing a course later re-flags it.

**UI (`SubmitTrackDialog`):** form replaced by a review screen — per-track New/Edited badge, per-course New/Modified/already-submitted, checkboxes — submitting all selected courses in one request. A user track missing a short name is shown disabled with a "needs a short name" note instead of failing the batch.

**Backend (kept minimal):**
- `submit-track` edge fn accepts a `submissions` array, validates each, caps batch size (200), rate-limits by rows/hour/IP, and inserts one row per course sharing a generated `batch_id`. The legacy single-submission body shape still works.
- Migration `20260603120000_submissions_batch_id.sql` adds `submissions.batch_id` (+ index).
- Admin **Submissions** tab groups a batch with **Approve all / Deny all**; per-row review/approve is unchanged, and **approval stays manual** (flips status; admin still builds/imports `tracks.json`).
- `DbSubmission.batch_id` carries the group id client-side (generated Supabase types untouched — `getSubmissions` casts).

## Deploy notes

- The **migration + edge function** must ship to Supabase for the end-to-end flow (the client no-ops the `batch_id` if absent, but the insert needs the column).

## Out of scope / follow-ups

- **Course drawings** aren't in the bulk payload — user courses don't persist a layout locally yet.
- **Cloud track-list reconciliation** (what happens to a user's local copy once their submission is approved into `tracks.json`) — the deliberate next step.

## Verification

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test:run` — 816 passed (15 new in `trackSubmission.test.ts`) ✓
- `npm run build` ✓

https://claude.ai/code/session_01JRXQjuRKccev5JjUjHThAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRXQjuRKccev5JjUjHThAv)_