### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-04
+
 ### Added
 - **Worldwide weather.** Session + local weather now work outside the US. The
   precise US path is unchanged (nearest NWS/ASOS station → historical METAR), but

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doves-dataviewer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doves-dataviewer",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@lovable.dev/cloud-auth-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",


### PR DESCRIPTION
Bumps the version to **2.2.0** and cuts the changelog so this can ship.

- `package.json` + `package-lock.json`: `2.1.0` → `2.2.0` (the footer build stamp reads the version from `package.json`).
- `CHANGELOG.md`: rename the `[Unreleased]` section to `[2.2.0] - 2026-06-04` and open a fresh empty `[Unreleased]`.

No tag (created separately). Contents of 2.2.0 (vs 2.1.0): AiM XRK/XRZ import, worldwide weather (Open-Meteo fallback), satellite imagery date picker, full-screen file-load overlay, plus the session date/time and overlay-legend fixes — see the release write-up on #145.

https://claude.ai/code/session_01NLM9gKMV74gQN11ANSZGDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLM9gKMV74gQN11ANSZGDw)_