### PR TITLE
Add Open-Meteo global fallback so weather works outside the US

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Worldwide weather.** Session + local weather now work outside the US. The
+  precise US path is unchanged (nearest NWS/ASOS station → historical METAR), but
+  when there's no US station (e.g. a session in Europe) it falls back to
+  [Open-Meteo](https://open-meteo.com)'s free, keyless, global historical
+  reanalysis by lat/lon — so temperature, humidity, pressure, density altitude,
+  and wind resolve anywhere. The source is shown in the widget ("Open-Meteo") and
+  cached per session like the station lookup.
 - **Native AiM `.xrk` / `.xrz` import.** MyChron / SoloDL binary logs can now be
   opened directly — drag in a `.xrk` (or zlib-compressed `.xrz`) and it flows
   through the normal analysis/plot pipeline like any other format, including as a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ src/
 │   ├── billing.ts         # ★ Pure subscription logic (tiers, coming-soon, annual-discount math), no Supabase import — see docs/backend.md
 │   ├── billingClient.ts / pendingCheckout.ts   # Supabase billing I/O + sign-up checkout stash
 │   ├── profanity.ts       # Basic client-side profanity filter for display names
-│   ├── weatherService.ts  # OpenWeatherMap (online-only)
+│   ├── weatherService.ts  # Historical weather (online-only): US → NWS station + IEM ASOS METAR; else → Open-Meteo reanalysis fallback (keyless, global). fetchSessionWeather orchestrates.
 │   ├── buildInfo.ts       # Build version/hash/branch/commit-date stamp (landing footer "what changed" marker; main → version+hash, other branches → branch+hash+commit time + amber preview-DB warning via isPreviewBuild(); values injected by vite define)
 │   └── utils.ts           # Tailwind cn() helper
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Built on the shoulders of these incredible open-source projects and free service
 - [Leaflet](https://leafletjs.com) · [OpenStreetMap](https://www.openstreetmap.org)
 - [TanStack Query](https://tanstack.com/query) · [Sonner](https://sonner.emilkowal.dev) · [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels)
 - [mp4-muxer](https://github.com/Vanilagy/mp4-muxer) · [Savitzky-Golay (ml.js)](https://github.com/mljs/savitzky-golay) · [JSZip](https://stuk.github.io/jszip) · [fix-webm-duration](https://github.com/yusitnikov/fix-webm-duration)
-- [IEM ASOS (Iowa State)](https://mesonet.agron.iastate.edu) · [NWS API](https://www.weather.gov/documentation/services-web-api)
+- [IEM ASOS (Iowa State)](https://mesonet.agron.iastate.edu) · [NWS API](https://www.weather.gov/documentation/services-web-api) · [Open-Meteo](https://open-meteo.com) (global weather fallback, CC-BY 4.0)
 - [MoTeC i2](https://www.motec.com.au) (file format reference)
 - [libxrk](https://github.com/m3rlin45/libxrk) (MIT) + [TrackDataAnalysis](https://github.com/racer-coder/TrackDataAnalysis) (MIT) — AiM XRK/XRZ parser (Rust → WebAssembly)
 

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -16,6 +16,7 @@ const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
   ["TanStack Query", "https://tanstack.com/query"],
   ["IEM ASOS (Iowa State)", "https://mesonet.agron.iastate.edu"],
   ["NWS API", "https://www.weather.gov/documentation/services-web-api"],
+  ["Open-Meteo", "https://open-meteo.com"],
   ["Savitzky-Golay (ml.js)", "https://github.com/mljs/savitzky-golay"],
   ["Sonner", "https://sonner.emilkowal.dev"],
   ["react-resizable-panels", "https://github.com/bvaughn/react-resizable-panels"],

--- a/src/components/LocalWeatherDialog.tsx
+++ b/src/components/LocalWeatherDialog.tsx
@@ -10,8 +10,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-  fetchNearestStation,
-  fetchWeatherData,
+  fetchSessionWeather,
   calculateDensityAltitude,
   WeatherStation,
   WeatherData,
@@ -59,18 +58,13 @@ export function LocalWeatherDialog({ sessionWeather, externalOpen, onExternalOpe
     setWeather(null);
 
     try {
-      const foundStation = await fetchNearestStation(lat, lon);
-      if (!foundStation) {
-        setError("No weather station found near this location.");
-        return;
-      }
-      setStation(foundStation);
-
-      const data = await fetchWeatherData(foundStation, new Date());
+      // US → nearest ASOS station; elsewhere → Open-Meteo global reanalysis.
+      const data = await fetchSessionWeather(lat, lon, new Date());
       if (!data) {
-        setError(`Station ${foundStation.stationId} found but no recent METAR data available.`);
+        setError("Weather is unavailable for this location right now.");
         return;
       }
+      setStation(data.station);
       setWeather(data);
     } catch {
       setError("Failed to fetch weather data. Please try again.");
@@ -252,8 +246,14 @@ function WeatherResultsView({ weather, resolvedLocation, showTuningNote = true }
       {/* Station info */}
       <div className="flex items-center justify-between text-xs text-muted-foreground border-b border-border pb-2">
         <span>
-          Station: <span className="font-mono font-medium text-foreground">{weather.station.stationId}</span>
-          {" "}({weather.station.distanceKm} km away)
+          {weather.station.source === "open-meteo" ? (
+            <>Source: <span className="font-medium text-foreground">Open-Meteo</span> (reanalysis)</>
+          ) : (
+            <>
+              Station: <span className="font-mono font-medium text-foreground">{weather.station.stationId}</span>
+              {" "}({weather.station.distanceKm} km away)
+            </>
+          )}
         </span>
         {resolvedLocation && (
           <span className="truncate ml-2 max-w-[150px]" title={resolvedLocation}>

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -3,8 +3,6 @@ import { Cloud, Thermometer, Droplets, Gauge, Wind, Mountain, Navigation } from 
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   fetchSessionWeather,
-  fetchWeatherData,
-  fetchNearestStation,
   isValidGpsPoint,
   WeatherData,
   WeatherStation,
@@ -65,34 +63,19 @@ export function WeatherPanel({
     const doFetch = async () => {
       setLoading(true);
       try {
-        if (cachedStation) {
-          // Skip NWS lookup, go straight to weather data
-          const data = await fetchWeatherData(cachedStation, sessionDate);
-          if (!cancelled) {
-            if (data) {
-              setWeather(data);
-              onWeatherLoadedRef.current?.(data);
-              setError(false);
-            }
-          }
+        // One call: cached/US-ASOS path with an automatic global (Open-Meteo)
+        // fallback, so non-US sessions still resolve.
+        const data = await fetchSessionWeather(lat, lon, sessionDate, cachedStation);
+        if (cancelled) return;
+        if (data) {
+          setWeather(data);
+          onWeatherLoadedRef.current?.(data);
+          // Cache the resolved source (real station or the Open-Meteo marker) so
+          // the next open skips re-resolving it.
+          if (!cachedStation) onStationResolvedRef.current?.(data.station);
+          setError(false);
         } else {
-          // Full lookup: find station then fetch weather
-          const station = await fetchNearestStation(lat, lon);
-          if (cancelled) return;
-          if (!station) {
-            setError(true);
-            return;
-          }
-          // Notify parent so it can cache the station
-          onStationResolvedRef.current?.(station);
-          const data = await fetchWeatherData(station, sessionDate);
-          if (!cancelled) {
-            if (data) {
-              setWeather(data);
-              onWeatherLoadedRef.current?.(data);
-              setError(false);
-            }
-          }
+          setError(true);
         }
       } catch (e) {
         if (!cancelled) {
@@ -129,7 +112,7 @@ export function WeatherPanel({
         <span>Weather</span>
         {weather && (
           <span className="text-muted-foreground ml-auto font-mono text-[10px]">
-            {weather.station.stationId}
+            {weather.station.source === "open-meteo" ? "Open-Meteo" : weather.station.stationId}
           </span>
         )}
       </div>

--- a/src/hooks/useSessionMetadata.ts
+++ b/src/hooks/useSessionMetadata.ts
@@ -20,6 +20,7 @@ export function useSessionMetadata(currentFileName: string | null) {
           stationId: meta.weatherStationId,
           name: meta.weatherStationName || meta.weatherStationId,
           distanceKm: meta.weatherStationDistanceKm || 0,
+          source: meta.weatherStationSource,
         });
       } else {
         setCachedWeatherStation(null);
@@ -43,6 +44,7 @@ export function useSessionMetadata(currentFileName: string | null) {
           weatherStationId: station.stationId,
           weatherStationName: station.name,
           weatherStationDistanceKm: station.distanceKm,
+          weatherStationSource: station.source,
         });
       }
     },

--- a/src/lib/fileStorage.ts
+++ b/src/lib/fileStorage.ts
@@ -18,6 +18,8 @@ export interface FileMetadata {
   weatherStationId?: string;
   weatherStationName?: string;
   weatherStationDistanceKm?: number;
+  /** "asos" (NWS/IEM) or "open-meteo" (global reanalysis); absent = "asos". */
+  weatherStationSource?: "asos" | "open-meteo";
   // Session kart/setup link
   sessionKartId?: string;
   sessionSetupId?: string;

--- a/src/lib/weatherService.test.ts
+++ b/src/lib/weatherService.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildOpenMeteoUrl,
+  parseOpenMeteoResponse,
+  parseOpenMeteoTime,
+  pickNearestHourIndex,
+} from "./weatherService";
+
+describe("parseOpenMeteoTime", () => {
+  it("parses an Open-Meteo UTC hour string", () => {
+    const d = parseOpenMeteoTime("2025-11-04T15:00");
+    expect(d?.toISOString()).toBe("2025-11-04T15:00:00.000Z");
+  });
+  it("returns null for garbage", () => {
+    expect(parseOpenMeteoTime("nope")).toBeNull();
+  });
+});
+
+describe("pickNearestHourIndex", () => {
+  const times = ["2025-11-04T14:00", "2025-11-04T15:00", "2025-11-04T16:00"];
+  it("finds the closest hour to the target", () => {
+    expect(pickNearestHourIndex(times, new Date("2025-11-04T15:40:00Z"))).toBe(2);
+    expect(pickNearestHourIndex(times, new Date("2025-11-04T15:10:00Z"))).toBe(1);
+  });
+  it("returns -1 when nothing parses", () => {
+    expect(pickNearestHourIndex(["x", "y"], new Date())).toBe(-1);
+  });
+});
+
+describe("buildOpenMeteoUrl", () => {
+  const now = new Date("2025-11-20T12:00:00Z");
+
+  it("uses the archive API for sessions older than ~5 days", () => {
+    const url = buildOpenMeteoUrl(45.04, 12.23, new Date("2025-11-04T15:50:00Z"), now);
+    expect(url).toContain("archive-api.open-meteo.com/v1/archive");
+    expect(url).toContain("start_date=2025-11-04");
+    expect(url).toContain("end_date=2025-11-04");
+    expect(url).toContain("latitude=45.0400");
+    expect(url).toContain("longitude=12.2300");
+    expect(url).toContain("wind_speed_unit=kn");
+  });
+
+  it("uses the forecast API (past_days) for recent sessions", () => {
+    const url = buildOpenMeteoUrl(45.04, 12.23, new Date("2025-11-19T08:00:00Z"), now);
+    expect(url).toContain("api.open-meteo.com/v1/forecast");
+    expect(url).toMatch(/past_days=\d+/);
+    expect(url).toContain("forecast_days=1");
+  });
+});
+
+describe("parseOpenMeteoResponse", () => {
+  const json = {
+    hourly: {
+      time: ["2025-11-04T15:00", "2025-11-04T16:00"],
+      temperature_2m: [18.3, 19.1],
+      relative_humidity_2m: [64, 60],
+      pressure_msl: [1018.2, 1017.5],
+      surface_pressure: [1005.0, 1004.3],
+      wind_speed_10m: [7.2, 9.0],
+      wind_direction_10m: [210, 215],
+      wind_gusts_10m: [12.4, 15.1],
+    },
+  };
+
+  it("picks the nearest hour and maps fields (pressure → inHg, temp → F)", () => {
+    const obs = parseOpenMeteoResponse(json, new Date("2025-11-04T15:10:00Z"))!;
+    expect(obs).not.toBeNull();
+    expect(obs.temperatureC).toBeCloseTo(18.3);
+    expect(obs.temperatureF).toBe(65); // 18.3°C ≈ 64.9 → 65
+    expect(obs.humidity).toBe(64);
+    expect(obs.altimeterInHg).toBeCloseTo(1018.2 * 0.0295299830714, 2);
+    expect(obs.windSpeedKts).toBe(7);
+    expect(obs.windDirectionDeg).toBe(210);
+    expect(obs.windGustKts).toBe(12);
+    expect(obs.time.toISOString()).toBe("2025-11-04T15:00:00.000Z");
+  });
+
+  it("falls back to surface_pressure when pressure_msl is missing", () => {
+    const noMsl = { hourly: { ...json.hourly, pressure_msl: [null, null] } };
+    const obs = parseOpenMeteoResponse(noMsl, new Date("2025-11-04T16:00:00Z"))!;
+    expect(obs.altimeterInHg).toBeCloseTo(1004.3 * 0.0295299830714, 2);
+  });
+
+  it("returns null when required fields are missing or empty", () => {
+    expect(parseOpenMeteoResponse({ hourly: { time: [] } }, new Date())).toBeNull();
+    expect(parseOpenMeteoResponse({}, new Date())).toBeNull();
+    const noTemp = { hourly: { time: ["2025-11-04T15:00"], temperature_2m: [null], relative_humidity_2m: [60], pressure_msl: [1018] } };
+    expect(parseOpenMeteoResponse(noTemp, new Date("2025-11-04T15:00:00Z"))).toBeNull();
+  });
+});

--- a/src/lib/weatherService.ts
+++ b/src/lib/weatherService.ts
@@ -1,9 +1,18 @@
-// Weather data service using NWS API for station lookup and IEM ASOS for historical data
+// Weather data service.
+//
+// US sessions: NWS API for station lookup + IEM ASOS for historical METAR (precise,
+// real nearby station). Everywhere else (NWS is US-only): Open-Meteo's free, keyless,
+// global historical reanalysis by lat/lon — see fetchSessionWeather's fallback.
+
+/** Where an observation came from: a real ASOS/METAR station, or Open-Meteo reanalysis. */
+export type WeatherSource = "asos" | "open-meteo";
 
 export interface WeatherStation {
-  stationId: string; // e.g., "KOKC"
-  name: string; // e.g., "Oklahoma City"
+  stationId: string; // e.g., "KOKC", or "open-meteo"
+  name: string; // e.g., "Oklahoma City", or "Open-Meteo"
   distanceKm: number;
+  /** Defaults to "asos" when absent (back-compat with older cached metadata). */
+  source?: WeatherSource;
 }
 
 export interface WeatherData {
@@ -336,8 +345,155 @@ function haversineDistance(
   return R * c;
 }
 
+// ─── Open-Meteo (global, keyless, historical reanalysis) ──────────────────────
+
+const HPA_TO_INHG = 0.0295299830714;
+
+/** The synthetic "station" representing an Open-Meteo point query. */
+export const OPEN_METEO_STATION: WeatherStation = {
+  stationId: "open-meteo",
+  name: "Open-Meteo",
+  distanceKm: 0,
+  source: "open-meteo",
+};
+
+/** Hourly variables requested from Open-Meteo (knots for wind, °C for temp). */
+const OPEN_METEO_HOURLY = [
+  "temperature_2m",
+  "relative_humidity_2m",
+  "pressure_msl",
+  "surface_pressure",
+  "wind_speed_10m",
+  "wind_direction_10m",
+  "wind_gusts_10m",
+].join(",");
+
+function utcDateStamp(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+/** Parse an Open-Meteo UTC hour string ("YYYY-MM-DDTHH:MM") into a Date (cross-browser). */
+export function parseOpenMeteoTime(t: string): Date | null {
+  const m = t.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/);
+  if (!m) return null;
+  return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5]));
+}
+
+/** Index of the hourly sample closest to `target`, or -1 when none parse. */
+export function pickNearestHourIndex(times: string[], target: Date): number {
+  let best = -1;
+  let bestDiff = Infinity;
+  for (let i = 0; i < times.length; i++) {
+    const d = parseOpenMeteoTime(times[i]);
+    if (!d) continue;
+    const diff = Math.abs(d.getTime() - target.getTime());
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = i;
+    }
+  }
+  return best;
+}
+
 /**
- * Main function to fetch weather for a session
+ * Build the Open-Meteo request URL. Historical reanalysis (ERA5) lags ~5 days, so
+ * older sessions use the archive API and recent ones the forecast API (`past_days`).
+ */
+export function buildOpenMeteoUrl(lat: number, lon: number, date: Date, now: Date = new Date()): string {
+  const ageMs = now.getTime() - date.getTime();
+  const ARCHIVE_AFTER_MS = 6 * 24 * 60 * 60 * 1000; // ERA5 ~5-day lag
+  const common = `latitude=${lat.toFixed(4)}&longitude=${lon.toFixed(4)}&hourly=${OPEN_METEO_HOURLY}&timezone=UTC&wind_speed_unit=kn`;
+  if (ageMs > ARCHIVE_AFTER_MS) {
+    const day = utcDateStamp(date);
+    return `https://archive-api.open-meteo.com/v1/archive?${common}&start_date=${day}&end_date=${day}`;
+  }
+  // Recent past / today: forecast endpoint with enough past_days to cover the date.
+  const pastDays = Math.min(92, Math.max(1, Math.ceil(ageMs / (24 * 60 * 60 * 1000)) + 1));
+  return `https://api.open-meteo.com/v1/forecast?${common}&past_days=${pastDays}&forecast_days=1`;
+}
+
+interface Observation {
+  temperatureF: number;
+  temperatureC: number;
+  humidity: number;
+  altimeterInHg: number;
+  windSpeedKts: number | null;
+  windDirectionDeg: number | null;
+  windGustKts: number | null;
+  time: Date;
+}
+
+/** Parse an Open-Meteo JSON response, picking the hour closest to `target`. Pure. */
+export function parseOpenMeteoResponse(json: unknown, target: Date): Observation | null {
+  const hourly = (json as { hourly?: Record<string, unknown> })?.hourly;
+  const times = hourly?.time as string[] | undefined;
+  if (!times || times.length === 0) return null;
+
+  const idx = pickNearestHourIndex(times, target);
+  if (idx < 0) return null;
+
+  const num = (key: string): number | null => {
+    const arr = hourly?.[key] as (number | null)[] | undefined;
+    const v = arr?.[idx];
+    return typeof v === "number" && Number.isFinite(v) ? v : null;
+  };
+
+  const tempC = num("temperature_2m");
+  const rh = num("relative_humidity_2m");
+  const pressureHpa = num("pressure_msl") ?? num("surface_pressure");
+  if (tempC === null || rh === null || pressureHpa === null) return null;
+
+  const obsTime = parseOpenMeteoTime(times[idx]) ?? target;
+  return {
+    temperatureC: Math.round(tempC * 10) / 10,
+    temperatureF: Math.round((tempC * 9) / 5 + 32),
+    humidity: Math.round(rh),
+    altimeterInHg: Math.round(pressureHpa * HPA_TO_INHG * 100) / 100,
+    windSpeedKts: num("wind_speed_10m") === null ? null : Math.round(num("wind_speed_10m")!),
+    windDirectionDeg: num("wind_direction_10m") === null ? null : Math.round(num("wind_direction_10m")!),
+    windGustKts: num("wind_gusts_10m") === null ? null : Math.round(num("wind_gusts_10m")!),
+    time: obsTime,
+  };
+}
+
+/** Fetch global historical weather for a point from Open-Meteo (no API key). */
+export async function fetchOpenMeteoWeather(
+  lat: number,
+  lon: number,
+  sessionDate: Date
+): Promise<WeatherData | null> {
+  try {
+    const response = await fetch(buildOpenMeteoUrl(lat, lon, sessionDate));
+    if (!response.ok) {
+      console.warn("Open-Meteo API failed:", response.status);
+      return null;
+    }
+    const obs = parseOpenMeteoResponse(await response.json(), sessionDate);
+    if (!obs) return null;
+
+    return {
+      station: OPEN_METEO_STATION,
+      temperatureF: obs.temperatureF,
+      temperatureC: obs.temperatureC,
+      humidity: obs.humidity,
+      altimeterInHg: obs.altimeterInHg,
+      densityAltitudeFt: calculateDensityAltitude(obs.temperatureC, obs.altimeterInHg),
+      windSpeedKts: obs.windSpeedKts,
+      windDirectionDeg: obs.windDirectionDeg,
+      windGustKts: obs.windGustKts,
+      observationTime: obs.time,
+    };
+  } catch (error) {
+    console.warn("Failed to fetch Open-Meteo weather:", error);
+    return null;
+  }
+}
+
+/**
+ * Main entry: fetch weather for a session. Tries the precise US path (cached or
+ * freshly-looked-up ASOS station → IEM METAR) first, then falls back to
+ * Open-Meteo's global reanalysis so non-US (and station-less) sessions still get
+ * weather. Returns null only when even the global fallback fails.
  */
 export async function fetchSessionWeather(
   lat: number,
@@ -349,10 +505,15 @@ export async function fetchSessionWeather(
     return null;
   }
 
-  const station = cachedStation ?? (await fetchNearestStation(lat, lon));
-  if (!station) {
-    return null;
+  // A cached Open-Meteo marker skips straight to the global path (no point trying
+  // ASOS again for a known non-US session).
+  if (cachedStation?.source !== "open-meteo") {
+    const station = cachedStation ?? (await fetchNearestStation(lat, lon));
+    if (station) {
+      const data = await fetchWeatherData(station, sessionDate);
+      if (data) return data;
+    }
   }
 
-  return fetchWeatherData(station, sessionDate);
+  return fetchOpenMeteoWeather(lat, lon, sessionDate);
 }


### PR DESCRIPTION
The session + local weather lookups went through the US National Weather Service (api.weather.gov), which only covers US territory — so a session in Italy (or anywhere non-US) found no station and showed nothing.

Now fetchSessionWeather keeps the precise US path (cached/NWS station → IEM ASOS METAR) and, when that yields nothing, falls back to Open-Meteo's free, keyless, global historical reanalysis by lat/lon. Temperature, humidity, pressure, density altitude, and wind resolve anywhere.

- weatherService: WeatherStation gains a `source` ("asos" | "open-meteo"); added buildOpenMeteoUrl (archive API for older sessions, forecast+past_days for recent), parseOpenMeteoResponse + pickNearestHour (pure, unit-tested), fetchOpenMeteoWeather, and the fallback in fetchSessionWeather.
- WeatherPanel + LocalWeatherDialog: one fetchSessionWeather call (fallback built in); show "Open-Meteo" as the source label.
- Persist weatherStationSource in FileMetadata so a known non-US session skips the (futile) NWS attempt on reopen.
- Pressure → density altitude uses pressure_msl to match the existing ASOS path.

Open-Meteo is CORS-enabled and needs no API key (keeps the offline-first/no-secret ethos). New unit tests; full suite green. Credits + docs updated.
