### PR TITLE
Home-screen track manager + user drawings in community submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a datalog *is* loaded the editor still offers **Generate from lap** to build the
   outline from your GPS trace. Drawings you make are saved with the course and
   travel with it (cloud sync + community submissions).
+- **Track drawings are now part of a community submission.** When you submit a
+  track/course that has a drawn (or generated) outline, the outline rides along
+  with it — flagged with a **+ drawing** badge in the review screen. Adding or
+  changing a drawing re-flags an otherwise-unchanged course so it can be
+  contributed. In the admin **Submissions** tab, a submitted drawing shows a
+  thumbnail preview and an **Apply to course layout** button that saves it onto
+  the matching DB course (so it flows into the exported drawings).
 
 ### Changed
+- **"Submit to DB" is always visible now, greyed out when there's nothing to
+  send.** Previously the button only appeared once you had local tracks. It now
+  shows whenever the track manager is open and uses the upload-diffing logic to
+  enable itself only when you actually have new/changed courses (or drawings) to
+  contribute, with the pending count in the label.
 - **"Submit to DB" is now a one-tap bulk contribution instead of a coordinate
   form.** The old flow made you hand-fill latitudes/longitudes for one course at
   a time. Now the app diffs everything you've created locally against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Manage your tracks straight from the home screen.** A new **Manage Tracks**
+  button (below "Download from Datalogger") opens the track manager without
+  having to load a datalog first — search for a location, drop the start/finish
+  and sector lines, and **draw the track outline** by clicking the map. The
+  manual **Draw** tool (previously admin-only) is now available to everyone; when
+  a datalog *is* loaded the editor still offers **Generate from lap** to build the
+  outline from your GPS trace. Drawings you make are saved with the course and
+  travel with it (cloud sync + community submissions).
+
 ### Changed
 - **"Submit to DB" is now a one-tap bulk contribution instead of a coordinate
   form.** The old flow made you hand-fill latitudes/longitudes for one course at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lap-generated outlines are resampled instead of using every raw sample.**
   "Generate from lap" previously copied the full logger-rate GPS trace (hundreds
   to thousands of unevenly-spaced points). It now arc-length-resamples to an even
-  ~5 m spacing, producing a clean, compact outline (typically a couple hundred
-  points for a kart track) that's lighter to store and submit.
+  spacing scaled to track length — 5 m for karting tracks, ramping up to 10 m for
+  long road courses (2→4 miles) — producing a clean, compact outline that's
+  lighter to store and submit.
 - **"Submit to DB" is now a one-tap bulk contribution instead of a coordinate
   form.** The old flow made you hand-fill latitudes/longitudes for one course at
   a time. Now the app diffs everything you've created locally against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shows whenever the track manager is open and uses the upload-diffing logic to
   enable itself only when you actually have new/changed courses (or drawings) to
   contribute, with the pending count in the label.
+- **Lap-generated outlines are resampled instead of using every raw sample.**
+  "Generate from lap" previously copied the full logger-rate GPS trace (hundreds
+  to thousands of unevenly-spaced points). It now arc-length-resamples to an even
+  ~5 m spacing, producing a clean, compact outline (typically a couple hundred
+  points for a kart track) that's lighter to store and submit.
 - **"Submit to DB" is now a one-tap bulk contribution instead of a coordinate
   form.** The old flow made you hand-fill latitudes/longitudes for one course at
   a time. Now the app diffs everything you've created locally against the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,7 @@ The `course_layouts` table stores polyline drawings of track layouts (1:1 with c
 
 **"Generate Course Mapping" button**: Placeholder in admin CoursesTab — will eventually produce fingerprint data for automatic track detection on the DovesDataLogger hardware.
 
-**Submissions**: The `submissions` table has `has_layout` (bool) and `layout_data` (jsonb) columns to carry drawing data through the submission workflow.
+**Submissions**: The `submissions` table has `has_layout` (bool) and `layout_data` (jsonb) columns to carry drawing data through the submission workflow. The client now sends a course's `layout` as `layout_data` (`SubmitTrackDialog` → `submit-track` edge fn, which validates point shape + caps at 5000 points), the drawing is folded into `courseContentHash` (so adding/editing a drawing re-flags the course for upload), and the admin **Submissions** tab previews the polyline (`DrawingPreview`) with an **Apply to course layout** action that matches the DB course (by short-name/name + course name) and calls `db.saveLayout`. `DbSubmission` carries `has_layout`/`layout_data`.
 
 **Public drawings**: Admin exports drawings to `public/drawings.json` (keyed by `shortName/courseName` → `[{lat, lon}, ...]`). Loaded by `trackStorage.ts:loadCourseDrawings()` (cached). Rendered on the race line map as a dashed polyline outline when a course is selected. Helper: `getDrawingForCourse(shortName, courseName)`.
 
