### PR TITLE
Footer: amber preview-database warning on non-main builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is deployed and when something changed. On **preview/non-`main` builds** the
   stamp instead reads **`<branch> · <hash> · <commit time>`**, so you can tell at
   a glance which branch a beta deployment is running.
+- **Preview builds shout that they're previews.** On any non-`main` build the
+  footer turns amber (standing out in light *and* dark mode) and adds a warning:
+  the branch runs on a preview database, accounts can be wiped at any time, don't
+  rely on anything but local data, and — if payments are ever enabled — never
+  enter real payment information.
 - **Manage your tracks straight from the home screen.** A new **Manage Tracks**
   button (below "Download from Datalogger") opens the track manager without
   having to load a datalog first — search for a location, drop the start/finish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ src/
 │   ├── billingClient.ts / pendingCheckout.ts   # Supabase billing I/O + sign-up checkout stash
 │   ├── profanity.ts       # Basic client-side profanity filter for display names
 │   ├── weatherService.ts  # OpenWeatherMap (online-only)
-│   ├── buildInfo.ts       # Build version/hash/branch/commit-date stamp (landing footer "what changed" marker; main → version+hash, other branches → branch+hash+commit time; values injected by vite define)
+│   ├── buildInfo.ts       # Build version/hash/branch/commit-date stamp (landing footer "what changed" marker; main → version+hash, other branches → branch+hash+commit time + amber preview-DB warning via isPreviewBuild(); values injected by vite define)
 │   └── utils.ts           # Tailwind cn() helper
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section
 │   ├── (framework)        # types, registry, index, panels, mounts, storage + PluginPanelHost/PluginMount
@@ -813,7 +813,7 @@ independently across deploys so app-only changes don't re-download vendor code.
 - **Tracks**: `public/tracks.json` is the source of truth at runtime; admin DB builds this file. Export format includes `longName`, `shortName`, `defaultCourse`, and per-course `lengthFt`. Tracks table has `default_course_id` FK. Course `lengthFt` values are imported as `length_ft_override` in the database.
 - **Course Detection**: `courseDetection.ts` handles auto-detection of track/course/direction on file load, with waypoint mode fallback. Find nearest track within 5mi, match course by lap distance vs `lengthFt`.
 - **Course Drawings**: Admin can export/import course layout drawings separately from tracks. Import clears `length_ft_override` for imported courses (drawing becomes source of truth).
-- **CSS**: use Tailwind semantic tokens from `index.css`, never hardcode colors in components
+- **CSS**: use Tailwind semantic tokens from `index.css`, never hardcode colors in components (e.g. `--warning`/`warning` — amber, light+dark — used for the preview-build footer)
 - **Admin code** is fully optional and gated behind env vars — core app has zero admin dependencies
 - **Edge functions** live in `supabase/functions/`, auto-deployed, configured in `supabase/config.toml`
 - **Stale-state gotcha**: When calling a function immediately after `setState`, the new value isn't available in the current closure. Pass values explicitly (e.g., `calculateAndSetLaps(course, samples, fileName)`) instead of relying on state that was just set.

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -10,7 +10,8 @@ import { AboutDialog } from "@/components/AboutDialog";
 import { CreditsDialog } from "@/components/CreditsDialog";
 import { PricingCards } from "@/components/PricingCards";
 import { useAuth } from "@/contexts/AuthContext";
