### PR TITLE
Add per-graph height resize handles in Pro mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Resizable Pro-mode graphs.** Each graph in the Pro view (and the G-G diagram)
+  now has a drag handle along its bottom edge — grab it and drag up/down to set
+  that graph's height individually. Heights are saved per session (and sync with
+  the rest of your graph layout when cloud sync is on), so a layout you tune for
+  one log comes back the next time you open it.
 - **"Open Garage" shortcut in the Pro vehicle tab.** When no vehicle is linked to
   the session, the Pro-view **Vehicle** tab now shows an **Open Garage** button
   below **Save Selection** that opens the file-manager drawer straight to the

--- a/src/components/graphview/GGDiagram.tsx
+++ b/src/components/graphview/GGDiagram.tsx
@@ -5,6 +5,10 @@ import { computeSmoothingWindowSize } from '@/lib/chartUtils';
 import { pickGForcePair, computeGGPoints, computeGGAxisMax } from '@/lib/ggDiagram';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
+import { GraphResizeHandle } from './GraphResizeHandle';
+
+/** Default height (px) for the G-G diagram card. */
+export const GG_DEFAULT_HEIGHT = 240;
 
 interface GGDiagramProps {
   samples: GpsSample[];
@@ -12,17 +16,26 @@ interface GGDiagramProps {
   currentIndex: number;
   label: string;
   onDelete: () => void;
+  /** Committed card height (px); defaults to GG_DEFAULT_HEIGHT. */
+  height?: number;
+  /** Persist a new card height (fired on resize-drag release). */
+  onHeightChange?: (height: number) => void;
 }
 
 const SESSION_COLOR = 'hsl(180, 70%, 55%)'; // cyan cloud (matches speed series)
 const CURRENT_COLOR = 'hsl(0, 75%, 55%)';   // red current point
 
-export function GGDiagram({ samples, referenceSamples, currentIndex, label, onDelete }: GGDiagramProps) {
+export function GGDiagram({ samples, referenceSamples, currentIndex, label, onDelete, height, onHeightChange }: GGDiagramProps) {
   const { gForceSmoothing, gForceSmoothingStrength, gForceSource, darkMode } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  // Live card height — driven by the resize handle, seeded from the committed prop.
+  const committedHeight = height ?? GG_DEFAULT_HEIGHT;
+  const [cardHeight, setCardHeight] = useState(committedHeight);
+  useEffect(() => { setCardHeight(committedHeight); }, [committedHeight]);
 
   const smoothingWindow = useMemo(
     () => computeSmoothingWindowSize(gForceSmoothing, gForceSmoothingStrength),
@@ -167,7 +180,7 @@ export function GGDiagram({ samples, referenceSamples, currentIndex, label, onDe
   }, [dimensions, sessionPoints, refPoints, axisMax, currentIndex, pair, chartColors]);
 
   return (
-    <div className="relative border-b border-border" style={{ minHeight: '200px', height: '240px' }}>
+    <div className="relative border-b border-border flex flex-col" style={{ height: `${cardHeight}px` }}>
       <div className="absolute top-1 left-2 z-10 flex items-center gap-1.5 pointer-events-none">
         <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: SESSION_COLOR }} />
         <span className="text-xs font-mono text-muted-foreground">{label}</span>
@@ -179,9 +192,14 @@ export function GGDiagram({ samples, referenceSamples, currentIndex, label, onDe
       >
         <X className="w-3.5 h-3.5" />
       </button>
-      <div ref={containerRef} className="w-full h-full min-h-0 overflow-hidden">
+      <div ref={containerRef} className="flex-1 w-full min-h-0 overflow-hidden">
         <canvas ref={canvasRef} className="block w-full h-full" />
       </div>
+      <GraphResizeHandle
+        height={cardHeight}
+        onResize={setCardHeight}
+        onCommit={(h) => { setCardHeight(h); onHeightChange?.(h); }}
+      />
     </div>
   );
 }

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -38,6 +38,7 @@ export function GraphPanel({
 }: GraphPanelProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   const [activeGraphs, setActiveGraphs] = useState<string[]>([]);
+  const [graphHeights, setGraphHeights] = useState<Record<string, number>>({});
   const loadedFileRef = useRef<string | null>(null);
 
   // Load saved graph prefs when session changes
@@ -45,15 +46,21 @@ export function GraphPanel({
     if (!sessionFileName || sessionFileName === loadedFileRef.current) return;
     loadedFileRef.current = sessionFileName;
     loadGraphPrefs(sessionFileName).then(saved => {
-      if (saved.length > 0) setActiveGraphs(saved);
+      if (saved.activeGraphs.length > 0) setActiveGraphs(saved.activeGraphs);
+      setGraphHeights(saved.graphHeights);
     }).catch(() => {});
   }, [sessionFileName]);
 
-  // Persist whenever activeGraphs change (skip initial empty state before load)
+  // Persist whenever active graphs or their heights change (skip initial empty
+  // state before load).
   useEffect(() => {
     if (!sessionFileName || loadedFileRef.current !== sessionFileName) return;
-    saveGraphPrefs(sessionFileName, activeGraphs).catch(() => {});
-  }, [activeGraphs, sessionFileName]);
+    saveGraphPrefs(sessionFileName, activeGraphs, graphHeights).catch(() => {});
+  }, [activeGraphs, graphHeights, sessionFileName]);
+
+  const setGraphHeight = useCallback((key: string, height: number) => {
+    setGraphHeights(prev => ({ ...prev, [key]: height }));
+  }, []);
 
   const hasReference = referenceSamples.length > 0;
 
@@ -188,6 +195,12 @@ export function GraphPanel({
 
   const removeGraph = useCallback((key: string) => {
     setActiveGraphs(prev => prev.filter(k => k !== key));
+    setGraphHeights(prev => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
   }, []);
 
   const getColor = (key: string) => {
@@ -235,6 +248,8 @@ export function GraphPanel({
                   currentIndex={currentIndex}
                   label={getLabel(key)}
                   onDelete={() => removeGraph(key)}
+                  height={graphHeights[key]}
+                  onHeightChange={(h) => setGraphHeight(key, h)}
                 />
               ) : (
                 <SingleSeriesChart
@@ -251,6 +266,8 @@ export function GraphPanel({
                   allSamples={filteredSamples}
                   rangeStart={visibleRange[0]}
                   overlayLines={overlayLines}
+                  height={graphHeights[key]}
+                  onHeightChange={(h) => setGraphHeight(key, h)}
                 />
               )
             ))}

--- a/src/components/graphview/GraphResizeHandle.tsx
+++ b/src/components/graphview/GraphResizeHandle.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Min/max pixel height a pro-mode graph can be dragged to. */
+export const GRAPH_MIN_HEIGHT = 120;
+export const GRAPH_MAX_HEIGHT = 800;
+
+interface GraphResizeHandleProps {
+  /** Current committed height (px) — the drag starts from here. */
+  height: number;
+  /** Live update on each drag move (transient, not persisted). */
+  onResize: (height: number) => void;
+  /** Fired once on pointer release with the final height (persist here). */
+  onCommit: (height: number) => void;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * A slim drag bar pinned to the bottom of a graph card. Pointer-drag adjusts the
+ * card's height; the parent owns the height value (so it can persist per session).
+ * Shared by SingleSeriesChart + GGDiagram.
+ */
+export function GraphResizeHandle({
+  height,
+  onResize,
+  onCommit,
+  min = GRAPH_MIN_HEIGHT,
+  max = GRAPH_MAX_HEIGHT,
+}: GraphResizeHandleProps) {
+  const [dragging, setDragging] = useState(false);
+  const startY = useRef(0);
+  const startH = useRef(height);
+  const latest = useRef(height);
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    const next = Math.max(min, Math.min(max, startH.current + (e.clientY - startY.current)));
+    latest.current = next;
+    onResize(next);
+  }, [min, max, onResize]);
+
+  const onPointerUp = useCallback(() => {
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    setDragging(false);
+    onCommit(latest.current);
+  }, [onPointerMove, onCommit]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    startY.current = e.clientY;
+    startH.current = height;
+    latest.current = height;
+    setDragging(true);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+  }, [height, onPointerMove, onPointerUp]);
+
+  // Safety net: detach window listeners if we unmount mid-drag.
+  useEffect(() => () => {
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+  }, [onPointerMove, onPointerUp]);
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      className="group/handle shrink-0 h-2 flex items-center justify-center cursor-ns-resize z-20 touch-none"
+      title="Drag to resize"
+      role="separator"
+      aria-orientation="horizontal"
+    >
+      <div
+        className={`h-1 w-10 rounded-full transition-colors ${
+          dragging ? 'bg-primary' : 'bg-border group-hover/handle:bg-primary/60'
+        }`}
+      />
+    </div>
+  );
+}

--- a/src/components/graphview/GraphResizeHandle.tsx
+++ b/src/components/graphview/GraphResizeHandle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 /** Min/max pixel height a pro-mode graph can be dragged to. */
 export const GRAPH_MIN_HEIGHT = 120;
@@ -19,6 +19,11 @@ interface GraphResizeHandleProps {
  * A slim drag bar pinned to the bottom of a graph card. Pointer-drag adjusts the
  * card's height; the parent owns the height value (so it can persist per session).
  * Shared by SingleSeriesChart + GGDiagram.
+ *
+ * Uses pointer capture so the drag keeps tracking even when the finger/cursor
+ * leaves the slim handle — without it, mobile touches escape the 8px target and
+ * the browser reclaims the gesture as a scroll (firing pointercancel), which is
+ * why the drag would only move a few pixels at a time.
  */
 export function GraphResizeHandle({
   height,
@@ -28,42 +33,41 @@ export function GraphResizeHandle({
   max = GRAPH_MAX_HEIGHT,
 }: GraphResizeHandleProps) {
   const [dragging, setDragging] = useState(false);
+  const draggingRef = useRef(false);
   const startY = useRef(0);
   const startH = useRef(height);
   const latest = useRef(height);
 
-  const onPointerMove = useCallback((e: PointerEvent) => {
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    startY.current = e.clientY;
+    startH.current = height;
+    latest.current = height;
+    draggingRef.current = true;
+    setDragging(true);
+  }, [height]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!draggingRef.current) return;
     const next = Math.max(min, Math.min(max, startH.current + (e.clientY - startY.current)));
     latest.current = next;
     onResize(next);
   }, [min, max, onResize]);
 
-  const onPointerUp = useCallback(() => {
-    window.removeEventListener('pointermove', onPointerMove);
-    window.removeEventListener('pointerup', onPointerUp);
+  const endDrag = useCallback(() => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
     setDragging(false);
     onCommit(latest.current);
-  }, [onPointerMove, onCommit]);
-
-  const onPointerDown = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    startY.current = e.clientY;
-    startH.current = height;
-    latest.current = height;
-    setDragging(true);
-    window.addEventListener('pointermove', onPointerMove);
-    window.addEventListener('pointerup', onPointerUp);
-  }, [height, onPointerMove, onPointerUp]);
-
-  // Safety net: detach window listeners if we unmount mid-drag.
-  useEffect(() => () => {
-    window.removeEventListener('pointermove', onPointerMove);
-    window.removeEventListener('pointerup', onPointerUp);
-  }, [onPointerMove, onPointerUp]);
+  }, [onCommit]);
 
   return (
     <div
       onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
       className="group/handle shrink-0 h-2 flex items-center justify-center cursor-ns-resize z-20 touch-none"
       title="Drag to resize"
       role="separator"

--- a/src/components/graphview/SingleSeriesChart.tsx
+++ b/src/components/graphview/SingleSeriesChart.tsx
@@ -7,6 +7,10 @@ import { getChartColors } from '@/lib/chartColors';
 import { buildChartAxis } from '@/lib/chartAxis';
 import { alignByDistance } from '@/lib/referenceUtils';
 import type { OverlayLine } from '@/lib/lapOverlays';
+import { GraphResizeHandle } from './GraphResizeHandle';
+
+/** Default height (px) for a single-series chart card. */
+export const SINGLE_SERIES_DEFAULT_HEIGHT = 180;
 
 interface SingleSeriesChartProps {
   samples: GpsSample[];
@@ -24,6 +28,10 @@ interface SingleSeriesChartProps {
   rangeStart?: number;
   /** Extra laps/snapshots to overlay (distance-aligned) for this series. */
   overlayLines?: OverlayLine[];
+  /** Committed card height (px); defaults to SINGLE_SERIES_DEFAULT_HEIGHT. */
+  height?: number;
+  /** Persist a new card height (fired on resize-drag release). */
+  onHeightChange?: (height: number) => void;
 }
 
 export function SingleSeriesChart({
@@ -31,6 +39,7 @@ export function SingleSeriesChart({
   color, label, onDelete,
   referenceValues = null, brakingGValues,
   allSamples, rangeStart, overlayLines = [],
+  height, onHeightChange,
 }: SingleSeriesChartProps) {
   const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
@@ -42,6 +51,12 @@ export function SingleSeriesChart({
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [isDragging, setIsDragging] = useState(false);
+
+  // Live card height — driven by the resize handle, seeded from the committed
+  // prop and re-synced whenever the parent's value changes.
+  const committedHeight = height ?? SINGLE_SERIES_DEFAULT_HEIGHT;
+  const [cardHeight, setCardHeight] = useState(committedHeight);
+  useEffect(() => { setCardHeight(committedHeight); }, [committedHeight]);
 
   const isSpeed = seriesKey === 'speed';
   const isPace = seriesKey === '__pace__';
@@ -373,7 +388,7 @@ export function SingleSeriesChart({
   const handleTouchMove = (e: React.TouchEvent) => { if (isDragging) handleScrub(e.touches[0].clientX); };
 
   return (
-    <div className="relative border-b border-border" style={{ minHeight: '150px', height: '180px' }}>
+    <div className="relative border-b border-border flex flex-col" style={{ height: `${cardHeight}px` }}>
       {/* Header */}
       <div className="absolute top-1 left-2 z-10 flex items-center gap-1.5">
         <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
@@ -388,7 +403,7 @@ export function SingleSeriesChart({
       </button>
       <div
         ref={containerRef}
-        className="w-full h-full min-h-0 overflow-hidden cursor-crosshair"
+        className="flex-1 w-full min-h-0 overflow-hidden cursor-crosshair"
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
@@ -399,6 +414,11 @@ export function SingleSeriesChart({
       >
         <canvas ref={canvasRef} className="block w-full h-full" />
       </div>
+      <GraphResizeHandle
+        height={cardHeight}
+        onResize={setCardHeight}
+        onCommit={(h) => { setCardHeight(h); onHeightChange?.(h); }}
+      />
     </div>
   );
 }

--- a/src/lib/graphPrefsStorage.test.ts
+++ b/src/lib/graphPrefsStorage.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { migrateGraphPrefs } from "./graphPrefsStorage";
+
+describe("migrateGraphPrefs", () => {
+  it("returns empty prefs for a missing record", () => {
+    expect(migrateGraphPrefs(undefined)).toEqual({
+      activeGraphs: [],
+      graphHeights: {},
+    });
+  });
+
+  it("defaults graphHeights to an empty map for legacy records without it", () => {
+    const result = migrateGraphPrefs({
+      sessionFileName: "run.dove",
+      activeGraphs: ["speed"],
+    });
+    expect(result).toEqual({ activeGraphs: ["speed"], graphHeights: {} });
+  });
+
+  it("migrates legacy display-name keys in both lists and the height map", () => {
+    const result = migrateGraphPrefs({
+      sessionFileName: "run.dove",
+      activeGraphs: ["speed", "Lat G", "Gizmo Voltage"],
+      graphHeights: { "Lat G": 300, "Gizmo Voltage": 220 },
+    });
+    expect(result.activeGraphs).toEqual(["speed", "lat_g", "custom:gizmo_voltage"]);
+    expect(result.graphHeights).toEqual({
+      lat_g: 300,
+      "custom:gizmo_voltage": 220,
+    });
+  });
+
+  it("leaves synthetic keys (speed / __pace__) untouched in the height map", () => {
+    const result = migrateGraphPrefs({
+      sessionFileName: "run.dove",
+      activeGraphs: ["speed", "__pace__"],
+      graphHeights: { speed: 200, __pace__: 160 },
+    });
+    expect(result.graphHeights).toEqual({ speed: 200, __pace__: 160 });
+  });
+});

--- a/src/lib/graphPrefsStorage.ts
+++ b/src/lib/graphPrefsStorage.ts
@@ -1,5 +1,5 @@
 /**
- * Persist active graph selections per session file in IndexedDB.
+ * Persist active graph selections + per-graph heights per session file in IndexedDB.
  */
 import { STORE_NAMES, withReadTransaction, withWriteTransaction } from './dbUtils';
 import { toChannelKey } from './channels';
@@ -7,6 +7,14 @@ import { toChannelKey } from './channels';
 interface GraphPrefsRecord {
   sessionFileName: string;
   activeGraphs: string[];
+  /** Per-graph pixel height, keyed by the same series key as activeGraphs. */
+  graphHeights?: Record<string, number>;
+}
+
+/** Resolved prefs returned to the UI (keys already migrated to channel ids). */
+export interface GraphPrefs {
+  activeGraphs: string[];
+  graphHeights: Record<string, number>;
 }
 
 const STORE = STORE_NAMES.GRAPH_PREFS;
@@ -18,18 +26,36 @@ function migrateGraphKey(key: string): string {
   return toChannelKey(key);
 }
 
-export async function saveGraphPrefs(sessionFileName: string, activeGraphs: string[]): Promise<void> {
+/**
+ * Migrate a persisted record's legacy display-name keys to canonical channel
+ * ids — for both the active-graph list and the height map. Pure (no IDB) so it
+ * stays unit-testable.
+ */
+export function migrateGraphPrefs(record: GraphPrefsRecord | undefined): GraphPrefs {
+  const activeGraphs = (record?.activeGraphs ?? []).map(migrateGraphKey);
+  const graphHeights: Record<string, number> = {};
+  for (const [key, height] of Object.entries(record?.graphHeights ?? {})) {
+    graphHeights[migrateGraphKey(key)] = height;
+  }
+  return { activeGraphs, graphHeights };
+}
+
+export async function saveGraphPrefs(
+  sessionFileName: string,
+  activeGraphs: string[],
+  graphHeights: Record<string, number> = {},
+): Promise<void> {
   await withWriteTransaction(STORE, (store) => {
-    store.put({ sessionFileName, activeGraphs } satisfies GraphPrefsRecord);
+    store.put({ sessionFileName, activeGraphs, graphHeights } satisfies GraphPrefsRecord);
   });
 }
 
-export async function loadGraphPrefs(sessionFileName: string): Promise<string[]> {
+export async function loadGraphPrefs(sessionFileName: string): Promise<GraphPrefs> {
   const record = await withReadTransaction<GraphPrefsRecord | undefined>(
     STORE,
     (store) => store.get(sessionFileName),
   );
-  return (record?.activeGraphs ?? []).map(migrateGraphKey);
+  return migrateGraphPrefs(record);
 }
 
 export async function deleteGraphPrefs(sessionFileName: string): Promise<void> {


### PR DESCRIPTION
## What & why

With overlays now packing a lot into the Pro graph view, every graph was locked
to a fixed height. This adds a **drag handle on the bottom edge of each graph**
(and the G-G diagram) so users can size each one individually — taller for the
channel they're studying, shorter for the rest.

## How it works

- **`GraphResizeHandle`** — a new reusable slim drag bar (pointer events, clamped
  120–800px). Lives in-flow at the bottom of the card so it never overlaps the
  canvas axis labels.
- **`SingleSeriesChart` / `GGDiagram`** take an optional `height` +
  `onHeightChange`. Each was restructured to a flex column (canvas fills, handle
  pinned below). Live drag updates local state for smooth feedback; release
  commits the final height to the parent.
- **`GraphPanel`** owns the per-series height map, passes it down, persists on
  drag release, and prunes a graph's height when it's removed.
- **`graphPrefsStorage`** now stores `graphHeights` alongside `activeGraphs` in
  the same `graph-prefs` record — so heights persist per session and ride the
  existing cloud-sync of that store with no schema change (it's a jsonb doc).
  A pure `migrateGraphPrefs` helper migrates legacy display-name keys in both the
  active-graph list **and** the height map.

## Persistence / sync

Heights save per session file. Because `graph-prefs` already syncs as a jsonb
document (`syncStores.ts`), no migration or schema change is needed — the new
field travels for free.

## Tests & checks

- New unit tests for `migrateGraphPrefs` (empty/legacy/synthetic-key cases).
- `npm run lint`, `npm run typecheck`, `npm run test:run` (897 passing), and
  `npm run build` all green.
- `CHANGELOG.md` updated under `[Unreleased]`.

https://claude.ai/code/session_01HgXe3sxpDpQXrGpn981u8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgXe3sxpDpQXrGpn981u8n)_