### PR TITLE
Route non-main branch builds to Supabase preview-branch DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,18 @@
 #
 # Precedence per key: VITE_* > HTT_* > built-in public fallback.
 #
+# PREVIEW BACKEND (per-branch): Cloudflare Workers Builds sets WORKERS_CI_BRANCH
+# on every build (Pages sets CF_PAGES_BRANCH). On any non-production branch
+# (anything other than `main`), vite.config.ts prefers parallel `*_PREVIEW`
+# build variables — VITE_<KEY>_PREVIEW or HTT_<KEY>_PREVIEW — when present, so a
+# beta/preview deployment points at the Supabase **preview-branch** database
+# instead of production. Set these in Cloudflare's build Variables & Secrets
+# (not committed). They are ignored on `main` and in local dev. Example keys:
+#   HTT_SUPABASE_URL_PREVIEW, HTT_SUPABASE_PUBLISHABLE_KEY_PREVIEW,
+#   HTT_SUPABASE_PROJECT_ID_PREVIEW  (and any feature flag, e.g.
+#   HTT_ENABLE_CLOUD_PREVIEW). Grab the URL/anon-key/ref from the Supabase
+#   Branches panel after enabling Branching.
+#
 # REMINDER: Lovable build secrets do NOT auto-inject into ad-hoc rebuilds in
 # every environment yet. Until that's seamless, you may need to either:
 #   - regenerate this .env on each fresh build env, OR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contributed. In the admin **Submissions** tab, a submitted drawing shows a
   thumbnail preview and an **Apply to course layout** button that saves it onto
   the matching DB course (so it flows into the exported drawings).
+- **Preview deployments can target a Supabase preview-branch database.** Builds
+  on a non-production branch (Cloudflare Workers Builds / Pages) now prefer
+  parallel `*_PREVIEW` build variables (e.g. `HTT_SUPABASE_URL_PREVIEW`), so
+  beta/preview URLs point at a Supabase branch database instead of production.
+  Production (`main`) builds and local dev are unaffected. See the README
+  "Preview-branch backend" deployment section.
 
 ### Changed
 - **"Submit to DB" is always visible now, greyed out when there's nothing to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -688,6 +688,8 @@ Static hosting (Cloudflare Workers): the build is a pure static SPA (no server r
 
 `vite.config.ts` defines public backend fallbacks for `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY`, and `VITE_SUPABASE_PROJECT_ID` so production builds still boot if managed env injection is missing; `.env` stays the preferred source when present.
 
+Per-branch preview backend: `vite.config.ts`'s `pick()` checks `WORKERS_CI_BRANCH` (Cloudflare Workers Builds) / `CF_PAGES_BRANCH` (Pages) and, on any non-`main` branch, prefers a parallel `*_PREVIEW` value for each key (`VITE_<KEY>_PREVIEW` or `HTT_<KEY>_PREVIEW`) before the normal value/fallback. This lets beta/preview deployments bake in a Supabase **preview-branch** database (creds are build-time-baked, never runtime). `main` builds and local dev never read the `_PREVIEW` vars. See the README "Preview-branch backend" deployment section.
+
 ---
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -357,6 +357,30 @@ client variable and does not belong in Cloudflare. The Supabase edge functions
 (`supabase/functions/`) continue to run on Supabase; the Worker only serves the
 static frontend.
 
