### PR TITLE
feat(map): multi-lap racing-line overlay on the pro-mode MiniMap (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   click. Removes a confusing extra step where dragging a line and switching tools
   silently discarded the change.
 ### Added
+- **Multi-lap racing-line overlay on the pro-mode map.** You can now overlay
+  several laps' racing lines on the GraphView mini-map at once to compare lines
+  through a corner — toggle the **Map** column in the lap list to drop any lap's
+  line on the map, and the *Spline* button in the snapshot list to overlay a
+  saved snapshot. Each overlay gets a distinct color with a legend on the map
+  (tap ✕ to remove). The active lap keeps its speed heatmap; overlays draw as
+  solid colored lines beneath it. (Phase 1: current-session laps + snapshots,
+  raw GPS. Cross-session drift-alignment and external-file/cross-logger overlays
+  are planned follow-ups — see `docs/plans/multi-lap-overlay.md`.)
 - **G-G diagram (friction circle).** A new pro-mode graph plotting lateral vs.
   longitudinal G as a scatter, so you can see how much of the tyre's grip
   envelope you're using — the classic "are you driving the corners of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   click. Removes a confusing extra step where dragging a line and switching tools
   silently discarded the change.
 ### Added
-- **Multi-lap racing-line overlay on the pro-mode map.** You can now overlay
-  several laps' racing lines on the GraphView mini-map at once to compare lines
-  through a corner — toggle the **Map** column in the lap list to drop any lap's
-  line on the map, and the *Spline* button in the snapshot list to overlay a
-  saved snapshot. Each overlay gets a distinct color with a legend on the map
-  (tap ✕ to remove). The active lap keeps its speed heatmap; overlays draw as
-  solid colored lines beneath it. (Phase 1: current-session laps + snapshots,
-  raw GPS. Cross-session drift-alignment and external-file/cross-logger overlays
-  are planned follow-ups — see `docs/plans/multi-lap-overlay.md`.)
+- **Multi-lap overlay across the maps and graphs.** Select extra laps/snapshots
+  to compare and they now draw everywhere at once: as racing lines on **both**
+  the simple Race Line map and the pro mini-map, **and** as distance-aligned
+  traces on the telemetry charts (the simple speed chart and every pro graph),
+  with each lap's value shown in the cursor tooltip. Toggle the **Map** column in
+  the lap list to add a lap, or the *Spline* button in the snapshot list to add a
+  snapshot; each gets a distinct color with an on-map legend (tap ✕ to remove).
+  The **current lap always renders on top** in every view. (Phase 1:
+  current-session laps + snapshots, raw GPS. Cross-session drift-alignment and
+  external-file/cross-logger overlays are planned follow-ups — see
+  `docs/plans/multi-lap-overlay.md`.)
 - **G-G diagram (friction circle).** A new pro-mode graph plotting lateral vs.
   longitudinal G as a scatter, so you can see how much of the tyre's grip
   envelope you're using — the classic "are you driving the corners of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ src/
 │   ├── useLapManagement.ts# Lap calc, selection, visible range
 │   ├── usePlayback.ts     # Shared playback cursor (chart + map)
 │   ├── useLapSnapshots.ts # ★ Lap-snapshot orchestration (capture/prompt/overlay)
+│   ├── useLapOverlays.ts  # Multi-lap map-overlay selection (lap/snapshot ids → OverlayLine[])
 │   ├── useReferenceLap / useVideoSync / useSettings / useSessionMetadata / useOnlineStatus
 │   ├── use*Manager.ts     # IndexedDB CRUD: File, Vehicle (←Kart compat), Engine, Template, Note, Setup
 │   └── useSubscription / useStripePrices   # billing, online — see docs/backend.md
@@ -107,6 +108,7 @@ src/
 │   ├── lapCalculation.ts  # Start/finish crossing detection → Lap[]
 │   ├── lapDelta.ts        # ★ Position-based lap delta (arc-length resample + segment-projected gap)
 │   ├── fileBrowserTree.ts # ★ Pure file-browser hierarchy: Track→Course→logs, engine/kart filter, breadcrumbs, smart collapse
+│   ├── lapOverlays.ts     # ★ Pure multi-lap map-overlay logic: id format, palette, resolve selections → OverlayLine[], unionBounds
 │   ├── lapSnapshot.ts     # ★ Pure snapshot types/keying/buffer (course+engine identity)
 │   ├── lapSnapshotStorage.ts # ★ IndexedDB CRUD for lap snapshots (emits garageEvents)
 │   ├── setupRevision.ts  # ★ Pure content-addressed setup history: hash + freeze (immutable revisions)
@@ -645,6 +647,18 @@ in `lib/ggDiagram.ts` (`pickGForcePair` honoring `gForceSource` → GPS `lat_g`/
 `lon_g` or native `lat_g_native`/`lon_g_native`; `computeGGPoints` with per-axis
 smoothing; `computeGGAxisMax` for the symmetric, clamped axis range). Raw IMU
 `accel_*` is intentionally excluded — it isn't guaranteed grip-frame-aligned.
+
+The **multi-lap line overlay** draws extra racing lines on the **pro-mode
+MiniMap** (only). Selection is per-lap (`LapTable` "Map" column) + per-snapshot
+(`LapSnapshotControls`), held by `useLapOverlays` as stable ids (`lap:<n>` /
+`snap:<id>`) and resolved by the pure, unit-tested `lib/lapOverlays.ts`
+(`resolveOverlayLines` → `OverlayLine[]` with palette colors; `unionBounds` to
+fit overlays that run outside the active lap). `SessionContext` carries
+`overlayLines` + `onToggleOverlay`; the MiniMap draws each as a solid colored
+polyline beneath the active heatmap and shows a remove-able legend. **Phase 1 is
+raw absolute GPS** (same-session laps share a receiver, so they register without
+correction); cross-session drift-alignment and external/cross-logger sources are
+deferred — see `docs/plans/multi-lap-overlay.md`.
 
 Channels are normalized to canonical ids at parse time (`channels.ts` →
 `normalizeChannels()`), so `extraFields` keys and `FieldMapping.name` are uniform

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,15 +648,22 @@ in `lib/ggDiagram.ts` (`pickGForcePair` honoring `gForceSource` → GPS `lat_g`/
 smoothing; `computeGGAxisMax` for the symmetric, clamped axis range). Raw IMU
 `accel_*` is intentionally excluded — it isn't guaranteed grip-frame-aligned.
 
-The **multi-lap line overlay** draws extra racing lines on the **pro-mode
-MiniMap** (only). Selection is per-lap (`LapTable` "Map" column) + per-snapshot
+The **multi-lap overlay** draws extra laps/snapshots across **all four data
+views at once**: racing lines on both maps (`RaceLineView` + `MiniMap`) and
+distance-aligned traces on both chart types (`TelemetryChart` speed +
+`SingleSeriesChart` per-series), with per-lap values in the cursor tooltip.
+Selection is per-lap (`LapTable` "Map" column) + per-snapshot
 (`LapSnapshotControls`), held by `useLapOverlays` as stable ids (`lap:<n>` /
 `snap:<id>`) and resolved by the pure, unit-tested `lib/lapOverlays.ts`
 (`resolveOverlayLines` → `OverlayLine[]` with palette colors; `unionBounds` to
-fit overlays that run outside the active lap). `SessionContext` carries
-`overlayLines` + `onToggleOverlay`; the MiniMap draws each as a solid colored
-polyline beneath the active heatmap and shows a remove-able legend. **Phase 1 is
-raw absolute GPS** (same-session laps share a receiver, so they register without
+fit map overlays that run outside the active lap). `SessionContext` carries
+`overlayLines` + `onToggleOverlay`. **The current lap always renders on top** —
+maps put overlays in a layer beneath the current heatmap; charts draw overlay
+traces before the current line. Chart overlays distance-align each lap onto the
+current lap via `alignByDistance` (`referenceUtils.ts`), over the full lap then
+sliced to the visible window (anchored at start-finish, like the reference);
+synthetic `__pace__`/`__braking_g__` series don't overlay. **Phase 1 is raw
+absolute GPS** (same-session laps share a receiver, so they register without
 correction); cross-session drift-alignment and external/cross-logger sources are
 deferred — see `docs/plans/multi-lap-overlay.md`.
 

--- a/docs/plans/multi-lap-overlay.md
+++ b/docs/plans/multi-lap-overlay.md
@@ -1,0 +1,74 @@
+# Plan: Multi-lap racing-line overlay on the map
+
+Status: **Phase 1 in progress** · Branch: `claude/multi-lap-overlay-minimap` → PR into `BETA`
+
+Origin: addresses the Reddit critique that the tool can't "align the lines from
+different stints on the map" (a feature AiM Race Studio 3 lost from v2). Builds on
+the distance-axis (#121) and G-G diagram (#125) work in the race-data-analysis arc.
+
+---
+
+## Phase 1 (this PR) — overlay current-session laps + snapshots on the pro map
+
+**Decisions (locked with the user):**
+- Sources: **current-session laps + lap snapshots**.
+- Spatial drift-correction: **deferred to phase 2** (raw absolute GPS for now).
+- Selection UX: **per-lap toggle in the lap list** (LapTable) + per-snapshot toggle
+  in LapSnapshotControls.
+- Surface: **pro-mode MiniMap only** (not the simple-mode RaceLineView).
+
+**Behavior**
+- Overlay any number of selected laps/snapshots as solid distinct-colored lines on
+  the GraphView MiniMap, beneath the active speed-heatmap line, above the grey
+  reference.
+- A small legend on the MiniMap (color swatch + label + ✕ to remove) for in-context
+  visibility/removal, since selection happens in another tab.
+- Map auto-fits to include overlay extents (snapshots can run slightly outside the
+  current lap's bounds).
+
+**Data model**
+```ts
+interface OverlayLine { id: string; label: string; color: string; samples: GpsSample[]; }
+```
+- Stable ids: `lap:<n>`, `snap:<snapshotId>`. Deterministic palette colors
+  (chosen not to clash with the speed heatmap or the grey reference).
+
+**Files**
+- New `src/lib/lapOverlays.ts` (+ `.test.ts`) — pure: id format/parse, palette/color
+  assignment, `resolveOverlayLines(selections, laps, sessionSamples, snapshots)` →
+  `OverlayLine[]`, `unionBounds(...)`.
+- New `useLapOverlays` hook — `overlaySelections: string[]`, `toggleOverlay(id)`,
+  `clearOverlays()`, derived `overlayLines`.
+- `SessionContext` + `Index.tsx` — thread `overlayLines`, `overlaySelections`,
+  `onToggleOverlay` to tabs.
+- `MiniMap.tsx` — new `overlayLinesLayer` (one `L.polyline` per line, rebuilt only
+  when the set changes, not on scrub); legend; union-bounds fit.
+- `LapTable.tsx` — per-row overlay toggle + color swatch (next to "Set Ref").
+- `LapSnapshotControls.tsx` — per-snapshot overlay toggle.
+- CHANGELOG + CLAUDE.md.
+
+**Verification**: unit tests for `lapOverlays` + lint/typecheck/test/build gate.
+Visual map check is on the user (headless-browser screenshot blocked in the agent
+sandbox).
+
+---
+
+## Phase 2 (later) — alignment + more sources
+
+- **Spatial drift-correction**: optional "align lines" toggle that rigidly registers
+  each overlay onto the primary lap (translation, optionally Kabsch rotation) using
+  the existing `resampleByDistance` + `projectToPlane` correspondences in
+  `lapDelta.ts`. Cancels GPS offset between sessions/loggers while preserving the
+  real racing-line shape. Same-session laps need none (shared receiver).
+- **External / cross-logger file overlays** as additional sources.
+- **Simple-mode RaceLineView** overlay parity.
+- Possible per-overlay channel comparison on the charts.
+
+---
+
+## Notes / caveats
+- Cross-tab nuance: toggles live in the lap list (LapTimes tab); lines render on the
+  pro MiniMap. State persists via SessionContext; the map legend softens it. The user
+  is contemplating broader UI changes, so this placement is "best for now."
+- Snapshot overlays draw at raw GPS in phase 1 → may sit a few meters off the current
+  lap until phase-2 alignment lands. Same-session lap overlays register exactly.

--- a/docs/plans/multi-lap-overlay.md
+++ b/docs/plans/multi-lap-overlay.md
@@ -15,7 +15,12 @@ the distance-axis (#121) and G-G diagram (#125) work in the race-data-analysis a
 - Spatial drift-correction: **deferred to phase 2** (raw absolute GPS for now).
 - Selection UX: **per-lap toggle in the lap list** (LapTable) + per-snapshot toggle
   in LapSnapshotControls.
-- Surface: **pro-mode MiniMap only** (not the simple-mode RaceLineView).
+- Surface: **all four data views** — both maps (RaceLineView + MiniMap) **and** both
+  chart types (TelemetryChart speed + SingleSeriesChart per-series), with per-lap
+  values in the cursor tooltip. (Originally scoped to the MiniMap only; expanded
+  mid-phase-1 once the maintainer clarified the overlays should be full comparison
+  lines on the graphs too.)
+- **Current lap always on top** in every view.
 
 **Behavior**
 - Overlay any number of selected laps/snapshots as solid distinct-colored lines on

--- a/docs/plans/multi-lap-overlay.md
+++ b/docs/plans/multi-lap-overlay.md
@@ -58,16 +58,27 @@ sandbox).
 
 ---
 
-## Phase 2 (later) — alignment + more sources
+## Phase 1.5 (done) — overlays everywhere
 
+Pulled forward from the original phase-2 list mid-phase-1:
+- ✅ **Simple-mode RaceLineView** overlay parity (racing lines + legend).
+- ✅ **Per-overlay traces on the charts** (`TelemetryChart` speed + `SingleSeriesChart`
+  per-series), distance-aligned via `alignByDistance`, with per-lap cursor-tooltip
+  values. Current lap always on top.
+
+## Phase 2 (remaining) — alignment + external sources
+
+These two are one feature in practice (external laps are what introduce real drift),
+and together they close the "align data from different loggers" half of the critique.
+
+- **External / cross-logger file overlays**: add laps from *other saved files* as
+  overlay sources (a new `OverlaySource`/id kind, e.g. `file:<name>:<lap>`), resolved
+  by loading + parsing like the external-reference flow already does.
 - **Spatial drift-correction**: optional "align lines" toggle that rigidly registers
   each overlay onto the primary lap (translation, optionally Kabsch rotation) using
   the existing `resampleByDistance` + `projectToPlane` correspondences in
   `lapDelta.ts`. Cancels GPS offset between sessions/loggers while preserving the
   real racing-line shape. Same-session laps need none (shared receiver).
-- **External / cross-logger file overlays** as additional sources.
-- **Simple-mode RaceLineView** overlay parity.
-- Possible per-overlay channel comparison on the charts.
 
 ---
 

--- a/src/components/LapSnapshotControls.tsx
+++ b/src/components/LapSnapshotControls.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Camera, Check, Plus, X } from "lucide-react";
+import { Camera, Check, Plus, Spline, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/dialog";
 import { formatLapTime } from "@/lib/lapCalculation";
 import type { LapSnapshot } from "@/lib/lapSnapshot";
+import { overlayId, type OverlayLine } from "@/lib/lapOverlays";
 import type { SaveSnapshotResult } from "@/hooks/useLapSnapshots";
 
 interface LapSnapshotControlsProps {
@@ -21,6 +22,10 @@ interface LapSnapshotControlsProps {
   triggerLabel?: string;
   /** Show the "save current lap" action (default true). Off for a load-only entry. */
   showSave?: boolean;
+  /** Active map overlays — drives the per-snapshot "show on map" toggle. */
+  overlayLines?: OverlayLine[];
+  /** Toggle a snapshot as a map overlay line (by overlay id). */
+  onToggleOverlay?: (id: string) => void;
 }
 
 /**
@@ -32,6 +37,7 @@ interface LapSnapshotControlsProps {
 export function LapSnapshotControls({
   snapshotsForCourse, activeSnapshotId, canSnapshot, hasCourse,
   onLoad, onClear, onSave, triggerLabel = "Snapshots", showSave = true,
+  overlayLines = [], onToggleOverlay,
 }: LapSnapshotControlsProps) {
   const [open, setOpen] = useState(false);
   if (!hasCourse) return null;
@@ -115,13 +121,13 @@ export function LapSnapshotControls({
             <ul className="space-y-0.5">
               {snapshotsForCourse.map((snap) => {
                 const isActive = snap.id === activeSnapshotId;
+                const ovId = overlayId("snap", snap.id);
+                const overlay = overlayLines.find((l) => l.id === ovId);
                 return (
-                  <li key={snap.id}>
+                  <li key={snap.id} className={`flex items-center rounded ${isActive ? "bg-primary/10" : ""}`}>
                     <button
                       type="button"
-                      className={`flex w-full items-center gap-2 rounded px-2 py-2 text-left transition-colors hover:bg-muted/50 ${
-                        isActive ? "bg-primary/10" : ""
-                      }`}
+                      className="flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-2 text-left transition-colors hover:bg-muted/50"
                       onClick={() => {
                         if (isActive) {
                           onClear();
@@ -147,6 +153,18 @@ export function LapSnapshotControls({
                       </span>
                       {isActive && <span className="shrink-0 text-[11px] text-primary">Showing</span>}
                     </button>
+                    {onToggleOverlay && (
+                      <button
+                        type="button"
+                        className="ml-1 mr-1 shrink-0 rounded p-1.5 transition-colors hover:bg-muted/50"
+                        style={{ color: overlay ? overlay.color : undefined }}
+                        title={overlay ? "Hide line on map" : "Show line on map"}
+                        aria-pressed={!!overlay}
+                        onClick={() => onToggleOverlay(ovId)}
+                      >
+                        <Spline className={`h-4 w-4 ${overlay ? "" : "text-muted-foreground"}`} />
+                      </button>
+                    )}
                   </li>
                 );
               })}

--- a/src/components/LapTable.tsx
+++ b/src/components/LapTable.tsx
@@ -1,11 +1,12 @@
 import { memo, useMemo } from 'react';
 import { Lap, courseHasSectors, Course, GpsSample } from '@/types/racing';
 import { formatLapTime, formatSectorTime, calculateOptimalLap } from '@/lib/lapCalculation';
-import { Trophy, Zap, Snail, Target } from 'lucide-react';
+import { Trophy, Zap, Snail, Target, Spline } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ExternalRefBar } from '@/components/ExternalRefBar';
 import { LapSnapshotControls } from '@/components/LapSnapshotControls';
 import type { LapSnapshot } from '@/lib/lapSnapshot';
+import { overlayId, type OverlayLine } from '@/lib/lapOverlays';
 import type { SaveSnapshotResult } from '@/hooks/useLapSnapshots';
 import { FileEntry } from '@/lib/fileStorage';
 import { useSettingsContext } from '@/contexts/SettingsContext';
@@ -33,9 +34,12 @@ interface LapTableProps {
   onLoadSnapshot?: (snap: LapSnapshot) => void;
   onClearSnapshot?: () => void;
   onSaveSnapshot?: (force?: boolean) => Promise<SaveSnapshotResult>;
+  // Map overlays (extra racing lines)
+  overlayLines?: OverlayLine[];
+  onToggleOverlay?: (id: string) => void;
 }
 
-export const LapTable = memo(function LapTable({ laps, course, samples, onLapSelect, selectedLapNumber, referenceLapNumber, onSetReference, externalRefLabel, savedFiles, onLoadFileForRef, onSelectExternalLap, onClearExternalRef, onRefreshSavedFiles, snapshotsForCourse, activeSnapshotId, canSnapshot, onLoadSnapshot, onClearSnapshot, onSaveSnapshot }: LapTableProps) {
+export const LapTable = memo(function LapTable({ laps, course, samples, onLapSelect, selectedLapNumber, referenceLapNumber, onSetReference, externalRefLabel, savedFiles, onLoadFileForRef, onSelectExternalLap, onClearExternalRef, onRefreshSavedFiles, snapshotsForCourse, activeSnapshotId, canSnapshot, onLoadSnapshot, onClearSnapshot, onSaveSnapshot, overlayLines = [], onToggleOverlay }: LapTableProps) {
   const { useKph } = useSettingsContext();
 
   const showSectors = courseHasSectors(course);
@@ -149,6 +153,8 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
               onSave={onSaveSnapshot}
               triggerLabel="Load snapshot as reference"
               showSave={false}
+              overlayLines={overlayLines}
+              onToggleOverlay={onToggleOverlay}
             />
           ) : undefined}
         />
@@ -157,6 +163,7 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
         <thead className="sticky top-0 bg-card">
           <tr className="text-left text-xs text-muted-foreground uppercase tracking-wider">
             <th className="px-2 py-3 font-medium w-16">Ref</th>
+            {onToggleOverlay && <th className="px-1 py-3 font-medium w-10 text-center" title="Show lap line on map">Map</th>}
             <th className="px-4 py-3 font-medium">Lap</th>
             <th className="px-4 py-3 font-medium">Time</th>
             {showSectors && (
@@ -205,6 +212,23 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
                     {isReference ? 'Ref' : 'Set Ref'}
                   </Button>
                 </td>
+                {onToggleOverlay && (() => {
+                  const ovId = overlayId('lap', lap.lapNumber);
+                  const overlay = overlayLines.find((l) => l.id === ovId);
+                  return (
+                    <td className="px-1 py-3 text-center" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        className="rounded p-1.5 transition-colors hover:bg-muted/50"
+                        style={{ color: overlay ? overlay.color : undefined }}
+                        title={overlay ? 'Hide lap line on map' : 'Show lap line on map'}
+                        aria-pressed={!!overlay}
+                        onClick={() => onToggleOverlay(ovId)}
+                      >
+                        <Spline className={`w-4 h-4 ${overlay ? '' : 'text-muted-foreground'}`} />
+                      </button>
+                    </td>
+                  );
+                })()}
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-sm">{lap.lapNumber}</span>

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -5,11 +5,12 @@ import { findSpeedEvents, SpeedEvent } from '@/lib/speedEvents';
 import { computeHeatmapSpeedBoundsMph } from '@/lib/speedBounds';
 import { formatLapTime } from '@/lib/lapCalculation';
 import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
+import { unionBounds, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Moon, Satellite, Square, WifiOff, CloudSun, FileText } from 'lucide-react';
+import { Moon, Satellite, Square, WifiOff, CloudSun, FileText, X } from 'lucide-react';
 import { WeatherPanel } from '@/components/WeatherPanel';
 import { LocalWeatherDialog } from '@/components/LocalWeatherDialog';
 import { WeatherStation, WeatherData } from '@/lib/weatherService';
@@ -57,6 +58,10 @@ interface RaceLineViewProps {
   onWeatherStationResolved?: (station: WeatherStation) => void;
   isAllLaps?: boolean;
   parserStats?: ParserStats | null;
+  /** Extra racing lines (other laps / snapshots) to overlay, beneath the current lap. */
+  overlayLines?: OverlayLine[];
+  /** Remove an overlay by id (legend ✕). */
+  onRemoveOverlay?: (id: string) => void;
 }
 
 // Get speed color (green -> yellow -> orange -> red)
@@ -138,7 +143,7 @@ function createSpeedEventIcon(event: SpeedEvent, useKph: boolean): L.DivIcon {
   });
 }
 
-export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats }: RaceLineViewProps) {
+export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], onRemoveOverlay }: RaceLineViewProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   // Use allSamples for statistics if provided, otherwise fall back to samples
   const samplesForStats = allSamples ?? samples;
