### PR TITLE
Fix track dropdown behind dialog; make adding a track name-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   thumbnail preview and an **Apply to course layout** button that saves it onto
   the matching DB course (so it flows into the exported drawings).
 
+### Fixed
+- **The track dropdown works again after loading a log.** Opening the
+  track/course selector from the header (or the track manager) put its dropdowns
+  *behind* the dialog, so picking a different track did nothing. The dropdown now
+  layers above the dialog and is fully clickable.
+
 ### Changed
+- **Adding a track is just a name now.** "Add Track" no longer makes you place a
+  start/finish line and define a course up front — a track is simply a name plus
+  an auto-filled short name. Courses (each with their own start/finish line) are
+  added afterwards from the track's course list, the same way everywhere a track
+  can be created. When a log loads on an unknown track, the prompt walks you
+  through it in two quick steps: create the track, then add its first course.
 - **"Submit to DB" is always visible now, greyed out when there's nothing to
   send.** Previously the button only appeared once you had local tracks. It now
   shows whenever the track manager is open and uses the upload-diffing logic to

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -274,12 +274,13 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
   };
 
   const handleAddTrack = async () => {
-    const course = form.buildCourse();
-    if (!course || !form.formTrackName.trim()) return;
-    await addTrackToStorage(form.formTrackName.trim(), course, form.formTrackShortName.trim() || undefined);
+    const name = form.formTrackName.trim();
+    if (!name) return;
+    // A track is just a name (+ short name); courses are added afterwards.
+    await addTrackToStorage(name, undefined, form.formTrackShortName.trim() || undefined);
     await refreshTracks();
-    setTempTrackName(form.formTrackName.trim());
-    setTempCourseName(course.name);
+    setTempTrackName(name);
+    setTempCourseName('');
     form.resetForm();
     setIsAddTrackOpen(false);
   };
@@ -354,23 +355,13 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
 
   const addTrackDialogProps = {
     open: isAddTrackOpen,
-    onOpenChange: (open: boolean) => { setIsAddTrackOpen(open); if (!open) form.setEditorMode('visual'); },
-    editorMode: form.editorMode,
-    onEditorModeChange: form.setEditorMode,
-    courseFormProps: form.courseFormProps,
+    onOpenChange: (open: boolean) => { setIsAddTrackOpen(open); if (!open) form.resetForm(); },
+    trackName: form.courseFormProps.trackName,
+    shortName: form.courseFormProps.trackShortName,
+    onTrackNameChange: form.courseFormProps.onTrackNameChange,
+    onShortNameChange: form.courseFormProps.onTrackShortNameChange,
     onSubmit: handleAddTrack,
     onCancel: () => { setIsAddTrackOpen(false); form.resetForm(); },
-    startFinishA: form.visualEditorStartFinishA,
-    startFinishB: form.visualEditorStartFinishB,
-    sector2: form.visualEditorSector2,
-    sector3: form.visualEditorSector3,
-    onStartFinishChange: form.handleVisualStartFinishChange,
-    onSector2Change: form.handleVisualSector2Change,
-    onSector3Change: form.handleVisualSector3Change,
-    layoutPoints: form.formLayout,
-    onLayoutChange: form.handleVisualLayoutChange,
-    laps,
-    samples,
   } as const;
 
   // Track/Course selection UI (shared between compact dialog and non-compact inline)

--- a/src/components/TrackPromptDialog.tsx
+++ b/src/components/TrackPromptDialog.tsx
@@ -15,7 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Track, TrackCourseSelection, Course, CourseDetectionResult } from '@/types/racing';
+import { Track, TrackCourseSelection, CourseDetectionResult } from '@/types/racing';
 import { AddCourseDialog } from '@/components/track-editor/AddCourseDialog';
 import { AddTrackDialog } from '@/components/track-editor/AddTrackDialog';
 import { useTrackEditorForm } from '@/hooks/useTrackEditorForm';
