### PR TITLE
feat(graphview): add G-G diagram (friction circle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **G-G diagram (friction circle).** A new pro-mode graph plotting lateral vs.
+  longitudinal G as a scatter, so you can see how much of the tyre's grip
+  envelope you're using — the classic "are you driving the corners of the
+  circle" view from MoTeC / Race Studio. Add it from the graph picker
+  ("G-G Diagram"); it shows concentric 0.5 g grip rings, your session's cloud,
+  the reference lap's cloud (when one is selected) for comparison, and the live
+  point as you scrub. Uses GPS-derived `lat_g`/`lon_g` (or the logger-native
+  pair when the HW G-force source is selected), with the same smoothing as the
+  other G-force charts.
 - **Distance vs. time chart scale.** The analysis charts (simple-mode telemetry
   chart and pro-mode graphs) can now plot against **track distance** instead of
   elapsed time, so laps line up corner-for-corner — the way Race Studio / MoTeC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ src/
 │   ├── ui/                # shadcn/ui primitives
 │   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, BannedIps, Tools, Messages)
 │   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach; Profile is mounted in the drawer)
-│   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, InfoBox
+│   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Notes, Setups, Device*)
 │   ├── track-editor/      # Track editor sub-components (VisualEditor is lazy — see Bundle Splitting)
 │   ├── video-overlays/    # Video-export overlay system: registry + themes + per-widget *Overlay,
@@ -605,6 +605,16 @@ in *absolute* distance/time from the lap origin (`0` = start-finish) rather than
 window-relative. The range-slider crop handles (`formatRangeLabel`, built in
 `Index.tsx`) follow the same scale — cumulative distance from the lap start in
 distance mode, elapsed time otherwise.
+
+The **G-G diagram** (friction circle) is a pro-mode graph
+(`graphview/GGDiagram.tsx`) added from the `GraphPanel` picker as the `__gg__`
+key. It scatters lateral vs longitudinal G (lat on X, accel-positive lon on Y)
+for the visible window, overlays the reference lap's cloud and the live scrub
+point, and draws concentric 0.5 g grip rings. The data prep is pure + unit-tested
+in `lib/ggDiagram.ts` (`pickGForcePair` honoring `gForceSource` → GPS `lat_g`/
+`lon_g` or native `lat_g_native`/`lon_g_native`; `computeGGPoints` with per-axis
+smoothing; `computeGGAxisMax` for the symmetric, clamped axis range). Raw IMU
+`accel_*` is intentionally excluded — it isn't guaranteed grip-frame-aligned.
 
 Channels are normalized to canonical ids at parse time (`channels.ts` →
 `normalizeChannels()`), so `extraFields` keys and `FieldMapping.name` are uniform