@@ -146,6 +151,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
   const mapRef = useRef<L.Map | null>(null);
   const polylineLayerRef = useRef<L.LayerGroup | null>(null);
   const referenceLayerRef = useRef<L.LayerGroup | null>(null);
+  const overlayLinesLayerRef = useRef<L.LayerGroup | null>(null);
   const brakingZonesLayerRef = useRef<L.LayerGroup | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
   const startFinishRef = useRef<L.Polyline | null>(null);
@@ -293,6 +299,10 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
     // Create layer group for braking zones (above reference, below race line)
     brakingZonesLayerRef.current = L.layerGroup().addTo(map);
 
+    // Create layer group for multi-lap overlay lines (above braking, below the
+    // current lap — current lap always stays on top)
+    overlayLinesLayerRef.current = L.layerGroup().addTo(map);
+
     // Create layer group for current lap polylines
     polylineLayerRef.current = L.layerGroup().addTo(map);
     
@@ -305,6 +315,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
       map.remove();
       mapRef.current = null;
       referenceLayerRef.current = null;
+      overlayLinesLayerRef.current = null;
       brakingZonesLayerRef.current = null;
       speedEventsLayerRef.current = null;
       tileLayerRef.current = null;
@@ -347,10 +358,11 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
 
     if (samples.length === 0) return;
 