@@ -42,14 +42,28 @@ export function TrackPromptDialog({
   const [selectedCourseName, setSelectedCourseName] = useState('');
   const [isAddCourseOpen, setIsAddCourseOpen] = useState(false);
   const [isAddTrackOpen, setIsAddTrackOpen] = useState(false);
+  // A track is just a name now, so creating one here is a two-step flow: make
+  // the bare track, then add its first course (timing needs a course). Once a
+  // track is created we pivot the prompt onto it via this name.
+  const [createdTrackName, setCreatedTrackName] = useState<string | null>(null);
   const form = useTrackEditorForm();
 
-  const track = detectedTrack ? tracks.find(t => t.name === detectedTrack.name) ?? detectedTrack : null;
+  const track = useMemo(() => {
+    if (createdTrackName) return tracks.find(t => t.name === createdTrackName) ?? null;
+    return detectedTrack ? tracks.find(t => t.name === detectedTrack.name) ?? detectedTrack : null;
+  }, [createdTrackName, tracks, detectedTrack]);
   const courses = useMemo(() => track?.courses ?? [], [track]);
+  // True once the user has created a bare track here and is adding its course.
+  const inCourseStep = createdTrackName != null;
 
   useEffect(() => {
     setTracks(initialTracks);
   }, [initialTracks]);
+
+  // Each fresh open starts clean — drop any in-progress track creation.
+  useEffect(() => {
+    if (open) setCreatedTrackName(null);
+  }, [open]);
 
   useEffect(() => {
     if (open && detectionResult && !detectionResult.isWaypointMode) {
@@ -86,18 +100,17 @@ export function TrackPromptDialog({
   };
 
   const handleAddTrack = async () => {
-    const course = form.buildCourse();
-    if (!course || !form.formTrackName.trim()) return;
-    await addTrackToStorage(form.formTrackName.trim(), course);
-    const loaded = await refreshTracks();
-    // Auto-select the newly created track+course
-    const newTrack = loaded.find(t => t.name === form.formTrackName.trim());
-    if (newTrack && course) {
-      onSelect({ trackName: newTrack.name, courseName: course.name, course });
-    }
-    form.resetForm();
+    const name = form.formTrackName.trim();
+    if (!name) return;
+    // Create the bare track (name + short name), then continue straight into
+    // adding its first course so lap timing can still be set up in one sitting.
+    await addTrackToStorage(name, undefined, form.formTrackShortName.trim() || undefined);
+    await refreshTracks();
+    setCreatedTrackName(name);
     setIsAddTrackOpen(false);
-    onOpenChange(false);
+    form.resetForm();
+    form.setFormTrackName(name);
+    setIsAddCourseOpen(true);
   };
 
   const addCourseDialogProps = {
@@ -120,20 +133,13 @@ export function TrackPromptDialog({
 
   const addTrackDialogProps = {
     open: isAddTrackOpen,
-    onOpenChange: (o: boolean) => { setIsAddTrackOpen(o); if (!o) form.setEditorMode('visual'); },
-    editorMode: form.editorMode,
-    onEditorModeChange: form.setEditorMode,
-    courseFormProps: form.courseFormProps,
+    onOpenChange: (o: boolean) => { setIsAddTrackOpen(o); if (!o) form.resetForm(); },
+    trackName: form.courseFormProps.trackName,
+    shortName: form.courseFormProps.trackShortName,
+    onTrackNameChange: form.courseFormProps.onTrackNameChange,
+    onShortNameChange: form.courseFormProps.onTrackShortNameChange,
     onSubmit: handleAddTrack,
     onCancel: () => { setIsAddTrackOpen(false); form.resetForm(); },
-    startFinishA: form.visualEditorStartFinishA,
-    startFinishB: form.visualEditorStartFinishB,
-    sector2: form.visualEditorSector2,
-    sector3: form.visualEditorSector3,
-    onStartFinishChange: form.handleVisualStartFinishChange,
-    onSector2Change: form.handleVisualSector2Change,
-    onSector3Change: form.handleVisualSector3Change,
-    initialCenter,
   } as const;
 
   return (
@@ -147,54 +153,31 @@ export function TrackPromptDialog({
             </DialogTitle>
           </DialogHeader>
 
-          {/* Waypoint mode notice */}
-          {detectionResult?.isWaypointMode && (
-            <div className="space-y-4">
-              <div className="p-3 rounded-md border border-yellow-500/30 bg-yellow-500/5">
-                <div className="flex items-start gap-2">
-                  <AlertTriangle className="w-4 h-4 text-yellow-500 mt-0.5 flex-shrink-0" />
-                  <div>
-                    <p className="text-sm font-medium text-foreground">Waypoint Timing</p>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      No known track matched this data. Lap times are estimated using a GPS waypoint — accuracy is lower than normal.
-                      Create a track and course for precise timing.
-                    </p>
-                    {detectionResult.laps.length > 0 && (
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Detected <span className="font-medium text-foreground">{detectionResult.laps.length} laps</span> from waypoint.
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <Button onClick={() => { form.resetForm(); setIsAddTrackOpen(true); }} className="flex-1">
-                  <Plus className="w-4 h-4 mr-2" /> Create Track & Course
-                </Button>
-                <Button variant="outline" onClick={() => onOpenChange(false)}>Use Waypoint</Button>
-              </div>
-            </div>
-          )}
-
-          {/* Normal track detected */}
-          {track && !detectionResult?.isWaypointMode ? (
+          {/* Course step: a track is selected/created — pick (or add) its course */}
+          {track && (inCourseStep || !detectionResult?.isWaypointMode) ? (
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                Detected <span className="font-medium text-foreground">{track.name}</span>.
-                {detectionResult?.direction && (
-                  <span className="inline-flex items-center gap-1 ml-1">
-                    <Navigation className="w-3 h-3" />
-                    <span className="font-medium text-foreground capitalize">{detectionResult.direction}</span>
-                  </span>
+                {inCourseStep ? (
+                  <>Add a course to <span className="font-medium text-foreground">{track.name}</span> to enable lap timing.</>
+                ) : (
+                  <>
+                    Detected <span className="font-medium text-foreground">{track.name}</span>.
+                    {detectionResult?.direction && (
+                      <span className="inline-flex items-center gap-1 ml-1">
+                        <Navigation className="w-3 h-3" />
+                        <span className="font-medium text-foreground capitalize">{detectionResult.direction}</span>
+                      </span>
+                    )}
+                    {' '}Which course layout?
+                  </>
                 )}
-                {' '}Which course layout?
               </p>
               <div className="space-y-2">
                 <Label>Course</Label>
                 <div className="flex gap-2">
-                  <Select value={selectedCourseName} onValueChange={setSelectedCourseName}>
+                  <Select value={selectedCourseName} onValueChange={setSelectedCourseName} disabled={courses.length === 0}>
                     <SelectTrigger className="flex-1">
-                      <SelectValue placeholder="Select course..." />
+                      <SelectValue placeholder={courses.length === 0 ? 'No courses yet — add one' : 'Select course...'} />
                     </SelectTrigger>
                     <SelectContent>
                       {courses.map(c => (
@@ -218,14 +201,42 @@ export function TrackPromptDialog({
                 <Button variant="outline" onClick={() => onOpenChange(false)}>Skip</Button>
               </div>
             </div>
-          ) : !detectionResult?.isWaypointMode && (
+          ) : detectionResult?.isWaypointMode ? (
+            /* Waypoint mode notice */
+            <div className="space-y-4">
+              <div className="p-3 rounded-md border border-yellow-500/30 bg-yellow-500/5">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="w-4 h-4 text-yellow-500 mt-0.5 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm font-medium text-foreground">Waypoint Timing</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      No known track matched this data. Lap times are estimated using a GPS waypoint — accuracy is lower than normal.
+                      Create a track (then add a course) for precise timing.
+                    </p>
+                    {detectionResult.laps.length > 0 && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Detected <span className="font-medium text-foreground">{detectionResult.laps.length} laps</span> from waypoint.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button onClick={() => { form.resetForm(); setIsAddTrackOpen(true); }} className="flex-1">
+                  <Plus className="w-4 h-4 mr-2" /> Create Track
+                </Button>
+                <Button variant="outline" onClick={() => onOpenChange(false)}>Use Waypoint</Button>
+              </div>
+            </div>
+          ) : (
+            /* No track detected */
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                No known track matches this GPS data. Create a new track and course to enable lap timing.
+                No known track matches this GPS data. Create a new track, then add a course to enable lap timing.
               </p>
               <div className="flex gap-2">
                 <Button onClick={() => { form.resetForm(); setIsAddTrackOpen(true); }} className="flex-1">
-                  <Plus className="w-4 h-4 mr-2" /> Create Track & Course
+                  <Plus className="w-4 h-4 mr-2" /> Create Track
                 </Button>
                 <Button variant="outline" onClick={() => onOpenChange(false)}>Skip</Button>
               </div>

--- a/src/components/track-editor/AddTrackDialog.tsx
+++ b/src/components/track-editor/AddTrackDialog.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from 'react';
 import { Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -10,105 +9,56 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { EditorModeToggle } from './EditorModeToggle';
-const VisualEditor = lazy(() =>
-  import('./VisualEditor').then((m) => ({ default: m.VisualEditor })),
-);
-import { CourseForm } from './CourseForm';
-import type { CourseFormProps } from '@/hooks/useTrackEditorForm';
-import type { GpsPoint } from './VisualEditor';
-import type { SectorLine, Lap, GpsSample } from '@/types/racing';
 
 interface AddTrackDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  editorMode: 'manual' | 'visual';
-  onEditorModeChange: (mode: 'manual' | 'visual') => void;
-  courseFormProps: Omit<CourseFormProps, 'onSubmit' | 'onCancel' | 'submitLabel' | 'showTrackName'>;
+  trackName: string;
+  shortName: string;
+  onTrackNameChange: (value: string) => void;
+  onShortNameChange: (value: string) => void;
   onSubmit: () => void;
   onCancel: () => void;
-  startFinishA: GpsPoint | null;
-  startFinishB: GpsPoint | null;
-  sector2: SectorLine | undefined;
-  sector3: SectorLine | undefined;
-  onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
-  onSector2Change: (line: SectorLine) => void;
-  onSector3Change: (line: SectorLine) => void;
-  initialCenter?: GpsPoint | null;
-  /** Drawing support — draw the outline manually or generate it from a lap. */
-  layoutPoints?: Array<{ lat: number; lon: number }>;
-  onLayoutChange?: (points: Array<{ lat: number; lon: number }>) => void;
-  laps?: Lap[];
-  samples?: GpsSample[];
 }
 
+/**
+ * Create a new track — just a name + short name. A track is simply a couple of
+ * names; its courses (each with a start/finish line) are added afterwards from
+ * the track's course list, so adding a track stays a quick, form-light action.
+ */
 export function AddTrackDialog({
   open, onOpenChange,
-  editorMode, onEditorModeChange,
-  courseFormProps,
+  trackName, shortName,
+  onTrackNameChange, onShortNameChange,
   onSubmit, onCancel,
-  startFinishA, startFinishB, sector2, sector3,
-  onStartFinishChange, onSector2Change, onSector3Change,
-  initialCenter,
-  layoutPoints, onLayoutChange, laps, samples,
 }: AddTrackDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild><span className="sr-only">Add track</span></DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Add New Track</DialogTitle>
         </DialogHeader>
-        <EditorModeToggle mode={editorMode} onModeChange={onEditorModeChange} />
-        {editorMode === 'manual' ? (
-          <CourseForm {...courseFormProps} onSubmit={onSubmit} onCancel={onCancel} submitLabel="Create Track" showShortName />
-        ) : (
-          <div className="space-y-4">
-            {/* Track/Course inputs above the map for better UX */}
-            <div className="space-y-3">
-              <div>
-                <Label htmlFor="newTrackName">Track Name</Label>
-                <Input id="newTrackName" value={courseFormProps.trackName} onChange={(e) => courseFormProps.onTrackNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., Orlando Kart Center" className="font-mono" />
-              </div>
-              <div>
-                <Label htmlFor="newTrackShortName">Short Name (max 8 chars)</Label>
-                <Input id="newTrackShortName" value={courseFormProps.trackShortName} onChange={(e) => courseFormProps.onTrackShortNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., OKC" maxLength={8} className="font-mono" />
-                <p className="text-xs text-muted-foreground mt-1">Auto-filled from the track name — edit it if you'd like.</p>
-              </div>
-              <div>
-                <Label htmlFor="newCourseName">Course Name</Label>
-                <Input id="newCourseName" value={courseFormProps.courseName} onChange={(e) => courseFormProps.onCourseNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., Full Track" className="font-mono" />
-              </div>
-            </div>
-            <Suspense fallback={null}>
-              <VisualEditor
-                startFinishA={startFinishA}
-                startFinishB={startFinishB}
-                sector2={sector2}
-                sector3={sector3}
-                isNewTrack={true}
-                initialCenter={initialCenter}
-                onStartFinishChange={onStartFinishChange}
-                onSector2Change={onSector2Change}
-                onSector3Change={onSector3Change}
-                showDrawTool={true}
-                layoutPoints={layoutPoints}
-                onLayoutChange={onLayoutChange}
-                laps={laps}
-                samples={samples}
-              />
-            </Suspense>
-            <div className="flex gap-2">
-              <Button onClick={onSubmit} className="flex-1" disabled={!courseFormProps.trackName.trim() || !courseFormProps.courseName.trim() || !courseFormProps.latA || !courseFormProps.lonA || !courseFormProps.latB || !courseFormProps.lonB}>
-                <Check className="w-4 h-4 mr-2" />
-                Create Track
-              </Button>
-              <Button variant="outline" onClick={onCancel}>
-                <X className="w-4 h-4" />
-              </Button>
-            </div>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="newTrackName">Track Name</Label>
+            <Input id="newTrackName" value={trackName} onChange={(e) => onTrackNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., Orlando Kart Center" className="font-mono" autoFocus />
           </div>
-        )}
+          <div>
+            <Label htmlFor="newTrackShortName">Short Name (max 8 chars)</Label>
+            <Input id="newTrackShortName" value={shortName} onChange={(e) => onShortNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., OKC" maxLength={8} className="font-mono" />
+            <p className="text-xs text-muted-foreground mt-1">Auto-filled from the track name — edit it if you'd like.</p>
+          </div>
+          <div className="flex gap-2 pt-2">
+            <Button onClick={onSubmit} className="flex-1" disabled={!trackName.trim()}>
+              <Check className="w-4 h-4 mr-2" />
+              Create Track
+            </Button>
+            <Button variant="outline" onClick={onCancel}>
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/track-editor/CourseForm.tsx
+++ b/src/components/track-editor/CourseForm.tsx
@@ -7,13 +7,13 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import type { CourseFormProps } from '@/hooks/useTrackEditorForm';
 
 export function CourseForm({
-  trackName, trackShortName, courseName, latA, lonA, latB, lonB,
+  trackName, courseName, latA, lonA, latB, lonB,
   sector2, sector3,
-  onTrackNameChange, onTrackShortNameChange, onCourseNameChange,
+  onTrackNameChange, onCourseNameChange,
   onLatAChange, onLonAChange, onLatBChange, onLonBChange,
   onSector2Change, onSector3Change,
-  onSubmit, onCancel, submitLabel, showTrackName = true, showShortName = false,
-}: CourseFormProps & { showShortName?: boolean }) {
+  onSubmit, onCancel, submitLabel, showTrackName = true,
+}: CourseFormProps) {
   const [showSectors, setShowSectors] = useState(
     Boolean(sector2.aLat || sector2.aLon || sector3.aLat || sector3.aLon)
   );
@@ -25,13 +25,6 @@ export function CourseForm({
         <div>
           <Label htmlFor="trackName">Track Name</Label>
           <Input id="trackName" value={trackName} onChange={(e) => onTrackNameChange(e.target.value)} onKeyDownCapture={stopKeys} placeholder="e.g., Orlando Kart Center" className="font-mono" />
-        </div>
-      )}
-      {showShortName && (
-        <div>
-          <Label htmlFor="trackShortName">Short Name (max 8 chars)</Label>
-          <Input id="trackShortName" value={trackShortName} onChange={(e) => onTrackShortNameChange(e.target.value)} onKeyDownCapture={stopKeys} placeholder="e.g., OKC" maxLength={8} className="font-mono" />
-          <p className="text-xs text-muted-foreground mt-1">Auto-filled from the track name — edit it if you'd like.</p>
         </div>
       )}
       <div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -66,7 +66,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-[10001] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[10020] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,


### PR DESCRIPTION
## Summary

Fixes two track-management issues reported after loading a log.

### 1. Track dropdown was unusable after loading a log
The track/course selector dialog renders at `z-[10010]`/`z-[10011]` (`dialog.tsx`), but the Select dropdown content was `z-[10001]` (`select.tsx`) — so the track/course list opened *behind* the dialog, invisible and unclickable. Clicks landed on the dialog, so you could never pick a different track. Bumped the Select content to `z-[10020]` so dropdowns always layer above any dialog (fixes this everywhere a Select opens inside a dialog, not just the track selector).

### 2. "Add Track" no longer forces course creation
A track is now simply a name + auto-filled short name — no up-front start/finish line or course step. Courses (each with their own start/finish line) are added afterwards from the track's course list, consistently across every place a track can be created:

- **`AddTrackDialog`** rewritten to a lightweight name/short-name form (was a full visual map editor + `CourseForm`).
- **`TrackEditor`** (Manage tab — header + landing page) creates a bare track, then courses are added from its course list.
- **`TrackPromptDialog`** (post-load "unknown track" prompt) is now a two-step flow: create the bare track, then it drops straight into adding its first course so lap timing still works.
- **Admin Tracks tab** already worked this way — now consistent across the app.
- Removed the now-dead course-creation props from `AddTrackDialog` and the unused short-name field/prop from `CourseForm`.

> Note: with the name-only model, applying a track that has no course yet clears the session selection (no course = no lap timing) — same intent as before, the course is just a separate quick step.

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (854 passed)
- `npm run build` ✅

`CHANGELOG.md` updated under `[Unreleased]` (Fixed + Changed).

https://claude.ai/code/session_014Ca9wmrjzeah2hTXVK1rYX

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ca9wmrjzeah2hTXVK1rYX)_