### PR TITLE
Glowing setup-status indicator in the tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Glowing setup-status indicator in the tab bar.** When the loaded session has
+  no setup assigned, an exclamation icon glows just right of the **Coach** tab.
+  It glows **red** when there's nothing to assign yet — clicking opens the Garage
+  to **Vehicles** (or **Setups** if you already have a vehicle), where the empty
+  states now read "No vehicles yet" / "No setups yet" in red. It glows **orange**
+  when setups exist but this session isn't linked to one — clicking opens the
+  Garage **Notes** tab, which now shows an orange reminder that "a setup should
+  be saved for historical data comparisons."
 - **"Open Garage" shortcut in the Pro vehicle tab.** When no vehicle is linked to
   the session, the Pro-view **Vehicle** tab now shows an **Open Garage** button
   below **Save Selection** that opens the file-manager drawer straight to the

--- a/src/components/drawer/NotesTab.tsx
+++ b/src/components/drawer/NotesTab.tsx
@@ -121,6 +121,11 @@ export function NotesTab({
         <Button className="w-full" size="sm" onClick={handleSaveSetup} disabled={!canSave}>
           {sessionKartId ? "Update Selection" : "Save Selection"}
         </Button>
+        {!sessionSetupId && (
+          <p className="text-xs text-orange-500">
+            A setup should be saved for historical data comparisons.
+          </p>
+        )}
         {isSaved && sessionSetupRev && (
           <p className="text-xs text-muted-foreground">
             Setup revision{" "}

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -286,7 +286,7 @@ export function SetupsTab({
           {setups.length === 0 ? (
             <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-3 py-16">
               <Wrench className="w-12 h-12 opacity-30" />
-              <p className="text-sm font-medium">No setups yet</p>
+              <p className="text-sm font-medium text-destructive">No setups yet</p>
               <p className="text-xs">Use the buttons below to get started.</p>
             </div>
           ) : (

--- a/src/components/drawer/VehiclesTab.tsx
+++ b/src/components/drawer/VehiclesTab.tsx
@@ -101,7 +101,7 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
         {vehicles.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
             <Car className="w-12 h-12 opacity-30" />
-            <p className="text-sm">No vehicles yet</p>
+            <p className="text-sm font-medium text-destructive">No vehicles yet</p>
             <p className="text-xs">Add a vehicle using the form below</p>
           </div>
         ) : (

--- a/src/lib/setupStatus.test.ts
+++ b/src/lib/setupStatus.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { getSetupIndicator } from "./setupStatus";
+
+describe("getSetupIndicator", () => {
+  it("returns null once the session has a setup assigned", () => {
+    expect(getSetupIndicator({ sessionSetupId: "abc", setupCount: 0, vehicleCount: 0 })).toBeNull();
+    expect(getSetupIndicator({ sessionSetupId: "abc", setupCount: 3, vehicleCount: 2 })).toBeNull();
+  });
+
+  it("glows red → vehicles when nothing exists at all", () => {
+    expect(getSetupIndicator({ sessionSetupId: null, setupCount: 0, vehicleCount: 0 })).toEqual({
+      tone: "red",
+      target: "vehicles",
+    });
+  });
+
+  it("glows red → setups when a vehicle exists but no setup does", () => {
+    expect(getSetupIndicator({ sessionSetupId: null, setupCount: 0, vehicleCount: 1 })).toEqual({
+      tone: "red",
+      target: "setups",
+    });
+  });
+
+  it("glows orange → notes when setups exist but this session isn't linked", () => {
+    expect(getSetupIndicator({ sessionSetupId: null, setupCount: 2, vehicleCount: 1 })).toEqual({
+      tone: "orange",
+      target: "notes",
+    });
+  });
+});

--- a/src/lib/setupStatus.ts
+++ b/src/lib/setupStatus.ts
@@ -1,0 +1,27 @@
+import type { GarageTabKey } from "@/hooks/useFileManager";
+
+/**
+ * The setup-status nag shown in the main tab bar when the loaded session has no
+ * setup assigned. Pure so it can be unit-tested independently of the view.
+ *
+ * - `red` (urgent): no setup exists to even assign yet. Point the driver at the
+ *   missing foundational piece — vehicles first, then setups.
+ * - `orange` (reminder): setups exist but this session isn't linked to one.
+ *   Send them to Notes, where the session-setup selector lives.
+ */
+export interface SetupIndicator {
+  tone: "red" | "orange";
+  target: GarageTabKey;
+}
+
+export function getSetupIndicator(args: {
+  sessionSetupId: string | null;
+  setupCount: number;
+  vehicleCount: number;
+}): SetupIndicator | null {
+  if (args.sessionSetupId) return null;
+  if (args.setupCount === 0) {
+    return { tone: "red", target: args.vehicleCount === 0 ? "vehicles" : "setups" };
+  }
+  return { tone: "orange", target: "notes" };
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical } from "lucide-react";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, AlertCircle } from "lucide-react";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { RaceLineTab } from "@/components/tabs/RaceLineTab";
@@ -36,6 +36,7 @@ import { TrackPromptDialog } from "@/components/TrackPromptDialog";
 import { useSettings } from "@/hooks/useSettings";
 import { usePlayback } from "@/hooks/usePlayback";
 import { useFileManager } from "@/hooks/useFileManager";
+import { getSetupIndicator, type SetupIndicator } from "@/lib/setupStatus";
 import { useVehicleManager } from "@/hooks/useVehicleManager";
 import { useNoteManager } from "@/hooks/useNoteManager";
 import { useSetupManager } from "@/hooks/useSetupManager";
@@ -137,6 +138,17 @@ export default function Index() {
   // Profile tab is self-gating too: appears only when a plugin (cloud-sync)
   // contributes a Profile panel (i.e. the cloud build flag is on).
   const showProfile = usePanelsForSlot(PanelSlot.Profile).length > 0;
+
+  // Setup-status nag: when the loaded session has no setup assigned, glow an
+  // exclamation in the tab bar (decision lives in the pure getSetupIndicator).
+  const setupIndicator = useMemo(
+    () => getSetupIndicator({
+      sessionSetupId,
+      setupCount: setupManager.setups.length,
+      vehicleCount: vehicleManager.vehicles.length,
+    }),
+    [sessionSetupId, setupManager.setups.length, vehicleManager.vehicles.length],
+  );
 
   // Video sync for Labs tab
   const videoSync = useVideoSync({
@@ -579,7 +591,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} setupIndicator={setupIndicator} onSetupIndicatorClick={() => setupIndicator && fileManager.open(setupIndicator.target)} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -618,7 +630,7 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, setupIndicator, onSetupIndicatorClick }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
@@ -626,6 +638,8 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   onToggleOverlays: () => void;
   showLabs: boolean;
   showCoach: boolean;
+  setupIndicator: SetupIndicator | null;
+  onSetupIndicatorClick: () => void;
 }) {
   const tabClass = (view: TopPanelView) =>
     `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
@@ -657,6 +671,32 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
         <button onClick={() => setTopPanelView("coach")} className={tabClass("coach")}>
           <Gauge className="w-4 h-4" /> <span className="hidden sm:inline">Coach</span>
         </button>
+      )}
+      {setupIndicator && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onSetupIndicatorClick}
+                aria-label="Session setup not configured"
+                className={`flex items-center px-3 py-2 animate-pulse transition-opacity hover:opacity-70 ${
+                  setupIndicator.tone === "red"
+                    ? "text-destructive drop-shadow-[0_0_6px_hsl(var(--destructive))]"
+                    : "text-orange-500 drop-shadow-[0_0_6px_rgba(249,115,22,0.85)]"
+                }`}
+              >
+                <AlertCircle className="w-5 h-5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                {setupIndicator.tone === "red"
+                  ? "No vehicle or setup saved yet — click to add one"
+                  : "No setup saved for this session — click to configure"}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
       {topPanelView === "raceline" && (
         <div className="ml-auto mr-3">


### PR DESCRIPTION
## Summary

Adds a glowing exclamation indicator to the main tab bar, just right of the **Coach** tab, that nags the driver when the loaded session has no setup assigned — so setup data gets recorded for historical comparisons.

### Behavior
- **Red (urgent)** when there's no setup to even assign yet. Clicking opens the Garage to **Vehicles** (or **Setups** if a vehicle already exists). The empty states in those tabs now read **"No vehicles yet"** / **"No setups yet"** in red.
- **Orange (reminder)** when setups exist but this session isn't linked to one. Clicking opens the Garage **Notes** tab, which now shows an orange reminder below **Save Selection**: *"A setup should be saved for historical data comparisons."*
- Hidden entirely once a setup is assigned to the session.

### Implementation
- The tone/target decision is a pure, unit-tested helper — `src/lib/setupStatus.ts` (`getSetupIndicator`). The tab-bar button owns only the glow (`animate-pulse` + drop-shadow) and click wiring.
- Colors use the `destructive` token for red and the existing `orange-500` convention (matches the device battery-low styling) for orange.

### Checks
- `npm run lint`, `npm run typecheck`, `npm run test:run` (897 tests, +4 new), and `npm run build` all pass.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Files
- `src/pages/Index.tsx` — compute indicator, render glowing button in `TabBar`
- `src/lib/setupStatus.ts` + `.test.ts` — pure decision helper + tests
- `src/components/drawer/VehiclesTab.tsx` / `SetupsTab.tsx` — red empty-state text
- `src/components/drawer/NotesTab.tsx` — orange reminder below Save Selection
- `CHANGELOG.md`

https://claude.ai/code/session_01KfmcASHLNs8C8GYCEEn1do

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfmcASHLNs8C8GYCEEn1do)_