@@ -491,10 +491,17 @@ classifies each user course as **new_track** (wholly new track —
 **course_modification** (an edited built-in course). A user "edit" that is
 byte-identical to the built-in course is skipped. The track-level rollup reads
 **New** vs **Edited** (adding a course never overwrites the track). A geometry
-**content hash** (`courseContentHash`, rounded to ~1cm) drives both the
-identical-skip and dedupe: `submittedTracksStorage.ts` (localStorage key
-`racing-datalog-submitted-v1`) remembers each submitted course's hash, so
-unchanged courses aren't re-sent and a later edit re-flags the course.
+**+ drawing content hash** (`courseContentHash`, rounded to ~1cm — now also folds
+in the course's `layout` polyline) drives both the identical-skip and dedupe:
+`submittedTracksStorage.ts` (localStorage key `racing-datalog-submitted-v1`)
+remembers each submitted course's hash, so unchanged courses aren't re-sent and a
+later edit — geometry *or* drawing — re-flags the course. A course's `layout`
+rides the plan as `SubmissionCourse.layout` → `layout_data` in the payload.
+
+The **"Submit to DB" button is always rendered** (in `TrackEditor`'s manage
+view) and **disabled when nothing is pending** — `TrackEditor` runs
+`buildSubmissionPlan` itself to compute `pendingSubmissionCount` for the
+enable/label (and refreshes it via `onSubmitted`).
 
 The review dialog sends all selected courses in **one** `submit-track` call
 (`{ submissions: [...], turnstile_token }`); the edge function validates each,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ Detection order matters: binary formats first (MoTeC LD → UBX), then text form
 | `ParserStats` | `totalRows`, `acceptedRows`, `rejected: { nanFields, zeroCoords, outOfRange, speedCap, teleportation, incompleteRow }` |
 | `DovexMetadata` | `datetime?`, `driver?`, `course?`, `shortName?`, `bestLapMs?`, `optimalMs?`, `lapTimesMs?[]` |
 | `Lap` | `lapNumber`, `startTime/endTime`, `lapTimeMs`, speed stats, `startIndex/endIndex`, `sectors?` |
-| `Course` | `name`, `lengthFt?`, `startFinishA/B` (lat/lon), optional `sector2/sector3` lines |
+| `Course` | `name`, `lengthFt?`, `startFinishA/B` (lat/lon), optional `sector2/sector3` lines, optional `layout?` (`{lat,lon}[]` user-drawn outline) |
 | `Track` | `name`, `shortName?` (max 8 chars), `courses[]` |
 | `CourseDetectionResult` | `track`, `course`, `direction?`, `laps[]`, `isWaypointMode`, `waypointNotice?` |
 | `CourseDirection` | `'forward' \| 'reverse'` |
@@ -467,9 +467,11 @@ The `course_layouts` table stores polyline drawings of track layouts (1:1 with c
 
 **Access**: Admin-only RLS (same pattern as courses table). Layout lengths (in feet) ARE exported to track JSON files as `lengthFt`.
 
-**Draw tool**: In the VisualEditor, a "Draw" button allows clicking on the satellite map to build a polyline outline. This manual drawing tool is **admin-only** (`isAdminEditor={true}` in CoursesTab).
+**Draw tool**: In the VisualEditor, a "Draw" button allows clicking on the satellite map to build a polyline outline. It is shown whenever `showDrawTool` is set — **available to all users**, not just admin (the old `isAdminEditor` gate was removed). User-drawn (or lap-generated) outlines are persisted on `Course.layout` (a `{lat, lon}[]` polyline) through the normal track-storage CRUD, so they ride cloud-sync and travel with a community submission. Built-in courses still get their outline from `public/drawings.json` (see `loadCourseDrawings`); when editing, the user's own `course.layout` takes precedence over the built-in drawing.
 
-**Generate Drawing**: A "Generate" button (visible when laps are available and `showDrawTool` is true) lets users select a lap and auto-populate the drawing from that lap's GPS samples. Always available in user-side TrackEditor when session data is loaded. Laps and samples are threaded from `Index.tsx` → `TrackEditor` → `VisualEditor`.
+**Manage Tracks (home screen)**: `FileImport` renders a **Manage Tracks** button (below "Download from Datalogger") that opens `TrackEditor` via its `triggerButton` + `startInManage` props — the track manager is reachable with no datalog loaded. The create-flow dialogs (`AddTrackDialog`/`AddCourseDialog`) pass `isNewTrack`/`showDrawTool` so location search + manual drawing are available there.
+
+**Generate Drawing**: A "Generate" button (visible when laps are available and `showDrawTool` is true) lets users select a lap and auto-populate the drawing from that lap's GPS samples. Available in user-side TrackEditor when session data is loaded. Laps and samples are threaded from `Index.tsx` → `TrackEditor` → `VisualEditor` (and into the create-flow dialogs). The drawing state lives in `useTrackEditorForm` (`formLayout`) and is written into the course via `buildCourse()`.
 
 **"Generate Course Mapping" button**: Placeholder in admin CoursesTab — will eventually produce fingerprint data for automatic track detection on the DovesDataLogger hardware.
 

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, lazy, Suspense } from "react";
-import { Upload, FileText, FolderOpen, Loader2 } from "lucide-react";
+import { Upload, FileText, FolderOpen, Loader2, Map } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { TrackEditor } from "@/components/TrackEditor";
 import { parseDatalogFile } from "@/lib/datalogParser";
 import { ParsedData } from "@/types/racing";
 // Lazy so the BLE module (Web Bluetooth protocol) stays out of the initial
@@ -110,6 +111,21 @@ export function FileImport({ onDataLoaded, onOpenFileManager, autoSave, autoSave
         <Suspense fallback={null}>
           <DataloggerDownload onDataLoaded={onDataLoaded} autoSave={autoSave} autoSaveFile={autoSaveFile} />
         </Suspense>
+      </div>
+
+      {/* Track manager — create/draw tracks & courses without loading a datalog.
+          With no session loaded the visual editor offers location search + manual
+          drawing; once a datalog is open the header editor adds "Generate from lap". */}
+      <div className="flex justify-center">
+        <TrackEditor
+          startInManage
+          triggerButton={
+            <Button variant="outline">
+              <Map className="w-4 h-4 mr-2" />
+              Manage Tracks
+            </Button>
+          }
+        />
       </div>
 
       {fileName && !error && <p className="text-sm text-muted-foreground font-mono">Loaded: {fileName}</p>}

--- a/src/components/SubmitTrackDialog.tsx
+++ b/src/components/SubmitTrackDialog.tsx
@@ -140,6 +140,7 @@ export function SubmitTrackDialog({ trigger, onSubmitted }: SubmitTrackDialogPro
         track_short_name: c.type === 'new_track' ? c.trackShortName : undefined,
         course_name: c.courseName,
         course_data: c.courseData,
+        layout_data: c.layout,
       }));
 
       const { data, error } = await supabase.functions.invoke('submit-track', {
@@ -245,6 +246,11 @@ export function SubmitTrackDialog({ trigger, onSubmitted }: SubmitTrackDialogPro
                                 <span className={`text-xs px-1.5 py-0.5 rounded ${CHANGE_STYLE[course.change]}`}>
                                   {CHANGE_LABEL[course.change]}
                                 </span>
+                                {course.layout && course.layout.length >= 2 && (
+                                  <span className="text-xs px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400">
+                                    + drawing
+                                  </span>
+                                )}
                                 {course.alreadySubmitted && (
                                   <span className="text-xs text-muted-foreground">already submitted</span>
                                 )}

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Track, TrackCourseSelection } from '@/types/racing';
 import {
   loadTracks,
+  loadDefaultTracks,
   addTrack as addTrackToStorage,
   addCourse as addCourseToStorage,
   updateCourse,
@@ -15,6 +16,8 @@ import {
   loadCourseDrawings,
   CourseDrawing,
 } from '@/lib/trackStorage';
+import { buildSubmissionPlan } from '@/lib/trackSubmission';
+import { loadSubmittedRecords } from '@/lib/submittedTracksStorage';
 import { abbreviateTrackName } from '@/lib/trackUtils';
 import {
   Select,
@@ -82,6 +85,9 @@ export function TrackEditor({
   const [tempCourseName, setTempCourseName] = useState<string>('');
   const [isJsonViewOpen, setIsJsonViewOpen] = useState(false);
   const [courseDrawings, setCourseDrawings] = useState<Record<string, CourseDrawing[]>>({});
+  // Courses that still differ from the community DB (drives the always-visible
+  // "Submit to DB" button: greyed out when there's nothing new to send).
+  const [pendingSubmissionCount, setPendingSubmissionCount] = useState(0);
 
   const form = useTrackEditorForm();
 /** Mini SVG preview of a course drawing outline */
@@ -131,6 +137,16 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     setTracks(loaded);
     return loaded;
   }, []);
+
+  // Recompute how many courses still need submitting (uses the same diffing the
+  // submit dialog does, so the button greys out when nothing is pending).
+  const refreshPendingSubmissionCount = useCallback(async () => {
+    const defaults = await loadDefaultTracks();
+    const plan = buildSubmissionPlan(tracks, defaults, loadSubmittedRecords());
+    setPendingSubmissionCount(plan.pendingCount);
+  }, [tracks]);
+
+  useEffect(() => { refreshPendingSubmissionCount(); }, [refreshPendingSubmissionCount]);
 
   const selectedTrack = tracks.find(t => t.name === tempTrackName);
   const availableCourses = selectedTrack?.courses ?? [];
@@ -486,12 +502,16 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
           <Button variant="outline" onClick={() => setIsJsonViewOpen(true)} disabled={!selectedTrack}>
             <Code className="w-4 h-4 mr-2" />View JSON
           </Button>
-          {tracks.some(t => t.isUserDefined || t.courses.some(c => c.isUserDefined)) && (
-            <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1">
             <SubmitTrackDialog
+              onSubmitted={refreshPendingSubmissionCount}
               trigger={
-                <Button className="animate-attention-glow">
-                  <Send className="w-4 h-4 mr-2" />Submit to DB
+                <Button
+                  className={pendingSubmissionCount > 0 ? 'animate-attention-glow' : ''}
+                  disabled={pendingSubmissionCount === 0}
+                >
+                  <Send className="w-4 h-4 mr-2" />
+                  Submit to DB{pendingSubmissionCount > 0 ? ` (${pendingSubmissionCount})` : ''}
                 </Button>
               }
             />
@@ -506,13 +526,12 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
                 </button>
               </TooltipTrigger>
               <TooltipContent className="max-w-xs">
-                <p>Sharing your track configurations to the database helps the
-                project grow — your tracks become available to everyone, so the
-                community spends less time mapping and more time driving.</p>
+                <p>{pendingSubmissionCount === 0
+                  ? 'Nothing new to share right now — create or edit a track/course (or add a drawing) and it\'ll show up here to contribute.'
+                  : 'Sharing your track configurations to the database helps the project grow — your tracks become available to everyone, so the community spends less time mapping and more time driving.'}</p>
               </TooltipContent>
             </Tooltip>
-            </div>
-          )}
+          </div>
         </div>
         <Button variant="outline" onClick={() => setIsManageMode(false)}>Back to Selection</Button>
       </div>

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -48,14 +48,30 @@ import { Send } from 'lucide-react';
 import type { Lap, GpsSample } from '@/types/racing';
 
 interface TrackCourseEditorProps {
-  selection: TrackCourseSelection | null;
-  onSelectionChange: (selection: TrackCourseSelection | null) => void;
+  selection?: TrackCourseSelection | null;
+  onSelectionChange?: (selection: TrackCourseSelection | null) => void;
   compact?: boolean;
   laps?: Lap[];
   samples?: GpsSample[];
+  /**
+   * Render a custom button that opens the editor (e.g. the landing-page "Manage
+   * Tracks" entry). When set, the editor renders only this trigger + its dialogs
+   * instead of the compact selection label.
+   */
+  triggerButton?: React.ReactNode;
+  /** Open straight into the manage (track/course CRUD) view. */
+  startInManage?: boolean;
 }
 
-export function TrackEditor({ selection, onSelectionChange, compact = false, laps, samples }: TrackCourseEditorProps) {
+export function TrackEditor({
+  selection = null,
+  onSelectionChange,
+  compact = false,
+  laps,
+  samples,
+  triggerButton,
+  startInManage = false,
+}: TrackCourseEditorProps) {
   const [tracks, setTracks] = useState<Track[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSelectDialogOpen, setIsSelectDialogOpen] = useState(false);
@@ -211,11 +227,11 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
   const handleCourseChange = (courseName: string) => setTempCourseName(courseName);
 
   const handleApplySelection = () => {
-    if (!tempTrackName || !tempCourseName) { onSelectionChange(null); }
+    if (!tempTrackName || !tempCourseName) { onSelectionChange?.(null); }
     else {
       const track = tracks.find(t => t.name === tempTrackName);
       const course = track?.courses.find(c => c.name === tempCourseName);
-      if (track && course) onSelectionChange({ trackName: tempTrackName, courseName: tempCourseName, course });
+      if (track && course) onSelectionChange?.({ trackName: tempTrackName, courseName: tempCourseName, course });
     }
     setIsSelectDialogOpen(false);
     setIsManageMode(false);
@@ -265,6 +281,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
         startFinishB: course.startFinishB,
         sector2: course.sector2,
         sector3: course.sector3,
+        layout: course.layout,
       });
     }
     await refreshTracks();
@@ -313,6 +330,10 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     onStartFinishChange: form.handleVisualStartFinishChange,
     onSector2Change: form.handleVisualSector2Change,
     onSector3Change: form.handleVisualSector3Change,
+    layoutPoints: form.formLayout,
+    onLayoutChange: form.handleVisualLayoutChange,
+    laps,
+    samples,
   } as const;
 
   const addTrackDialogProps = {
@@ -330,6 +351,10 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     onStartFinishChange: form.handleVisualStartFinishChange,
     onSector2Change: form.handleVisualSector2Change,
     onSector3Change: form.handleVisualSector3Change,
+    layoutPoints: form.formLayout,
+    onLayoutChange: form.handleVisualLayoutChange,
+    laps,
+    samples,
   } as const;
 
   // Track/Course selection UI (shared between compact dialog and non-compact inline)
@@ -387,7 +412,8 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
                     showDrawTool={true}
                     laps={laps}
                     samples={samples}
-                    layoutPoints={resolveCourseDrawing(selectedTrack, form.editingCourse?.courseName)}
+                    layoutPoints={form.formLayout.length >= 2 ? form.formLayout : resolveCourseDrawing(selectedTrack, form.editingCourse?.courseName)}
+                    onLayoutChange={form.handleVisualLayoutChange}
                     showKnownDrawingToggle={true}
                   />
                 </Suspense>
@@ -520,6 +546,44 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     </Dialog>
   );
 
+  // Open the editor dialog, optionally jumping straight into manage mode.
+  const openEditor = () => {
+    if (startInManage) setIsManageMode(true);
+    setIsSelectDialogOpen(true);
+  };
+
+  const selectDialog = (
+    <Dialog open={isSelectDialogOpen} onOpenChange={(open) => { setIsSelectDialogOpen(open); if (!open) { setIsManageMode(false); form.setEditingCourse(null); form.resetForm(); } }}>
+      <DialogTrigger asChild><span className="sr-only">Open track selector</span></DialogTrigger>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader><DialogTitle>{isManageMode ? 'Manage Tracks & Courses' : 'Select Track & Course'}</DialogTitle></DialogHeader>
+        {!isManageMode ? (
+          <>
+            {selectionUI}
+            <div className="flex gap-2 pt-4">
+              <Button onClick={handleApplySelection} className="flex-1">Apply</Button>
+              <Button variant="outline" onClick={() => setIsManageMode(true)}><Settings className="w-4 h-4 mr-2" />Manage</Button>
+            </div>
+          </>
+        ) : manageModeContent}
+      </DialogContent>
+    </Dialog>
+  );
+
+  // Custom-trigger mode (e.g. the landing-page "Manage Tracks" button): render
+  // just the trigger + the dialogs, no compact selection label.
+  if (triggerButton) {
+    return (
+      <>
+        <span onClick={openEditor} className="contents">{triggerButton}</span>
+        {selectDialog}
+        {jsonViewDialog}
+        <AddCourseDialog {...addCourseDialogProps} />
+        <AddTrackDialog {...addTrackDialogProps} />
+      </>
+    );
+  }
+
   if (compact) {
     const displayLabel = selection ? `${abbreviateTrackName(selection.trackName)} : ${selection.courseName}` : 'No track selected';
 
@@ -532,22 +596,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
           </Button>
         </div>
 
-        <Dialog open={isSelectDialogOpen} onOpenChange={(open) => { setIsSelectDialogOpen(open); if (!open) { setIsManageMode(false); form.setEditingCourse(null); form.resetForm(); } }}>
-          <DialogTrigger asChild><span className="sr-only">Open track selector</span></DialogTrigger>
-          <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
-            <DialogHeader><DialogTitle>{isManageMode ? 'Manage Tracks & Courses' : 'Select Track & Course'}</DialogTitle></DialogHeader>
-            {!isManageMode ? (
-              <>
-                {selectionUI}
-                <div className="flex gap-2 pt-4">
-                  <Button onClick={handleApplySelection} className="flex-1">Apply</Button>
-                  <Button variant="outline" onClick={() => setIsManageMode(true)}><Settings className="w-4 h-4 mr-2" />Manage</Button>
-                </div>
-              </>
-            ) : manageModeContent}
-          </DialogContent>
-        </Dialog>
-
+        {selectDialog}
         {jsonViewDialog}
         <AddCourseDialog {...addCourseDialogProps} />
         <AddTrackDialog {...addTrackDialogProps} />
@@ -562,7 +611,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
         <Button onClick={() => {
           const track = tracks.find(t => t.name === tempTrackName);
           const course = track?.courses.find(c => c.name === tempCourseName);
-          if (track && course) onSelectionChange({ trackName: tempTrackName, courseName: tempCourseName, course });
+          if (track && course) onSelectionChange?.({ trackName: tempTrackName, courseName: tempCourseName, course });
         }} className="w-full"><Check className="w-4 h-4 mr-2" />Apply Selection</Button>
       )}
       <AddCourseDialog {...addCourseDialogProps} />

--- a/src/components/admin/CoursesTab.tsx
+++ b/src/components/admin/CoursesTab.tsx
@@ -322,7 +322,6 @@ export function CoursesTab() {
             onSector3Change={handleVisualSector3}
             isNewTrack={!editingId}
             showDrawTool={true}
-            isAdminEditor={true}
             layoutPoints={layoutPoints}
             onLayoutChange={handleLayoutChange}
           />

--- a/src/components/admin/SubmissionsTab.tsx
+++ b/src/components/admin/SubmissionsTab.tsx
@@ -5,7 +5,30 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { toast } from '@/hooks/use-toast';
 import { getDatabase } from '@/lib/db';
 import type { DbSubmission } from '@/lib/db/types';
-import { Check, X, Layers } from 'lucide-react';
+import { Check, X, Layers, Route } from 'lucide-react';
+
+/** Mini SVG preview of a submitted track outline. */
+function DrawingPreview({ points, size = 64 }: { points: Array<{ lat: number; lon: number }>; size?: number }) {
+  if (points.length < 2) return null;
+  const padding = 3;
+  const lats = points.map(p => p.lat);
+  const lons = points.map(p => p.lon);
+  const minLat = Math.min(...lats), maxLat = Math.max(...lats);
+  const minLon = Math.min(...lons), maxLon = Math.max(...lons);
+  const rangeLat = maxLat - minLat || 0.0001;
+  const rangeLon = maxLon - minLon || 0.0001;
+  const scale = (size - padding * 2) / Math.max(rangeLat, rangeLon);
+  const svgPoints = points.map(p => {
+    const x = padding + (p.lon - minLon) * scale;
+    const y = padding + (maxLat - p.lat) * scale; // flip Y
+    return `${x},${y}`;
+  }).join(' ');
+  return (
+    <svg width={size} height={size} className="shrink-0 rounded border border-border" style={{ background: 'hsl(var(--muted))' }}>
+      <polyline points={svgPoints} fill="none" stroke="hsl(var(--primary))" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
 
 /** A batch of submissions uploaded together, or a single legacy submission. */
 interface SubmissionGroup {
@@ -77,8 +100,35 @@ export function SubmissionsTab() {
     }
   };
 
+  // Save a submitted drawing onto the matching DB course's layout, so the
+  // existing drawings.json export (Tools tab) picks it up. The course must
+  // already exist in the DB (matched by track short-name/name + course name).
+  const handleApplyDrawing = async (sub: DbSubmission) => {
+    const layout = sub.layout_data;
+    if (!Array.isArray(layout) || layout.length < 2) return;
+    try {
+      const [tracks, courses] = await Promise.all([db.getTracks(), db.getAllCourses()]);
+      const track = tracks.find(t =>
+        (sub.track_short_name && t.short_name === sub.track_short_name) || t.name === sub.track_name);
+      const course = track && courses.find(c => c.track_id === track.id && c.name === sub.course_name);
+      if (!course) {
+        toast({
+          title: 'No matching course',
+          description: 'Create the course in the DB first, then apply its drawing.',
+          variant: 'destructive',
+        });
+        return;
+      }
+      await db.saveLayout(course.id, layout);
+      toast({ title: 'Drawing applied', description: `${sub.track_name} → ${sub.course_name}` });
+    } catch (e: unknown) {
+      toast({ title: 'Error applying drawing', description: (e as Error).message, variant: 'destructive' });
+    }
+  };
+
   const renderCard = (sub: DbSubmission) => {
-    const hasLayout = (sub as unknown as { has_layout?: boolean }).has_layout;
+    const layout = Array.isArray(sub.layout_data) ? sub.layout_data : null;
+    const hasLayout = sub.has_layout || (layout?.length ?? 0) > 0;
     return (
       <div key={sub.id} className="racing-card p-4 space-y-2">
         <div className="flex items-center justify-between">
@@ -99,6 +149,17 @@ export function SubmissionsTab() {
         <pre className="text-xs font-mono bg-muted p-2 rounded overflow-x-auto max-h-32">
           {JSON.stringify(sub.course_data, null, 2)}
         </pre>
+        {layout && layout.length >= 2 && (
+          <div className="flex items-center gap-3">
+            <DrawingPreview points={layout} />
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground">{layout.length} point outline submitted</p>
+              <Button size="sm" variant="outline" onClick={() => handleApplyDrawing(sub)} className="gap-1">
+                <Route className="w-3 h-3" /> Apply to course layout
+              </Button>
+            </div>
+          </div>
+        )}
         <p className="text-xs text-muted-foreground">
           IP: {sub.submitted_by_ip || 'unknown'} • {new Date(sub.created_at).toLocaleString()}
         </p>

--- a/src/components/track-editor/AddCourseDialog.tsx
+++ b/src/components/track-editor/AddCourseDialog.tsx
@@ -17,7 +17,7 @@ const VisualEditor = lazy(() =>
 import { CourseForm } from './CourseForm';
 import type { CourseFormProps } from '@/hooks/useTrackEditorForm';
 import type { GpsPoint } from './VisualEditor';
-import type { SectorLine } from '@/types/racing';
+import type { SectorLine, Lap, GpsSample } from '@/types/racing';
 
 interface AddCourseDialogProps {
   open: boolean;
@@ -35,6 +35,11 @@ interface AddCourseDialogProps {
   onSector2Change: (line: SectorLine) => void;
   onSector3Change: (line: SectorLine) => void;
   initialCenter?: GpsPoint | null;
+  /** Drawing support — draw the outline manually or generate it from a lap. */
+  layoutPoints?: Array<{ lat: number; lon: number }>;
+  onLayoutChange?: (points: Array<{ lat: number; lon: number }>) => void;
+  laps?: Lap[];
+  samples?: GpsSample[];
 }
 
 export function AddCourseDialog({
@@ -45,6 +50,7 @@ export function AddCourseDialog({
   startFinishA, startFinishB, sector2, sector3,
   onStartFinishChange, onSector2Change, onSector3Change,
   initialCenter,
+  layoutPoints, onLayoutChange, laps, samples,
 }: AddCourseDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -68,6 +74,12 @@ export function AddCourseDialog({
                 onStartFinishChange={onStartFinishChange}
                 onSector2Change={onSector2Change}
                 onSector3Change={onSector3Change}
+                isNewTrack={true}
+                showDrawTool={true}
+                layoutPoints={layoutPoints}
+                onLayoutChange={onLayoutChange}
+                laps={laps}
+                samples={samples}
               />
             </Suspense>
             <div className="space-y-3">

--- a/src/components/track-editor/AddTrackDialog.tsx
+++ b/src/components/track-editor/AddTrackDialog.tsx
@@ -17,7 +17,7 @@ const VisualEditor = lazy(() =>
 import { CourseForm } from './CourseForm';
 import type { CourseFormProps } from '@/hooks/useTrackEditorForm';
 import type { GpsPoint } from './VisualEditor';
-import type { SectorLine } from '@/types/racing';
+import type { SectorLine, Lap, GpsSample } from '@/types/racing';
 
 interface AddTrackDialogProps {
   open: boolean;
@@ -35,6 +35,11 @@ interface AddTrackDialogProps {
   onSector2Change: (line: SectorLine) => void;
   onSector3Change: (line: SectorLine) => void;
   initialCenter?: GpsPoint | null;
+  /** Drawing support — draw the outline manually or generate it from a lap. */
+  layoutPoints?: Array<{ lat: number; lon: number }>;
+  onLayoutChange?: (points: Array<{ lat: number; lon: number }>) => void;
+  laps?: Lap[];
+  samples?: GpsSample[];
 }
 
 export function AddTrackDialog({
@@ -45,6 +50,7 @@ export function AddTrackDialog({
   startFinishA, startFinishB, sector2, sector3,
   onStartFinishChange, onSector2Change, onSector3Change,
   initialCenter,
+  layoutPoints, onLayoutChange, laps, samples,
 }: AddTrackDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -85,6 +91,11 @@ export function AddTrackDialog({
                 onStartFinishChange={onStartFinishChange}
                 onSector2Change={onSector2Change}
                 onSector3Change={onSector3Change}
+                showDrawTool={true}
+                layoutPoints={layoutPoints}
+                onLayoutChange={onLayoutChange}
+                laps={laps}
+                samples={samples}
               />
             </Suspense>
             <div className="flex gap-2">

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -29,8 +29,6 @@ interface VisualEditorProps {
   initialCenter?: GpsPoint | null;
   /** Whether to show the Draw/Generate tools */
   showDrawTool?: boolean;
-  /** Whether the caller is an admin (shows manual Draw button) */
-  isAdminEditor?: boolean;
   /** Existing layout drawing to display as a static polyline */
   layoutPoints?: Array<{ lat: number; lon: number }>;
   /** Show a button to toggle visibility of known drawing */
@@ -48,7 +46,6 @@ interface VisualEditorToolbarProps {
   onToolChange: (tool: VisualEditorTool) => void;
   onDone: () => void;
   showDrawTool?: boolean;
-  isAdminEditor?: boolean;
   drawPointCount?: number;
   canToggleKnownDrawing?: boolean;
   showKnownDrawing?: boolean;
@@ -59,7 +56,7 @@ interface VisualEditorToolbarProps {
   onGenerateFromLap?: (lapNumber: number) => void;
 }
 
-function VisualEditorToolbar({ activeTool, onToolChange, onDone, showDrawTool, isAdminEditor, drawPointCount = 0, canToggleKnownDrawing = false, showKnownDrawing = true, onToggleKnownDrawing, onUndoDraw, onClearDraw, laps, onGenerateFromLap }: VisualEditorToolbarProps) {
+function VisualEditorToolbar({ activeTool, onToolChange, onDone, showDrawTool, drawPointCount = 0, canToggleKnownDrawing = false, showKnownDrawing = true, onToggleKnownDrawing, onUndoDraw, onClearDraw, laps, onGenerateFromLap }: VisualEditorToolbarProps) {
   const [showLapPicker, setShowLapPicker] = useState(false);
 
   const handleStartFinish = () => {
@@ -131,7 +128,7 @@ function VisualEditorToolbar({ activeTool, onToolChange, onDone, showDrawTool, i
           <Timer className="w-3.5 h-3.5" />
           Sector 3
         </Button>
-        {showDrawTool && isAdminEditor && (
+        {showDrawTool && (
             <Button
               variant={activeTool === 'draw' ? 'default' : 'outline'}
               size="sm"
@@ -226,7 +223,7 @@ export function VisualEditor({
   startFinishA, startFinishB, sector2, sector3,
   onStartFinishChange, onSector2Change, onSector3Change, onDone,
   isNewTrack = false, initialCenter: initialCenterProp = null,
-  showDrawTool = false, isAdminEditor = false, layoutPoints: layoutPointsProp, showKnownDrawingToggle = false, onLayoutChange,
+  showDrawTool = false, layoutPoints: layoutPointsProp, showKnownDrawingToggle = false, onLayoutChange,
   laps, samples,
 }: VisualEditorProps) {
   const mapContainerRef = useRef<HTMLDivElement>(null);
@@ -869,7 +866,6 @@ export function VisualEditor({
         onToolChange={handleToolChange}
         onDone={handleDone}
         showDrawTool={showDrawTool}
-        isAdminEditor={isAdminEditor}
         drawPointCount={drawPoints.length}
         canToggleKnownDrawing={showKnownDrawingToggle && drawPoints.length > 1}
         showKnownDrawing={showKnownDrawing}

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -5,12 +5,20 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/hooks/use-toast';
 import { SectorLine } from '@/types/racing';
 import type { Lap, GpsSample } from '@/types/racing';
+import { resamplePolyline } from '@/lib/trackUtils';
 import L from 'leaflet';
 
 export interface GpsPoint {
   lat: number;
   lon: number;
 }
+
+/**
+ * Spacing (meters) for a lap-generated outline. The raw lap is logged at the
+ * full device rate; an outline only needs a coarse, evenly-spaced polyline —
+ * ~5 m keeps a kart track around a couple hundred points while staying smooth.
+ */
+const GENERATED_DRAWING_SPACING_M = 5;
 
 export type VisualEditorTool = 'startFinish' | 'sector2' | 'sector3' | 'draw' | null;
 export type EditorMode = 'manual' | 'visual';
@@ -595,13 +603,17 @@ export function VisualEditor({
     const lap = laps.find(l => l.lapNumber === lapNumber);
     if (!lap) return;
     const lapSamples = samples.slice(lap.startIndex, lap.endIndex + 1);
-    const points = lapSamples
+    const rawPoints = lapSamples
       .filter(s => s.lat !== 0 && s.lon !== 0)
       .map(s => ({ lat: s.lat, lon: s.lon }));
-    if (points.length < 2) {
+    if (rawPoints.length < 2) {
       toast({ title: 'Not enough GPS data', description: 'This lap has insufficient GPS points for a drawing', variant: 'destructive' });
       return;
     }
+    // The raw lap is the full logger rate (10–25 Hz) — far denser than an
+    // outline needs, and unevenly so (more points in slow corners). Arc-length
+    // resample to a fixed spacing for a clean, compact polyline.
+    const points = resamplePolyline(rawPoints, GENERATED_DRAWING_SPACING_M);
     setDrawPoints(points);
     updateDrawPolyline(points);
     // Fit map to the generated drawing

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -5,20 +5,13 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/hooks/use-toast';
 import { SectorLine } from '@/types/racing';
 import type { Lap, GpsSample } from '@/types/racing';
-import { resamplePolyline } from '@/lib/trackUtils';
+import { resamplePolyline, calculatePolylineLength, generatedDrawingSpacing } from '@/lib/trackUtils';
 import L from 'leaflet';
 
 export interface GpsPoint {
   lat: number;
   lon: number;
 }
-
-/**
- * Spacing (meters) for a lap-generated outline. The raw lap is logged at the
- * full device rate; an outline only needs a coarse, evenly-spaced polyline —
- * ~5 m keeps a kart track around a couple hundred points while staying smooth.
- */
-const GENERATED_DRAWING_SPACING_M = 5;
 
 export type VisualEditorTool = 'startFinish' | 'sector2' | 'sector3' | 'draw' | null;
 export type EditorMode = 'manual' | 'visual';
@@ -612,8 +605,10 @@ export function VisualEditor({
     }
     // The raw lap is the full logger rate (10–25 Hz) — far denser than an
     // outline needs, and unevenly so (more points in slow corners). Arc-length
-    // resample to a fixed spacing for a clean, compact polyline.
-    const points = resamplePolyline(rawPoints, GENERATED_DRAWING_SPACING_M);
+    // resample to an even spacing scaled to track length for a clean, compact
+    // polyline (5 m for karting up to 10 m for long road courses).
+    const spacing = generatedDrawingSpacing(calculatePolylineLength(rawPoints));
+    const points = resamplePolyline(rawPoints, spacing);
     setDrawPoints(points);
     updateDrawPolyline(points);
     // Fit map to the generated drawing

--- a/src/hooks/useTrackEditorForm.ts
+++ b/src/hooks/useTrackEditorForm.ts
@@ -43,6 +43,9 @@ export function useTrackEditorForm() {
   const [formLonB, setFormLonB] = useState('');
   const [formSector2, setFormSector2] = useState<SectorFormState>({ aLat: '', aLon: '', bLat: '', bLon: '' });
   const [formSector3, setFormSector3] = useState<SectorFormState>({ aLat: '', aLon: '', bLat: '', bLon: '' });
+  // The drawn/generated course outline (polyline). Travels into the created
+  // course and rides cloud-sync + community submission.
+  const [formLayout, setFormLayout] = useState<Array<{ lat: number; lon: number }>>([]);
   const [editingCourse, setEditingCourse] = useState<{ trackName: string; courseName: string } | null>(null);
   const [editorMode, setEditorMode] = useState<'manual' | 'visual'>('visual');
 
@@ -52,6 +55,7 @@ export function useTrackEditorForm() {
     setFormLatA(''); setFormLonA(''); setFormLatB(''); setFormLonB('');
     setFormSector2({ aLat: '', aLon: '', bLat: '', bLon: '' });
     setFormSector3({ aLat: '', aLon: '', bLat: '', bLon: '' });
+    setFormLayout([]);
   }, []);
 
   // Editing the long name auto-fills the short name (until the user overrides it).
@@ -81,8 +85,9 @@ export function useTrackEditorForm() {
     const s2 = parseSectorLine(formSector2);
     const s3 = parseSectorLine(formSector3);
     if (s2 && s3) { course.sector2 = s2; course.sector3 = s3; }
+    if (formLayout.length >= 2) course.layout = formLayout;
     return course;
-  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSector2, formSector3]);
+  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSector2, formSector3, formLayout]);
 
   const openEditCourse = useCallback((trackName: string, course: Course) => {
     setEditingCourse({ trackName, courseName: course.name });
@@ -100,6 +105,7 @@ export function useTrackEditorForm() {
       aLat: course.sector3.a.lat.toString(), aLon: course.sector3.a.lon.toString(),
       bLat: course.sector3.b.lat.toString(), bLon: course.sector3.b.lon.toString()
     } : { aLat: '', aLon: '', bLat: '', bLon: '' });
+    setFormLayout(course.layout ?? []);
   }, []);
 
   const handleSector2Change = useCallback((field: 'aLat' | 'aLon' | 'bLat' | 'bLon', value: string) => {
@@ -136,6 +142,10 @@ export function useTrackEditorForm() {
     });
   }, []);
 
+  const handleVisualLayoutChange = useCallback((points: Array<{ lat: number; lon: number }>) => {
+    setFormLayout(points);
+  }, []);
+
   // Parsed form values for VisualEditor props
   const visualEditorStartFinishA = formLatA && formLonA ? { lat: parseFloat(formLatA), lon: parseFloat(formLonA) } : null;
   const visualEditorStartFinishB = formLatB && formLonB ? { lat: parseFloat(formLatB), lon: parseFloat(formLonB) } : null;
@@ -159,6 +169,7 @@ export function useTrackEditorForm() {
     formCourseName, setFormCourseName,
     formLatA, formLonA, formLatB, formLonB,
     formSector2, formSector3,
+    formLayout,
     editingCourse, setEditingCourse,
     editorMode, setEditorMode,
     resetForm,
@@ -169,6 +180,7 @@ export function useTrackEditorForm() {
     handleVisualStartFinishChange,
     handleVisualSector2Change,
     handleVisualSector3Change,
+    handleVisualLayoutChange,
     visualEditorStartFinishA,
     visualEditorStartFinishB,
     visualEditorSector2,

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -42,6 +42,10 @@ export interface DbSubmission {
   course_data: Record<string, unknown>;
   status: 'pending' | 'approved' | 'denied';
   submitted_by_ip: string | null;
+  /** True when the submitter included a drawn track outline. */
+  has_layout?: boolean;
+  /** The drawn outline polyline, when `has_layout`. */
+  layout_data?: Array<{ lat: number; lon: number }> | null;
   /** Ties courses uploaded together in one bulk submit. NULL for legacy rows. */
   batch_id: string | null;
   created_at: string;

--- a/src/lib/trackSubmission.test.ts
+++ b/src/lib/trackSubmission.test.ts
@@ -63,6 +63,18 @@ describe('courseContentHash', () => {
   it('changes when sectors are added', () => {
     expect(courseContentHash(course('A', sectors))).not.toBe(courseContentHash(course('A')));
   });
+
+  it('changes when a drawing is added or edited', () => {
+    const drawn = course('A', { layout: [{ lat: 28.41, lon: -81.38 }, { lat: 28.42, lon: -81.39 }] });
+    expect(courseContentHash(drawn)).not.toBe(courseContentHash(course('A')));
+    const moved = course('A', { layout: [{ lat: 28.41, lon: -81.38 }, { lat: 28.425, lon: -81.39 }] });
+    expect(courseContentHash(moved)).not.toBe(courseContentHash(drawn));
+  });
+
+  it('ignores a degenerate one-point drawing', () => {
+    const onePoint = course('A', { layout: [{ lat: 28.41, lon: -81.38 }] });
+    expect(courseContentHash(onePoint)).toBe(courseContentHash(course('A')));
+  });
 });
 
 describe('buildSubmissionPlan', () => {
@@ -154,6 +166,37 @@ describe('buildSubmissionPlan', () => {
     const plan = buildSubmissionPlan(merged, builtin);
     expect(plan.groups).toHaveLength(0);
     expect(plan.pendingCount).toBe(0);
+  });
+
+  it('re-flags a geometry-identical built-in course once the user adds a drawing, and carries the layout', () => {
+    const layout = [{ lat: 28.41, lon: -81.38 }, { lat: 28.42, lon: -81.39 }, { lat: 28.43, lon: -81.40 }];
+    const merged: Track[] = [
+      {
+        ...builtin[0],
+        // same geometry as the built-in, but now with a drawn outline
+        courses: [{ ...course('Normal'), isUserDefined: true, layout }],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    expect(plan.groups).toHaveLength(1);
+    const sub = plan.groups[0].courses[0];
+    expect(sub.type).toBe('course_modification');
+    expect(sub.layout).toEqual(layout);
+    expect(plan.pendingCount).toBe(1);
+  });
+
+  it('does not attach a degenerate one-point layout to a submission', () => {
+    const merged: Track[] = [
+      ...builtin,
+      {
+        name: 'My Backyard',
+        shortName: 'YARD',
+        isUserDefined: true,
+        courses: [{ ...course('Loop'), isUserDefined: true, layout: [{ lat: 28.41, lon: -81.38 }] }],
+      },
+    ];
+    const plan = buildSubmissionPlan(merged, builtin);
+    expect(plan.groups.find((g) => g.trackName === 'My Backyard')!.courses[0].layout).toBeUndefined();
   });
 
   it('never includes untouched built-in courses', () => {

--- a/src/lib/trackSubmission.ts
+++ b/src/lib/trackSubmission.ts
@@ -50,11 +50,17 @@ export interface SubmissionCourse {
   type: SubmissionType;
   change: CourseChange;
   courseData: CourseSubmissionData;
-  /** Geometry hash — identity for dedupe against already-submitted content. */
+  /**
+   * Drawn track outline (polyline), when the user has one. Sent to the edge fn
+   * as `layout_data` (separate from `course_data`); also folded into the content
+   * hash so adding/changing a drawing re-flags an otherwise-unchanged course.
+   */
+  layout?: Array<{ lat: number; lon: number }>;
+  /** Geometry + drawing hash — identity for dedupe against already-submitted content. */
   contentHash: string;
   /** Stable key (track + course) used by the already-submitted store. */
   key: string;
-  /** True when this exact geometry was already submitted (unchanged since). */
+  /** True when this exact content was already submitted (unchanged since). */
   alreadySubmitted: boolean;
 }
 
@@ -127,9 +133,16 @@ function fnv1a(str: string): string {
   return (h >>> 0).toString(16).padStart(8, '0');
 }
 
+/** Canonical (rounded) string for a drawn outline, or '' when there is none. */
+function layoutHashInput(layout?: Array<{ lat: number; lon: number }>): string {
+  if (!layout || layout.length < 2) return '';
+  return layout.map((p) => `${r(p.lat)} ${r(p.lon)}`).join(';');
+}
+
 /**
- * Deterministic hash of a course's geometry (rounded). Name is intentionally
- * excluded — identity is carried by the key; the hash detects geometry edits.
+ * Deterministic hash of a course's geometry + drawn outline (rounded). Name is
+ * intentionally excluded — identity is carried by the key; the hash detects
+ * geometry *or* drawing edits so a freshly-drawn outline re-flags the course.
  */
 export function courseContentHash(course: Course): string {
   const d = courseToSubmissionData(course);
@@ -138,6 +151,7 @@ export function courseContentHash(course: Course): string {
     d.sector_2_a_lat, d.sector_2_a_lng, d.sector_2_b_lat, d.sector_2_b_lng,
     d.sector_3_a_lat, d.sector_3_a_lng, d.sector_3_b_lat, d.sector_3_b_lng,
   ].map((n) => (n === undefined ? '' : String(r(n))));
+  parts.push(layoutHashInput(course.layout));
   return fnv1a(parts.join(','));
 }
 
@@ -214,6 +228,7 @@ export function buildSubmissionPlan(
         type,
         change,
         courseData: courseToSubmissionData(course),
+        layout: course.layout && course.layout.length >= 2 ? course.layout : undefined,
         contentHash: hash,
         key,
         alreadySubmitted,

--- a/src/lib/trackUtils.test.ts
+++ b/src/lib/trackUtils.test.ts
@@ -9,6 +9,7 @@ import {
   calculatePolylineLength,
   formatTrackLength,
   resamplePolyline,
+  generatedDrawingSpacing,
 } from "./trackUtils";
 import { haversineDistance } from "./parserUtils";
 
@@ -298,5 +299,32 @@ describe("resamplePolyline", () => {
       const step = haversineDistance(out[i - 1].lat, out[i - 1].lon, out[i].lat, out[i].lon);
       expect(step).toBeCloseTo(100, -1);
     }
+  });
+});
+
+// ─── generatedDrawingSpacing ────────────────────────────────────────────────────
+
+describe("generatedDrawingSpacing", () => {
+  const MILE = 1609.344;
+
+  it("uses the 5m minimum for short (karting) tracks under 2 miles", () => {
+    expect(generatedDrawingSpacing(0)).toBe(5);
+    expect(generatedDrawingSpacing(800)).toBe(5);
+    expect(generatedDrawingSpacing(2 * MILE)).toBe(5); // exactly at the ramp start
+  });
+
+  it("caps at 10m for tracks at or beyond 4 miles", () => {
+    expect(generatedDrawingSpacing(4 * MILE)).toBe(10);
+    expect(generatedDrawingSpacing(10 * MILE)).toBe(10);
+  });
+
+  it("ramps linearly from 5m to 10m between 2 and 4 miles", () => {
+    expect(generatedDrawingSpacing(3 * MILE)).toBeCloseTo(7.5, 5); // midpoint
+    expect(generatedDrawingSpacing(2.5 * MILE)).toBeCloseTo(6.25, 5);
+  });
+
+  it("falls back to the minimum for NaN / negative lengths", () => {
+    expect(generatedDrawingSpacing(NaN)).toBe(5);
+    expect(generatedDrawingSpacing(-100)).toBe(5);
   });
 });

--- a/src/lib/trackUtils.ts
+++ b/src/lib/trackUtils.ts
@@ -110,6 +110,29 @@ export function formatTrackLength(meters: number): string {
   return `${Math.round(feet).toLocaleString()} ft / ${Math.round(meters).toLocaleString()} m`;
 }
 
+const MILE_METERS = 1609.344;
+
+/**
+ * Resample spacing (meters) for a lap-generated track outline, scaled to track
+ * length. Short tracks (karting) stay fine at 5 m; from 2 miles the spacing
+ * ramps linearly up to 10 m by 4 miles and is capped there — so long road
+ * courses don't generate an excessively dense outline.
+ *
+ * `lengthMeters` is the lap distance. NaN / non-positive lengths fall back to
+ * the minimum spacing.
+ */
+export function generatedDrawingSpacing(lengthMeters: number): number {
+  const MIN = 5;
+  const MAX = 10;
+  const rampStart = 2 * MILE_METERS;
+  const rampEnd = 4 * MILE_METERS;
+  // `!(... > rampStart)` also catches NaN and lengths at/below the ramp start.
+  if (!(lengthMeters > rampStart)) return MIN;
+  if (lengthMeters >= rampEnd) return MAX;
+  const t = (lengthMeters - rampStart) / (rampEnd - rampStart);
+  return MIN + t * (MAX - MIN);
+}
+
 /**
  * Resample a polyline to evenly spaced points.
  * Walks along the path segment-by-segment, emitting a new interpolated

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -25,6 +25,13 @@ export interface Course {
   sector2?: SectorLine; // Optional sector 2 line
   sector3?: SectorLine; // Optional sector 3 line
   isUserDefined?: boolean; // true if user added/modified this course
+  /**
+   * User-drawn (or lap-generated) track outline — an ordered polyline of
+   * {lat, lon} points. Persisted alongside the course so it rides cloud-sync
+   * and travels with a community submission. Built-in courses get their outline
+   * from public/drawings.json instead (see loadCourseDrawings).
+   */
+  layout?: Array<{ lat: number; lon: number }>;
 }
 
 // Helper to check if course has valid sector lines

--- a/supabase/functions/submit-track/index.ts
+++ b/supabase/functions/submit-track/index.ts
@@ -9,6 +9,8 @@ const corsHeaders = {
 // flood the queue. Also cap how many rows one IP can add per rolling hour.
 const MAX_BATCH = 200;
 const MAX_ROWS_PER_HOUR = 300;
+// A drawn outline is a polyline; cap it so one row can't carry an unbounded blob.
+const MAX_LAYOUT_POINTS = 5000;
 
 interface SubmissionInput {
   type?: string;
@@ -66,6 +68,20 @@ function validateSubmission(s: SubmissionInput): string | null {
   for (const key of optionalCoords) {
     const v = course_data[key];
     if (v !== undefined && (typeof v !== 'number' || isNaN(v))) return `Invalid coordinate: ${key}`;
+  }
+
+  // Optional drawn outline. Accept undefined/null; otherwise it must be a
+  // bounded array of {lat, lon} numbers.
+  if (s.layout_data !== undefined && s.layout_data !== null) {
+    if (!Array.isArray(s.layout_data)) return 'Invalid layout data';
+    if (s.layout_data.length > MAX_LAYOUT_POINTS) return 'Too many layout points';
+    for (const p of s.layout_data) {
+      const pt = p as { lat?: unknown; lon?: unknown };
+      if (typeof pt?.lat !== 'number' || isNaN(pt.lat) ||
+          typeof pt?.lon !== 'number' || isNaN(pt.lon)) {
+        return 'Invalid layout point';
+      }
+    }
   }
 
   return null;


### PR DESCRIPTION
Continues the track-management work, branched off the latest `BETA`. Two commits.

## Phase 1 — Home-screen track manager with user drawing
- New **Manage Tracks** button on the landing page (below "Download from Datalogger") opens the track manager with no datalog loaded, via new `TrackEditor` `triggerButton` + `startInManage` props.
- The manual **Draw** tool is no longer admin-only — it shows wherever `showDrawTool` is set (removed the `isAdminEditor` gate). On the home screen you get **location search + Draw**; with a datalog loaded the editor still offers **Generate from lap**.
- The create-flow dialogs (`AddTrackDialog`/`AddCourseDialog`) now expose search, Draw, and Generate; the edit flow prefers the course's own saved layout over the built-in `drawings.json` outline.
- User-drawn / lap-generated outlines persist on a new `Course.layout` field through the normal track-storage CRUD, so they ride cloud-sync and travel with submissions.

## Phase 2 — Drawings in community submissions + always-on Submit button
- A course's `layout` rides the submission plan as `SubmissionCourse.layout` → `layout_data` in the `submit-track` payload (the edge fn already persisted it; now validates point shape and caps at 5000 points). Courses with an outline get a **+ drawing** badge in the review screen.
- `courseContentHash` now folds in the drawing, so adding/editing an outline re-flags an otherwise-unchanged course for upload.
- Admin **Submissions** tab previews the submitted outline (thumbnail) and adds **Apply to course layout**, which matches the DB course (short-name/name + course name) and calls `db.saveLayout`, feeding the existing `drawings.json` export. `DbSubmission` now types `has_layout`/`layout_data` (dropped the cast).
- **"Submit to DB" is always visible**, greyed out (with a pending count in the label) when the upload-diffing logic finds nothing new to send.

## Validation
- `npm run typecheck`, `npm run lint`, `npm run build` all pass.
- `npm run test:run`: **839 passing** (added 6 tests covering the drawing content-hash and the submission-plan layout carry / re-flag).
- Docs updated: `CHANGELOG.md` (Unreleased), `CLAUDE.md`.

https://claude.ai/code/session_01VMfDiQHwzLY38tkhdByM5P

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMfDiQHwzLY38tkhdByM5P)_