### PR TITLE
Desktop-only text labels on header controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Desktop text labels on header controls.** On large (desktop) screens the
+  **Settings** and **Garage** buttons in the header, the **track selection**
+  (pencil) button, and the **Snapshots** control now show a text label next to
+  their icon, taking advantage of the extra real estate. On tablet and mobile
+  these stay icon-only — the Snapshots control keeps its count bubble at every
+  size.
+
 ### Added
 - **"Open Garage" shortcut in the Pro vehicle tab.** When no vehicle is linked to
   the session, the Pro-view **Vehicle** tab now shows an **Open Garage** button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Desktop text labels on header controls.** On large (desktop) screens the
   **Settings** and **Garage** buttons in the header, the **track selection**
-  (pencil) button, and the **Snapshots** control now show a text label next to
-  their icon, taking advantage of the extra real estate. On tablet and mobile
-  these stay icon-only — the Snapshots control keeps its count bubble at every
-  size.
+  (pencil) button, and the **Snapshots** and **Overlays** controls now show a
+  text label next to their icon, taking advantage of the extra real estate. On
+  tablet and mobile these stay icon-only — the Snapshots and Overlays controls
+  keep their count bubble at every size.
 
 ### Added
 - **"Open Garage" shortcut in the Pro vehicle tab.** When no vehicle is linked to

--- a/src/components/LapSnapshotControls.tsx
+++ b/src/components/LapSnapshotControls.tsx
@@ -67,7 +67,7 @@ export function LapSnapshotControls({
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="h-8 gap-1.5 text-sm">
           <Camera className="h-3.5 w-3.5" />
-          <span className="hidden sm:inline">{triggerLabel}</span>
+          <span className="hidden lg:inline">{triggerLabel}</span>
           {count > 0 && (
             <span className="ml-0.5 rounded bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">
               {count}

--- a/src/components/OverlaysMenu.tsx
+++ b/src/components/OverlaysMenu.tsx
@@ -141,7 +141,7 @@ export function OverlaysMenu({
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="h-8 gap-1.5 text-sm" onClick={openDialog}>
           <Layers className="h-3.5 w-3.5" />
-          <span className="hidden sm:inline">Overlays</span>
+          <span className="hidden lg:inline">Overlays</span>
           {overlayLines.length > 0 && (
             <span className="ml-0.5 rounded bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">
               {overlayLines.length}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -30,8 +30,9 @@ export function SettingsModal({
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" size="icon" className="h-8 w-8">
+        <Button variant="outline" size="sm" className="h-8 gap-1.5 px-2 lg:px-3">
           <Settings className="w-4 h-4" />
+          <span className="hidden lg:inline">Settings</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-2xl max-h-[85vh] flex flex-col">

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -596,8 +596,9 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
       <>
         <div className="flex items-center gap-2">
           <span className="font-mono text-sm">{displayLabel}</span>
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setIsSelectDialogOpen(true)}>
+          <Button variant="ghost" size="sm" className="h-7 gap-1.5 px-2 lg:px-3" onClick={() => setIsSelectDialogOpen(true)}>
             <Edit2 className="w-4 h-4" />
+            <span className="hidden lg:inline">Select track</span>
           </Button>
         </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -572,8 +572,9 @@ export default function Index() {
           />
 
           <SettingsModal settings={settings} onSettingsChange={setSettings} onToggleFieldDefault={toggleFieldDefault} />
-          <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => fileManager.open()}>
+          <Button variant="outline" size="sm" className="h-8 gap-1.5 px-2 lg:px-3" onClick={() => fileManager.open()}>
             <FolderOpen className="w-4 h-4" />
+            <span className="hidden lg:inline">Garage</span>
           </Button>
         </div>
       </header>


### PR DESCRIPTION
## Summary

Adds text labels next to the icons on header controls **on desktop only**, taking advantage of the extra real estate. Tablet and mobile keep the existing compact icon-only treatment.

The desktop breakpoint used is Tailwind's `lg:` (≥1024px), which excludes tablets — so the labels appear only on true desktop widths via a `hidden lg:inline` span.

### Changes

1. **Settings button** (`SettingsModal.tsx`) — now shows "Settings" next to the gear icon on desktop.
2. **Garage button** (`Index.tsx` header) — now shows "Garage" next to the folder icon on desktop.
3. **Snapshots control** (`LapSnapshotControls.tsx`) — the label was previously shown from `sm:` up (tablet + desktop); it now shows from `lg:` up only, so **tablet and mobile go back to icon-only** while **keeping the count bubble at every size** (the bubble is needed on small screens).
4. **Track selection pencil** (`TrackEditor.tsx`) — now shows "Select track" next to the pencil icon on desktop.

### Checks

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (893 passed)
- `npm run build` ✅

CHANGELOG updated under `[Unreleased] → Changed`.

https://claude.ai/code/session_011sirMKvEoqp9t5onArZVmt

---
_Generated by [Claude Code](https://claude.ai/code/session_011sirMKvEoqp9t5onArZVmt)_