### PR TITLE
Add build version + commit hash stamp to home-page footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Build version + commit stamp in the home-page footer.** The landing page now
+  shows the running app version and the short git commit hash (e.g.
+  `v2.0.0 · 837b514`), baked in at build time. The hash links to that commit on
+  GitHub and the build date shows on hover, so it's easy to tell which revision
+  is deployed and when something changed.
 - **Manage your tracks straight from the home screen.** A new **Manage Tracks**
   button (below "Download from Datalogger") opens the track manager without
   having to load a datalog first — search for a location, drop the start/finish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ src/
 │   ├── billingClient.ts / pendingCheckout.ts   # Supabase billing I/O + sign-up checkout stash
 │   ├── profanity.ts       # Basic client-side profanity filter for display names
 │   ├── weatherService.ts  # OpenWeatherMap (online-only)
+│   ├── buildInfo.ts       # Build version + git-hash + build-date stamp (landing footer "what changed" marker; values injected by vite define)
 │   └── utils.ts           # Tailwind cn() helper
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section
 │   ├── (framework)        # types, registry, index, panels, mounts, storage + PluginPanelHost/PluginMount
@@ -681,6 +682,7 @@ existing user data keeps resolving without a destructive migration.
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `DOVE_PLUGIN_PACKAGES` | Build | Comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`) when set |
+| `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` | Build (auto) | Footer version stamp — **not hand-set**. `vite.config.ts` bakes them in from `package.json` + git (`buildInfo.ts` reads them). Git hash prefers CI SHAs (`WORKERS_CI_COMMIT_SHA`/`CF_PAGES_COMMIT_SHA`/`GITHUB_SHA`), falls back to local `git`, then `"unknown"`. |
 
 PWA deployment detail: the active offline-capable worker is emitted as `/service-worker.js` and registered only outside preview/iframe contexts. `public/sw.js` is reserved as a legacy kill-switch worker to evict stale caches from older installs that previously registered `/sw.js`.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ The app includes an optional admin system for managing a community track databas
 
 > **Note:** `TURNSTILE_SECRET_KEY` is a server-side secret stored in Lovable Cloud, not a `VITE_` client variable. If not set, Turnstile verification is skipped.
 
+> **Build version stamp:** `VITE_APP_VERSION`, `VITE_GIT_HASH`, and
+> `VITE_BUILD_DATE` are **not** configured by hand — `vite.config.ts` bakes them
+> in automatically (from `package.json` and git) for the home-page footer
+> version/commit stamp. The commit hash prefers CI-provided SHAs
+> (`WORKERS_CI_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` / `GITHUB_SHA`) so it's correct
+> even on shallow checkouts, falling back to a local `git` call and then
+> `"unknown"`.
+
 > **Stripe / paid tiers:** `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are
 > edge-function secrets (not `VITE_` client vars). Prices are resolved live by
 > **lookup_key** — there are no Price ids in code or env. Create the

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -10,6 +10,7 @@ import { AboutDialog } from "@/components/AboutDialog";
 import { CreditsDialog } from "@/components/CreditsDialog";
 import { PricingCards } from "@/components/PricingCards";
 import { useAuth } from "@/contexts/AuthContext";