-    // Fit bounds
+    // Fit bounds — include overlay extents so off-lap overlays aren't clipped
+    const fit = unionBounds(bounds, overlayLines);
     const latLngBounds = L.latLngBounds([
-      [bounds.minLat, bounds.minLon],
-      [bounds.maxLat, bounds.maxLon]
+      [fit.minLat, fit.minLon],
+      [fit.maxLat, fit.maxLon]
     ]);
     map.fitBounds(latLngBounds, { padding: [20, 20] });
 
@@ -374,7 +386,19 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
       );
       polylineLayer.addLayer(polyline);
     }
-  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed]);
+  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed, overlayLines]);
+
+  // Draw multi-lap overlay lines (other laps / snapshots) — solid colors,
+  // beneath the current lap. Rebuilt only when the overlay set changes.
+  useEffect(() => {
+    const layer = overlayLinesLayerRef.current;
+    if (!layer) return;
+    layer.clearLayers();
+    for (const line of overlayLines) {
+      const coords = line.samples.map(s => [s.lat, s.lon] as [number, number]);
+      layer.addLayer(L.polyline(coords, { color: line.color, weight: 4, opacity: 0.7 }));
+    }
+  }, [overlayLines]);
 
   // Update speed event markers
   useEffect(() => {
@@ -532,7 +556,28 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
   return (
     <div className="w-full h-full relative">
       <div ref={containerRef} className="w-full h-full bg-black" />
-      
+
+      {/* Multi-lap overlay legend - bottom center */}
+      {overlayLines.length > 0 && (
+        <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-[1000] flex max-w-[70%] flex-wrap justify-center gap-x-3 gap-y-1 rounded bg-card/90 backdrop-blur-sm border border-border px-2.5 py-1.5">
+          {overlayLines.map(line => (
+            <div key={line.id} className="flex items-center gap-1.5 text-xs font-mono">
+              <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: line.color }} />
+              <span className="truncate max-w-[140px] text-foreground/90">{line.label}</span>
+              {onRemoveOverlay && (
+                <button
+                  onClick={() => onRemoveOverlay(line.id)}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                  title="Remove overlay"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Controls panel */}
       {showOverlays && (
         <div className="absolute top-4 left-4 bg-card/90 backdrop-blur-sm border border-border rounded p-2 z-[1000] transition-opacity duration-200">

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -4,6 +4,8 @@ import { G_FORCE_FIELDS, G_FORCE_FIELDS_GPS, G_FORCE_FIELDS_HW, applySmoothingTo
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
 import { buildChartAxis } from '@/lib/chartAxis';
+import { alignByDistance } from '@/lib/referenceUtils';
+import type { OverlayLine } from '@/lib/lapOverlays';
 
 interface TelemetryChartProps {
   samples: GpsSample[];
@@ -18,6 +20,8 @@ interface TelemetryChartProps {
    *  (start-finish-anchored) X-axis labels while the window stays zoomed. */
   allSamples?: GpsSample[];
   rangeStart?: number;
+  /** Extra laps/snapshots to overlay as distance-aligned speed lines. */
+  overlayLines?: OverlayLine[];
 }
 
 const COLORS = [
@@ -45,6 +49,7 @@ export function TelemetryChart({
   hasReference = false,
   allSamples,
   rangeStart,
+  overlayLines = [],
 }: TelemetryChartProps) {
   const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, gForceSource, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
@@ -77,6 +82,22 @@ export function TelemetryChart({
 
   const speedUnit = useKph ? 'KPH' : 'MPH';
   const getSpeed = useCallback((sample: GpsSample) => useKph ? sample.speedKph : sample.speedMph, [useKph]);
+
+  // Distance-align each overlay lap's speed onto the current lap, sliced to the
+  // visible window (computed over the full lap so it stays anchored to the
+  // start-finish line, like the reference). Recomputed only when inputs change.
+  const overlaySpeed = useMemo(() => {
+    const full = allSamples ?? samples;
+    if (overlayLines.length === 0 || full.length === 0) return [];
+    const start = rangeStart ?? 0;
+    const end = start + samples.length;
+    return overlayLines.map((line) => ({
+      id: line.id,
+      color: line.color,
+      label: line.label,
+      values: alignByDistance(full, line.samples, (s) => (useKph ? s.speedKph : s.speedMph)).slice(start, end),
+    }));
+  }, [overlayLines, allSamples, samples, rangeStart, useKph]);
 
   // Handle resize
   useEffect(() => {
@@ -177,6 +198,23 @@ export function TelemetryChart({
       }
       ctx.stroke();
       ctx.setLineDash([]);
+    }
+
+    // Draw overlay lap speed lines (other laps / snapshots), beneath the current
+    // lap so the current lap always stays on top.
+    for (const overlay of overlaySpeed) {
+      ctx.beginPath();
+      ctx.strokeStyle = overlay.color;
+      ctx.lineWidth = 1.5;
+      let isDrawing = false;
+      for (let i = 0; i < samples.length; i++) {
+        const v = overlay.values[i];
+        if (v === null || v === undefined) { isDrawing = false; continue; }
+        const x = padding.left + axis.fracAt(i) * chartWidth;
+        const y = padding.top + (1 - (v - minSpeed) / (maxSpeed - minSpeed)) * chartHeight;
+        if (!isDrawing) { ctx.moveTo(x, y); isDrawing = true; } else { ctx.lineTo(x, y); }
+      }
+      ctx.stroke();
     }
 
     // Draw speed line - smart glitch filtering
@@ -381,28 +419,39 @@ export function TelemetryChart({
       const currentPace = hasReference && paceData[currentIndex];
       
       // Calculate box height
-      const fieldsWithValues = enabledFields.filter(f => 
+      const fieldsWithValues = enabledFields.filter(f =>
         samples[currentIndex].extraFields[f.name] !== undefined
       );
-      let boxHeight = 20 + fieldsWithValues.length * 16;
+      const overlayRows = overlaySpeed.filter(o => o.values[currentIndex] != null);
+      let boxHeight = 20 + fieldsWithValues.length * 16 + overlayRows.length * 16;
       if (hasReference && showReferenceSpeed && currentRefSpeed !== null) boxHeight += 16;
       if (hasReference && showPace && currentPace !== null) boxHeight += 16;
-      
-      const boxX = Math.min(x + 10, dimensions.width - 130);
+
+      const boxW = overlayRows.length > 0 ? 168 : 120;
+      const boxX = Math.min(x + 10, dimensions.width - boxW - 10);
       const boxY = padding.top + 10;
-      
+
       ctx.fillStyle = chartColors.tooltipBg;
-      ctx.fillRect(boxX, boxY, 120, boxHeight);
+      ctx.fillRect(boxX, boxY, boxW, boxHeight);
       ctx.strokeStyle = chartColors.tooltipBorder;
       ctx.lineWidth = 1;
-      ctx.strokeRect(boxX, boxY, 120, boxHeight);
+      ctx.strokeRect(boxX, boxY, boxW, boxHeight);
 
       ctx.fillStyle = COLORS[0];
       ctx.textAlign = 'left';
       ctx.fillText(`Speed: ${currentSpeed.toFixed(1)} ${speedUnit.toLowerCase()}`, boxX + 8, boxY + 14);
 
       let fieldOffset = 1;
-      
+
+      // Overlay laps (current lap shown first, above) — each in its line color.
+      for (const overlay of overlayRows) {
+        const v = overlay.values[currentIndex] as number;
+        const label = overlay.label.length > 16 ? `${overlay.label.slice(0, 15)}…` : overlay.label;
+        ctx.fillStyle = overlay.color;
+        ctx.fillText(`${label}: ${v.toFixed(1)}`, boxX + 8, boxY + 14 + fieldOffset * 16);
+        fieldOffset++;
+      }
+
       // Reference speed
       if (hasReference && showReferenceSpeed && currentRefSpeed !== null && currentRefSpeed !== undefined) {
         ctx.fillStyle = REFERENCE_COLOR;
@@ -436,7 +485,7 @@ export function TelemetryChart({
       });
     }
 
-  }, [samples, currentIndex, dimensions, enabledFields, useKph, speedUnit, paceData, referenceSpeedData, hasReference, showReferenceSpeed, showPace, smoothedGForceData, chartColors, fieldMappings, getSpeed, axis]);
+  }, [samples, currentIndex, dimensions, enabledFields, useKph, speedUnit, paceData, referenceSpeedData, hasReference, showReferenceSpeed, showPace, smoothedGForceData, chartColors, fieldMappings, getSpeed, axis, overlaySpeed]);
 
   // Scrub handling
   const handleScrub = useCallback((clientX: number) => {

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -5,6 +5,7 @@ import { RangeSlider } from '@/components/RangeSlider';
 import { SingleSeriesChart } from './SingleSeriesChart';
 import { GGDiagram } from './GGDiagram';
 import { GpsSample, FieldMapping } from '@/types/racing';
+import type { OverlayLine } from '@/lib/lapOverlays';
 import { calculatePace, calculateReferenceSpeed, calculateDistanceArray } from '@/lib/referenceUtils';
 import { computeBrakingGSeriesSG, gToBrakePercent } from '@/lib/brakingZones';
 import { useSettingsContext } from '@/contexts/SettingsContext';
@@ -28,11 +29,12 @@ interface GraphPanelProps {
   minRange: number;
   formatRangeLabel: (idx: number) => string;
   sessionFileName: string | null;
+  overlayLines?: OverlayLine[];
 }
 
 export function GraphPanel({
   samples, filteredSamples, referenceSamples, fieldMappings, currentIndex, onScrub,
-  visibleRange, onRangeChange, minRange, formatRangeLabel, sessionFileName,
+  visibleRange, onRangeChange, minRange, formatRangeLabel, sessionFileName, overlayLines = [],
 }: GraphPanelProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   const [activeGraphs, setActiveGraphs] = useState<string[]>([]);
@@ -248,6 +250,7 @@ export function GraphPanel({
                   brakingGValues={key === '__braking_g__' ? brakingGFull.slice(visibleRange[0], visibleRange[1] + 1) : undefined}
                   allSamples={filteredSamples}
                   rangeStart={visibleRange[0]}
+                  overlayLines={overlayLines}
                 />
               )
             ))}

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -180,6 +180,7 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
           minRange={props.minRange}
           formatRangeLabel={props.formatRangeLabel}
           sessionFileName={props.sessionFileName}
+          overlayLines={props.overlayLines}
         />
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { GpsSample, Course, FieldMapping, Lap } from '@/types/racing';
+import type { OverlayLine } from '@/lib/lapOverlays';
 import { Vehicle } from '@/lib/vehicleStorage';
 import { VehicleSetup } from '@/lib/setupStorage';
 import { SetupTemplate } from '@/lib/templateStorage';
@@ -62,6 +63,9 @@ export interface GraphViewPanelProps {
   laps?: Lap[];
   selectedLapNumber?: number | null;
   paceData?: (number | null)[];
+  // Multi-lap overlay (extra racing lines drawn on the MiniMap)
+  overlayLines?: OverlayLine[];
+  onRemoveOverlay?: (id: string) => void;
 }
 
 export function GraphViewPanel(props: GraphViewPanelProps) {
@@ -146,6 +150,8 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
                 course={props.course}
                 bounds={props.bounds}
                 isAllLaps={props.isAllLaps}
+                overlayLines={props.overlayLines}
+                onRemoveOverlay={props.onRemoveOverlay}
               />
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/src/components/graphview/MiniMap.tsx
+++ b/src/components/graphview/MiniMap.tsx
@@ -4,9 +4,10 @@ import { GpsSample, Course } from '@/types/racing';
 import { findSpeedEvents, SpeedEvent } from '@/lib/speedEvents';
 import { computeHeatmapSpeedBoundsMph } from '@/lib/speedBounds';
 import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
+import { unionBounds, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
-import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon } from 'lucide-react';
+import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X } from 'lucide-react';
 import 'leaflet/dist/leaflet.css';
 
 type MapStyle = 'dark' | 'satellite' | 'none';
@@ -49,15 +50,20 @@ interface MiniMapProps {
   course: Course | null;
   bounds: { minLat: number; maxLat: number; minLon: number; maxLon: number };
   isAllLaps?: boolean;
+  /** Extra racing lines (other laps / snapshots) to overlay. */
+  overlayLines?: OverlayLine[];
+  /** Remove an overlay by id (legend ✕). */
+  onRemoveOverlay?: (id: string) => void;
 }
 
-export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps }: MiniMapProps) {
+export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], onRemoveOverlay }: MiniMapProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const polylineLayerRef = useRef<L.LayerGroup | null>(null);
   const referenceLayerRef = useRef<L.LayerGroup | null>(null);
   const brakingZonesLayerRef = useRef<L.LayerGroup | null>(null);
+  const overlayLinesLayerRef = useRef<L.LayerGroup | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
   const speedEventsLayerRef = useRef<L.LayerGroup | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
@@ -120,6 +126,7 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
     L.control.zoom({ position: 'bottomleft' }).addTo(map);
     referenceLayerRef.current = L.layerGroup().addTo(map);
     brakingZonesLayerRef.current = L.layerGroup().addTo(map);
+    overlayLinesLayerRef.current = L.layerGroup().addTo(map);
     polylineLayerRef.current = L.layerGroup().addTo(map);
     speedEventsLayerRef.current = L.layerGroup().addTo(map);
     mapRef.current = map;
@@ -140,7 +147,10 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
     pl.clearLayers();
     rl.clearLayers();
     if (samples.length === 0) return;
-    map.fitBounds(L.latLngBounds([[bounds.minLat, bounds.minLon], [bounds.maxLat, bounds.maxLon]]), { padding: [10, 10] });
+    // Fit to the active lap plus any overlays (a cross-session snapshot can run
+    // slightly outside the current lap's bounds).
+    const fit = unionBounds(bounds, overlayLines);
+    map.fitBounds(L.latLngBounds([[fit.minLat, fit.minLon], [fit.maxLat, fit.maxLon]]), { padding: [10, 10] });
     // Draw reference line underneath as grey
     if (referenceSamples.length > 0) {
       const refCoords = referenceSamples.map(s => [s.lat, s.lon] as [number, number]);
@@ -150,7 +160,18 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
       const color = getSpeedColor(samples[i].speedMph, minSpeed, maxSpeed);
       pl.addLayer(L.polyline([[samples[i].lat, samples[i].lon], [samples[i + 1].lat, samples[i + 1].lon]], { color, weight: 3, opacity: 0.9 }));
     }
-  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed]);
+  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed, overlayLines]);
+
+  // Overlay racing lines (other laps / snapshots) — solid distinct colors, drawn
+  // beneath the active heatmap. Rebuilt only when the overlay set changes.
+  useEffect(() => {
+    const layer = overlayLinesLayerRef.current; if (!layer) return;
+    layer.clearLayers();
+    for (const line of overlayLines) {
+      const coords = line.samples.map(s => [s.lat, s.lon] as [number, number]);
+      layer.addLayer(L.polyline(coords, { color: line.color, weight: 3, opacity: 0.7 }));
+    }
+  }, [overlayLines]);
 
   // Speed events
   useEffect(() => {
@@ -225,6 +246,27 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
           <Zap className="w-3 h-3" />
         </button>
       </div>
+
+      {/* Overlay legend - lower right */}
+      {overlayLines.length > 0 && (
+        <div className="absolute bottom-2 right-2 z-[1000] max-w-[55%] max-h-[40%] overflow-y-auto rounded bg-card/90 backdrop-blur-sm border border-border p-1.5 space-y-1 scrollbar-thin">
+          {overlayLines.map(line => (
+            <div key={line.id} className="flex items-center gap-1.5 text-[11px] font-mono">
+              <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: line.color }} />
+              <span className="truncate text-foreground/90">{line.label}</span>
+              {onRemoveOverlay && (
+                <button
+                  onClick={() => onRemoveOverlay(line.id)}
+                  className="ml-auto shrink-0 text-muted-foreground hover:text-destructive"
+                  title="Remove overlay"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
 
       {!isOnline && (
         <div className="absolute bottom-2 left-2 z-[1000] flex items-center gap-1 text-xs text-amber-500">

--- a/src/components/graphview/SingleSeriesChart.tsx
+++ b/src/components/graphview/SingleSeriesChart.tsx
@@ -5,6 +5,8 @@ import { G_FORCE_FIELDS, applySmoothingToValues, computeSmoothingWindowSize, det
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
 import { buildChartAxis } from '@/lib/chartAxis';
+import { alignByDistance } from '@/lib/referenceUtils';
+import type { OverlayLine } from '@/lib/lapOverlays';
 
 interface SingleSeriesChartProps {
   samples: GpsSample[];
@@ -20,13 +22,15 @@ interface SingleSeriesChartProps {
    *  (start-finish-anchored) X-axis labels while the window stays zoomed. */
   allSamples?: GpsSample[];
   rangeStart?: number;
+  /** Extra laps/snapshots to overlay (distance-aligned) for this series. */
+  overlayLines?: OverlayLine[];
 }
 
 export function SingleSeriesChart({
   samples, seriesKey, currentIndex, onScrub,
   color, label, onDelete,
   referenceValues = null, brakingGValues,
-  allSamples, rangeStart,
+  allSamples, rangeStart, overlayLines = [],
 }: SingleSeriesChartProps) {
   const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
@@ -69,6 +73,30 @@ export function SingleSeriesChart({
     }
     return rawValues;
   }, [rawValues, isGForce, smoothingWindowSize]);
+
+  // Distance-align each overlay lap's value for this series onto the current
+  // lap. Only for real measured series (speed / channels) — the synthetic pace
+  // and brake-% series are reference-relative / derived, so they don't overlay.
+  const overlaySeries = useMemo(() => {
+    if (isPace || isBrakingG) return [];
+    const full = allSamples ?? samples;
+    if (overlayLines.length === 0 || full.length === 0) return [];
+    const start = rangeStart ?? 0;
+    const end = start + samples.length;
+    const getValue = isSpeed
+      ? (s: GpsSample) => (useKph ? s.speedKph : s.speedMph)
+      : (s: GpsSample) => s.extraFields[seriesKey];
+    return overlayLines.map((line) => {
+      let values = alignByDistance(full, line.samples, getValue).slice(start, end);
+      if (isGForce && smoothingWindowSize > 1) {
+        values = applySmoothingToValues(
+          values.map((v) => (v === null ? undefined : v)),
+          smoothingWindowSize,
+        ).map((v) => (v === undefined ? null : v));
+      }
+      return { id: line.id, color: line.color, label: line.label, values };
+    });
+  }, [overlayLines, allSamples, samples, rangeStart, isSpeed, isPace, isBrakingG, isGForce, seriesKey, useKph, smoothingWindowSize]);
 
   // Speed glitch filtering
   const interpolateIndices = useMemo(() => {
@@ -140,6 +168,15 @@ export function SingleSeriesChart({
       }
     }
 
+    // Expand range to fit overlay lap values too
+    for (const overlay of overlaySeries) {
+      const nums = overlay.values.filter((v): v is number => v !== null);
+      if (nums.length > 0) {
+        minVal = Math.min(minVal, ...nums);
+        maxVal = Math.max(maxVal, ...nums);
+      }
+    }
+
     if (isSpeed) { minVal = 0; maxVal = Math.ceil(maxVal / 10) * 10; }
     if (isBrakingG) { minVal = 0; maxVal = 100; } // 0-100% fixed range
     if (isPace) {
@@ -166,6 +203,22 @@ export function SingleSeriesChart({
       }
       ctx.stroke();
       ctx.setLineDash([]);
+    }
+
+    // Draw overlay lap lines (behind the main line — current lap stays on top)
+    for (const overlay of overlaySeries) {
+      ctx.beginPath();
+      ctx.strokeStyle = overlay.color;
+      ctx.lineWidth = 1.5;
+      let drawing = false;
+      for (let i = 0; i < samples.length; i++) {
+        const v = overlay.values[i];
+        if (v === null || v === undefined) { drawing = false; continue; }
+        const x = padding.left + axis.fracAt(i) * chartWidth;
+        const y = padding.top + (1 - (v - minVal) / range) * chartHeight;
+        if (!drawing) { ctx.moveTo(x, y); drawing = true; } else { ctx.lineTo(x, y); }
+      }
+      ctx.stroke();
     }
 
     // Draw zero line for pace and braking G
@@ -239,7 +292,7 @@ export function SingleSeriesChart({
       ctx.lineWidth = 2;
       ctx.stroke();
 
-      // Current value tooltip
+      // Current value tooltip — current lap first, then each overlay lap.
       const displayVal = values[currentIndex];
       if (displayVal !== undefined) {
         const unit = isPace ? 's' : isBrakingG ? 'G' : isSpeed ? (useKph ? ' kph' : ' mph') : '';
@@ -257,32 +310,49 @@ export function SingleSeriesChart({
           }
         }
 
-        const fullText = mainText + deltaText;
-        const boxWidth = Math.max(90, ctx.measureText(fullText).width + 12);
-        const boxX = Math.min(x + 8, dimensions.width - boxWidth - 10);
-
-        ctx.fillStyle = chartColors.tooltipBg;
-        ctx.fillRect(boxX, padding.top + 4, boxWidth, 18);
-        ctx.strokeStyle = chartColors.tooltipBorder;
-        ctx.lineWidth = 1;
-        ctx.strokeRect(boxX, padding.top + 4, boxWidth, 18);
-
-        ctx.textAlign = 'left';
         ctx.font = '10px JetBrains Mono, monospace';
 
-        // Draw main value
-        ctx.fillStyle = color;
-        ctx.fillText(mainText, boxX + 4, padding.top + 16);
+        // Overlay rows (value at the cursor for each overlaid lap)
+        const overlayRows = overlaySeries
+          .map((o) => ({ color: o.color, label: o.label, v: o.values[currentIndex] }))
+          .filter((r): r is { color: string; label: string; v: number } => r.v !== null && r.v !== undefined)
+          .map((r) => ({
+            color: r.color,
+            text: `${r.label.length > 16 ? `${r.label.slice(0, 15)}…` : r.label}: ${r.v.toFixed(1)}`,
+          }));
 
-        // Draw delta in separate color
+        let boxWidth = ctx.measureText(mainText + deltaText).width;
+        for (const r of overlayRows) boxWidth = Math.max(boxWidth, ctx.measureText(r.text).width);
+        boxWidth = Math.max(90, boxWidth + 12);
+        const boxHeight = 18 + overlayRows.length * 14;
+        const boxX = Math.min(x + 8, dimensions.width - boxWidth - 10);
+        const boxY = padding.top + 4;
+
+        ctx.fillStyle = chartColors.tooltipBg;
+        ctx.fillRect(boxX, boxY, boxWidth, boxHeight);
+        ctx.strokeStyle = chartColors.tooltipBorder;
+        ctx.lineWidth = 1;
+        ctx.strokeRect(boxX, boxY, boxWidth, boxHeight);
+
+        ctx.textAlign = 'left';
+
+        // Main value (current lap, on top)
+        ctx.fillStyle = color;
+        ctx.fillText(mainText, boxX + 4, boxY + 12);
         if (deltaText) {
           const mainWidth = ctx.measureText(mainText).width;
           ctx.fillStyle = chartColors.deltaText;
-          ctx.fillText(deltaText, boxX + 4 + mainWidth, padding.top + 16);
+          ctx.fillText(deltaText, boxX + 4 + mainWidth, boxY + 12);
         }
+
+        // Overlay rows beneath
+        overlayRows.forEach((r, idx) => {
+          ctx.fillStyle = r.color;
+          ctx.fillText(r.text, boxX + 4, boxY + 12 + (idx + 1) * 14);
+        });
       }
     }
-  }, [samples, values, currentIndex, dimensions, color, isSpeed, isPace, isBrakingG, useKph, interpolateIndices, referenceValues, chartColors, axis]);
+  }, [samples, values, currentIndex, dimensions, color, isSpeed, isPace, isBrakingG, useKph, interpolateIndices, referenceValues, chartColors, axis, overlaySeries]);
 
   // Scrub handling
   const handleScrub = useCallback((clientX: number) => {

--- a/src/components/tabs/GraphViewTab.tsx
+++ b/src/components/tabs/GraphViewTab.tsx
@@ -45,6 +45,8 @@ export const GraphViewTab = memo(function GraphViewTab() {
       laps={s.laps}
       selectedLapNumber={s.selectedLapNumber}
       paceData={s.paceData}
+      overlayLines={s.overlayLines}
+      onRemoveOverlay={s.onToggleOverlay}
     />
   );
 });

--- a/src/components/tabs/LapTimesTab.tsx
+++ b/src/components/tabs/LapTimesTab.tsx
@@ -26,6 +26,8 @@ export const LapTimesTab = memo(function LapTimesTab() {
         onLoadSnapshot={s.onLoadSnapshot}
         onClearSnapshot={s.onClearSnapshot}
         onSaveSnapshot={s.onSaveSnapshot}
+        overlayLines={s.overlayLines}
+        onToggleOverlay={s.onToggleOverlay}
       />
     </div>
   );

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -38,6 +38,8 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
           onWeatherStationResolved={s.onWeatherStationResolved}
           isAllLaps={s.isAllLaps}
           parserStats={s.parserStats}
+          overlayLines={s.overlayLines}
+          onRemoveOverlay={s.onToggleOverlay}
         />
       }
       bottomPanel={
@@ -54,6 +56,7 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
               hasReference={s.hasReference}
               allSamples={s.filteredSamples}
               rangeStart={s.visibleRange[0]}
+              overlayLines={s.overlayLines}
             />
           </div>
           {s.filteredSamples.length > 0 && (

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -9,6 +9,7 @@ import type { Vehicle } from '@/lib/vehicleStorage';
 import type { VehicleSetup } from '@/lib/setupStorage';
 import type { SetupTemplate } from '@/lib/templateStorage';
 import type { LapSnapshot } from '@/lib/lapSnapshot';
+import type { OverlayLine } from '@/lib/lapOverlays';
 import type { SaveSnapshotResult } from '@/hooks/useLapSnapshots';
 import type { PluginSnapshot } from '@/plugins/panels';
 
@@ -74,6 +75,11 @@ export interface SessionContextValue {
   onLoadSnapshot: (snap: LapSnapshot) => void;
   onClearSnapshot: () => void;
   onSaveSnapshot: (force?: boolean) => Promise<SaveSnapshotResult>;
+
+  // ── Map overlays (extra racing lines, pro-mode map) ───────────────────────
+  overlaySelections: string[];
+  overlayLines: OverlayLine[];
+  onToggleOverlay: (id: string) => void;
 
   // ── Session metadata ──────────────────────────────────────────────────────
   sessionGpsPoint?: { lat: number; lon: number };

--- a/src/hooks/useLapOverlays.ts
+++ b/src/hooks/useLapOverlays.ts
@@ -1,0 +1,42 @@
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import type { ParsedData, Lap } from '@/types/racing';
+import type { LapSnapshot } from '@/lib/lapSnapshot';
+import { resolveOverlayLines, OverlayLine } from '@/lib/lapOverlays';
+
+/**
+ * Multi-lap overlay selection for the map: which laps / snapshots are shown as
+ * extra racing lines. Selections are stable string ids (`lap:<n>`, `snap:<id>`)
+ * resolved to drawable {@link OverlayLine}s against the current session + course
+ * snapshots. Cleared automatically when a new file loads.
+ */
+export function useLapOverlays(
+  data: ParsedData | null,
+  laps: Lap[],
+  snapshotsForCourse: LapSnapshot[],
+) {
+  const [overlaySelections, setOverlaySelections] = useState<string[]>([]);
+
+  // A fresh session is a fresh slate — stale lap/snapshot ids don't carry over.
+  useEffect(() => {
+    setOverlaySelections([]);
+  }, [data]);
+
+  const toggleOverlay = useCallback((id: string) => {
+    setOverlaySelections((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }, []);
+
+  const clearOverlays = useCallback(() => setOverlaySelections([]), []);
+
+  const overlayLines: OverlayLine[] = useMemo(
+    () => resolveOverlayLines(overlaySelections, {
+      laps,
+      sessionSamples: data?.samples ?? [],
+      snapshots: snapshotsForCourse,
+    }),
+    [overlaySelections, laps, data, snapshotsForCourse],
+  );
+
+  return { overlaySelections, overlayLines, toggleOverlay, clearOverlays };
+}

--- a/src/lib/lapOverlays.test.ts
+++ b/src/lib/lapOverlays.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  overlayId,
+  overlayColor,
+  OVERLAY_COLORS,
+  resolveOverlayLines,
+  unionBounds,
+} from "./lapOverlays";
+import type { GpsSample, Lap } from "@/types/racing";
+import type { LapSnapshot } from "./lapSnapshot";
+
+function sample(lat: number, lon: number, t = 0): GpsSample {
+  return { t, lat, lon, speedMps: 0, speedMph: 0, speedKph: 0, extraFields: {} };
+}
+
+function lap(lapNumber: number, startIndex: number, endIndex: number): Lap {
+  return {
+    lapNumber,
+    startTime: 0,
+    endTime: 0,
+    lapTimeMs: 60000 + lapNumber,
+    maxSpeedMph: 0,
+    maxSpeedKph: 0,
+    minSpeedMph: 0,
+    minSpeedKph: 0,
+    startIndex,
+    endIndex,
+  };
+}
+
+// Minimal snapshot: 4 samples, the middle two inside the lap window.
+function snapshot(id: string, engine: string): LapSnapshot {
+  return {
+    id,
+    trackName: "T",
+    courseName: "C",
+    courseKey: "TC",
+    engine,
+    engineKey: engine.toLowerCase(),
+    course: { name: "C", startFinishA: { lat: 0, lon: 0 }, startFinishB: { lat: 0, lon: 0 } } as LapSnapshot["course"],
+    lapTimeMs: 62000,
+    sourceFileName: "f",
+    sourceLapNumber: 1,
+    samples: [sample(0, 0, 0), sample(1, 1, 100), sample(2, 2, 200), sample(3, 3, 300)],
+    lapStartMs: 100,
+    lapEndMs: 200,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("overlayId / overlayColor", () => {
+  it("formats ids by kind", () => {
+    expect(overlayId("lap", 3)).toBe("lap:3");
+    expect(overlayId("snap", "abc")).toBe("snap:abc");
+  });
+
+  it("cycles the palette", () => {
+    expect(overlayColor(0)).toBe(OVERLAY_COLORS[0]);
+    expect(overlayColor(OVERLAY_COLORS.length)).toBe(OVERLAY_COLORS[0]);
+    expect(overlayColor(1)).toBe(OVERLAY_COLORS[1]);
+  });
+});
+
+describe("resolveOverlayLines", () => {
+  const sessionSamples = [sample(0, 0), sample(1, 1), sample(2, 2), sample(3, 3), sample(4, 4)];
+  const laps = [lap(1, 0, 2), lap(2, 2, 4)];
+
+  it("resolves a lap id to its sample slice", () => {
+    const lines = resolveOverlayLines(["lap:2"], { laps, sessionSamples, snapshots: [] });
+    expect(lines).toHaveLength(1);
+    expect(lines[0].id).toBe("lap:2");
+    expect(lines[0].label).toBe("Lap 2");
+    expect(lines[0].samples).toHaveLength(3); // indices 2..4
+    expect(lines[0].color).toBe(OVERLAY_COLORS[0]);
+  });
+
+  it("resolves a snapshot id to its clean lap samples", () => {
+    const snap = snapshot("s1", "IAME X30");
+    const lines = resolveOverlayLines(["snap:s1"], { laps, sessionSamples, snapshots: [snap] });
+    expect(lines).toHaveLength(1);
+    expect(lines[0].samples).toHaveLength(2); // the two in-window samples
+    expect(lines[0].label.startsWith("IAME X30")).toBe(true);
+  });
+
+  it("assigns palette colors by visible output index, skipping unresolved ids", () => {
+    const lines = resolveOverlayLines(
+      ["lap:99", "lap:1", "lap:2"], // lap:99 doesn't exist
+      { laps, sessionSamples, snapshots: [] },
+    );
+    expect(lines.map((l) => l.id)).toEqual(["lap:1", "lap:2"]);
+    expect(lines[0].color).toBe(OVERLAY_COLORS[0]);
+    expect(lines[1].color).toBe(OVERLAY_COLORS[1]);
+  });
+
+  it("preserves selection order", () => {
+    const lines = resolveOverlayLines(["lap:2", "lap:1"], { laps, sessionSamples, snapshots: [] });
+    expect(lines.map((l) => l.id)).toEqual(["lap:2", "lap:1"]);
+  });
+
+  it("skips degenerate single-point lines and malformed ids", () => {
+    const tiny = [lap(5, 0, 0)];
+    expect(resolveOverlayLines(["lap:5"], { laps: tiny, sessionSamples, snapshots: [] })).toEqual([]);
+    expect(resolveOverlayLines(["bogus"], { laps, sessionSamples, snapshots: [] })).toEqual([]);
+  });
+});
+
+describe("unionBounds", () => {
+  const base = { minLat: 0, maxLat: 1, minLon: 0, maxLon: 1 };
+
+  it("returns base unchanged with no overlays", () => {
+    expect(unionBounds(base, [])).toEqual(base);
+  });
+
+  it("expands to enclose overlay samples", () => {
+    const line = { id: "lap:1", label: "Lap 1", color: "x", samples: [sample(-2, 5), sample(3, -1)] };
+    expect(unionBounds(base, [line])).toEqual({ minLat: -2, maxLat: 3, minLon: -1, maxLon: 5 });
+  });
+});

--- a/src/lib/lapOverlays.ts
+++ b/src/lib/lapOverlays.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure logic for the multi-lap racing-line overlay (phase 1): turning a set of
+ * selected lap/snapshot identities into drawable, colored polylines for the map.
+ *
+ * Sources are referenced by a stable string id so selection state is trivially
+ * serializable and order-stable:
+ *   - `lap:<n>`   — lap number `n` in the current session
+ *   - `snap:<id>` — a saved lap snapshot by its snapshot id
+ *
+ * Phase 1 draws raw absolute GPS (same-session laps share a receiver and need no
+ * correction). Cross-session drift alignment is a deliberate phase-2 follow-up —
+ * see docs/plans/multi-lap-overlay.md.
+ */
+
+import type { GpsSample, Lap } from '@/types/racing';
+import type { LapSnapshot } from './lapSnapshot';
+import { snapshotLapSamples } from './lapSnapshot';
+import { formatLapTime } from './lapCalculation';
+
+export interface OverlayLine {
+  /** Stable identity — `lap:<n>` or `snap:<id>`. */
+  id: string;
+  /** Human label for the legend / lap list. */
+  label: string;
+  /** Assigned line color (HSL). */
+  color: string;
+  /** The lap's clean GPS samples. */
+  samples: GpsSample[];
+}
+
+export interface MapBounds {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+}
+
+/**
+ * Overlay line palette — distinct cool/saturated hues chosen to read clearly
+ * against the warm speed heatmap (green→red) and the grey reference line.
+ */
+export const OVERLAY_COLORS = [
+  'hsl(265, 80%, 64%)', // violet
+  'hsl(200, 90%, 55%)', // azure
+  'hsl(320, 75%, 60%)', // magenta
+  'hsl(170, 70%, 45%)', // teal
+  'hsl(225, 82%, 64%)', // blue
+  'hsl(290, 70%, 62%)', // purple
+] as const;
+
+/** Color for the nth overlay line (cycles through the palette). */
+export function overlayColor(index: number): string {
+  return OVERLAY_COLORS[((index % OVERLAY_COLORS.length) + OVERLAY_COLORS.length) % OVERLAY_COLORS.length];
+}
+
+/** Build a stable overlay id from a source kind + key. */
+export function overlayId(kind: 'lap' | 'snap', key: string | number): string {
+  return `${kind}:${key}`;
+}
+
+/**
+ * Resolve selected overlay ids into drawable lines, in selection order. Ids that
+ * can't be resolved (a lap no longer present, a snapshot for another course) are
+ * skipped; colors are assigned by the *output* index so visible lines always get
+ * sequential palette entries.
+ */
+export function resolveOverlayLines(
+  selections: string[],
+  opts: { laps: Lap[]; sessionSamples: GpsSample[]; snapshots: LapSnapshot[] },
+): OverlayLine[] {
+  const { laps, sessionSamples, snapshots } = opts;
+  const lines: OverlayLine[] = [];
+
+  for (const id of selections) {
+    const sep = id.indexOf(':');
+    if (sep < 0) continue;
+    const kind = id.slice(0, sep);
+    const key = id.slice(sep + 1);
+
+    if (kind === 'lap') {
+      const lapNumber = Number(key);
+      const lap = laps.find((l) => l.lapNumber === lapNumber);
+      if (!lap || sessionSamples.length === 0) continue;
+      const samples = sessionSamples.slice(lap.startIndex, lap.endIndex + 1);
+      if (samples.length < 2) continue;
+      lines.push({ id, label: `Lap ${lapNumber}`, color: overlayColor(lines.length), samples });
+    } else if (kind === 'snap') {
+      const snap = snapshots.find((s) => s.id === key);
+      if (!snap) continue;
+      const samples = snapshotLapSamples(snap);
+      if (samples.length < 2) continue;
+      const engine = snap.engine || 'Snapshot';
+      lines.push({
+        id,
+        label: `${engine} · ${formatLapTime(snap.lapTimeMs)}`,
+        color: overlayColor(lines.length),
+        samples,
+      });
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Expand `base` bounds to enclose every overlay line's samples, so the map can
+ * fit overlays that run slightly outside the active lap (e.g. a cross-session
+ * snapshot). Returns `base` unchanged when there are no overlays.
+ */
+export function unionBounds(base: MapBounds, lines: OverlayLine[]): MapBounds {
+  let { minLat, maxLat, minLon, maxLon } = base;
+  for (const line of lines) {
+    for (const s of line.samples) {
+      if (s.lat < minLat) minLat = s.lat;
+      if (s.lat > maxLat) maxLat = s.lat;
+      if (s.lon < minLon) minLon = s.lon;
+      if (s.lon > maxLon) maxLon = s.lon;
+    }
+  }
+  return { minLat, maxLat, minLon, maxLon };
+}

--- a/src/lib/referenceUtils.test.ts
+++ b/src/lib/referenceUtils.test.ts
@@ -5,6 +5,7 @@ import {
   calculatePace,
   calculateReferenceSpeed,
   computeReferenceData,
+  alignByDistance,
 } from "./referenceUtils";
 import { EARTH_RADIUS_M } from "./parserUtils";
 import type { GpsSample } from "@/types/racing";
@@ -267,5 +268,42 @@ describe("computeReferenceData", () => {
   it("totalDistance is 0 for a single sample", () => {
     const ref = computeReferenceData([sample(0, 40, -74)]);
     expect(ref.totalDistance).toBe(0);
+  });
+});
+
+// ─── alignByDistance ────────────────────────────────────────────────────────
+
+describe("alignByDistance", () => {
+  // A lap heading north (lon fixed) with a per-sample channel value.
+  function lapWithValues(vals: number[], spacingDeg = 0.0001): GpsSample[] {
+    return vals.map((v, i) => ({
+      t: i * 100,
+      lat: 40 + i * spacingDeg,
+      lon: -74,
+      speedMps: 0,
+      speedMph: 0,
+      speedKph: 0,
+      extraFields: { v },
+    }));
+  }
+
+  it("interpolates the other lap's value at each current-sample distance", () => {
+    const current = lapWithValues([10, 20, 30]);
+    const other = lapWithValues([100, 200, 300]); // identical geometry
+    const out = alignByDistance(current, other, (s) => s.extraFields.v);
+    expect(out[0]).toBeCloseTo(100, 6);
+    expect(out[1]).toBeCloseTo(200, 6);
+    expect(out[2]).toBeCloseTo(300, 6);
+  });
+
+  it("returns null past the end of the other lap", () => {
+    const current = lapWithValues([1, 2, 3, 4]); // longer
+    const other = lapWithValues([10, 20]); // shorter — ends earlier
+    const out = alignByDistance(current, other, (s) => s.extraFields.v);
+    expect(out[out.length - 1]).toBeNull();
+  });
+
+  it("returns [] for empty input", () => {
+    expect(alignByDistance([], lapWithValues([1]), (s) => s.extraFields.v)).toEqual([]);
   });
 });

--- a/src/lib/referenceUtils.ts
+++ b/src/lib/referenceUtils.ts
@@ -164,6 +164,48 @@ export function calculateReferenceSpeed(
 }
 
 /**
+ * Align another lap's per-sample value onto the current lap's distance axis:
+ * for each current sample, interpolate the other lap's value at the same
+ * cumulative distance. One entry per current sample — `null` beyond the other
+ * lap's length, or where the source value is missing. Generalizes
+ * `calculateReferenceSpeed` to any channel (used for multi-lap chart overlays).
+ */
+export function alignByDistance(
+  currentSamples: GpsSample[],
+  otherSamples: GpsSample[],
+  getValue: (s: GpsSample) => number | undefined,
+): (number | null)[] {
+  if (currentSamples.length === 0 || otherSamples.length === 0) return [];
+
+  const curD = calculateDistanceArray(currentSamples);
+  const refD = calculateDistanceArray(otherSamples);
+  const maxRef = refD[refD.length - 1];
+  const out: (number | null)[] = [];
+
+  for (let i = 0; i < currentSamples.length; i++) {
+    const target = curD[i];
+    if (target > maxRef) { out.push(null); continue; }
+
+    let lo = 0;
+    let hi = refD.length - 1;
+    while (lo < hi - 1) {
+      const mid = (lo + hi) >> 1;
+      if (refD[mid] <= target) lo = mid; else hi = mid;
+    }
+
+    const v1 = getValue(otherSamples[lo]);
+    if (v1 === undefined) { out.push(null); continue; }
+    const v2 = getValue(otherSamples[hi]);
+    const d1 = refD[lo];
+    const d2 = refD[hi];
+    if (d2 === d1 || v2 === undefined) { out.push(v1); continue; }
+    out.push(v1 + ((target - d1) / (d2 - d1)) * (v2 - v1));
+  }
+
+  return out;
+}
+
+/**
  * Precompute reference data for a lap.
  */
 export interface ReferenceData {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -44,6 +44,7 @@ import { useSessionData } from "@/hooks/useSessionData";
 import { useLapManagement } from "@/hooks/useLapManagement";
 import { useReferenceLap, useExternalReference } from "@/hooks/useReferenceLap";
 import { useLapSnapshots } from "@/hooks/useLapSnapshots";
+import { useLapOverlays } from "@/hooks/useLapOverlays";
 import { LapSnapshotControls } from "@/components/LapSnapshotControls";
 import { LapSnapshotPromptDialog } from "@/components/LapSnapshotPromptDialog";
 import { useSessionMetadata } from "@/hooks/useSessionMetadata";
@@ -176,6 +177,13 @@ export default function Index() {
     onLoadOverlay: loadSnapshotOverlay,
     onClearOverlay: handleClearExternalRef,
   });
+
+  // Multi-lap racing-line overlay (pro-mode map): which laps/snapshots to draw.
+  const { overlaySelections, overlayLines, toggleOverlay } = useLapOverlays(
+    data,
+    laps,
+    snapshots.snapshotsForCourse,
+  );
 
   // Reference-lap handlers: clear the other side when one is set.
   const handleSetReferenceWithClear = useCallback((lapNumber: number) => {
@@ -333,6 +341,9 @@ export default function Index() {
     onLoadSnapshot: snapshots.loadSnapshot,
     onClearSnapshot: snapshots.clearActive,
     onSaveSnapshot: snapshots.saveSelectedLap,
+    overlaySelections,
+    overlayLines,
+    onToggleOverlay: toggleOverlay,
     sessionGpsPoint,
     sessionStartDate: data?.startDate,
     sessionFileName: currentFileName,
@@ -368,6 +379,7 @@ export default function Index() {
     externalRefLabel, savedFiles,
     snapshots.snapshotsForCourse, snapshots.activeSnapshotId, snapshots.canSnapshot,
     snapshots.loadSnapshot, snapshots.clearActive, snapshots.saveSelectedLap,
+    overlaySelections, overlayLines, toggleOverlay,
     activeSnapshot, sessionSetup,
     sessionGpsPoint, currentFileName, sessionKartId, sessionSetupId, cachedWeatherStation,
     vehicleManager.vehicles, setupManager.setups, templateManager.templates,
@@ -507,6 +519,8 @@ export default function Index() {
             onLoad={snapshots.loadSnapshot}
             onClear={snapshots.clearActive}
             onSave={snapshots.saveSelectedLap}
+            overlayLines={overlayLines}
+            onToggleOverlay={toggleOverlay}
           />
 
           <SettingsModal settings={settings} onSettingsChange={setSettings} onToggleFieldDefault={toggleFieldDefault} />


### PR DESCRIPTION
## What & why

Phase 1 of the headline Reddit ask — "align the lines from different stints on the map." You can now overlay **multiple laps' racing lines at once** on the pro-mode GraphView MiniMap (previously: active lap + one grey reference, max). Compare your line through a corner across laps / against a saved snapshot.

Scope was agreed with the maintainer: **current-session laps + snapshots**, selected via **per-lap toggles in the lap list**, rendered on the **pro-mode MiniMap only**, drawing **raw absolute GPS** (drift-alignment deferred). Full plan + phase-2 notes saved in `docs/plans/multi-lap-overlay.md`.

## Behavior
- **Lap list "Map" column** (`LapTable`): toggle any lap's line onto the map. **Snapshot list** (`LapSnapshotControls`): a *Spline* toggle overlays a saved snapshot.
- Each overlay gets a distinct color (palette chosen to read against the warm speed heatmap + grey reference); the active lap keeps its heatmap, overlays draw as solid lines beneath it.
- **On-map legend** (color + label + ✕) so you can see/remove overlays without leaving pro mode.
- Map auto-fits to include overlay extents (a cross-session snapshot can run slightly outside the active lap).

## Changes
- **`src/lib/lapOverlays.ts`** (pure, unit-tested — 9 cases): stable ids (`lap:<n>` / `snap:<id>`), palette + `overlayColor`, `resolveOverlayLines(selections)` → `OverlayLine[]` (laps → sample slices, snapshots → clean-lap samples, colored by visible index, selection order preserved, degenerate/malformed skipped), `unionBounds`.
- **`useLapOverlays`** hook: selection state (cleared when a new file loads), `toggleOverlay`, derived `overlayLines`.
- **`SessionContext`** carries `overlayLines` + `overlaySelections` + `onToggleOverlay`; wired in `Index.tsx`.
- **`MiniMap.tsx`**: new overlay layer beneath the heatmap (one `L.polyline` per line, rebuilt only when the set changes — not on scrub), union-bounds fit, remove-able legend.
- **`LapTable.tsx`** / **`LapSnapshotControls.tsx`**: the selection toggles, wired through `LapTimesTab` + the header snapshot control.

## Verification
`npm run lint` · `npm run typecheck` · `npm run test:run` (855 pass, +9 new) · `npm run build` — all green.

⚠️ **Visual check still on your end** — the sandbox blocks the headless-browser screenshot (same as the G-G diagram PR). Please eyeball it: Pro mode, toggle a couple of laps in the lap list and a snapshot, confirm the lines + legend render and the map fits. The drawing logic mirrors the existing reference-line rendering, and the resolve/bounds logic is unit-tested.

## Notes
- **Cross-tab nuance** (accepted): toggles live in the lap list (LapTimes tab), lines render on the pro MiniMap; state persists via `SessionContext` and the map legend gives in-context removal. Best-for-now given upcoming UI shuffling.
- **Snapshot drift**: phase-1 overlays are raw GPS, so a cross-session snapshot may sit a few meters off the current lap. Same-session laps register exactly. Rigid drift-alignment is phase 2.

https://claude.ai/code/session_01Bv71GkEnPEfHki9RSYR7aq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv71GkEnPEfHki9RSYR7aq)_