--- a/src/components/graphview/GGDiagram.tsx
+++ b/src/components/graphview/GGDiagram.tsx
@@ -1,0 +1,187 @@
+import { useRef, useEffect, useState, useMemo } from 'react';
+import { X } from 'lucide-react';
+import { GpsSample } from '@/types/racing';
+import { computeSmoothingWindowSize } from '@/lib/chartUtils';
+import { pickGForcePair, computeGGPoints, computeGGAxisMax } from '@/lib/ggDiagram';
+import { useSettingsContext } from '@/contexts/SettingsContext';
+import { getChartColors } from '@/lib/chartColors';
+
+interface GGDiagramProps {
+  samples: GpsSample[];
+  referenceSamples?: GpsSample[];
+  currentIndex: number;
+  label: string;
+  onDelete: () => void;
+}
+
+const SESSION_COLOR = 'hsl(180, 70%, 55%)'; // cyan cloud (matches speed series)
+const CURRENT_COLOR = 'hsl(0, 75%, 55%)';   // red current point
+
+export function GGDiagram({ samples, referenceSamples, currentIndex, label, onDelete }: GGDiagramProps) {
+  const { gForceSmoothing, gForceSmoothingStrength, gForceSource, darkMode } = useSettingsContext();
+  const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  const smoothingWindow = useMemo(
+    () => computeSmoothingWindowSize(gForceSmoothing, gForceSmoothingStrength),
+    [gForceSmoothing, gForceSmoothingStrength],
+  );
+
+  const pair = useMemo(() => pickGForcePair(samples, gForceSource), [samples, gForceSource]);
+
+  const sessionPoints = useMemo(
+    () => (pair ? computeGGPoints(samples, pair, smoothingWindow) : []),
+    [samples, pair, smoothingWindow],
+  );
+  const refPoints = useMemo(
+    () => (pair && referenceSamples && referenceSamples.length > 0
+      ? computeGGPoints(referenceSamples, pair, smoothingWindow)
+      : []),
+    [referenceSamples, pair, smoothingWindow],
+  );
+  const axisMax = useMemo(() => computeGGAxisMax(sessionPoints, refPoints), [sessionPoints, refPoints]);
+
+  // Resize observer
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setDimensions({ width, height });
+      }
+    });
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, []);
+
+  // Draw
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || dimensions.width === 0 || dimensions.height === 0) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = dimensions.width * dpr;
+    canvas.height = dimensions.height * dpr;
+    ctx.scale(dpr, dpr);
+
+    ctx.fillStyle = chartColors.background;
+    ctx.fillRect(0, 0, dimensions.width, dimensions.height);
+
+    // Square plot region, centred, leaving a margin for ring labels.
+    const margin = 18;
+    const size = Math.max(0, Math.min(dimensions.width, dimensions.height) - margin * 2);
+    const cx = dimensions.width / 2;
+    const cy = dimensions.height / 2;
+    const R = size / 2;
+    if (R <= 0) return;
+    const scale = R / axisMax; // px per g
+
+    // Map a (lat, lon) g point to screen — positive lon_g (accel) points up.
+    const sx = (gx: number) => cx + gx * scale;
+    const sy = (gy: number) => cy - gy * scale;
+
+    if (!pair || sessionPoints.length === 0) {
+      ctx.fillStyle = chartColors.axisText;
+      ctx.font = '12px JetBrains Mono, monospace';
+      ctx.textAlign = 'center';
+      ctx.fillText('No G-force data', cx, cy);
+      return;
+    }
+
+    // Concentric grip rings at every 0.5 g, labelled.
+    ctx.font = '9px JetBrains Mono, monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    for (let g = 0.5; g <= axisMax + 1e-6; g += 0.5) {
+      ctx.beginPath();
+      ctx.strokeStyle = chartColors.grid;
+      ctx.lineWidth = 1;
+      ctx.arc(cx, cy, g * scale, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.fillStyle = chartColors.axisText;
+      ctx.fillText(g.toFixed(1), cx, cy - g * scale);
+    }
+
+    // Centre crosshair (zero axes).
+    ctx.beginPath();
+    ctx.strokeStyle = chartColors.zeroLine;
+    ctx.lineWidth = 1;
+    ctx.moveTo(cx - R, cy); ctx.lineTo(cx + R, cy);
+    ctx.moveTo(cx, cy - R); ctx.lineTo(cx, cy + R);
+    ctx.stroke();
+
+    // Axis hint labels.
+    ctx.fillStyle = chartColors.axisText;
+    ctx.font = '9px JetBrains Mono, monospace';
+    ctx.textBaseline = 'top';
+    ctx.fillText('ACCEL', cx, cy - R - margin + 2);
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('BRAKE', cx, cy + R + margin - 2);
+    // Lateral hint, anchored just inside the right end of the x-axis.
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('LAT', cx + R - 2, cy - 2);
+
+    // Helper: draw a cloud as cheap 1.5px squares.
+    const drawCloud = (points: typeof sessionPoints, color: string, alpha: number) => {
+      ctx.fillStyle = color;
+      ctx.globalAlpha = alpha;
+      for (const p of points) {
+        if (!p) continue;
+        ctx.fillRect(sx(p.x) - 0.75, sy(p.y) - 0.75, 1.5, 1.5);
+      }
+      ctx.globalAlpha = 1;
+    };
+
+    drawCloud(refPoints, chartColors.refLine, 0.5);
+    drawCloud(sessionPoints, SESSION_COLOR, 0.45);
+
+    // Current point.
+    const cur = sessionPoints[currentIndex];
+    if (cur) {
+      ctx.beginPath();
+      ctx.fillStyle = CURRENT_COLOR;
+      ctx.arc(sx(cur.x), sy(cur.y), 4, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Readout in the bottom-right corner (clear of the header + delete button).
+      ctx.fillStyle = chartColors.axisText;
+      ctx.font = '10px JetBrains Mono, monospace';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(`Lon ${cur.y >= 0 ? '+' : ''}${cur.y.toFixed(2)}g`, dimensions.width - 4, dimensions.height - 4);
+      ctx.fillText(`Lat ${cur.x >= 0 ? '+' : ''}${cur.x.toFixed(2)}g`, dimensions.width - 4, dimensions.height - 16);
+    }
+
+    // Source badge, bottom-left.
+    ctx.fillStyle = chartColors.axisText;
+    ctx.font = '9px JetBrains Mono, monospace';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText(pair.source, 4, dimensions.height - 4);
+  }, [dimensions, sessionPoints, refPoints, axisMax, currentIndex, pair, chartColors]);
+
+  return (
+    <div className="relative border-b border-border" style={{ minHeight: '200px', height: '240px' }}>
+      <div className="absolute top-1 left-2 z-10 flex items-center gap-1.5 pointer-events-none">
+        <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: SESSION_COLOR }} />
+        <span className="text-xs font-mono text-muted-foreground">{label}</span>
+      </div>
+      <button
+        onClick={onDelete}
+        className="absolute top-1 right-1 z-10 p-1 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
+        title="Remove graph"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+      <div ref={containerRef} className="w-full h-full min-h-0 overflow-hidden">
+        <canvas ref={canvasRef} className="block w-full h-full" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { RangeSlider } from '@/components/RangeSlider';
 import { SingleSeriesChart } from './SingleSeriesChart';