+import { buildInfo, formatBuildLabel, commitUrl } from "@/lib/buildInfo";
 import type { ParsedData } from "@/types/racing";
 
 interface LandingPageProps {
@@ -205,6 +206,23 @@ export function LandingPage({
           >
             PerchWerks LLC
           </a>
+        </p>
+        <p
+          className="mt-1 text-center text-[11px] text-muted-foreground/60"
+          title={buildInfo.buildDate ? `Built ${new Date(buildInfo.buildDate).toLocaleString()}` : undefined}
+        >
+          {commitUrl() ? (
+            <a
+              href={commitUrl()!}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline-offset-4 transition-colors hover:text-muted-foreground hover:underline"
+            >
+              {formatBuildLabel()}
+            </a>
+          ) : (
+            formatBuildLabel()
+          )}
         </p>
       </footer>
     </div>

--- a/src/lib/buildInfo.test.ts
+++ b/src/lib/buildInfo.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { hasCommit, formatBuildLabel, commitUrl, type BuildInfo } from "./buildInfo";
+
+const withCommit: BuildInfo = { version: "2.0.0", commit: "837b514", buildDate: "2026-06-03T00:00:00.000Z" };
+const noCommit: BuildInfo = { version: "2.0.0", commit: "unknown", buildDate: "" };
+const emptyCommit: BuildInfo = { version: "1.5.0", commit: "", buildDate: "" };
+
+describe("buildInfo helpers", () => {
+  describe("hasCommit", () => {
+    it("is true for a real hash", () => {
+      expect(hasCommit(withCommit)).toBe(true);
+    });
+    it("is false for 'unknown' or empty", () => {
+      expect(hasCommit(noCommit)).toBe(false);
+      expect(hasCommit(emptyCommit)).toBe(false);
+    });
+  });
+
+  describe("formatBuildLabel", () => {
+    it("includes the hash when present", () => {
+      expect(formatBuildLabel(withCommit)).toBe("v2.0.0 · 837b514");
+    });
+    it("omits the hash when unknown", () => {
+      expect(formatBuildLabel(noCommit)).toBe("v2.0.0");
+      expect(formatBuildLabel(emptyCommit)).toBe("v1.5.0");
+    });
+  });
+
+  describe("commitUrl", () => {
+    it("builds a GitHub commit URL for a real hash", () => {
+      expect(commitUrl(withCommit)).toBe(
+        "https://github.com/TheAngryRaven/DovesDataViewer/commit/837b514",
+      );
+    });
+    it("returns null without a real hash", () => {
+      expect(commitUrl(noCommit)).toBeNull();
+      expect(commitUrl(emptyCommit)).toBeNull();
+    });
+  });
+});

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,0 +1,35 @@
+// Build-time version metadata, surfaced in the landing-page footer so it's easy
+// to tell at a glance which revision is deployed. The raw values are injected by
+// Vite's `define` (see vite.config.ts) from package.json + git at build time.
+
+export interface BuildInfo {
+  /** App version from package.json (e.g. "2.0.0"). */
+  version: string;
+  /** Short git commit hash, or "unknown" when it couldn't be resolved. */
+  commit: string;
+  /** ISO build timestamp, or "" when unavailable. */
+  buildDate: string;
+}
+
+const GITHUB_REPO = "TheAngryRaven/DovesDataViewer";
+
+export const buildInfo: BuildInfo = {
+  version: import.meta.env.VITE_APP_VERSION ?? "0.0.0",
+  commit: import.meta.env.VITE_GIT_HASH ?? "unknown",
+  buildDate: import.meta.env.VITE_BUILD_DATE ?? "",
+};
+
+/** True when we have a real commit hash worth linking/displaying. */
+export function hasCommit(info: BuildInfo = buildInfo): boolean {
+  return !!info.commit && info.commit !== "unknown";
+}
+
+/** Short human label, e.g. "v2.0.0 · 837b514" (omits the hash if unknown). */
+export function formatBuildLabel(info: BuildInfo = buildInfo): string {
+  return hasCommit(info) ? `v${info.version} · ${info.commit}` : `v${info.version}`;
+}
+
+/** GitHub commit URL for the build's hash, or null when there's no real hash. */
+export function commitUrl(info: BuildInfo = buildInfo): string | null {
+  return hasCommit(info) ? `https://github.com/${GITHUB_REPO}/commit/${info.commit}` : null;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,15 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+interface ImportMetaEnv {
+  /** App version, baked in from package.json at build time. */
+  readonly VITE_APP_VERSION?: string;
+  /** Short git commit hash of the build (or "unknown" if unavailable). */
+  readonly VITE_GIT_HASH?: string;
+  /** ISO timestamp of when the bundle was built. */
+  readonly VITE_BUILD_DATE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,38 @@ import { defineConfig, loadEnv, type Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import fs from "fs";
+import { execSync } from "child_process";
 import { componentTagger } from "lovable-tagger";
 import { VitePWA } from "vite-plugin-pwa";
+
+// Build-time version metadata for the footer "what changed" stamp. The app
+// version comes from package.json; the commit hash + build date are baked in at
+// build so a deployed bundle can show exactly which revision is live. The CI
+// commit-SHA env vars are preferred (Cloudflare Workers Builds / Pages, generic
+// CI) so the hash is correct even on a shallow checkout; we fall back to a local
+// `git` call for dev, and to "unknown" when neither is available.
+function readAppVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, "package.json"), "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+function gitShortHash(): string {
+  const fromEnv =
+    process.env.WORKERS_CI_COMMIT_SHA ||
+    process.env.CF_PAGES_COMMIT_SHA ||
+    process.env.GIT_COMMIT_SHA ||
+    process.env.GITHUB_SHA;
+  if (fromEnv) return fromEnv.slice(0, 7);
+  try {
+    return execSync("git rev-parse --short=7 HEAD", { cwd: __dirname }).toString().trim();
+  } catch {
+    return "unknown";
+  }
+}
 
 // Build-time loader for external plugin npm packages (the AI coach). Candidate
 // package names default to the public coach and can be overridden via the
@@ -90,6 +120,10 @@ export default defineConfig(({ mode }) => {
     return env[viteKey] || process.env[viteKey] || env[httKey] || process.env[httKey] || fallback;
   };
 
+  const appVersion = readAppVersion();
+  const gitHash = gitShortHash();
+  const buildDate = new Date().toISOString();
+
   const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)
     .split(",")
@@ -117,6 +151,9 @@ export default defineConfig(({ mode }) => {
       "import.meta.env.VITE_ENABLE_CLOUD": JSON.stringify(
         pick("VITE_ENABLE_CLOUD", "HTT_ENABLE_CLOUD", PUBLIC_BACKEND_FALLBACKS.VITE_ENABLE_CLOUD),
       ),
+      "import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
+      "import.meta.env.VITE_GIT_HASH": JSON.stringify(gitHash),
+      "import.meta.env.VITE_BUILD_DATE": JSON.stringify(buildDate),
     },
     plugins: [
       react(),


### PR DESCRIPTION
## What

Adds a build version + commit-hash stamp to the landing-page footer so it's easy to tell which revision is deployed and when something changed.

The footer now shows a line like **`v2.0.0 · 837b514`** under "Operated by PerchWerks LLC":
- **Version** from `package.json`
- **Short commit hash**, baked in at build time, linking to that exact commit on GitHub
- **Build date** on hover

## How

- **`vite.config.ts`** injects three build-time constants via `define`: `VITE_APP_VERSION`, `VITE_GIT_HASH`, `VITE_BUILD_DATE`. The git hash prefers CI-provided commit SHAs (`WORKERS_CI_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` / `GITHUB_SHA`) so it's correct even on shallow checkouts, falling back to a local `git` call, then `"unknown"`.
- **`src/lib/buildInfo.ts`** — small pure module exposing the values plus `formatBuildLabel()` / `commitUrl()` / `hasCommit()` helpers (testable + reusable). The hash renders as a GitHub commit link when available, plain text otherwise.
- **`src/components/LandingPage.tsx`** renders the stamp in the footer.
- **`src/vite-env.d.ts`** types the new env vars.

## Docs

- `README.md` env table note (these are auto-set, not hand-configured)
- `CLAUDE.md` architecture map + env table
- `CHANGELOG.md` under `[Unreleased]`

## Verification

- `npm run lint`, `npm run typecheck`, `npm run build` — all green
- `npm run test:run` — 860 tests pass (6 new `buildInfo` tests)
- Confirmed the real commit hash is baked into the production bundle

## Note

The version number tracks `package.json`, so it only bumps when that's bumped — the commit hash is what changes every build. Happy to extend to a fuller scheme (build number / commit count) if preferred.

https://claude.ai/code/session_01L92jSQDgbWbFxCFNGctW2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01L92jSQDgbWbFxCFNGctW2D)_