-import { buildInfo, formatBuildLabel, commitUrl } from "@/lib/buildInfo";
+import { buildInfo, formatBuildLabel, commitUrl, isPreviewBuild } from "@/lib/buildInfo";
+import { cn } from "@/lib/utils";
 import type { ParsedData } from "@/types/racing";
 
 interface LandingPageProps {
@@ -195,7 +196,12 @@ export function LandingPage({
         </div>
       </main>
 
-      <footer className="border-t border-border px-6 py-4">
+      <footer
+        className={cn(
+          "border-t px-6 py-4",
+          isPreviewBuild() ? "border-warning/60 bg-warning/10" : "border-border",
+        )}
+      >
         <p className="text-center text-xs text-muted-foreground">
           Operated by{" "}
           <a
@@ -208,7 +214,10 @@ export function LandingPage({
           </a>
         </p>
         <p
-          className="mt-1 text-center text-[11px] text-muted-foreground/60"
+          className={cn(
+            "mt-1 text-center text-[11px]",
+            isPreviewBuild() ? "font-semibold text-warning" : "text-muted-foreground/60",
+          )}
           title={buildInfo.buildDate ? `Built ${new Date(buildInfo.buildDate).toLocaleString()}` : undefined}
         >
           {commitUrl() ? (
@@ -216,7 +225,10 @@ export function LandingPage({
               href={commitUrl()!}
               target="_blank"
               rel="noopener noreferrer"
-              className="underline-offset-4 transition-colors hover:text-muted-foreground hover:underline"
+              className={cn(
+                "underline-offset-4 transition-colors hover:underline",
+                isPreviewBuild() ? "hover:text-warning/80" : "hover:text-muted-foreground",
+              )}
             >
               {formatBuildLabel()}
             </a>
@@ -224,6 +236,13 @@ export function LandingPage({
             formatBuildLabel()
           )}
         </p>
+        {isPreviewBuild() && (
+          <p className="mx-auto mt-2 max-w-2xl text-center text-[11px] leading-relaxed text-warning">
+            This branch is running on a preview database — accounts can be wiped at any time. Do not
+            rely on data being saved anywhere other than locally. If payments are activated,{" "}
+            <strong>do not enter real payment information.</strong>
+          </p>
+        )}
       </footer>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,10 @@
     --destructive: 0 70% 50%;
     --destructive-foreground: 0 0% 100%;
 
+    /* Warning / preview state — amber that pops in light mode */
+    --warning: 32 95% 44%;
+    --warning-foreground: 0 0% 100%;
+
     --border: 220 15% 85%;
     --input: 220 15% 88%;
     --ring: 180 70% 35%;
@@ -86,6 +90,10 @@
 
     --destructive: 0 70% 50%;
     --destructive-foreground: 210 20% 98%;
+
+    /* Warning / preview state — brighter amber that pops in dark mode */
+    --warning: 38 96% 56%;
+    --warning-foreground: 220 20% 6%;
 
     --border: 220 15% 20%;
     --input: 220 15% 18%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,6 +36,10 @@ export default {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",


### PR DESCRIPTION
## What

Adds visible flare + a safety warning to the footer **on non-`main` (preview) builds only**, so nobody mistakes a beta deployment for production.

On any preview build the footer now:
- Turns **amber** — a new `--warning` semantic token tuned to stand out in **both light and dark mode** (subtle `bg-warning/10` tint, `border-warning/60` top border, bold amber version stamp).
- Shows a notice under the version stamp:
  > This branch is running on a preview database — accounts can be wiped at any time. Do not rely on data being saved anywhere other than locally. If payments are activated, **do not enter real payment information.**

On `main`, the footer is unchanged (plain muted version + hash).

## How

- **`src/index.css`** — new `--warning` / `--warning-foreground` token pair (amber) for light and dark.
- **`tailwind.config.ts`** — maps the `warning` color so `text-warning` / `bg-warning` / `border-warning` work.
- **`src/components/LandingPage.tsx`** — gates the footer color + warning note on the existing `isPreviewBuild()` helper (from #135).

## Verification

- `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:run` — all green (893 tests).
- Confirmed in the built bundle: the warning copy + `border-warning/60` are present, and the compiled CSS carries both light (`--warning: 32 95% 44%`) and dark (`38 96% 56%`) values plus the `text/bg/border-warning` utilities.

## Docs

- `CHANGELOG.md`, `CLAUDE.md` (architecture map + CSS-token convention note).

> Reuses the `isPreviewBuild()` branch detection landed in #135 — no new build-time wiring needed.

https://claude.ai/code/session_01L92jSQDgbWbFxCFNGctW2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01L92jSQDgbWbFxCFNGctW2D)_