+import { GGDiagram } from './GGDiagram';
 import { GpsSample, FieldMapping } from '@/types/racing';
 import { calculatePace, calculateReferenceSpeed, calculateDistanceArray } from '@/lib/referenceUtils';
 import { computeBrakingGSeriesSG, gToBrakePercent } from '@/lib/brakingZones';
@@ -136,6 +137,13 @@ export function GraphPanel({
     return filteredSamples.some(s => s.extraFields['lat_g'] !== undefined);
   }, [filteredSamples]);
 
+  const hasNativeG = useMemo(() => {
+    return filteredSamples.some(s => s.extraFields['lat_g_native'] !== undefined);
+  }, [filteredSamples]);
+
+  // The G-G diagram needs a lateral/longitudinal g pair (GPS-derived or native).
+  const hasGForce = hasGpsG || hasNativeG;
+
   const hasBothSources = hasHwAccel && hasGpsG;
 
   // Available data sources
@@ -147,6 +155,9 @@ export function GraphPanel({
       sources.push({ key: '__pace__', label: 'Pace (Δs)' });
     }
     sources.push({ key: '__braking_g__', label: hasBothSources ? 'Brake % (GPS)' : 'Brake % (computed)' });
+    if (hasGForce) {
+      sources.push({ key: '__gg__', label: 'G-G Diagram' });
+    }
     fieldMappings.forEach(f => {
       const display = f.label ?? f.name;
       let label = display + (f.unit ? ` (${f.unit})` : '');
@@ -161,7 +172,7 @@ export function GraphPanel({
       sources.push({ key: f.name, label });
     });
     return sources;
-  }, [fieldMappings, useKph, hasReference, hasBothSources]);
+  }, [fieldMappings, useKph, hasReference, hasBothSources, hasGForce]);
 
   const unusedSources = useMemo(() => {
     return availableSources.filter(s => !activeGraphs.includes(s.key));
@@ -214,20 +225,31 @@ export function GraphPanel({
         ) : (
           <>
             {activeGraphs.map(key => (
-              <SingleSeriesChart
-                key={key}
-                samples={samples}
-                seriesKey={key}
-                currentIndex={currentIndex}
-                onScrub={onScrub}
-                color={getColor(key)}
-                label={getLabel(key)}
-                onDelete={() => removeGraph(key)}
-                referenceValues={referenceValuesByKey[key]?.slice(visibleRange[0], visibleRange[1] + 1) ?? null}
-                brakingGValues={key === '__braking_g__' ? brakingGFull.slice(visibleRange[0], visibleRange[1] + 1) : undefined}
-                allSamples={filteredSamples}
-                rangeStart={visibleRange[0]}
-              />
+              key === '__gg__' ? (
+                <GGDiagram
+                  key={key}
+                  samples={samples}
+                  referenceSamples={referenceSamples}
+                  currentIndex={currentIndex}
+                  label={getLabel(key)}
+                  onDelete={() => removeGraph(key)}
+                />
+              ) : (
+                <SingleSeriesChart
+                  key={key}
+                  samples={samples}
+                  seriesKey={key}
+                  currentIndex={currentIndex}
+                  onScrub={onScrub}
+                  color={getColor(key)}
+                  label={getLabel(key)}
+                  onDelete={() => removeGraph(key)}
+                  referenceValues={referenceValuesByKey[key]?.slice(visibleRange[0], visibleRange[1] + 1) ?? null}
+                  brakingGValues={key === '__braking_g__' ? brakingGFull.slice(visibleRange[0], visibleRange[1] + 1) : undefined}
+                  allSamples={filteredSamples}
+                  rangeStart={visibleRange[0]}
+                />
+              )
             ))}
             {/* Add more button */}
             {unusedSources.length > 0 && (

--- a/src/lib/chartUtils.ts
+++ b/src/lib/chartUtils.ts
@@ -11,6 +11,9 @@ export const G_FORCE_FIELDS_HW = ['accel_x', 'accel_y'];
 /** All G-force field names (for smoothing detection). */
 export const G_FORCE_FIELDS = [...G_FORCE_FIELDS_GPS, ...G_FORCE_FIELDS_HW];
 
+/** Which G-force source the user prefers in the analysis charts. */
+export type GForceSource = 'gps' | 'hw';
+
 /**
  * Map a smoothing strength (0-100) to a window size for moving average.
  * Returns odd numbers for symmetric smoothing. Range: 1-15.

--- a/src/lib/ggDiagram.test.ts
+++ b/src/lib/ggDiagram.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { pickGForcePair, computeGGPoints, computeGGAxisMax } from "./ggDiagram";
+import type { GpsSample } from "@/types/racing";
+
+function sample(extra: Record<string, number>): GpsSample {
+  return {
+    t: 0,
+    lat: 0,
+    lon: 0,
+    speedMps: 0,
+    speedMph: 0,
+    speedKph: 0,
+    extraFields: extra,
+  };
+}
+
+describe("pickGForcePair", () => {
+  it("prefers the GPS pair for the gps source", () => {
+    const samples = [sample({ lat_g: 0.5, lon_g: -0.3, lat_g_native: 0.4, lon_g_native: -0.2 })];
+    expect(pickGForcePair(samples, "gps")).toMatchObject({ x: "lat_g", y: "lon_g", source: "GPS" });
+  });
+
+  it("prefers the native pair for the hw source when present", () => {
+    const samples = [sample({ lat_g: 0.5, lon_g: -0.3, lat_g_native: 0.4, lon_g_native: -0.2 })];
+    expect(pickGForcePair(samples, "hw")).toMatchObject({ x: "lat_g_native", y: "lon_g_native" });
+  });
+
+  it("falls back to whichever pair has data", () => {
+    const onlyGps = [sample({ lat_g: 0.5, lon_g: -0.3 })];
+    expect(pickGForcePair(onlyGps, "hw")).toMatchObject({ x: "lat_g", y: "lon_g" });
+  });
+
+  it("returns null when no g-force channels exist", () => {
+    expect(pickGForcePair([sample({ rpm: 8000 })], "gps")).toBeNull();
+  });
+});
+
+describe("computeGGPoints", () => {
+  const pair = { x: "lat_g", y: "lon_g", source: "GPS" };
+
+  it("pairs lateral and longitudinal values per sample", () => {
+    const samples = [sample({ lat_g: 0.5, lon_g: -0.3 }), sample({ lat_g: -0.2, lon_g: 0.9 })];
+    expect(computeGGPoints(samples, pair)).toEqual([
+      { x: 0.5, y: -0.3 },
+      { x: -0.2, y: 0.9 },
+    ]);
+  });
+
+  it("returns null for samples missing either component (kept aligned to index)", () => {
+    const samples = [sample({ lat_g: 0.5 }), sample({ lat_g: 0.1, lon_g: 0.1 })];
+    const points = computeGGPoints(samples, pair);
+    expect(points[0]).toBeNull();
+    expect(points[1]).toEqual({ x: 0.1, y: 0.1 });
+  });
+
+  it("smooths each axis with a moving average when a window is given", () => {
+    const samples = [
+      sample({ lat_g: 0, lon_g: 0 }),
+      sample({ lat_g: 3, lon_g: 3 }),
+      sample({ lat_g: 0, lon_g: 0 }),
+    ];
+    const points = computeGGPoints(samples, pair, 3);
+    // Middle point is the average of its 3-wide neighbourhood: (0+3+0)/3 = 1.
+    expect(points[1]).toEqual({ x: 1, y: 1 });
+  });
+});
+
+describe("computeGGAxisMax", () => {
+  it("rounds the peak magnitude up to a clean 0.5 g ring", () => {
+    const points = [{ x: 0.8, y: -1.1 }, { x: 0.2, y: 0.3 }];
+    // peak 1.1 * 1.05 = 1.155 -> ceil to 1.5
+    expect(computeGGAxisMax(points)).toBe(1.5);
+  });
+
+  it("clamps to a [1.5, 3.0] g window", () => {
+    expect(computeGGAxisMax([{ x: 0.1, y: 0.1 }])).toBe(1.5); // floor
+    expect(computeGGAxisMax([{ x: 4, y: 0 }])).toBe(3.0); // ceiling
+  });
+
+  it("covers every supplied point set (session + reference)", () => {
+    const session = [{ x: 0.5, y: 0.5 }];
+    const reference = [{ x: 0, y: -2.2 }];
+    // reference peak 2.2 * 1.05 = 2.31 -> ceil to 2.5
+    expect(computeGGAxisMax(session, reference)).toBe(2.5);
+  });
+
+  it("ignores null points and handles empty input", () => {
+    expect(computeGGAxisMax([null, null])).toBe(1.5);
+    expect(computeGGAxisMax()).toBe(1.5);
+  });
+});

--- a/src/lib/ggDiagram.ts
+++ b/src/lib/ggDiagram.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure data prep for the G-G diagram (friction circle): a lateral-vs-
+ * longitudinal G scatter that shows how much of the tyre's grip envelope a
+ * driver is using. View code (GGDiagram.tsx) handles the canvas; everything
+ * here is pure and unit-tested.
+ *
+ * Axis convention (screen mapping lives in the view): X = lateral g, Y =
+ * longitudinal g with **positive = acceleration**. The data is unsigned here —
+ * the view decides which way is up.
+ */
+
+import { GpsSample } from '@/types/racing';
+import { applySmoothingToValues } from './chartUtils';
+import type { GForceSource } from './chartUtils';
+
+export interface GForcePair {
+  /** Lateral-g channel id (X axis). */
+  x: string;
+  /** Longitudinal-g channel id (Y axis). */
+  y: string;
+  /** Short human label for the source (e.g. "GPS", "Native"). */
+  source: string;
+}
+
+/** A single plotted point, or null where the sample lacks usable g data. */
+export type GGPoint = { x: number; y: number } | null;
+
+// Candidate lateral/longitudinal pairs, best-first. The raw IMU accel_x/y/z are
+// deliberately excluded — they're body-frame and not guaranteed grip-aligned.
+const GPS_PAIR: GForcePair = { x: 'lat_g', y: 'lon_g', source: 'GPS' };
+const NATIVE_PAIR: GForcePair = { x: 'lat_g_native', y: 'lon_g_native', source: 'Native' };
+
+function pairHasData(samples: GpsSample[], pair: GForcePair): boolean {
+  return samples.some(
+    (s) => s.extraFields[pair.x] !== undefined || s.extraFields[pair.y] !== undefined,
+  );
+}
+
+/**
+ * Pick the lateral/longitudinal g pair to plot. Honors the user's G-force
+ * source preference (HW prefers the logger-native pair), falling back to
+ * whichever pair actually carries data. Returns null when neither is present.
+ */
+export function pickGForcePair(samples: GpsSample[], source: GForceSource): GForcePair | null {
+  const order = source === 'hw' ? [NATIVE_PAIR, GPS_PAIR] : [GPS_PAIR, NATIVE_PAIR];
+  for (const pair of order) {
+    if (pairHasData(samples, pair)) return pair;
+  }
+  return null;
+}
+
+/**
+ * Build per-sample G-G points (aligned to `samples`, null where a sample lacks
+ * either component), with optional moving-average smoothing applied per axis to
+ * tame GPS jitter. `smoothingWindow <= 1` disables smoothing.
+ */
+export function computeGGPoints(
+  samples: GpsSample[],
+  pair: GForcePair,
+  smoothingWindow = 1,
+): GGPoint[] {
+  if (samples.length === 0) return [];
+
+  const rawX = samples.map((s) => s.extraFields[pair.x]);
+  const rawY = samples.map((s) => s.extraFields[pair.y]);
+  const xs = smoothingWindow > 1 ? applySmoothingToValues(rawX, smoothingWindow) : rawX;
+  const ys = smoothingWindow > 1 ? applySmoothingToValues(rawY, smoothingWindow) : rawY;
+
+  return samples.map((_, i) => {
+    const x = xs[i];
+    const y = ys[i];
+    if (x === undefined || y === undefined) return null;
+    return { x, y };
+  });
+}
+
+/**
+ * Symmetric axis extent (in g) covering every supplied point set, rounded up to
+ * a clean 0.5 g ring and clamped to a sane [1.5, 3.0] g window so the circle
+ * never collapses or runs off scale.
+ */
+export function computeGGAxisMax(...pointSets: GGPoint[][]): number {
+  let peak = 0;
+  for (const points of pointSets) {
+    for (const p of points) {
+      if (!p) continue;
+      peak = Math.max(peak, Math.abs(p.x), Math.abs(p.y));
+    }
+  }
+  const padded = peak * 1.05;
+  const rounded = Math.ceil(padded / 0.5) * 0.5;
+  return Math.min(3.0, Math.max(1.5, rounded));
+}


### PR DESCRIPTION
## What & why

Second step in the race-data-analysis arc. Adds the **G-G diagram (friction circle)** — a lateral-vs-longitudinal G scatter that shows how much of the tyre's grip envelope the driver is using. It's one of the most iconic "real telemetry tool" views (MoTeC i2, Race Studio) and was a named gap from the original Reddit critique. The data (`lat_g`/`lon_g`) is already computed on every file, so this is purely a new visualization.

## Changes

- **`src/lib/ggDiagram.ts`** (pure, unit-tested — 11 cases):
  - `pickGForcePair` — honors the existing `gForceSource` setting: GPS-derived `lat_g`/`lon_g` preferred, logger-native `lat_g_native`/`lon_g_native` when HW is selected, with graceful fallback to whichever pair has data. Raw IMU `accel_*` is deliberately **excluded** (body-frame, not guaranteed grip-aligned).
  - `computeGGPoints` — pairs lateral/longitudinal per sample (kept index-aligned, `null` where a component is missing), with the same per-axis moving-average smoothing as the other G-force charts.
  - `computeGGAxisMax` — symmetric axis extent, rounded up to a clean 0.5 g ring and clamped to `[1.5, 3.0]` g.
- **`src/components/graphview/GGDiagram.tsx`** — canvas view (mirrors `SingleSeriesChart`'s structure): concentric 0.5 g grip rings, the session's G cloud, the **reference lap's cloud** when one is selected (for envelope comparison), the live scrub point, and ACCEL/BRAKE/LAT hints + a per-point g readout.
- **`GraphPanel`** — wired in as the `__gg__` entry in the "Add Graph" picker; only offered when a lateral/longitudinal pair is present, and persists in graph-prefs like any other graph.
- `GForceSource` type extracted to `chartUtils.ts`.
- CHANGELOG + CLAUDE.md updated.

## Verification

`npm run lint` · `npm run typecheck` · `npm run test:run` (826 pass, +11 new) · `npm run build` — all green.

⚠️ **Visual check still needed on your end.** I couldn't screenshot the rendered canvas here — the remote environment's network policy blocks the headless-browser download (`playwright install chromium` fails). The drawing logic is covered by unit tests and follows the proven `SingleSeriesChart` canvas pattern, but please eyeball it in the app (Pro mode → Add Graph → G-G Diagram) before merging — ring spacing, label placement, and cloud density are the things tests can't catch.

## Follow-ups

- Honoring HW source via the raw IMU `accel_*` (needs a known body-frame mapping) is left out by design.
- Next up per our plan: the map multi-lap line alignment (the headline Reddit ask).

https://claude.ai/code/session_01Bv71GkEnPEfHki9RSYR7aq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv71GkEnPEfHki9RSYR7aq)_