+#### Preview-branch backend (Supabase Branching → preview deployments)
+
+Pushes to a **non-production branch** produce a preview version/URL of the same
+Worker. To point those preview builds at a Supabase **preview-branch database**
+(so beta work doesn't touch production data), set parallel `*_PREVIEW` build
+variables. Workers Builds exposes `WORKERS_CI_BRANCH` (Pages: `CF_PAGES_BRANCH`)
+on every build; `vite.config.ts` prefers the `_PREVIEW` value of each key
+whenever that branch isn't `main`, and ignores them on `main` and in local dev.
+
+1. Enable **Branching** in Supabase, then copy the preview branch's URL, anon
+   key, and project ref from the **Branches** panel.
+2. In the Worker → **Settings → Build → Variables and Secrets**, add (alongside
+   the production values):
+
+   | Variable | Value |
+   |----------|-------|
+   | `HTT_SUPABASE_URL_PREVIEW` | preview branch URL |
+   | `HTT_SUPABASE_PUBLISHABLE_KEY_PREVIEW` | preview branch anon key |
+   | `HTT_SUPABASE_PROJECT_ID_PREVIEW` | preview branch project ref |
+
+   Any key works the same way (e.g. `HTT_ENABLE_CLOUD_PREVIEW`). `VITE_*_PREVIEW`
+   is also accepted. Add the Cloudflare preview URL to the preview branch's
+   **Auth → Redirect URLs** so cloud sign-in works there.
+
 ---
 
 ## Project Structure

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,8 +66,29 @@ export default defineConfig(({ mode }) => {
   // process.env. Lovable injects build secrets as real env vars, so we must
   // check process.env explicitly for the HTT_* (and VITE_*) fallbacks to work
   // when there's no committed .env file.
-  const pick = (viteKey: string, httKey: string, fallback: string) =>
-    env[viteKey] || process.env[viteKey] || env[httKey] || process.env[httKey] || fallback;
+  //
+  // PREVIEW BACKEND: Cloudflare Workers Builds sets WORKERS_CI_BRANCH on every
+  // build (Pages sets CF_PAGES_BRANCH). On any non-production branch we prefer
+  // parallel `*_PREVIEW` build variables (VITE_*_PREVIEW / HTT_*_PREVIEW), so a
+  // beta/preview deployment bakes in the Supabase **preview-branch** database
+  // instead of production. Production (`main`) builds and local dev never see
+  // the _PREVIEW values, so they're untouched. The creds are build-time-baked,
+  // not runtime — picking them here is the only place to switch backends.
+  const ciBranch = process.env.WORKERS_CI_BRANCH || process.env.CF_PAGES_BRANCH;
+  const PROD_BRANCH = "main";
+  const isPreviewBuild = !!ciBranch && ciBranch !== PROD_BRANCH;
+
+  const pick = (viteKey: string, httKey: string, fallback: string) => {
+    if (isPreviewBuild) {
+      const previewVal =
+        env[`${viteKey}_PREVIEW`] ||
+        process.env[`${viteKey}_PREVIEW`] ||
+        env[`${httKey}_PREVIEW`] ||
+        process.env[`${httKey}_PREVIEW`];
+      if (previewVal) return previewVal;
+    }
+    return env[viteKey] || process.env[viteKey] || env[httKey] || process.env[httKey] || fallback;
+  };
 
   const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)


### PR DESCRIPTION
## What

Cloudflare preview deployments (BETA + other non-`main` branches) should hit a Supabase **preview-branch** database instead of production. Because the Supabase creds are baked in at **build time** by Vite (`VITE_SUPABASE_*`), the switch has to happen during the build — there's no runtime binding to flip.

## How

`vite.config.ts`'s `pick()` now detects non-production builds via `WORKERS_CI_BRANCH` (Cloudflare Workers Builds) / `CF_PAGES_BRANCH` (Pages). On any branch other than `main`, it prefers a parallel `*_PREVIEW` value for each key (`VITE_<KEY>_PREVIEW` or `HTT_<KEY>_PREVIEW`) before the normal value/fallback. `main` builds and local dev never read the `_PREVIEW` vars.

Operator setup (already done in Cloudflare for this repo): add `HTT_SUPABASE_URL_PREVIEW` / `HTT_SUPABASE_PUBLISHABLE_KEY_PREVIEW` / `HTT_SUPABASE_PROJECT_ID_PREVIEW` build variables, pointed at the Supabase preview branch. Any key works the same way (e.g. `HTT_ENABLE_CLOUD_PREVIEW`).

## Verification

- All four gates green: `lint`, `typecheck`, `test:run` (854), `build`.
- Built with `WORKERS_CI_BRANCH=beta` + a preview URL → bundle contains the **preview** URL, prod fallback gone.
- Built with `WORKERS_CI_BRANCH=main` + the same preview var set → preview URL **ignored**, prod baked in.

## Docs

README "Preview-branch backend" deployment section, `.env.example`, `CLAUDE.md` env notes, and a CHANGELOG entry.

> Note: still keys off `main` as the production branch. BETA is correctly treated as non-prod → preview DB.

https://claude.ai/code/session_01PXa22wPzVg73f31gPwNLMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXa22wPzVg73f31gPwNLMH)_