### PR TITLE
Collapse the overlay legend on the maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Hide overlay lines from the maps.** The multi-lap overlay legend (both the
+  race-line map and the pro-mode MiniMap) now has a show/hide toggle. With many
+  overlays loaded the racing lines and legend can overwhelm the map, so one tap
+  tucks every overlay line away — collapsing the legend to a compact "N hidden"
+  pill — without dropping the selections (the charts and the picker keep them).
+  Tap again to bring them back.
+
 ### Changed
 - **About dialog feature list refreshed.** The home-screen **About** popup now
   lists the analysis features added across the last two releases — the G-G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Hide overlay lines from the maps.** The multi-lap overlay legend (both the
-  race-line map and the pro-mode MiniMap) now has a show/hide toggle. With many
-  overlays loaded the racing lines and legend can overwhelm the map, so one tap
-  tucks every overlay line away — collapsing the legend to a compact "N hidden"
-  pill — without dropping the selections (the charts and the picker keep them).
-  Tap again to bring them back.
+- **Collapse the overlay legend on the maps.** The multi-lap overlay legend
+  (both the race-line map and the pro-mode MiniMap) now has a collapse toggle.
+  With many overlays loaded the per-lap list can bury the map under labels, so
+  one tap folds it down to a compact "N overlays" pill — **the racing lines stay
+  drawn on the map**, only the list is hidden. Tap again to expand.
 
 ### Changed
 - **About dialog feature list refreshed.** The home-screen **About** popup now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -685,8 +685,12 @@ toggle. **Cross-session overlays (`snap:`/`file:`) can be drift-aligned** onto t
 current lap via `lib/lapAlignment.ts` (2D Kabsch rigid registration, map-only —
 charts compare by distance and are transform-invariant); same-session `lap:`
 overlays are never transformed. The **Align lines** toggle lives on the map
-legend (`useLapOverlays.alignOverlays`, default on). **The current lap always
-renders on top** —
+legend (`useLapOverlays.alignOverlays`, default on). A sibling **show/hide
+overlays** toggle (`useLapOverlays.overlaysVisible`, default on; same legend on
+both `RaceLineView` + `MiniMap`) drops every overlay line from the *maps* without
+clearing the selections — collapsing the legend to an "N hidden" pill — so a
+crowded 5+ line-up doesn't overwhelm the race line (map-only; charts + picker keep
+the selections). **The current lap always renders on top** —
 maps put overlays in a layer beneath the current heatmap; charts draw overlay
 traces before the current line. Chart overlays distance-align each lap onto the
 current lap via `alignByDistance` (`referenceUtils.ts`), over the full lap then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -685,12 +685,12 @@ toggle. **Cross-session overlays (`snap:`/`file:`) can be drift-aligned** onto t
 current lap via `lib/lapAlignment.ts` (2D Kabsch rigid registration, map-only —
 charts compare by distance and are transform-invariant); same-session `lap:`
 overlays are never transformed. The **Align lines** toggle lives on the map
-legend (`useLapOverlays.alignOverlays`, default on). A sibling **show/hide
-overlays** toggle (`useLapOverlays.overlaysVisible`, default on; same legend on
-both `RaceLineView` + `MiniMap`) drops every overlay line from the *maps* without
-clearing the selections — collapsing the legend to an "N hidden" pill — so a
-crowded 5+ line-up doesn't overwhelm the race line (map-only; charts + picker keep
-the selections). **The current lap always renders on top** —
+legend (`useLapOverlays.alignOverlays`, default on). A sibling **collapse-legend**
+toggle (`useLapOverlays.showOverlayLegend`, default on; same legend on both
+`RaceLineView` + `MiniMap`) folds the per-lap *list* down to a compact "N overlays"
+pill so a crowded 5+ line-up doesn't bury the map under labels — the racing lines
+themselves stay drawn (it hides only the legend chrome, not the overlays).
+**The current lap always renders on top** —
 maps put overlays in a layer beneath the current heatmap; charts draw overlay
 traces before the current line. Chart overlays distance-align each lap onto the
 current lap via `alignByDistance` (`referenceUtils.ts`), over the full lap then

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -10,7 +10,7 @@ import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Moon, Satellite, Square, WifiOff, CloudSun, FileText, X, Crosshair } from 'lucide-react';
+import { Moon, Satellite, Square, WifiOff, CloudSun, FileText, X, Crosshair, Eye, EyeOff } from 'lucide-react';
 import { WeatherPanel } from '@/components/WeatherPanel';
 import { LocalWeatherDialog } from '@/components/LocalWeatherDialog';
 import { WeatherStation, WeatherData } from '@/lib/weatherService';
