### PR TITLE
Footer stamp: branch + hash + commit time on non-main builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shows the running app version and the short git commit hash (e.g.
   `v2.0.0 · 837b514`), baked in at build time. The hash links to that commit on
   GitHub and the build date shows on hover, so it's easy to tell which revision
-  is deployed and when something changed.
+  is deployed and when something changed. On **preview/non-`main` builds** the
+  stamp instead reads **`<branch> · <hash> · <commit time>`**, so you can tell at
+  a glance which branch a beta deployment is running.
 - **Manage your tracks straight from the home screen.** A new **Manage Tracks**
   button (below "Download from Datalogger") opens the track manager without
   having to load a datalog first — search for a location, drop the start/finish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ src/
 │   ├── billingClient.ts / pendingCheckout.ts   # Supabase billing I/O + sign-up checkout stash
 │   ├── profanity.ts       # Basic client-side profanity filter for display names
 │   ├── weatherService.ts  # OpenWeatherMap (online-only)
-│   ├── buildInfo.ts       # Build version + git-hash + build-date stamp (landing footer "what changed" marker; values injected by vite define)
+│   ├── buildInfo.ts       # Build version/hash/branch/commit-date stamp (landing footer "what changed" marker; main → version+hash, other branches → branch+hash+commit time; values injected by vite define)
 │   └── utils.ts           # Tailwind cn() helper
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section
 │   ├── (framework)        # types, registry, index, panels, mounts, storage + PluginPanelHost/PluginMount
@@ -712,7 +712,7 @@ existing user data keeps resolving without a destructive migration.
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `DOVE_PLUGIN_PACKAGES` | Build | Comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`) when set |
-| `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` | Build (auto) | Footer version stamp — **not hand-set**. `vite.config.ts` bakes them in from `package.json` + git (`buildInfo.ts` reads them). Git hash prefers CI SHAs (`WORKERS_CI_COMMIT_SHA`/`CF_PAGES_COMMIT_SHA`/`GITHUB_SHA`), falls back to local `git`, then `"unknown"`. |
+| `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` / `VITE_GIT_BRANCH` / `VITE_GIT_COMMIT_DATE` | Build (auto) | Footer version stamp — **not hand-set**. `vite.config.ts` bakes them in from `package.json` + git (`buildInfo.ts` reads them). The stamp mirrors the `_PREVIEW` switch: `main` shows `v<version> · <hash>`; any other branch shows `<branch> · <hash> · <commit time>`. Hash prefers CI SHAs (`WORKERS_CI_COMMIT_SHA`/`CF_PAGES_COMMIT_SHA`/`GITHUB_SHA`), branch prefers CI branch vars (`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`/`GITHUB_REF_NAME`); both fall back to local `git`, then `"unknown"`. |
 
 PWA deployment detail: the active offline-capable worker is emitted as `/service-worker.js` and registered only outside preview/iframe contexts. `public/sw.js` is reserved as a legacy kill-switch worker to evict stale caches from older installs that previously registered `/sw.js`.
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,16 @@ The app includes an optional admin system for managing a community track databas
 
 > **Note:** `TURNSTILE_SECRET_KEY` is a server-side secret stored in Lovable Cloud, not a `VITE_` client variable. If not set, Turnstile verification is skipped.
 
-> **Build version stamp:** `VITE_APP_VERSION`, `VITE_GIT_HASH`, and
-> `VITE_BUILD_DATE` are **not** configured by hand — `vite.config.ts` bakes them
-> in automatically (from `package.json` and git) for the home-page footer
-> version/commit stamp. The commit hash prefers CI-provided SHAs
-> (`WORKERS_CI_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` / `GITHUB_SHA`) so it's correct
-> even on shallow checkouts, falling back to a local `git` call and then
-> `"unknown"`.
+> **Build version stamp:** `VITE_APP_VERSION`, `VITE_GIT_HASH`, `VITE_BUILD_DATE`,
+> `VITE_GIT_BRANCH`, and `VITE_GIT_COMMIT_DATE` are **not** configured by hand —
+> `vite.config.ts` bakes them in automatically (from `package.json` and git) for
+> the home-page footer version/commit stamp. The stamp mirrors the `_PREVIEW`
+> backend switch: a `main` build shows **`v<version> · <hash>`**, while any other
+> branch shows **`<branch> · <hash> · <commit time>`**. The commit hash prefers
+> CI-provided SHAs (`WORKERS_CI_COMMIT_SHA` / `CF_PAGES_COMMIT_SHA` /
+> `GITHUB_SHA`) and the branch prefers CI branch vars (`WORKERS_CI_BRANCH` /
+> `CF_PAGES_BRANCH` / `GITHUB_REF_NAME`) so both are correct even on shallow
+> checkouts, falling back to a local `git` call and then `"unknown"`.
 
 > **Stripe / paid tiers:** `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are
 > edge-function secrets (not `VITE_` client vars). Prices are resolved live by

