### PR TITLE
UI tweaks: helper messages + Open Garage shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are calculated from), and the Snapshots menu explains that you can save one
   snapshot per engine per course, capturing the full lap plus the session's setup
   information.
+- **Video panel note when empty.** The "No video loaded" state now mentions that
+  segmented videos are not yet supported.
 - **Overlays menu — manage overlay lines and set references in one place.** The
   header **Overlays** button (renamed from "Overlay file") now opens a
   three-section menu: **Current overlays** lists every active overlay line, lets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **"Open Garage" shortcut in the Pro vehicle tab.** When no vehicle is linked to
+  the session, the Pro-view **Vehicle** tab now shows an **Open Garage** button
+  below **Save Selection** that opens the file-manager drawer straight to the
+  relevant Garage sub-tab — **Vehicles** when you have no vehicles yet, or
+  **Setups** when you already have one — so you can create what you need without
+  hunting for the tab.
+- **Inline helper text in the Overlays and Snapshots menus.** The Overlays menu
+  now notes that overlays are separate from the main reference lap (where deltas
+  are calculated from), and the Snapshots menu explains that you can save one
+  snapshot per engine per course, capturing the full lap plus the session's setup
+  information.
 - **Overlays menu — manage overlay lines and set references in one place.** The
   header **Overlays** button (renamed from "Overlay file") now opens a
   three-section menu: **Current overlays** lists every active overlay line, lets

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -46,6 +46,8 @@ interface FileManagerDrawerProps {
   onSaveFile: (name: string, blob: Blob) => Promise<void>;
   onDataLoaded: (data: ParsedData, fileName?: string) => void;
   autoSave: boolean;
+  // Garage sub-tab to open straight to (defaults to "files").
+  initialGarageTab?: GarageTab;
   // Profile tab is gated on a plugin (cloud-sync) contributing a Profile panel.
   showProfile: boolean;
   // Vehicle props
@@ -82,6 +84,7 @@ interface FileManagerDrawerProps {
 export function FileManagerDrawer({
   isOpen, files, fileMetadataMap, storageUsed, storageQuota,
   onClose, onLoadFile, onDeleteFile, onExportFile, onSaveFile, onDataLoaded, autoSave,
+  initialGarageTab = "files",
   showProfile,
   vehicles, vehicleTypes, templates,
   onAddVehicle, onUpdateVehicle, onRemoveVehicle,
@@ -102,11 +105,11 @@ export function FileManagerDrawer({
   useEffect(() => {
     if (isOpen) {
       setTopTab("garage");
-      setGarageTab("files");
+      setGarageTab(initialGarageTab);
       setDeviceTab("settings");
       setBattery(null);
     }
-  }, [isOpen]);
+  }, [isOpen, initialGarageTab]);
 
   // Fetch battery on connect / when switching to device tab
   const fetchBattery = useCallback(async () => {

--- a/src/components/LapSnapshotControls.tsx
+++ b/src/components/LapSnapshotControls.tsx
@@ -80,6 +80,10 @@ export function LapSnapshotControls({
           <DialogTitle>Lap Snapshots</DialogTitle>
         </DialogHeader>
 
+        <p className="text-xs text-muted-foreground">
+          You can only save one snapshot per engine per course. It records the full lap data, along with the setup information from the recorded session.
+        </p>
+
         {showSave && (
           <>
             <Button

--- a/src/components/OverlaysMenu.tsx
+++ b/src/components/OverlaysMenu.tsx
@@ -154,6 +154,10 @@ export function OverlaysMenu({
           <DialogTitle>Overlays</DialogTitle>
         </DialogHeader>
 
+        <p className="text-xs text-muted-foreground">
+          Overlays are technically separate from the main reference lap — the reference lap is where deltas are calculated from.
+        </p>
+
         <div className="overflow-y-auto flex-1 -mx-2 px-2 divide-y divide-border">
           {/* ── Section 1: current overlays ────────────────────────────── */}
           <Collapsible open={showCurrent} onOpenChange={setShowCurrent}>

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -525,6 +525,7 @@ export const VideoPlayer = memo(function VideoPlayer({
         <Button variant="outline" size="sm" onClick={actions.loadVideo} className="gap-2">
           <Video className="w-4 h-4" /> Load Video
         </Button>
+        <p className="text-xs text-muted-foreground/70">Segmented videos are not yet supported.</p>
       </div>
     );
   }

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -45,6 +45,7 @@ export interface GraphViewPanelProps {
   sessionSetupId: string | null;
   onSaveSessionSetup: (kartId: string | null, setupId: string | null) => Promise<void>;
   onOpenSetupEditor?: (setupId: string) => void;
+  onOpenGarage?: (garageTab?: 'files' | 'vehicles' | 'setups' | 'notes') => void;
   // Range slider
   visibleRange: [number, number];
   onRangeChange: (range: [number, number]) => void;
@@ -116,6 +117,7 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
                 sessionSetupId={props.sessionSetupId}
                 onSaveSessionSetup={props.onSaveSessionSetup}
                 onOpenSetupEditor={props.onOpenSetupEditor}
+                onOpenGarage={props.onOpenGarage}
                 videoState={props.videoState}
                 videoActions={props.videoActions}
                 onVideoLoadedMetadata={props.onVideoLoadedMetadata}

--- a/src/components/graphview/InfoBox.tsx
+++ b/src/components/graphview/InfoBox.tsx
@@ -35,6 +35,7 @@ interface InfoBoxProps {
   sessionSetupId: string | null;
   onSaveSessionSetup: (kartId: string | null, setupId: string | null) => Promise<void>;
   onOpenSetupEditor?: (setupId: string) => void;
+  onOpenGarage?: (garageTab?: 'files' | 'vehicles' | 'setups' | 'notes') => void;
   videoState?: VideoSyncState;
   videoActions?: VideoSyncActions;
   onVideoLoadedMetadata?: () => void;
@@ -57,7 +58,7 @@ export function InfoBox({
   filteredSamples, course, lapTimeMs, paceDiff, paceDiffLabel,
   deltaTopSpeed, deltaMinSpeed, referenceLapNumber, lapToFastestDelta,
   sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved,
-  vehicles, setups, templates, sessionKartId, sessionSetupId, onSaveSessionSetup, onOpenSetupEditor,
+  vehicles, setups, templates, sessionKartId, sessionSetupId, onSaveSessionSetup, onOpenSetupEditor, onOpenGarage,
   videoState, videoActions, onVideoLoadedMetadata, currentSample,
   visibleSamples, allSamples, currentIndex, fieldMappings, laps, selectedLapNumber,
   referenceSamples, paceData, sessionFileName,
@@ -252,6 +253,16 @@ export function InfoBox({
                   </SelectContent>
                 </Select>
                 <Button className="w-full" size="sm" onClick={handleSave} disabled={isSaved}>Save Selection</Button>
+                {onOpenGarage && (
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    size="sm"
+                    onClick={() => onOpenGarage(vehicles.length > 0 ? 'setups' : 'vehicles')}
+                  >
+                    Open Garage
+                  </Button>
+                )}
               </div>
             )}
           </>

--- a/src/components/tabs/GraphViewTab.tsx
+++ b/src/components/tabs/GraphViewTab.tsx
@@ -31,6 +31,7 @@ export const GraphViewTab = memo(function GraphViewTab() {
       sessionKartId={s.sessionKartId}
       sessionSetupId={s.sessionSetupId}
       onSaveSessionSetup={s.onSaveSessionSetup}
+      onOpenGarage={s.onOpenGarage}
       visibleRange={s.visibleRange}
       onRangeChange={s.onRangeChange}
       minRange={s.minRange}

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -119,6 +119,8 @@ export interface SessionContextValue {
   onFieldToggle: (fieldName: string) => void;
   onWeatherStationResolved: (station: WeatherStation) => void;
   onSaveSessionSetup: (kartId: string | null, setupId: string | null) => Promise<void>;
+  /** Open the file-manager drawer, optionally straight to a Garage sub-tab. */
+  onOpenGarage: (garageTab?: 'files' | 'vehicles' | 'setups' | 'notes') => void;
   formatRangeLabel: (idx: number) => string;
 }
 

--- a/src/hooks/useFileManager.ts
+++ b/src/hooks/useFileManager.ts
@@ -10,12 +10,16 @@ import {
   getFileMetadata,
 } from "@/lib/fileStorage";
 
+/** Garage sub-tabs the drawer can be opened directly to. */
+export type GarageTabKey = "files" | "vehicles" | "setups" | "notes";
+
 export function useFileManager() {
   const [isOpen, setIsOpen] = useState(false);
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [fileMetadataMap, setFileMetadataMap] = useState<Map<string, FileMetadata>>(new Map());
   const [storageUsed, setStorageUsed] = useState(0);
   const [storageQuota, setStorageQuota] = useState(0);
+  const [initialGarageTab, setInitialGarageTab] = useState<GarageTabKey>("files");
 
   const refresh = useCallback(async () => {
     const [fileList, estimate] = await Promise.all([listFiles(), getStorageEstimate()]);
@@ -38,7 +42,11 @@ export function useFileManager() {
     setFileMetadataMap(map);
   }, []);
 
-  const open = useCallback(() => {
+  // Accepts an optional garage sub-tab to open straight to. Guarded against
+  // being wired directly as an event handler (e.g. onClick), where the first
+  // argument would be a MouseEvent rather than a tab key.
+  const open = useCallback((garageTab?: GarageTabKey) => {
+    setInitialGarageTab(typeof garageTab === "string" ? garageTab : "files");
     setIsOpen(true);
     refresh();
   }, [refresh]);
@@ -84,6 +92,7 @@ export function useFileManager() {
     fileMetadataMap,
     storageUsed,
     storageQuota,
+    initialGarageTab,
     open,
     close,
     refresh,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -397,6 +397,7 @@ export default function Index() {
     onFieldToggle: sessionData.handleFieldToggle,
     onWeatherStationResolved: sessionMeta.handleWeatherStationResolved,
     onSaveSessionSetup: handleSaveSessionSetupWithSnapshot,
+    onOpenGarage: fileManager.open,
     formatRangeLabel,
   }), [
     data, visibleSamples, filteredSamples, referenceSamples, currentSample, fieldMappings,
@@ -418,7 +419,7 @@ export default function Index() {
     handleSelectExternalLapWithClear, handleClearExternalRefWithSnapshot, handleLoadFileForRef,
     refreshSavedFiles, handleRangeChange,
     sessionData.handleFieldToggle, sessionMeta.handleWeatherStationResolved,
-    handleSaveSessionSetupWithSnapshot, formatRangeLabel,
+    handleSaveSessionSetupWithSnapshot, fileManager.open, formatRangeLabel,
   ]);
 
   // Shared FileManagerDrawer props
@@ -435,6 +436,7 @@ export default function Index() {
     onSaveFile: fileManager.saveFile,
     onDataLoaded: handleDataLoaded,
     autoSave: settings.autoSaveFiles,
+    initialGarageTab: fileManager.initialGarageTab,
     showProfile,
     vehicles: vehicleManager.vehicles,
     vehicleTypes: templateManager.vehicleTypes,
@@ -463,6 +465,7 @@ export default function Index() {
   }), [
     fileManager.isOpen, fileManager.files, fileManager.fileMetadataMap, fileManager.storageUsed, fileManager.storageQuota,
     fileManager.close, fileManager.loadFile, fileManager.removeFile, fileManager.exportFile, fileManager.saveFile,
+    fileManager.initialGarageTab,
     handleDataLoaded, settings.autoSaveFiles, showProfile,
     vehicleManager.vehicles, vehicleManager.addVehicle, vehicleManager.updateVehicle, vehicleManager.removeVehicle,
     templateManager.vehicleTypes, templateManager.templates, templateManager.addVehicleType, templateManager.removeVehicleType,
@@ -569,7 +572,7 @@ export default function Index() {
           />
 
           <SettingsModal settings={settings} onSettingsChange={setSettings} onToggleFieldDefault={toggleFieldDefault} />
-          <Button variant="outline" size="icon" className="h-8 w-8" onClick={fileManager.open}>
+          <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => fileManager.open()}>
             <FolderOpen className="w-4 h-4" />
           </Button>
         </div>


### PR DESCRIPTION
## Summary

Small UI polish on top of `BETA` — two helper messages and one new shortcut button.

### 1. Overlays menu helper text
Subtle muted line under the title: *"Overlays are technically separate from the main reference lap — the reference lap is where deltas are calculated from."*

### 2. Snapshots menu helper text
Subtle muted line under the title: *"You can only save one snapshot per engine per course. It records the full lap data, along with the setup information from the recorded session."*

### 3. "Open Garage" button in the Pro-view Vehicle tab
When no vehicle is linked to the session, an **Open Garage** button now appears below **Save Selection**. It opens the file-manager drawer straight to the relevant Garage sub-tab:
- **No vehicles yet** → opens the **Vehicles** tab.
- **Already have a vehicle** → opens the **Setups** tab.

To support this, the drawer can now be opened to a specific Garage sub-tab:
- `useFileManager.open(garageTab?)` — accepts an optional sub-tab, guarded so it's still safe wired directly as an event handler.
- `FileManagerDrawer` honors a new `initialGarageTab` prop.
- A new `onOpenGarage` handler is threaded through `SessionContext` → `GraphViewTab` → `GraphViewPanel` → `InfoBox`.

## Checks
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (893 tests)
- `npm run build` ✅
- `CHANGELOG.md` updated under `[Unreleased]`.

https://claude.ai/code/session_0121xjDuj3HJj84qsf3165fF

---
_Generated by [Claude Code](https://claude.ai/code/session_0121xjDuj3HJj84qsf3165fF)_