@@ -67,6 +67,9 @@ interface RaceLineViewProps {
   /** Whether cross-session overlays are drift-aligned onto the current lap. */
   alignOverlays?: boolean;
   onToggleAlignOverlays?: () => void;
+  /** Show the overlay racing lines on the map (selections survive when off). */
+  overlaysVisible?: boolean;
+  onToggleOverlaysVisible?: () => void;
 }
 
 // Get speed color (green -> yellow -> orange -> red)
@@ -148,7 +151,7 @@ function createSpeedEventIcon(event: SpeedEvent, useKph: boolean): L.DivIcon {
   });
 }
 
-export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays }: RaceLineViewProps) {
+export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, overlaysVisible = true, onToggleOverlaysVisible }: RaceLineViewProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   // Use allSamples for statistics if provided, otherwise fall back to samples
   const samplesForStats = allSamples ?? samples;
@@ -157,8 +160,10 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
   // cropping the range shrinks them on the map exactly like the heatmap line
   // (`samples` is already the cropped window; `samplesForStats` is the full lap).
   const drawnOverlayLines = useMemo(
-    () => cropOverlayLinesToWindow(overlayLines, samplesForStats, rangeStart, rangeStart + samples.length - 1),
-    [overlayLines, samplesForStats, rangeStart, samples.length],
+    () => overlaysVisible
+      ? cropOverlayLinesToWindow(overlayLines, samplesForStats, rangeStart, rangeStart + samples.length - 1)
+      : [],
+    [overlaysVisible, overlayLines, samplesForStats, rangeStart, samples.length],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -573,7 +578,19 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
       {/* Multi-lap overlay legend - bottom center */}
       {overlayLines.length > 0 && (
         <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-[1000] flex max-w-[70%] flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded bg-card/90 backdrop-blur-sm border border-border px-2.5 py-1.5">
-          {onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
+          {/* Show/hide the overlay lines without dropping the selections — keeps a
+              crowded line-up (5+ overlays) from overwhelming the map. */}
+          {onToggleOverlaysVisible && (
+            <button
+              onClick={onToggleOverlaysVisible}
+              className={`flex items-center gap-1.5 text-xs font-mono ${overlaysVisible ? 'text-primary' : 'text-muted-foreground'}`}
+              title={overlaysVisible ? 'Hide overlay lines' : `Show ${overlayLines.length} overlay line${overlayLines.length === 1 ? '' : 's'}`}
+            >
+              {overlaysVisible ? <Eye className="w-3 h-3 shrink-0" /> : <EyeOff className="w-3 h-3 shrink-0" />}
+              <span>{overlaysVisible ? 'Overlays' : `${overlayLines.length} hidden`}</span>
+            </button>
+          )}
+          {overlaysVisible && onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
             <button
               onClick={onToggleAlignOverlays}
               className={`flex items-center gap-1.5 text-xs font-mono ${alignOverlays ? 'text-primary' : 'text-muted-foreground'}`}
@@ -583,7 +600,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
               <span>Align: {alignOverlays ? 'on' : 'off'}</span>
             </button>
           )}
-          {overlayLines.map(line => (
+          {overlaysVisible && overlayLines.map(line => (
             <div key={line.id} className="flex items-center gap-1.5 text-xs font-mono">
               <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: line.color }} />
               <span className="truncate max-w-[140px] text-foreground/90">{line.label}</span>

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -10,7 +10,7 @@ import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Moon, Satellite, Square, WifiOff, CloudSun, FileText, X, Crosshair, Eye, EyeOff } from 'lucide-react';
+import { Moon, Satellite, Square, WifiOff, CloudSun, FileText, X, Crosshair, List, ChevronDown, ChevronUp } from 'lucide-react';
 import { WeatherPanel } from '@/components/WeatherPanel';
 import { LocalWeatherDialog } from '@/components/LocalWeatherDialog';
 import { WeatherStation, WeatherData } from '@/lib/weatherService';
@@ -67,9 +67,9 @@ interface RaceLineViewProps {
   /** Whether cross-session overlays are drift-aligned onto the current lap. */
   alignOverlays?: boolean;
   onToggleAlignOverlays?: () => void;
-  /** Show the overlay racing lines on the map (selections survive when off). */
-  overlaysVisible?: boolean;
-  onToggleOverlaysVisible?: () => void;
+  /** Expand the overlay legend (per-lap list). Racing lines stay drawn when collapsed. */
+  showOverlayLegend?: boolean;
+  onToggleOverlayLegend?: () => void;
 }
 
 // Get speed color (green -> yellow -> orange -> red)
@@ -151,7 +151,7 @@ function createSpeedEventIcon(event: SpeedEvent, useKph: boolean): L.DivIcon {
   });
 }
 
-export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, overlaysVisible = true, onToggleOverlaysVisible }: RaceLineViewProps) {
+export function RaceLineView({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, showOverlayLegend = true, onToggleOverlayLegend }: RaceLineViewProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
   // Use allSamples for statistics if provided, otherwise fall back to samples
   const samplesForStats = allSamples ?? samples;
@@ -160,10 +160,8 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
   // cropping the range shrinks them on the map exactly like the heatmap line
   // (`samples` is already the cropped window; `samplesForStats` is the full lap).
   const drawnOverlayLines = useMemo(
-    () => overlaysVisible
-      ? cropOverlayLinesToWindow(overlayLines, samplesForStats, rangeStart, rangeStart + samples.length - 1)
-      : [],
-    [overlaysVisible, overlayLines, samplesForStats, rangeStart, samples.length],
+    () => cropOverlayLinesToWindow(overlayLines, samplesForStats, rangeStart, rangeStart + samples.length - 1),
+    [overlayLines, samplesForStats, rangeStart, samples.length],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -578,19 +576,20 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
       {/* Multi-lap overlay legend - bottom center */}
       {overlayLines.length > 0 && (
         <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-[1000] flex max-w-[70%] flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded bg-card/90 backdrop-blur-sm border border-border px-2.5 py-1.5">
-          {/* Show/hide the overlay lines without dropping the selections — keeps a
-              crowded line-up (5+ overlays) from overwhelming the map. */}
-          {onToggleOverlaysVisible && (
+          {/* Collapse the per-lap list without touching the racing lines — keeps a
+              crowded line-up (5+ overlays) from burying the map under labels. */}
+          {onToggleOverlayLegend && (
             <button
-              onClick={onToggleOverlaysVisible}
-              className={`flex items-center gap-1.5 text-xs font-mono ${overlaysVisible ? 'text-primary' : 'text-muted-foreground'}`}
-              title={overlaysVisible ? 'Hide overlay lines' : `Show ${overlayLines.length} overlay line${overlayLines.length === 1 ? '' : 's'}`}
+              onClick={onToggleOverlayLegend}
+              className={`flex items-center gap-1.5 text-xs font-mono ${showOverlayLegend ? 'text-primary' : 'text-muted-foreground'}`}
+              title={showOverlayLegend ? 'Collapse overlay list' : `Show overlay list (${overlayLines.length})`}
             >
-              {overlaysVisible ? <Eye className="w-3 h-3 shrink-0" /> : <EyeOff className="w-3 h-3 shrink-0" />}
-              <span>{overlaysVisible ? 'Overlays' : `${overlayLines.length} hidden`}</span>
+              <List className="w-3 h-3 shrink-0" />
+              <span>{showOverlayLegend ? 'Overlays' : `${overlayLines.length} overlay${overlayLines.length === 1 ? '' : 's'}`}</span>
+              {showOverlayLegend ? <ChevronDown className="w-3 h-3 shrink-0" /> : <ChevronUp className="w-3 h-3 shrink-0" />}
             </button>
           )}
-          {overlaysVisible && onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
+          {showOverlayLegend && onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
             <button
               onClick={onToggleAlignOverlays}
               className={`flex items-center gap-1.5 text-xs font-mono ${alignOverlays ? 'text-primary' : 'text-muted-foreground'}`}
@@ -600,7 +599,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], curre
               <span>Align: {alignOverlays ? 'on' : 'off'}</span>
             </button>
           )}
-          {overlaysVisible && overlayLines.map(line => (
+          {showOverlayLegend && overlayLines.map(line => (
             <div key={line.id} className="flex items-center gap-1.5 text-xs font-mono">
               <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: line.color }} />
               <span className="truncate max-w-[140px] text-foreground/90">{line.label}</span>

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -69,6 +69,8 @@ export interface GraphViewPanelProps {
   onRemoveOverlay?: (id: string) => void;
   alignOverlays?: boolean;
   onToggleAlignOverlays?: () => void;
+  overlaysVisible?: boolean;
+  onToggleOverlaysVisible?: () => void;
 }
 
 export function GraphViewPanel(props: GraphViewPanelProps) {
@@ -159,6 +161,8 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
                 onRemoveOverlay={props.onRemoveOverlay}
                 alignOverlays={props.alignOverlays}
                 onToggleAlignOverlays={props.onToggleAlignOverlays}
+                overlaysVisible={props.overlaysVisible}
+                onToggleOverlaysVisible={props.onToggleOverlaysVisible}
               />
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -69,8 +69,8 @@ export interface GraphViewPanelProps {
   onRemoveOverlay?: (id: string) => void;
   alignOverlays?: boolean;
   onToggleAlignOverlays?: () => void;
-  overlaysVisible?: boolean;
-  onToggleOverlaysVisible?: () => void;
+  showOverlayLegend?: boolean;
+  onToggleOverlayLegend?: () => void;
 }
 
 export function GraphViewPanel(props: GraphViewPanelProps) {
@@ -161,8 +161,8 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
                 onRemoveOverlay={props.onRemoveOverlay}
                 alignOverlays={props.alignOverlays}
                 onToggleAlignOverlays={props.onToggleAlignOverlays}
-                overlaysVisible={props.overlaysVisible}
-                onToggleOverlaysVisible={props.onToggleOverlaysVisible}
+                showOverlayLegend={props.showOverlayLegend}
+                onToggleOverlayLegend={props.onToggleOverlayLegend}
               />
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/src/components/graphview/MiniMap.tsx
+++ b/src/components/graphview/MiniMap.tsx
@@ -7,7 +7,7 @@ import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
 import { unionBounds, cropOverlayLinesToWindow, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
-import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X, Crosshair } from 'lucide-react';
+import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X, Crosshair, Eye, EyeOff } from 'lucide-react';
 import 'leaflet/dist/leaflet.css';
 
 type MapStyle = 'dark' | 'satellite' | 'none';
@@ -59,17 +59,22 @@ interface MiniMapProps {
   /** Whether cross-session overlays are drift-aligned onto the current lap. */
   alignOverlays?: boolean;
   onToggleAlignOverlays?: () => void;
+  /** Show the overlay racing lines on the map (selections survive when off). */
+  overlaysVisible?: boolean;
+  onToggleOverlaysVisible?: () => void;
 }
 
-export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays }: MiniMapProps) {
+export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, overlaysVisible = true, onToggleOverlaysVisible }: MiniMapProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
 
   // Crop overlay racing lines to the same playback window as the active lap, so
   // cropping the range shrinks them on the map exactly like the heatmap line
   // (`samples` is the cropped window; `allSamples` is the full current lap).
   const drawnOverlayLines = useMemo(
-    () => cropOverlayLinesToWindow(overlayLines, allSamples, rangeStart, rangeStart + samples.length - 1),
-    [overlayLines, allSamples, rangeStart, samples.length],
+    () => overlaysVisible
+      ? cropOverlayLinesToWindow(overlayLines, allSamples, rangeStart, rangeStart + samples.length - 1)
+      : [],
+    [overlaysVisible, overlayLines, allSamples, rangeStart, samples.length],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -263,7 +268,17 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
       {/* Overlay legend - lower right */}
       {overlayLines.length > 0 && (
         <div className="absolute bottom-2 right-2 z-[1000] max-w-[55%] max-h-[40%] overflow-y-auto rounded bg-card/90 backdrop-blur-sm border border-border p-1.5 space-y-1 scrollbar-thin">
-          {onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
+          {onToggleOverlaysVisible && (
+            <button
+              onClick={onToggleOverlaysVisible}
+              className={`flex w-full items-center gap-1.5 text-[11px] font-mono ${overlaysVisible ? 'text-primary' : 'text-muted-foreground'}`}
+              title={overlaysVisible ? 'Hide overlay lines' : `Show ${overlayLines.length} overlay line${overlayLines.length === 1 ? '' : 's'}`}
+            >
+              {overlaysVisible ? <Eye className="w-3 h-3 shrink-0" /> : <EyeOff className="w-3 h-3 shrink-0" />}
+              <span>{overlaysVisible ? 'Overlay lines' : `${overlayLines.length} hidden`}</span>
+            </button>
+          )}
+          {overlaysVisible && onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
             <button
               onClick={onToggleAlignOverlays}
               className={`flex w-full items-center gap-1.5 text-[11px] font-mono ${alignOverlays ? 'text-primary' : 'text-muted-foreground'}`}
@@ -273,7 +288,7 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
               <span>Align lines: {alignOverlays ? 'on' : 'off'}</span>
             </button>
           )}
-          {overlayLines.map(line => (
+          {overlaysVisible && overlayLines.map(line => (
             <div key={line.id} className="flex items-center gap-1.5 text-[11px] font-mono">
               <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: line.color }} />
               <span className="truncate text-foreground/90">{line.label}</span>

--- a/src/components/graphview/MiniMap.tsx
+++ b/src/components/graphview/MiniMap.tsx
@@ -7,7 +7,7 @@ import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
 import { unionBounds, cropOverlayLinesToWindow, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useSettingsContext } from '@/contexts/SettingsContext';
-import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X, Crosshair, Eye, EyeOff } from 'lucide-react';
+import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X, Crosshair, List, ChevronDown, ChevronUp } from 'lucide-react';
 import 'leaflet/dist/leaflet.css';
 
 type MapStyle = 'dark' | 'satellite' | 'none';
@@ -59,22 +59,20 @@ interface MiniMapProps {
   /** Whether cross-session overlays are drift-aligned onto the current lap. */
   alignOverlays?: boolean;
   onToggleAlignOverlays?: () => void;
-  /** Show the overlay racing lines on the map (selections survive when off). */
-  overlaysVisible?: boolean;
-  onToggleOverlaysVisible?: () => void;
+  /** Expand the overlay legend (per-lap list). Racing lines stay drawn when collapsed. */
+  showOverlayLegend?: boolean;
+  onToggleOverlayLegend?: () => void;
 }
 
-export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, overlaysVisible = true, onToggleOverlaysVisible }: MiniMapProps) {
+export function MiniMap({ samples, allSamples, referenceSamples = [], currentIndex, course, bounds, isAllLaps, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, showOverlayLegend = true, onToggleOverlayLegend }: MiniMapProps) {
   const { useKph, brakingZoneSettings } = useSettingsContext();
 
   // Crop overlay racing lines to the same playback window as the active lap, so
   // cropping the range shrinks them on the map exactly like the heatmap line
   // (`samples` is the cropped window; `allSamples` is the full current lap).
   const drawnOverlayLines = useMemo(
-    () => overlaysVisible
-      ? cropOverlayLinesToWindow(overlayLines, allSamples, rangeStart, rangeStart + samples.length - 1)
-      : [],
-    [overlaysVisible, overlayLines, allSamples, rangeStart, samples.length],
+    () => cropOverlayLinesToWindow(overlayLines, allSamples, rangeStart, rangeStart + samples.length - 1),
+    [overlayLines, allSamples, rangeStart, samples.length],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -268,17 +266,18 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
       {/* Overlay legend - lower right */}
       {overlayLines.length > 0 && (
         <div className="absolute bottom-2 right-2 z-[1000] max-w-[55%] max-h-[40%] overflow-y-auto rounded bg-card/90 backdrop-blur-sm border border-border p-1.5 space-y-1 scrollbar-thin">
-          {onToggleOverlaysVisible && (
+          {onToggleOverlayLegend && (
             <button
-              onClick={onToggleOverlaysVisible}
-              className={`flex w-full items-center gap-1.5 text-[11px] font-mono ${overlaysVisible ? 'text-primary' : 'text-muted-foreground'}`}
-              title={overlaysVisible ? 'Hide overlay lines' : `Show ${overlayLines.length} overlay line${overlayLines.length === 1 ? '' : 's'}`}
+              onClick={onToggleOverlayLegend}
+              className={`flex w-full items-center gap-1.5 text-[11px] font-mono ${showOverlayLegend ? 'text-primary' : 'text-muted-foreground'}`}
+              title={showOverlayLegend ? 'Collapse overlay list' : `Show overlay list (${overlayLines.length})`}
             >
-              {overlaysVisible ? <Eye className="w-3 h-3 shrink-0" /> : <EyeOff className="w-3 h-3 shrink-0" />}
-              <span>{overlaysVisible ? 'Overlay lines' : `${overlayLines.length} hidden`}</span>
+              <List className="w-3 h-3 shrink-0" />
+              <span>{showOverlayLegend ? 'Overlays' : `${overlayLines.length} overlay${overlayLines.length === 1 ? '' : 's'}`}</span>
+              {showOverlayLegend ? <ChevronDown className="w-3 h-3 shrink-0 ml-auto" /> : <ChevronUp className="w-3 h-3 shrink-0 ml-auto" />}
             </button>
           )}
-          {overlaysVisible && onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
+          {showOverlayLegend && onToggleAlignOverlays && overlayLines.some(l => !l.id.startsWith('lap:')) && (
             <button
               onClick={onToggleAlignOverlays}
               className={`flex w-full items-center gap-1.5 text-[11px] font-mono ${alignOverlays ? 'text-primary' : 'text-muted-foreground'}`}
@@ -288,7 +287,7 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], currentInd
               <span>Align lines: {alignOverlays ? 'on' : 'off'}</span>
             </button>
           )}
-          {overlaysVisible && overlayLines.map(line => (
+          {showOverlayLegend && overlayLines.map(line => (
             <div key={line.id} className="flex items-center gap-1.5 text-[11px] font-mono">
               <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: line.color }} />
               <span className="truncate text-foreground/90">{line.label}</span>

--- a/src/components/tabs/GraphViewTab.tsx
+++ b/src/components/tabs/GraphViewTab.tsx
@@ -50,6 +50,8 @@ export const GraphViewTab = memo(function GraphViewTab() {
       onRemoveOverlay={s.onToggleOverlay}
       alignOverlays={s.alignOverlays}
       onToggleAlignOverlays={s.onToggleAlignOverlays}
+      overlaysVisible={s.overlaysVisible}
+      onToggleOverlaysVisible={s.onToggleOverlaysVisible}
     />
   );
 });

--- a/src/components/tabs/GraphViewTab.tsx
+++ b/src/components/tabs/GraphViewTab.tsx
@@ -50,8 +50,8 @@ export const GraphViewTab = memo(function GraphViewTab() {
       onRemoveOverlay={s.onToggleOverlay}
       alignOverlays={s.alignOverlays}
       onToggleAlignOverlays={s.onToggleAlignOverlays}
-      overlaysVisible={s.overlaysVisible}
-      onToggleOverlaysVisible={s.onToggleOverlaysVisible}
+      showOverlayLegend={s.showOverlayLegend}
+      onToggleOverlayLegend={s.onToggleOverlayLegend}
     />
   );
 });

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -43,6 +43,8 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
           onRemoveOverlay={s.onToggleOverlay}
           alignOverlays={s.alignOverlays}
           onToggleAlignOverlays={s.onToggleAlignOverlays}
+          overlaysVisible={s.overlaysVisible}
+          onToggleOverlaysVisible={s.onToggleOverlaysVisible}
         />
       }
       bottomPanel={

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -43,8 +43,8 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
           onRemoveOverlay={s.onToggleOverlay}
           alignOverlays={s.alignOverlays}
           onToggleAlignOverlays={s.onToggleAlignOverlays}
-          overlaysVisible={s.overlaysVisible}
-          onToggleOverlaysVisible={s.onToggleOverlaysVisible}
+          showOverlayLegend={s.showOverlayLegend}
+          onToggleOverlayLegend={s.onToggleOverlayLegend}
         />
       }
       bottomPanel={

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -83,6 +83,9 @@ export interface SessionContextValue {
   /** Drift-align cross-session overlays onto the current lap (map only). */
   alignOverlays: boolean;
   onToggleAlignOverlays: () => void;
+  /** Show the overlay racing lines on the maps (selections survive when off). */
+  overlaysVisible: boolean;
+  onToggleOverlaysVisible: () => void;
   /** Load another saved file's laps for the overlay picker. */
   onLoadOverlayFile: (fileName: string) => Promise<Array<{ lapNumber: number; lapTimeMs: number }> | null>;
   /** Add a lap from a loaded external file as an overlay. */

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -83,9 +83,9 @@ export interface SessionContextValue {
   /** Drift-align cross-session overlays onto the current lap (map only). */
   alignOverlays: boolean;
   onToggleAlignOverlays: () => void;
-  /** Show the overlay racing lines on the maps (selections survive when off). */
-  overlaysVisible: boolean;
-  onToggleOverlaysVisible: () => void;
+  /** Expand the overlay legend (per-lap list) on the maps. Lines stay drawn when collapsed. */
+  showOverlayLegend: boolean;
+  onToggleOverlayLegend: () => void;
   /** Load another saved file's laps for the overlay picker. */
   onLoadOverlayFile: (fileName: string) => Promise<Array<{ lapNumber: number; lapTimeMs: number }> | null>;
   /** Add a lap from a loaded external file as an overlay. */

--- a/src/hooks/useLapOverlays.ts
+++ b/src/hooks/useLapOverlays.ts
@@ -43,6 +43,10 @@ export function useLapOverlays({
   const [overlaySelections, setOverlaySelections] = useState<string[]>([]);
   const [externalOverlays, setExternalOverlays] = useState<Record<string, ExternalOverlay>>({});
   const [alignOverlays, setAlignOverlays] = useState(true);
+  // View-only toggle: hide the overlay racing lines from the maps (and their
+  // legend) without dropping the selections, so a crowded line-up (5+ overlays)
+  // can be tucked away without re-picking each lap. Selections survive.
+  const [overlaysVisible, setOverlaysVisible] = useState(true);
   // Parsed external files (samples + laps) cached by name, for the picker.
   const parsedFiles = useRef<Map<string, { samples: GpsSample[]; laps: Lap[] }>>(new Map());
 
@@ -69,6 +73,7 @@ export function useLapOverlays({
 
   const clearOverlays = useCallback(() => setOverlaySelections([]), []);
   const toggleAlignOverlays = useCallback(() => setAlignOverlays((v) => !v), []);
+  const toggleOverlaysVisible = useCallback(() => setOverlaysVisible((v) => !v), []);
 
   // Load another saved file and compute its laps for the current course (for the
   // overlay picker). Returns the lap list, or null when it can't be used.
@@ -132,6 +137,8 @@ export function useLapOverlays({
     clearOverlays,
     alignOverlays,
     toggleAlignOverlays,
+    overlaysVisible,
+    toggleOverlaysVisible,
     loadOverlayFile,
     addExternalOverlay,
   };

--- a/src/hooks/useLapOverlays.ts
+++ b/src/hooks/useLapOverlays.ts
@@ -43,10 +43,10 @@ export function useLapOverlays({
   const [overlaySelections, setOverlaySelections] = useState<string[]>([]);
   const [externalOverlays, setExternalOverlays] = useState<Record<string, ExternalOverlay>>({});
   const [alignOverlays, setAlignOverlays] = useState(true);
-  // View-only toggle: hide the overlay racing lines from the maps (and their
-  // legend) without dropping the selections, so a crowded line-up (5+ overlays)
-  // can be tucked away without re-picking each lap. Selections survive.
-  const [overlaysVisible, setOverlaysVisible] = useState(true);
+  // View-only toggle: collapse the overlay *legend* (the per-lap list shown on
+  // the maps) without touching the racing lines themselves, so a crowded line-up
+  // (5+ overlays) doesn't bury the map under labels. Lines stay drawn.
+  const [showOverlayLegend, setShowOverlayLegend] = useState(true);
   // Parsed external files (samples + laps) cached by name, for the picker.
   const parsedFiles = useRef<Map<string, { samples: GpsSample[]; laps: Lap[] }>>(new Map());
 
@@ -73,7 +73,7 @@ export function useLapOverlays({
 
   const clearOverlays = useCallback(() => setOverlaySelections([]), []);
   const toggleAlignOverlays = useCallback(() => setAlignOverlays((v) => !v), []);
-  const toggleOverlaysVisible = useCallback(() => setOverlaysVisible((v) => !v), []);
+  const toggleOverlayLegend = useCallback(() => setShowOverlayLegend((v) => !v), []);
 
   // Load another saved file and compute its laps for the current course (for the
   // overlay picker). Returns the lap list, or null when it can't be used.
@@ -137,8 +137,8 @@ export function useLapOverlays({
     clearOverlays,
     alignOverlays,
     toggleAlignOverlays,
-    overlaysVisible,
-    toggleOverlaysVisible,
+    showOverlayLegend,
+    toggleOverlayLegend,
     loadOverlayFile,
     addExternalOverlay,
   };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -196,7 +196,8 @@ export default function Index() {
   // to draw, plus cross-session drift alignment.
   const {
     overlaySelections, overlayLines, toggleOverlay,
-    alignOverlays, toggleAlignOverlays, loadOverlayFile, addExternalOverlay,
+    alignOverlays, toggleAlignOverlays, overlaysVisible, toggleOverlaysVisible,
+    loadOverlayFile, addExternalOverlay,
   } = useLapOverlays({
     data,
     laps,
@@ -383,6 +384,8 @@ export default function Index() {
     onToggleOverlay: toggleOverlay,
     alignOverlays,
     onToggleAlignOverlays: toggleAlignOverlays,
+    overlaysVisible,
+    onToggleOverlaysVisible: toggleOverlaysVisible,
     onLoadOverlayFile: loadOverlayFile,
     onAddExternalOverlay: addExternalOverlay,
     sessionGpsPoint,
@@ -422,7 +425,8 @@ export default function Index() {
     snapshots.snapshotsForCourse, snapshots.activeSnapshotId, snapshots.canSnapshot,
     snapshots.loadSnapshot, snapshots.clearActive, snapshots.saveSelectedLap,
     overlaySelections, overlayLines, toggleOverlay,
-    alignOverlays, toggleAlignOverlays, loadOverlayFile, addExternalOverlay,
+    alignOverlays, toggleAlignOverlays, overlaysVisible, toggleOverlaysVisible,
+    loadOverlayFile, addExternalOverlay,
     activeSnapshot, sessionSetup,
     sessionGpsPoint, currentFileName, sessionKartId, sessionSetupId, cachedWeatherStation,
     vehicleManager.vehicles, setupManager.setups, templateManager.templates,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -196,7 +196,7 @@ export default function Index() {
   // to draw, plus cross-session drift alignment.
   const {
     overlaySelections, overlayLines, toggleOverlay,
-    alignOverlays, toggleAlignOverlays, overlaysVisible, toggleOverlaysVisible,
+    alignOverlays, toggleAlignOverlays, showOverlayLegend, toggleOverlayLegend,
     loadOverlayFile, addExternalOverlay,
   } = useLapOverlays({
     data,
@@ -384,8 +384,8 @@ export default function Index() {
     onToggleOverlay: toggleOverlay,
     alignOverlays,
     onToggleAlignOverlays: toggleAlignOverlays,
-    overlaysVisible,
-    onToggleOverlaysVisible: toggleOverlaysVisible,
+    showOverlayLegend,
+    onToggleOverlayLegend: toggleOverlayLegend,
     onLoadOverlayFile: loadOverlayFile,
     onAddExternalOverlay: addExternalOverlay,
     sessionGpsPoint,
@@ -425,7 +425,7 @@ export default function Index() {
     snapshots.snapshotsForCourse, snapshots.activeSnapshotId, snapshots.canSnapshot,
     snapshots.loadSnapshot, snapshots.clearActive, snapshots.saveSelectedLap,
     overlaySelections, overlayLines, toggleOverlay,
-    alignOverlays, toggleAlignOverlays, overlaysVisible, toggleOverlaysVisible,
+    alignOverlays, toggleAlignOverlays, showOverlayLegend, toggleOverlayLegend,
     loadOverlayFile, addExternalOverlay,
     activeSnapshot, sessionSetup,
     sessionGpsPoint, currentFileName, sessionKartId, sessionSetupId, cachedWeatherStation,


### PR DESCRIPTION
## What

Adds a **collapse toggle** to the multi-lap overlay legend so the per-lap list doesn't bury the map under labels when 5+ overlays are loaded. One tap folds the legend down to a compact "N overlays" pill; tap again to expand.

**The racing lines stay drawn on the map** — only the legend chrome (the align toggle + per-lap label rows) is hidden. This is purely the on-map list panel, not the overlays themselves.

## Why

With drift-aligned overlays it's easy to stack snapshots + laps from several past sessions. The legend lists every one of them, and at 5+ that label panel covers a big chunk of the race-line map. There was no way to dismiss the list without removing the overlays.

## How

- New `showOverlayLegend` state + `toggleOverlayLegend` in `useLapOverlays` (default open), threaded through `SessionContext` like the existing `alignOverlays` toggle.
- A leading `List` + chevron button on the legend (both `RaceLineView` and the pro-mode `MiniMap`) collapses/expands the rest of the panel. The overlay polylines are never gated — they always render.

## Checks

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (910 tests)
- `npm run build` ✅

View-layer only (components + the hook/context seam), so no new unit tests — the overlay-resolution logic in `lib/lapOverlays.ts` is unchanged. CHANGELOG and CLAUDE.md updated.

https://claude.ai/code/session_01Dkr299eavrZR5EzDeBqPRU