--- a/src/lib/buildInfo.test.ts
+++ b/src/lib/buildInfo.test.ts
@@ -1,14 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { hasCommit, formatBuildLabel, commitUrl, type BuildInfo } from "./buildInfo";
+import {
+  hasCommit,
+  isPreviewBuild,
+  formatCommitTime,
+  formatBuildLabel,
+  commitUrl,
+  type BuildInfo,
+} from "./buildInfo";
 
-const withCommit: BuildInfo = { version: "2.0.0", commit: "837b514", buildDate: "2026-06-03T00:00:00.000Z" };
-const noCommit: BuildInfo = { version: "2.0.0", commit: "unknown", buildDate: "" };
-const emptyCommit: BuildInfo = { version: "1.5.0", commit: "", buildDate: "" };
+const mainBuild: BuildInfo = {
+  version: "2.0.0",
+  commit: "837b514",
+  buildDate: "2026-06-03T00:00:00.000Z",
+  branch: "main",
+  commitDate: "2026-06-02T23:28:13-04:00",
+};
+const branchBuild: BuildInfo = {
+  ...mainBuild,
+  branch: "claude/footer-branch-preview-stamp",
+};
+const noCommit: BuildInfo = {
+  version: "2.0.0",
+  commit: "unknown",
+  buildDate: "",
+  branch: "unknown",
+  commitDate: "",
+};
+const emptyCommit: BuildInfo = { ...noCommit, version: "1.5.0", commit: "" };
 
 describe("buildInfo helpers", () => {
   describe("hasCommit", () => {
     it("is true for a real hash", () => {
-      expect(hasCommit(withCommit)).toBe(true);
+      expect(hasCommit(mainBuild)).toBe(true);
     });
     it("is false for 'unknown' or empty", () => {
       expect(hasCommit(noCommit)).toBe(false);
@@ -16,19 +39,52 @@ describe("buildInfo helpers", () => {
     });
   });
 
-  describe("formatBuildLabel", () => {
-    it("includes the hash when present", () => {
-      expect(formatBuildLabel(withCommit)).toBe("v2.0.0 · 837b514");
+  describe("isPreviewBuild", () => {
+    it("is false on main", () => {
+      expect(isPreviewBuild(mainBuild)).toBe(false);
     });
-    it("omits the hash when unknown", () => {
+    it("is false for an unknown branch (falls back to prod stamp)", () => {
+      expect(isPreviewBuild(noCommit)).toBe(false);
+    });
+    it("is true on any other known branch", () => {
+      expect(isPreviewBuild(branchBuild)).toBe(true);
+    });
+  });
+
+  describe("formatCommitTime", () => {
+    it("formats an ISO timestamp in UTC", () => {
+      // 23:28:13 -04:00 → 03:28 UTC the next day
+      expect(formatCommitTime("2026-06-02T23:28:13-04:00")).toBe("Jun 3, 2026, 3:28 AM UTC");
+    });
+    it("returns '' for empty or unparseable input", () => {
+      expect(formatCommitTime("")).toBe("");
+      expect(formatCommitTime("not-a-date")).toBe("");
+    });
+  });
+
+  describe("formatBuildLabel", () => {
+    it("shows version + hash on main", () => {
+      expect(formatBuildLabel(mainBuild)).toBe("v2.0.0 · 837b514");
+    });
+    it("omits the hash when unknown on main", () => {
       expect(formatBuildLabel(noCommit)).toBe("v2.0.0");
       expect(formatBuildLabel(emptyCommit)).toBe("v1.5.0");
+    });
+    it("shows branch + hash + commit time on a non-main branch", () => {
+      expect(formatBuildLabel(branchBuild)).toBe(
+        "claude/footer-branch-preview-stamp · 837b514 · Jun 3, 2026, 3:28 AM UTC",
+      );
+    });
+    it("drops missing parts on a branch build", () => {
+      expect(formatBuildLabel({ ...branchBuild, commit: "unknown", commitDate: "" })).toBe(
+        "claude/footer-branch-preview-stamp",
+      );
     });
   });
 
   describe("commitUrl", () => {
     it("builds a GitHub commit URL for a real hash", () => {
-      expect(commitUrl(withCommit)).toBe(
+      expect(commitUrl(mainBuild)).toBe(
         "https://github.com/TheAngryRaven/DovesDataViewer/commit/837b514",
       );
     });

--- a/src/lib/buildInfo.ts
+++ b/src/lib/buildInfo.ts
@@ -1,6 +1,10 @@
 // Build-time version metadata, surfaced in the landing-page footer so it's easy
 // to tell at a glance which revision is deployed. The raw values are injected by
 // Vite's `define` (see vite.config.ts) from package.json + git at build time.
+//
+// The footer stamp has two modes, mirroring the _PREVIEW backend switch:
+//   - `main` build      → "v2.0.0 · 837b514"          (version + hash)
+//   - any other branch  → "my-branch · 837b514 · <commit time>"
 
 export interface BuildInfo {
   /** App version from package.json (e.g. "2.0.0"). */
@@ -9,14 +13,21 @@ export interface BuildInfo {
   commit: string;
   /** ISO build timestamp, or "" when unavailable. */
   buildDate: string;
+  /** Branch the build came from, or "unknown" when it couldn't be resolved. */
+  branch: string;
+  /** ISO commit (committer) date of the build's commit, or "" when unavailable. */
+  commitDate: string;
 }
 
 const GITHUB_REPO = "TheAngryRaven/DovesDataViewer";
+const PROD_BRANCH = "main";
 
 export const buildInfo: BuildInfo = {
   version: import.meta.env.VITE_APP_VERSION ?? "0.0.0",
   commit: import.meta.env.VITE_GIT_HASH ?? "unknown",
   buildDate: import.meta.env.VITE_BUILD_DATE ?? "",
+  branch: import.meta.env.VITE_GIT_BRANCH ?? "unknown",
+  commitDate: import.meta.env.VITE_GIT_COMMIT_DATE ?? "",
 };
 
 /** True when we have a real commit hash worth linking/displaying. */
@@ -24,8 +35,42 @@ export function hasCommit(info: BuildInfo = buildInfo): boolean {
   return !!info.commit && info.commit !== "unknown";
 }
 
-/** Short human label, e.g. "v2.0.0 · 837b514" (omits the hash if unknown). */
+/**
+ * True for a build off any branch other than `main` (a known, non-prod branch).
+ * An unknown branch falls back to the production stamp.
+ */
+export function isPreviewBuild(info: BuildInfo = buildInfo): boolean {
+  return !!info.branch && info.branch !== "unknown" && info.branch !== PROD_BRANCH;
+}
+
+/** Human-readable commit time (UTC), e.g. "Jun 3, 2026, 3:28 AM UTC"; "" if unparseable. */
+export function formatCommitTime(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+}
+
+/**
+ * Footer stamp label. On `main`: "v{version} · {hash}". On any other branch:
+ * "{branch} · {hash} · {commit time}". Missing parts are dropped gracefully.
+ */
 export function formatBuildLabel(info: BuildInfo = buildInfo): string {
+  if (isPreviewBuild(info)) {
+    const parts = [info.branch];
+    if (hasCommit(info)) parts.push(info.commit);
+    const time = formatCommitTime(info.commitDate);
+    if (time) parts.push(time);
+    return parts.join(" · ");
+  }
   return hasCommit(info) ? `v${info.version} · ${info.commit}` : `v${info.version}`;
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,6 +8,10 @@ interface ImportMetaEnv {
   readonly VITE_GIT_HASH?: string;
   /** ISO timestamp of when the bundle was built. */
   readonly VITE_BUILD_DATE?: string;
+  /** Branch the build came from (or "unknown"). Drives the footer stamp mode. */
+  readonly VITE_GIT_BRANCH?: string;
+  /** ISO commit (committer) date of the build's commit. */
+  readonly VITE_GIT_COMMIT_DATE?: string;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,30 @@ function gitShortHash(): string {
   }
 }
 
+// Branch the build came from. Drives the footer stamp's mode: `main` shows the
+// version + hash; any other branch shows branch + hash + commit time (mirrors
+// the _PREVIEW backend switch). CI branch env vars are preferred so it's right
+// on detached/shallow CI checkouts, falling back to local `git`, then "unknown".
+function gitBranch(): string {
+  const fromEnv =
+    process.env.WORKERS_CI_BRANCH || process.env.CF_PAGES_BRANCH || process.env.GITHUB_REF_NAME;
+  if (fromEnv) return fromEnv;
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", { cwd: __dirname }).toString().trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+// ISO timestamp of the build's commit (committer date), for the preview stamp.
+function gitCommitDate(): string {
+  try {
+    return execSync("git log -1 --format=%cI", { cwd: __dirname }).toString().trim();
+  } catch {
+    return "";
+  }
+}
+
 // Build-time loader for external plugin npm packages (the AI coach). Candidate
 // package names default to the public coach and can be overridden via the
 // DOVE_PLUGIN_PACKAGES env var (comma-separated). Only packages actually
@@ -123,6 +147,8 @@ export default defineConfig(({ mode }) => {
   const appVersion = readAppVersion();
   const gitHash = gitShortHash();
   const buildDate = new Date().toISOString();
+  const branch = gitBranch();
+  const commitDate = gitCommitDate();
 
   const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)
@@ -154,6 +180,8 @@ export default defineConfig(({ mode }) => {
       "import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
       "import.meta.env.VITE_GIT_HASH": JSON.stringify(gitHash),
       "import.meta.env.VITE_BUILD_DATE": JSON.stringify(buildDate),
+      "import.meta.env.VITE_GIT_BRANCH": JSON.stringify(branch),
+      "import.meta.env.VITE_GIT_COMMIT_DATE": JSON.stringify(commitDate),
     },
     plugins: [
       react(),


### PR DESCRIPTION
## What

Follow-up tweak to the footer version stamp (#129). The stamp now has two modes, mirroring the `_PREVIEW` backend switch:

- **`main` build** → `v2.0.0 · 837b514` (version + hash, unchanged)
- **Any other branch** → `<branch> · <hash> · <commit time>`, e.g. `claude/footer-branch-preview-stamp · b8db1e1 · Jun 3, 2026, 12:32 AM UTC`

So a beta/preview deployment now makes clear which branch it's running and when that commit landed.

## How

- **`vite.config.ts`** bakes in two new build-time constants:
  - `VITE_GIT_BRANCH` — prefers CI branch vars (`WORKERS_CI_BRANCH` / `CF_PAGES_BRANCH` / `GITHUB_REF_NAME`), falls back to local `git`, then `"unknown"`.
  - `VITE_GIT_COMMIT_DATE` — the commit's committer date (`git log -1 --format=%cI`).
- **`src/lib/buildInfo.ts`** — new `isPreviewBuild()` (true for any known non-`main` branch; an unknown branch falls back to the production stamp) and `formatCommitTime()` (UTC) drive the two-mode `formatBuildLabel()`. The hash still links to the GitHub commit; missing parts (no hash / no commit date) are dropped gracefully.
- **`src/vite-env.d.ts`** types the two new env vars.

## Tests

- New cases cover both stamp modes, the `main` vs branch vs unknown-branch decision, and the deterministic UTC commit-time formatting.
- `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:run` — all green (888 tests).
- Verified the branch name + commit date are actually baked into the production bundle.

## Docs

- `README.md` env note, `CLAUDE.md` (architecture map + env table), `CHANGELOG.md`.

https://claude.ai/code/session_01L92jSQDgbWbFxCFNGctW2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01L92jSQDgbWbFxCFNGctW2D)_