### PR TITLE
Crop map overlay racing lines to the playback window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Preview-branch backend" deployment section.
 
 ### Fixed
+- **Cropping the playback range now crops the overlay racing lines on the map
+  too.** Narrowing the range slider shrank the active lap's heatmap line (and the
+  comparison charts) to the selected section, but the overlaid laps/snapshots on
+  the race-line map and Pro mini-map stayed drawn at full lap length. They now
+  crop to the same on-track window as the active lap, so every line on the map
+  reflects the cropped section.
 - **The track dropdown works again after loading a log.** Opening the
   track/course selector from the header (or the track manager) put its dropdowns
   *behind* the dialog, so picking a different track did nothing. The dropdown now

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -5,7 +5,7 @@ import { findSpeedEvents, SpeedEvent } from '@/lib/speedEvents';
 import { computeHeatmapSpeedBoundsMph } from '@/lib/speedBounds';
 import { formatLapTime } from '@/lib/lapCalculation';
 import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
-import { unionBounds, type OverlayLine } from '@/lib/lapOverlays';
+import { unionBounds, cropOverlayLinesToWindow, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { Switch } from '@/components/ui/switch';
@@ -60,6 +60,8 @@ interface RaceLineViewProps {
   parserStats?: ParserStats | null;
   /** Extra racing lines (other laps / snapshots) to overlay, beneath the current lap. */
   overlayLines?: OverlayLine[];
+  /** Visible-range start index into `allSamples` — crops overlays to the playback window. */
+  rangeStart?: number;
   /** Remove an overlay by id (legend ✕). */
   onRemoveOverlay?: (id: string) => void;
   /** Whether cross-session overlays are drift-aligned onto the current lap. */
@@ -146,10 +148,18 @@ function createSpeedEventIcon(event: SpeedEvent, useKph: boolean): L.DivIcon {
   });
 }
 
-export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], onRemoveOverlay, alignOverlays, onToggleAlignOverlays }: RaceLineViewProps) {
+export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays }: RaceLineViewProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   // Use allSamples for statistics if provided, otherwise fall back to samples
   const samplesForStats = allSamples ?? samples;
+
+  // Crop overlay racing lines to the same playback window as the active lap, so
+  // cropping the range shrinks them on the map exactly like the heatmap line
+  // (`samples` is already the cropped window; `samplesForStats` is the full lap).
+  const drawnOverlayLines = useMemo(
+    () => cropOverlayLinesToWindow(overlayLines, samplesForStats, rangeStart, rangeStart + samples.length - 1),
+    [overlayLines, samplesForStats, rangeStart, samples.length],
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const polylineLayerRef = useRef<L.LayerGroup | null>(null);
@@ -362,7 +372,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
     if (samples.length === 0) return;
 
     // Fit bounds — include overlay extents so off-lap overlays aren't clipped
-    const fit = unionBounds(bounds, overlayLines);
+    const fit = unionBounds(bounds, drawnOverlayLines);
     const latLngBounds = L.latLngBounds([
       [fit.minLat, fit.minLon],
       [fit.maxLat, fit.maxLon]
@@ -389,7 +399,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
       );
       polylineLayer.addLayer(polyline);
     }
-  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed, overlayLines]);
+  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed, drawnOverlayLines]);
 
   // Draw multi-lap overlay lines (other laps / snapshots) — solid colors,
   // beneath the current lap. Rebuilt only when the overlay set changes.
@@ -397,11 +407,11 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
     const layer = overlayLinesLayerRef.current;
     if (!layer) return;
     layer.clearLayers();
-    for (const line of overlayLines) {
+    for (const line of drawnOverlayLines) {
       const coords = line.samples.map(s => [s.lat, s.lon] as [number, number]);
       layer.addLayer(L.polyline(coords, { color: line.color, weight: 4, opacity: 0.7 }));
     }
-  }, [overlayLines]);
+  }, [drawnOverlayLines]);
 
   // Update speed event markers
   useEffect(() => {

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -155,6 +155,7 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
                 bounds={props.bounds}
                 isAllLaps={props.isAllLaps}
                 overlayLines={props.overlayLines}
+                rangeStart={props.visibleRange[0]}
                 onRemoveOverlay={props.onRemoveOverlay}
                 alignOverlays={props.alignOverlays}
                 onToggleAlignOverlays={props.onToggleAlignOverlays}

--- a/src/components/graphview/MiniMap.tsx
+++ b/src/components/graphview/MiniMap.tsx
@@ -4,7 +4,7 @@ import { GpsSample, Course } from '@/types/racing';
 import { findSpeedEvents, SpeedEvent } from '@/lib/speedEvents';
 import { computeHeatmapSpeedBoundsMph } from '@/lib/speedBounds';
 import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
-import { unionBounds, type OverlayLine } from '@/lib/lapOverlays';
+import { unionBounds, cropOverlayLinesToWindow, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X, Crosshair } from 'lucide-react';
@@ -52,6 +52,8 @@ interface MiniMapProps {
   isAllLaps?: boolean;
   /** Extra racing lines (other laps / snapshots) to overlay. */
   overlayLines?: OverlayLine[];
+  /** Visible-range start index into `allSamples` — crops overlays to the playback window. */
+  rangeStart?: number;
   /** Remove an overlay by id (legend ✕). */
   onRemoveOverlay?: (id: string) => void;
   /** Whether cross-session overlays are drift-aligned onto the current lap. */
@@ -59,8 +61,16 @@ interface MiniMapProps {
   onToggleAlignOverlays?: () => void;
 }
 
-export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], onRemoveOverlay, alignOverlays, onToggleAlignOverlays }: MiniMapProps) {
+export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays }: MiniMapProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
+
+  // Crop overlay racing lines to the same playback window as the active lap, so
+  // cropping the range shrinks them on the map exactly like the heatmap line
+  // (`samples` is the cropped window; `allSamples` is the full current lap).
+  const drawnOverlayLines = useMemo(
+    () => cropOverlayLinesToWindow(overlayLines, allSamples, rangeStart, rangeStart + samples.length - 1),
+    [overlayLines, allSamples, rangeStart, samples.length],
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const polylineLayerRef = useRef<L.LayerGroup | null>(null);
@@ -152,7 +162,7 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
     if (samples.length === 0) return;
     // Fit to the active lap plus any overlays (a cross-session snapshot can run
     // slightly outside the current lap's bounds).
-    const fit = unionBounds(bounds, overlayLines);
+    const fit = unionBounds(bounds, drawnOverlayLines);
     map.fitBounds(L.latLngBounds([[fit.minLat, fit.minLon], [fit.maxLat, fit.maxLon]]), { padding: [10, 10] });
     // Draw reference line underneath as grey
     if (referenceSamples.length > 0) {
@@ -163,18 +173,18 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
       const color = getSpeedColor(samples[i].speedMph, minSpeed, maxSpeed);
       pl.addLayer(L.polyline([[samples[i].lat, samples[i].lon], [samples[i + 1].lat, samples[i + 1].lon]], { color, weight: 3, opacity: 0.9 }));
     }
-  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed, overlayLines]);
+  }, [samples, referenceSamples, bounds, minSpeed, maxSpeed, drawnOverlayLines]);
 
   // Overlay racing lines (other laps / snapshots) — solid distinct colors, drawn
   // beneath the active heatmap. Rebuilt only when the overlay set changes.
   useEffect(() => {
     const layer = overlayLinesLayerRef.current; if (!layer) return;
     layer.clearLayers();
-    for (const line of overlayLines) {
+    for (const line of drawnOverlayLines) {
       const coords = line.samples.map(s => [s.lat, s.lon] as [number, number]);
       layer.addLayer(L.polyline(coords, { color: line.color, weight: 3, opacity: 0.7 }));
     }
-  }, [overlayLines]);
+  }, [drawnOverlayLines]);
 
   // Speed events
   useEffect(() => {

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -39,6 +39,7 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
           isAllLaps={s.isAllLaps}
           parserStats={s.parserStats}
           overlayLines={s.overlayLines}
+          rangeStart={s.visibleRange[0]}
           onRemoveOverlay={s.onToggleOverlay}
           alignOverlays={s.alignOverlays}
           onToggleAlignOverlays={s.onToggleAlignOverlays}

--- a/src/lib/lapOverlays.test.ts
+++ b/src/lib/lapOverlays.test.ts
@@ -6,6 +6,8 @@ import {
   externalOverlayId,
   resolveOverlayLines,
   unionBounds,
+  cropOverlayLinesToWindow,
+  type OverlayLine,
 } from "./lapOverlays";
 import type { GpsSample, Lap } from "@/types/racing";
 import type { LapSnapshot } from "./lapSnapshot";
@@ -132,5 +134,49 @@ describe("unionBounds", () => {
   it("expands to enclose overlay samples", () => {
     const line = { id: "lap:1", label: "Lap 1", color: "x", samples: [sample(-2, 5), sample(3, -1)] };
     expect(unionBounds(base, [line])).toEqual({ minLat: -2, maxLat: 3, minLon: -1, maxLon: 5 });
+  });
+});
+
+describe("cropOverlayLinesToWindow", () => {
+  // 11-point straight line along longitude — cumulative distance is monotonic.
+  const lineOf = (id: string, n: number): OverlayLine => ({
+    id,
+    label: id,
+    color: "x",
+    samples: Array.from({ length: n }, (_, i) => sample(0, i)),
+  });
+  const current = lineOf("cur", 11).samples;
+
+  it("returns the lines unchanged when the range spans the whole lap", () => {
+    const lines = [lineOf("a", 11)];
+    expect(cropOverlayLinesToWindow(lines, current, 0, current.length - 1)).toBe(lines);
+  });
+
+  it("returns the lines unchanged with no overlays or no current lap", () => {
+    expect(cropOverlayLinesToWindow([], current, 2, 5)).toEqual([]);
+    const lines = [lineOf("a", 11)];
+    expect(cropOverlayLinesToWindow(lines, [], 2, 5)).toBe(lines);
+  });
+
+  it("crops an overlay to the same on-track window as the active lap", () => {
+    const [cropped] = cropOverlayLinesToWindow([lineOf("a", 11)], current, 3, 7);
+    // Window covers lon 3..7; the crop brackets it by one sample each side so the
+    // line reaches the window edges → lon 2..8 (7 samples).
+    expect(cropped.samples.map((s) => s.lon)).toEqual([2, 3, 4, 5, 6, 7, 8]);
+    expect(cropped.id).toBe("a");
+  });
+
+  it("preserves label/color/id of each line", () => {
+    const line: OverlayLine = { id: "snap:s1", label: "Engine · 1:02", color: "hsl(1,2%,3%)", samples: lineOf("x", 11).samples };
+    const [cropped] = cropOverlayLinesToWindow([line], current, 4, 6);
+    expect(cropped.id).toBe("snap:s1");
+    expect(cropped.label).toBe("Engine · 1:02");
+    expect(cropped.color).toBe("hsl(1,2%,3%)");
+  });
+
+  it("leaves a degenerate single-point line untouched", () => {
+    const tiny: OverlayLine = { id: "t", label: "t", color: "x", samples: [sample(0, 0)] };
+    const [out] = cropOverlayLinesToWindow([tiny], current, 3, 7);
+    expect(out.samples).toHaveLength(1);
   });
 });

--- a/src/lib/lapOverlays.ts
+++ b/src/lib/lapOverlays.ts
@@ -18,6 +18,7 @@ import type { GpsSample, Lap } from '@/types/racing';
 import type { LapSnapshot } from './lapSnapshot';
 import { snapshotLapSamples } from './lapSnapshot';
 import { formatLapTime } from './lapCalculation';
+import { calculateDistanceArray } from './referenceUtils';
 
 export interface OverlayLine {
   /** Stable identity — `lap:<n>` or `snap:<id>`. */
@@ -143,4 +144,52 @@ export function unionBounds(base: MapBounds, lines: OverlayLine[]): MapBounds {
     }
   }
   return { minLat, maxLat, minLon, maxLon };
+}
+
+/**
+ * Crop each overlay line to the same on-track window as the current lap's
+ * visible playback range, so cropping the range shrinks the overlay racing
+ * lines on the map exactly like the active heatmap line (the charts already do
+ * this via {@link alignByDistance}).
+ *
+ * The window is the cumulative-distance span between `rangeStart` and
+ * `rangeEnd` (inclusive indices into `currentFull`, the full current lap); each
+ * overlay is sliced to the samples falling in that distance span. Both laps
+ * start at the start-finish line, so distance-from-start corresponds to track
+ * position — the same correspondence the charts use. Returns the lines
+ * unchanged when the range already spans the whole lap (the common case).
+ */
+export function cropOverlayLinesToWindow(
+  lines: OverlayLine[],
+  currentFull: GpsSample[],
+  rangeStart: number,
+  rangeEnd: number,
+): OverlayLine[] {
+  if (lines.length === 0 || currentFull.length === 0) return lines;
+  const lastIdx = currentFull.length - 1;
+  const start = Math.max(0, Math.min(rangeStart, lastIdx));
+  const end = Math.max(start, Math.min(rangeEnd, lastIdx));
+  // Whole lap visible — nothing to crop.
+  if (start <= 0 && end >= lastIdx) return lines;
+
+  const cum = calculateDistanceArray(currentFull);
+  const dStart = cum[start];
+  const dEnd = cum[end];
+
+  return lines.map((line) => {
+    if (line.samples.length < 2) return line;
+    const ov = calculateDistanceArray(line.samples);
+    // First sample at/after the window start; keep the one before (when any) so
+    // the cropped line reaches the window's leading edge rather than starting a
+    // sample short.
+    let lo = ov.findIndex((d) => d >= dStart);
+    if (lo === -1) lo = ov.length - 1;
+    if (lo > 0) lo -= 1;
+    // Last sample at/before the window end; extend one past it (when any) so the
+    // line reaches the trailing edge.
+    let hi = lo;
+    while (hi < ov.length - 1 && ov[hi + 1] <= dEnd) hi++;
+    if (hi < ov.length - 1) hi++;
+    return { ...line, samples: line.samples.slice(lo, hi + 1) };
+  });
 }


### PR DESCRIPTION
## The bug

Narrowing the playback **range slider** crops the active lap's speed-heatmap line (and the comparison charts) down to the selected on-track section — but the **overlaid laps/snapshots** on the race-line map and the Pro **mini-map** stayed drawn at *full lap length*. So cropping the playback area only appeared to crop the active line, leaving the overlay comparison lines uncropped and cluttering the view.

The charts already crop overlays correctly (`alignByDistance(...).slice(start, end)` in `TelemetryChart`); the maps just never did the equivalent.

## The fix

- New pure, unit-tested helper `cropOverlayLinesToWindow()` in `lib/lapOverlays.ts`. It slices each overlay line to the same **cumulative-distance window** as the active lap's visible range (both laps start at the start-finish line, so distance-from-start corresponds to track position — the same correspondence the charts use). Returns the lines unchanged when the range spans the whole lap (the common case), so there's no cost when uncropped.
- `RaceLineView` and `MiniMap` now take a `rangeStart` prop and crop overlays through that helper before drawing — and feed the cropped extents into the map's `fitBounds` too. The legend still lists the full overlay set (labels/colors/remove unchanged).
- Threaded `rangeStart={visibleRange[0]}` from `RaceLineTab` and `GraphViewPanel`.

## Tests

Added `cropOverlayLinesToWindow` coverage to `lapOverlays.test.ts` (whole-lap no-op, empty inputs, inner-window crop with edge-bracketing, label/color/id preservation, degenerate single-point line). 

`npm run lint`, `npm run typecheck`, `npm run test:run` (898 passing), and `npm run build` all green.

https://claude.ai/code/session_0116WfgRYsHCZsJ3wjRFpiEE

---
_Generated by [Claude Code](https://claude.ai/code/session_0116WfgRYsHCZsJ3wjRFpiEE)_