### PR TITLE
test: cover the IndexedDB storage layer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^15.15.0",
         "lovable-tagger": "^1.1.13",
         "postcss": "^8.5.6",
@@ -846,6 +847,8 @@
     "eta": ["eta@4.6.0", "", {}, "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^15.15.0",
         "lovable-tagger": "^1.1.13",
         "postcss": "^8.5.6",
@@ -6250,6 +6251,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^15.15.0",
     "lovable-tagger": "^1.1.13",
     "postcss": "^8.5.6",

--- a/src/lib/__test__/idb.ts
+++ b/src/lib/__test__/idb.ts
@@ -1,0 +1,13 @@
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
+
+/**
+ * Install a fresh, empty in-memory IndexedDB as the global `indexedDB`.
+ * Call in `beforeEach` so every test starts from a clean schema with no
+ * cross-test state. The storage modules read the global lazily, so swapping the
+ * factory is enough to reset them. We also expose `IDBKeyRange` globally, since
+ * some modules use it directly (e.g. videoFileStorage's existence check).
+ */
+export function freshIndexedDB(): void {
+  globalThis.indexedDB = new IDBFactory();
+  globalThis.IDBKeyRange = IDBKeyRange;
+}

--- a/src/lib/engineStorage.test.ts
+++ b/src/lib/engineStorage.test.ts
@@ -1,0 +1,48 @@
+/**
+ * IndexedDB CRUD tests for engineStorage — the reusable engine-type list.
+ * Covers round-trip, the updatedAt stamp, and garage-change events.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import { saveEngine, listEngines, deleteEngine, type Engine } from "./engineStorage";
+import { onGarageChange } from "./garageEvents";
+
+beforeEach(() => freshIndexedDB());
+
+const engine = (id: string, name = "X30"): Engine => ({ id, name, createdAt: 1 });
+
+describe("engineStorage CRUD", () => {
+  it("saves and lists engines", async () => {
+    await saveEngine(engine("e1", "X30"));
+    await saveEngine(engine("e2", "KA100"));
+    expect((await listEngines()).map((e) => e.name).sort()).toEqual(["KA100", "X30"]);
+  });
+
+  it("stamps updatedAt on save", async () => {
+    const before = Date.now();
+    await saveEngine(engine("e1"));
+    const [saved] = await listEngines();
+    expect(saved.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("overwrites on re-save and deletes", async () => {
+    await saveEngine(engine("e1", "X30"));
+    await saveEngine(engine("e1", "X30 Shifter"));
+    expect(await listEngines()).toHaveLength(1);
+    await deleteEngine("e1");
+    expect(await listEngines()).toHaveLength(0);
+  });
+});
+
+describe("engineStorage garage events", () => {
+  it("emits put then delete", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await saveEngine(engine("e1"));
+    await deleteEngine("e1");
+    off();
+    expect(seen).toHaveBeenNthCalledWith(1, { store: "engines", key: "e1", type: "put" });
+    expect(seen).toHaveBeenNthCalledWith(2, { store: "engines", key: "e1", type: "delete" });
+  });
+});

--- a/src/lib/fileStorage.test.ts
+++ b/src/lib/fileStorage.test.ts
@@ -1,0 +1,143 @@
+/**
+ * IndexedDB CRUD tests for fileStorage — raw log blobs + per-file metadata.
+ *
+ * Runs against fake-indexeddb (reset per test). The headline behavior is
+ * `updateFileMetadata`'s read-merge-write: a partial patch must never clobber
+ * untouched tags (track/course/kart/setup), which is the whole reason it exists.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  saveFile,
+  getFile,
+  listFiles,
+  deleteFile,
+  saveFileMetadata,
+  getFileMetadata,
+  updateFileMetadata,
+  listAllMetadata,
+  getStorageEstimate,
+  type FileMetadata,
+} from "./fileStorage";
+
+beforeEach(() => freshIndexedDB());
+
+// ─── Blob storage ───────────────────────────────────────────────────────────
+
+describe("file blobs", () => {
+  it("round-trips a saved blob by name", async () => {
+    await saveFile("session.dove", new Blob(["timestamp,lat,lng"]));
+    const blob = await getFile("session.dove");
+    expect(blob).not.toBeNull();
+    expect(await blob!.text()).toBe("timestamp,lat,lng");
+  });
+
+  it("returns null for a missing file", async () => {
+    expect(await getFile("nope.dove")).toBeNull();
+  });
+
+  it("overwrites a file on re-save (keyed by name)", async () => {
+    await saveFile("a.dove", new Blob(["v1"]));
+    await saveFile("a.dove", new Blob(["v2"]));
+    expect(await (await getFile("a.dove"))!.text()).toBe("v2");
+    expect(await listFiles()).toHaveLength(1);
+  });
+
+  it("lists files newest-first with size + savedAt", async () => {
+    await saveFile("old.dove", new Blob(["aaaa"]));
+    await new Promise((r) => setTimeout(r, 2));
+    await saveFile("new.dove", new Blob(["bb"]));
+    const files = await listFiles();
+    expect(files.map((f) => f.name)).toEqual(["new.dove", "old.dove"]);
+    expect(files[0].size).toBe(2);
+    expect(files[1].size).toBe(4);
+  });
+
+  it("deletes a file", async () => {
+    await saveFile("gone.dove", new Blob(["x"]));
+    await deleteFile("gone.dove");
+    expect(await getFile("gone.dove")).toBeNull();
+    expect(await listFiles()).toHaveLength(0);
+  });
+});
+
+// ─── Metadata: save / get / list ────────────────────────────────────────────
+
+describe("file metadata", () => {
+  const base: FileMetadata = {
+    fileName: "s.dove",
+    trackName: "OKC",
+    courseName: "CW",
+  };
+
+  it("saves and reads a metadata record", async () => {
+    await saveFileMetadata(base);
+    expect(await getFileMetadata("s.dove")).toMatchObject({ trackName: "OKC", courseName: "CW" });
+  });
+
+  it("returns null for missing metadata", async () => {
+    expect(await getFileMetadata("missing")).toBeNull();
+  });
+
+  it("lists all metadata records", async () => {
+    await saveFileMetadata(base);
+    await saveFileMetadata({ ...base, fileName: "s2.dove", trackName: "BMP" });
+    const all = await listAllMetadata();
+    expect(all).toHaveLength(2);
+    expect(all.map((m) => m.fileName).sort()).toEqual(["s.dove", "s2.dove"]);
+  });
+});
+
+// ─── updateFileMetadata (read-merge-write) ──────────────────────────────────
+
+describe("updateFileMetadata — partial merge", () => {
+  it("creates a fresh record (defaulting track/course to empty) when none exists", async () => {
+    const merged = await updateFileMetadata("new.dove", { fastestLapMs: 62000 });
+    expect(merged).toMatchObject({
+      fileName: "new.dove",
+      trackName: "",
+      courseName: "",
+      fastestLapMs: 62000,
+    });
+  });
+
+  it("preserves untouched tags when patching one field", async () => {
+    await saveFileMetadata({
+      fileName: "s.dove",
+      trackName: "OKC",
+      courseName: "CW",
+      sessionKartId: "kart-1",
+      sessionSetupId: "setup-1",
+    });
+    // Patch only the fastest lap — track/course/kart/setup must survive.
+    const merged = await updateFileMetadata("s.dove", { fastestLapMs: 61000, fastestLapNumber: 4 });
+    expect(merged).toMatchObject({
+      trackName: "OKC",
+      courseName: "CW",
+      sessionKartId: "kart-1",
+      sessionSetupId: "setup-1",
+      fastestLapMs: 61000,
+      fastestLapNumber: 4,
+    });
+    // And it's persisted, not just returned.
+    expect(await getFileMetadata("s.dove")).toMatchObject({ sessionKartId: "kart-1", fastestLapMs: 61000 });
+  });
+
+  it("lets a patch override an existing field without dropping the rest", async () => {
+    await saveFileMetadata({ fileName: "s.dove", trackName: "OKC", courseName: "CW", sessionEngine: "X30" });
+    const merged = await updateFileMetadata("s.dove", { courseName: "Reverse" });
+    expect(merged.courseName).toBe("Reverse");
+    expect(merged.trackName).toBe("OKC");
+    expect(merged.sessionEngine).toBe("X30");
+  });
+});
+
+// ─── getStorageEstimate ─────────────────────────────────────────────────────
+
+describe("getStorageEstimate", () => {
+  it("returns null (or an estimate) without throwing when the API is absent", async () => {
+    const est = await getStorageEstimate();
+    expect(est === null || typeof est.used === "number").toBe(true);
+  });
+});

--- a/src/lib/graphPrefsStorage.idb.test.ts
+++ b/src/lib/graphPrefsStorage.idb.test.ts
@@ -1,0 +1,50 @@
+/**
+ * IndexedDB round-trip tests for graphPrefsStorage (the pure migrateGraphPrefs
+ * helper is covered in graphPrefsStorage.test.ts). Covers save/load/delete and
+ * that load applies channel-key migration to persisted records.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  saveGraphPrefs,
+  loadGraphPrefs,
+  deleteGraphPrefs,
+} from "./graphPrefsStorage";
+
+beforeEach(() => freshIndexedDB());
+
+describe("graphPrefsStorage round-trip", () => {
+  it("returns empty prefs when nothing is stored for the session", async () => {
+    expect(await loadGraphPrefs("none.dove")).toEqual({ activeGraphs: [], graphHeights: {} });
+  });
+
+  it("saves and loads active graphs + heights for a session", async () => {
+    await saveGraphPrefs("s.dove", ["speed", "rpm"], { speed: 120, rpm: 90 });
+    const prefs = await loadGraphPrefs("s.dove");
+    expect(prefs.activeGraphs).toContain("speed");
+    expect(prefs.activeGraphs).toContain("rpm");
+    expect(prefs.graphHeights.speed).toBe(120);
+  });
+
+  it("is scoped per session file name", async () => {
+    await saveGraphPrefs("a.dove", ["speed"], {});
+    await saveGraphPrefs("b.dove", ["rpm"], {});
+    expect((await loadGraphPrefs("a.dove")).activeGraphs).toEqual(["speed"]);
+    expect((await loadGraphPrefs("b.dove")).activeGraphs).toEqual(["rpm"]);
+  });
+
+  it("migrates legacy display-name keys to canonical channel ids on load", async () => {
+    // "Lat G" is a legacy display name; load() runs it through migrateGraphPrefs.
+    await saveGraphPrefs("s.dove", ["Lat G"], { "Lat G": 80 });
+    const prefs = await loadGraphPrefs("s.dove");
+    expect(prefs.activeGraphs).toEqual(["lat_g"]);
+    expect(prefs.graphHeights.lat_g).toBe(80);
+  });
+
+  it("deletes a session's prefs", async () => {
+    await saveGraphPrefs("s.dove", ["speed"], {});
+    await deleteGraphPrefs("s.dove");
+    expect(await loadGraphPrefs("s.dove")).toEqual({ activeGraphs: [], graphHeights: {} });
+  });
+});

--- a/src/lib/kartStorage.test.ts
+++ b/src/lib/kartStorage.test.ts
@@ -1,0 +1,39 @@
+/**
+ * IndexedDB CRUD tests for the legacy kartStorage module. It shares the "karts"
+ * object store with vehicleStorage (back-compat surface), so these just pin the
+ * basic round-trip via the older Kart shape.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import { saveKart, listKarts, getKart, deleteKart, type Kart } from "./kartStorage";
+
+beforeEach(() => freshIndexedDB());
+
+const kart = (id: string, name = "Kart 1"): Kart => ({
+  id,
+  name,
+  engine: "X30",
+  number: 7,
+  weight: 160,
+  weightUnit: "lb",
+});
+
+describe("kartStorage CRUD", () => {
+  it("saves, reads, and lists karts", async () => {
+    await saveKart(kart("k1", "A"));
+    await saveKart(kart("k2", "B"));
+    expect(await getKart("k1")).toMatchObject({ id: "k1", engine: "X30" });
+    expect((await listKarts()).map((k) => k.id).sort()).toEqual(["k1", "k2"]);
+  });
+
+  it("returns null for a missing kart", async () => {
+    expect(await getKart("none")).toBeNull();
+  });
+
+  it("deletes a kart", async () => {
+    await saveKart(kart("k1"));
+    await deleteKart("k1");
+    expect(await getKart("k1")).toBeNull();
+  });
+});

--- a/src/lib/lapSnapshotStorage.test.ts
+++ b/src/lib/lapSnapshotStorage.test.ts
@@ -1,0 +1,105 @@
+/**
+ * IndexedDB CRUD tests for lapSnapshotStorage. Covers the round-trip, the
+ * courseKey-indexed query (fastest-first), newest-first listing, the
+ * event-emitting `saveSnapshot` vs the silent `putSnapshotRaw` (cloud-pull path),
+ * and that a local delete still emits a garage event.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  listSnapshots,
+  listSnapshotsForCourse,
+  getSnapshot,
+  saveSnapshot,
+  putSnapshotRaw,
+  deleteSnapshot,
+} from "./lapSnapshotStorage";
+import type { LapSnapshot } from "./lapSnapshot";
+import type { Course } from "@/types/racing";
+import { onGarageChange } from "./garageEvents";
+
+beforeEach(() => freshIndexedDB());
+
+const course: Course = {
+  name: "CW",
+  startFinishA: { lat: 28.4, lon: -81.4 },
+  startFinishB: { lat: 28.4, lon: -81.399 },
+};
+
+function snap(id: string, opts: Partial<LapSnapshot> = {}): LapSnapshot {
+  return {
+    id,
+    trackName: "OKC",
+    courseName: "CW",
+    courseKey: "okc:cw",
+    engine: "X30",
+    engineKey: "x30",
+    course,
+    lapTimeMs: 62000,
+    sourceFileName: "s.dove",
+    sourceLapNumber: 1,
+    samples: [],
+    lapStartMs: 0,
+    lapEndMs: 62000,
+    createdAt: 1,
+    updatedAt: 1,
+    ...opts,
+  };
+}
+
+describe("lapSnapshotStorage CRUD", () => {
+  it("saves and reads a snapshot by id", async () => {
+    await saveSnapshot(snap("snap1"));
+    expect(await getSnapshot("snap1")).toMatchObject({ id: "snap1", engine: "X30" });
+  });
+
+  it("returns null for a missing snapshot", async () => {
+    expect(await getSnapshot("none")).toBeNull();
+  });
+
+  it("lists snapshots newest-first by updatedAt", async () => {
+    // putSnapshotRaw preserves updatedAt (saveSnapshot re-stamps to now), so use
+    // it to pin deterministic timestamps and assert the sort order.
+    await putSnapshotRaw(snap("a", { updatedAt: 100 }));
+    await putSnapshotRaw(snap("b", { updatedAt: 300 }));
+    await putSnapshotRaw(snap("c", { updatedAt: 200 }));
+    expect((await listSnapshots()).map((s) => s.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns course snapshots fastest-first via the courseKey index", async () => {
+    await saveSnapshot(snap("slow", { courseKey: "okc:cw", lapTimeMs: 63000 }));
+    await saveSnapshot(snap("fast", { courseKey: "okc:cw", lapTimeMs: 61000 }));
+    await saveSnapshot(snap("other", { courseKey: "bmp:cw", lapTimeMs: 60000 }));
+    const forCourse = await listSnapshotsForCourse("okc:cw");
+    expect(forCourse.map((s) => s.id)).toEqual(["fast", "slow"]);
+  });
+
+  it("deletes a snapshot", async () => {
+    await saveSnapshot(snap("snap1"));
+    await deleteSnapshot("snap1");
+    expect(await getSnapshot("snap1")).toBeNull();
+  });
+});
+
+describe("lapSnapshotStorage events", () => {
+  it("saveSnapshot emits a put; deleteSnapshot emits a delete", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await saveSnapshot(snap("snap1"));
+    await deleteSnapshot("snap1");
+    off();
+    expect(seen).toHaveBeenNthCalledWith(1, { store: "lap-snapshots", key: "snap1", type: "put" });
+    expect(seen).toHaveBeenNthCalledWith(2, { store: "lap-snapshots", key: "snap1", type: "delete" });
+  });
+
+  it("putSnapshotRaw writes WITHOUT emitting an event (cloud-pull path) or re-stamping", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await putSnapshotRaw(snap("pulled", { updatedAt: 42 }));
+    off();
+    expect(seen).not.toHaveBeenCalled();
+    // updatedAt is preserved exactly (not re-stamped to Date.now()).
+    expect((await getSnapshot("pulled"))!.updatedAt).toBe(42);
+  });
+});

--- a/src/lib/noteStorage.idb.test.ts
+++ b/src/lib/noteStorage.idb.test.ts
@@ -1,0 +1,71 @@
+/**
+ * IndexedDB CRUD tests for noteStorage (the pure size-cap helpers are covered in
+ * noteStorage.test.ts). Covers the fileName-indexed list (newest-first), the
+ * save size-cap guard, garage events, and delete.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  listNotes,
+  saveNote,
+  deleteNote,
+  MAX_NOTE_BYTES,
+  type Note,
+} from "./noteStorage";
+import { onGarageChange } from "./garageEvents";
+
+beforeEach(() => freshIndexedDB());
+
+const note = (id: string, fileName: string, text = "note", createdAt = 1): Note => ({
+  id,
+  fileName,
+  text,
+  createdAt,
+  updatedAt: createdAt,
+});
+
+describe("noteStorage CRUD", () => {
+  it("lists notes for a file newest-first (createdAt desc), scoped by fileName", async () => {
+    await saveNote(note("n1", "a.dove", "first", 100));
+    await saveNote(note("n2", "a.dove", "second", 300));
+    await saveNote(note("n3", "b.dove", "other", 200));
+    const notes = await listNotes("a.dove");
+    expect(notes.map((n) => n.id)).toEqual(["n2", "n1"]);
+  });
+
+  it("returns an empty list for a file with no notes", async () => {
+    expect(await listNotes("empty.dove")).toEqual([]);
+  });
+
+  it("stamps updatedAt on save", async () => {
+    const before = Date.now();
+    await saveNote(note("n1", "a.dove"));
+    const [saved] = await listNotes("a.dove");
+    expect(saved.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("refuses to save a note over the size cap", async () => {
+    const huge = note("n1", "a.dove", "x".repeat(MAX_NOTE_BYTES + 1));
+    await expect(saveNote(huge)).rejects.toThrow(/limit/i);
+    expect(await listNotes("a.dove")).toHaveLength(0);
+  });
+
+  it("deletes a note", async () => {
+    await saveNote(note("n1", "a.dove"));
+    await deleteNote("n1");
+    expect(await listNotes("a.dove")).toHaveLength(0);
+  });
+});
+
+describe("noteStorage garage events", () => {
+  it("emits put then delete", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await saveNote(note("n1", "a.dove"));
+    await deleteNote("n1");
+    off();
+    expect(seen).toHaveBeenNthCalledWith(1, { store: "notes", key: "n1", type: "put" });
+    expect(seen).toHaveBeenNthCalledWith(2, { store: "notes", key: "n1", type: "delete" });
+  });
+});

--- a/src/lib/setupRevisionStorage.test.ts
+++ b/src/lib/setupRevisionStorage.test.ts
@@ -1,0 +1,135 @@
+/**
+ * IndexedDB tests for setupRevisionStorage — immutable, content-addressed frozen
+ * setups. Covers freeze (hash id), dedup/idempotency, a value change producing a
+ * new revision, and the orphan prune (a revision no FileMetadata references is
+ * swept). freezeSetupRevision spans the setups, templates, and metadata stores.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  freezeSetupRevision,
+  getSetupRevision,
+  listSetupRevisions,
+  deleteSetupRevision,
+  pruneSetupRevisions,
+} from "./setupRevisionStorage";
+import { saveSetup, type VehicleSetup } from "./setupStorage";
+import { saveTemplate, type SetupTemplate } from "./templateStorage";
+import { saveFileMetadata } from "./fileStorage";
+
+beforeEach(() => freshIndexedDB());
+
+const template: SetupTemplate = {
+  id: "tpl1",
+  vehicleTypeId: "vt1",
+  name: "Kart",
+  sections: [{ id: "sec1", name: "Alignment", fields: [{ id: "f-toe", name: "Toe", type: "number" }] }],
+  wheelCount: 4,
+  includeTires: true,
+  isDefault: false,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function setup(id: string, overrides: Partial<VehicleSetup> = {}): VehicleSetup {
+  return {
+    id,
+    vehicleId: "v1",
+    templateId: "tpl1",
+    name: "Baseline",
+    unitSystem: "mm",
+    tireBrand: "MOJO",
+    psiMode: "single",
+    psiFrontLeft: 12,
+    psiFrontRight: 12,
+    psiRearLeft: 13,
+    psiRearRight: 13,
+    tireWidthMode: "halves",
+    tireWidthFrontLeft: null,
+    tireWidthFrontRight: null,
+    tireWidthRearLeft: null,
+    tireWidthRearRight: null,
+    tireDiameterMode: "halves",
+    tireDiameterFrontLeft: null,
+    tireDiameterFrontRight: null,
+    tireDiameterRearLeft: null,
+    tireDiameterRearRight: null,
+    customFields: { "f-toe": 2 },
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("freezeSetupRevision", () => {
+  it("freezes a live setup into a content-addressed revision", async () => {
+    await saveTemplate(template);
+    await saveSetup(setup("s1"));
+    const revId = await freezeSetupRevision("s1");
+    expect(revId).toBeTruthy();
+    const rev = await getSetupRevision(revId!);
+    expect(rev).not.toBeNull();
+    expect(rev!.setupId).toBe("s1");
+    expect(rev!.id).toBe(revId);
+    // Embeds a frozen copy of the template structure for stable rendering.
+    expect(rev!.template?.sections[0].fields[0].name).toBe("Toe");
+  });
+
+  it("returns null when the setup no longer exists", async () => {
+    expect(await freezeSetupRevision("missing")).toBeNull();
+  });
+
+  it("is idempotent — re-freezing identical content reuses the same revision", async () => {
+    await saveTemplate(template);
+    await saveSetup(setup("s1"));
+    const a = await freezeSetupRevision("s1");
+    const b = await freezeSetupRevision("s1");
+    expect(a).toBe(b);
+    expect(await listSetupRevisions()).toHaveLength(1);
+  });
+
+  it("produces a new revision when a setup value changes", async () => {
+    await saveTemplate(template);
+    await saveSetup(setup("s1"));
+    const a = await freezeSetupRevision("s1");
+    await saveSetup(setup("s1", { customFields: { "f-toe": 5 } })); // value changed
+    const b = await freezeSetupRevision("s1");
+    expect(b).not.toBe(a);
+    expect(await listSetupRevisions()).toHaveLength(2);
+  });
+});
+
+describe("pruneSetupRevisions (orphan sweep)", () => {
+  it("deletes a revision that no session metadata references", async () => {
+    await saveTemplate(template);
+    await saveSetup(setup("s1"));
+    const revId = await freezeSetupRevision("s1");
+    expect(await listSetupRevisions()).toHaveLength(1);
+
+    const pruned = await pruneSetupRevisions();
+    expect(pruned).toEqual([revId]);
+    expect(await getSetupRevision(revId!)).toBeNull();
+  });
+
+  it("keeps a revision still referenced by a session's sessionSetupRev", async () => {
+    await saveTemplate(template);
+    await saveSetup(setup("s1"));
+    const revId = await freezeSetupRevision("s1");
+    await saveFileMetadata({ fileName: "s.dove", trackName: "OKC", courseName: "CW", sessionSetupRev: revId! });
+
+    const pruned = await pruneSetupRevisions();
+    expect(pruned).toEqual([]);
+    expect(await getSetupRevision(revId!)).not.toBeNull();
+  });
+});
+
+describe("deleteSetupRevision", () => {
+  it("removes a revision locally", async () => {
+    await saveTemplate(template);
+    await saveSetup(setup("s1"));
+    const revId = await freezeSetupRevision("s1");
+    await deleteSetupRevision(revId!);
+    expect(await getSetupRevision(revId!)).toBeNull();
+  });
+});

--- a/src/lib/setupStorage.test.ts
+++ b/src/lib/setupStorage.test.ts
@@ -1,0 +1,92 @@
+/**
+ * IndexedDB CRUD tests for setupStorage. Beyond the round-trip, this pins
+ * `getLatestSetupForVehicle` (vehicleId index + newest-by-updatedAt pick) and the
+ * newest-first list ordering, plus garage-change events.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  listSetups,
+  saveSetup,
+  deleteSetup,
+  getSetup,
+  getLatestSetupForVehicle,
+  type VehicleSetup,
+} from "./setupStorage";
+import { onGarageChange } from "./garageEvents";
+
+beforeEach(() => freshIndexedDB());
+
+function setup(id: string, vehicleId: string, overrides: Partial<VehicleSetup> = {}): VehicleSetup {
+  return {
+    id,
+    vehicleId,
+    templateId: "default-kart-template",
+    name: id,
+    unitSystem: "mm",
+    tireBrand: "",
+    psiMode: "single",
+    psiFrontLeft: null,
+    psiFrontRight: null,
+    psiRearLeft: null,
+    psiRearRight: null,
+    tireWidthMode: "halves",
+    tireWidthFrontLeft: null,
+    tireWidthFrontRight: null,
+    tireWidthRearLeft: null,
+    tireWidthRearRight: null,
+    tireDiameterMode: "halves",
+    tireDiameterFrontLeft: null,
+    tireDiameterFrontRight: null,
+    tireDiameterRearLeft: null,
+    tireDiameterRearRight: null,
+    customFields: {},
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("setupStorage CRUD", () => {
+  it("saves, reads, and deletes a setup", async () => {
+    await saveSetup(setup("s1", "v1"));
+    expect(await getSetup("s1")).toMatchObject({ id: "s1", vehicleId: "v1" });
+    await deleteSetup("s1");
+    expect(await getSetup("s1")).toBeNull();
+  });
+
+  it("stamps updatedAt and lists newest-first", async () => {
+    await saveSetup(setup("s1", "v1"));
+    await new Promise((r) => setTimeout(r, 2));
+    await saveSetup(setup("s2", "v1"));
+    const list = await listSetups();
+    expect(list.map((s) => s.id)).toEqual(["s2", "s1"]); // newest updatedAt first
+  });
+
+  it("emits garage events on save and delete", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await saveSetup(setup("s1", "v1"));
+    await deleteSetup("s1");
+    off();
+    expect(seen).toHaveBeenNthCalledWith(1, { store: "setups", key: "s1", type: "put" });
+    expect(seen).toHaveBeenNthCalledWith(2, { store: "setups", key: "s1", type: "delete" });
+  });
+});
+
+describe("getLatestSetupForVehicle", () => {
+  it("returns the most-recently-updated setup for a vehicle (via the index)", async () => {
+    await saveSetup(setup("s1", "v1"));
+    await new Promise((r) => setTimeout(r, 2));
+    await saveSetup(setup("s2", "v1"));
+    await saveSetup(setup("s3", "v2")); // different vehicle — must be ignored
+    const latest = await getLatestSetupForVehicle("v1");
+    expect(latest!.id).toBe("s2");
+  });
+
+  it("returns null when the vehicle has no setups", async () => {
+    await saveSetup(setup("s1", "v1"));
+    expect(await getLatestSetupForVehicle("v-none")).toBeNull();
+  });
+});

--- a/src/lib/templateStorage.test.ts
+++ b/src/lib/templateStorage.test.ts
@@ -1,0 +1,107 @@
+/**
+ * IndexedDB tests for templateStorage — the vehicle-types + setup-templates
+ * stores. Covers default seeding (idempotent), the atomic
+ * create/delete-vehicle-type-with-template pair, plain CRUD, and garage events.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  ensureDefaults,
+  listVehicleTypes,
+  getVehicleType,
+  saveVehicleType,
+  deleteVehicleType,
+  listTemplates,
+  getTemplate,
+  saveTemplate,
+  createVehicleTypeWithTemplate,
+  deleteVehicleTypeWithTemplate,
+  DEFAULT_KART_VEHICLE_TYPE_ID,
+  DEFAULT_KART_TEMPLATE_ID,
+  type TemplateSection,
+} from "./templateStorage";
+import { onGarageChange } from "./garageEvents";
+
+beforeEach(() => freshIndexedDB());
+
+const sections: TemplateSection[] = [
+  { id: "sec1", name: "Alignment", fields: [{ id: "f-toe", name: "Toe", type: "number" }] },
+];
+
+describe("ensureDefaults", () => {
+  it("seeds the default kart vehicle type + template on first run", async () => {
+    await ensureDefaults();
+    expect(await getVehicleType(DEFAULT_KART_VEHICLE_TYPE_ID)).not.toBeNull();
+    expect(await getTemplate(DEFAULT_KART_TEMPLATE_ID)).not.toBeNull();
+  });
+
+  it("is idempotent — a second run doesn't duplicate the defaults", async () => {
+    await ensureDefaults();
+    await ensureDefaults();
+    expect(await listVehicleTypes()).toHaveLength(1);
+    expect(await listTemplates()).toHaveLength(1);
+  });
+});
+
+describe("vehicle-type + template CRUD", () => {
+  it("saves and reads a vehicle type and a template", async () => {
+    await saveVehicleType({
+      id: "vt1",
+      name: "Shifter",
+      templateId: "tpl1",
+      wheelCount: 4,
+      isDefault: false,
+      createdAt: 1,
+    });
+    await saveTemplate({
+      id: "tpl1",
+      vehicleTypeId: "vt1",
+      name: "Shifter",
+      sections,
+      wheelCount: 4,
+      includeTires: true,
+      isDefault: false,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    expect(await getVehicleType("vt1")).toMatchObject({ name: "Shifter" });
+    expect(await getTemplate("tpl1")).toMatchObject({ vehicleTypeId: "vt1" });
+  });
+
+  it("emits garage events on vehicle-type save/delete", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await saveVehicleType({ id: "vt1", name: "X", templateId: "t", wheelCount: 2, isDefault: false, createdAt: 1 });
+    await deleteVehicleType("vt1");
+    off();
+    expect(seen).toHaveBeenNthCalledWith(1, { store: "vehicle-types", key: "vt1", type: "put" });
+    expect(seen).toHaveBeenNthCalledWith(2, { store: "vehicle-types", key: "vt1", type: "delete" });
+  });
+});
+
+describe("createVehicleTypeWithTemplate / deleteVehicleTypeWithTemplate", () => {
+  it("creates a linked vehicle type + template atomically", async () => {
+    const { vehicleType, template } = await createVehicleTypeWithTemplate("Superkart", 4, true, sections);
+    expect(vehicleType.templateId).toBe(template.id);
+    expect(template.vehicleTypeId).toBe(vehicleType.id);
+    expect(await getVehicleType(vehicleType.id)).not.toBeNull();
+    expect(await getTemplate(template.id)).not.toBeNull();
+  });
+
+  it("deletes both halves of the pair", async () => {
+    const { vehicleType, template } = await createVehicleTypeWithTemplate("Superkart", 4, true, sections);
+    await deleteVehicleTypeWithTemplate(vehicleType.id, template.id);
+    expect(await getVehicleType(vehicleType.id)).toBeNull();
+    expect(await getTemplate(template.id)).toBeNull();
+  });
+
+  it("emits a put for both stores on create", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    const { vehicleType, template } = await createVehicleTypeWithTemplate("S", 2, false, sections);
+    off();
+    expect(seen).toHaveBeenCalledWith({ store: "vehicle-types", key: vehicleType.id, type: "put" });
+    expect(seen).toHaveBeenCalledWith({ store: "setup-templates", key: template.id, type: "put" });
+  });
+});

--- a/src/lib/vehicleStorage.test.ts
+++ b/src/lib/vehicleStorage.test.ts
@@ -1,0 +1,86 @@
+/**
+ * IndexedDB CRUD tests for vehicleStorage (the "karts" store, renamed). Covers
+ * the round-trip, the updatedAt stamp applied on save, and the garage-change
+ * events the cloud-sync plugin rides on.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  saveVehicle,
+  listVehicles,
+  getVehicle,
+  deleteVehicle,
+  type Vehicle,
+} from "./vehicleStorage";
+import { onGarageChange } from "./garageEvents";
+
+beforeEach(() => freshIndexedDB());
+
+function vehicle(id: string, name = "Kart 1"): Vehicle {
+  return {
+    id,
+    name,
+    vehicleTypeId: "default-kart-type",
+    engine: "X30",
+    number: 7,
+    weight: 160,
+    weightUnit: "lb",
+  };
+}
+
+describe("vehicleStorage CRUD", () => {
+  it("saves and reads a vehicle by id", async () => {
+    await saveVehicle(vehicle("v1"));
+    expect(await getVehicle("v1")).toMatchObject({ id: "v1", engine: "X30", number: 7 });
+  });
+
+  it("stamps updatedAt on save", async () => {
+    const before = Date.now();
+    await saveVehicle(vehicle("v1"));
+    const saved = await getVehicle("v1");
+    expect(saved!.updatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("returns null for a missing vehicle", async () => {
+    expect(await getVehicle("ghost")).toBeNull();
+  });
+
+  it("lists all vehicles", async () => {
+    await saveVehicle(vehicle("v1", "A"));
+    await saveVehicle(vehicle("v2", "B"));
+    expect((await listVehicles()).map((v) => v.id).sort()).toEqual(["v1", "v2"]);
+  });
+
+  it("overwrites on re-save (same id)", async () => {
+    await saveVehicle(vehicle("v1", "First"));
+    await saveVehicle(vehicle("v1", "Renamed"));
+    expect((await listVehicles())).toHaveLength(1);
+    expect((await getVehicle("v1"))!.name).toBe("Renamed");
+  });
+
+  it("deletes a vehicle", async () => {
+    await saveVehicle(vehicle("v1"));
+    await deleteVehicle("v1");
+    expect(await getVehicle("v1")).toBeNull();
+  });
+});
+
+describe("vehicleStorage garage events", () => {
+  it("emits a put event on save", async () => {
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await saveVehicle(vehicle("v1"));
+    off();
+    expect(seen).toHaveBeenCalledWith({ store: "karts", key: "v1", type: "put" });
+  });
+
+  it("emits a delete event on delete", async () => {
+    await saveVehicle(vehicle("v1"));
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await deleteVehicle("v1");
+    off();
+    expect(seen).toHaveBeenCalledWith({ store: "karts", key: "v1", type: "delete" });
+  });
+});

--- a/src/lib/videoFileStorage.test.ts
+++ b/src/lib/videoFileStorage.test.ts
@@ -1,0 +1,70 @@
+/**
+ * IndexedDB tests for videoFileStorage — stored exported-video blobs per session.
+ * Covers save + load (blob + metadata), the blob-free metadata readers
+ * (getSessionVideoMeta / listSessionVideos), the existence check, and delete.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  saveSessionVideo,
+  loadSessionVideo,
+  deleteSessionVideo,
+  hasSessionVideo,
+  getSessionVideoMeta,
+  listSessionVideos,
+} from "./videoFileStorage";
+
+beforeEach(() => freshIndexedDB());
+
+describe("videoFileStorage", () => {
+  it("saves and loads a video blob with its metadata", async () => {
+    await saveSessionVideo("s.dove", new Blob(["video-bytes"]), "clip.mp4", "lap", true, 3);
+    const loaded = await loadSessionVideo("s.dove");
+    expect(loaded).not.toBeNull();
+    expect(await loaded!.blob.text()).toBe("video-bytes");
+    expect(loaded!.meta).toMatchObject({
+      videoFileName: "clip.mp4",
+      exportType: "lap",
+      hasOverlays: true,
+      lapNumber: 3,
+      size: 11,
+    });
+  });
+
+  it("returns null when loading a session with no stored video", async () => {
+    expect(await loadSessionVideo("none.dove")).toBeNull();
+  });
+
+  it("reports existence via hasSessionVideo", async () => {
+    expect(await hasSessionVideo("s.dove")).toBe(false);
+    await saveSessionVideo("s.dove", new Blob(["x"]), "c.mp4");
+    expect(await hasSessionVideo("s.dove")).toBe(true);
+  });
+
+  it("returns metadata without the blob via getSessionVideoMeta", async () => {
+    await saveSessionVideo("s.dove", new Blob(["abcd"]), "c.mp4", "session", false);
+    const meta = await getSessionVideoMeta("s.dove");
+    expect(meta).toMatchObject({ videoFileName: "c.mp4", exportType: "session", size: 4 });
+    expect(meta).not.toHaveProperty("videoBlob");
+  });
+
+  it("defaults exportType to 'raw' and hasOverlays to false", async () => {
+    await saveSessionVideo("s.dove", new Blob(["x"]), "c.mp4");
+    expect(await getSessionVideoMeta("s.dove")).toMatchObject({ exportType: "raw", hasOverlays: false });
+  });
+
+  it("lists all stored videos as blob-free metadata", async () => {
+    await saveSessionVideo("a.dove", new Blob(["aa"]), "a.mp4");
+    await saveSessionVideo("b.dove", new Blob(["bbbb"]), "b.mp4");
+    const list = await listSessionVideos();
+    expect(list.map((m) => m.sessionFileName).sort()).toEqual(["a.dove", "b.dove"]);
+    expect(list[0]).not.toHaveProperty("videoBlob");
+  });
+
+  it("deletes a stored video", async () => {
+    await saveSessionVideo("s.dove", new Blob(["x"]), "c.mp4");
+    await deleteSessionVideo("s.dove");
+    expect(await hasSessionVideo("s.dove")).toBe(false);
+  });
+});

--- a/src/lib/videoStorage.test.ts
+++ b/src/lib/videoStorage.test.ts
@@ -1,0 +1,72 @@
+/**
+ * IndexedDB tests for videoStorage — per-session video sync records. Covers the
+ * save/load/delete round-trip and the legacy→new overlay-settings migration that
+ * loadVideoSync applies on read.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  saveVideoSync,
+  loadVideoSync,
+  deleteVideoSync,
+  type VideoSyncRecord,
+} from "./videoStorage";
+
+beforeEach(() => freshIndexedDB());
+
+describe("videoStorage round-trip", () => {
+  it("saves and loads a sync record", async () => {
+    const rec: VideoSyncRecord = {
+      sessionFileName: "s.dove",
+      syncOffsetMs: 1500,
+      videoFileName: "clip.mp4",
+      isLocked: true,
+    };
+    await saveVideoSync(rec);
+    const loaded = await loadVideoSync("s.dove");
+    expect(loaded).toMatchObject({ syncOffsetMs: 1500, videoFileName: "clip.mp4", isLocked: true });
+  });
+
+  it("returns undefined for a session with no sync record", async () => {
+    expect(await loadVideoSync("none.dove")).toBeUndefined();
+  });
+
+  it("deletes a sync record", async () => {
+    await saveVideoSync({ sessionFileName: "s.dove", syncOffsetMs: 0, videoFileName: "c.mp4" });
+    await deleteVideoSync("s.dove");
+    expect(await loadVideoSync("s.dove")).toBeUndefined();
+  });
+
+  it("migrates legacy overlay settings to the new overlays-array shape on load", async () => {
+    // Persist a record carrying the OLD overlay format, then read it back.
+    const legacy = {
+      sessionFileName: "s.dove",
+      syncOffsetMs: 0,
+      videoFileName: "c.mp4",
+      overlaySettings: {
+        showSpeed: true,
+        overlaysLocked: true,
+        positions: { speed: { x: 3, y: 3 } },
+      },
+    } as unknown as VideoSyncRecord;
+    await saveVideoSync(legacy);
+
+    const loaded = await loadVideoSync("s.dove");
+    const settings = loaded!.overlaySettings!;
+    expect(Array.isArray(settings.overlays)).toBe(true);
+    expect(settings.overlays).toHaveLength(1);
+    expect(settings.overlays[0]).toMatchObject({ dataSource: "speed", type: "digital" });
+  });
+
+  it("passes through already-migrated overlay settings unchanged", async () => {
+    await saveVideoSync({
+      sessionFileName: "s.dove",
+      syncOffsetMs: 0,
+      videoFileName: "c.mp4",
+      overlaySettings: { overlaysLocked: false, overlays: [] },
+    });
+    const loaded = await loadVideoSync("s.dove");
+    expect(loaded!.overlaySettings).toMatchObject({ overlaysLocked: false, overlays: [] });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
       // below current actuals so routine churn doesn't redden CI; ratchet up as
       // coverage grows.
       thresholds: {
-        lines: 41,
-        functions: 33,
-        branches: 40,
-        statements: 40,
+        lines: 50,
+        functions: 45,
+        branches: 45,
+        statements: 49,
       },
     },
   },


### PR DESCRIPTION
## What

Adds **`fake-indexeddb`** (devDependency) and a shared `freshIndexedDB()` reset helper (`src/lib/__test__/idb.ts`), then real CRUD round-trip tests for the IndexedDB storage layer — the offline-first core of the app, which was almost entirely untested (most storage modules sat at 0%).

## Modules now covered
| Module | What's tested |
|---|---|
| `fileStorage` | blob CRUD + **`updateFileMetadata` read-merge-write** (a partial patch must never clobber untouched track/course/kart/setup tags) |
| `vehicleStorage` / `engineStorage` / `kartStorage` | CRUD, `updatedAt` stamping, `garageEvents` put/delete emissions |
| `setupStorage` | CRUD, newest-first list, **`getLatestSetupForVehicle`** (vehicleId index + newest pick) |
| `templateStorage` | idempotent default seeding + **atomic vehicle-type/template create+delete** pair |
| `lapSnapshotStorage` | courseKey-indexed **fastest-first** query, newest-first list, event-emitting `saveSnapshot` vs **silent `putSnapshotRaw`** (cloud-pull path) |
| `setupRevisionStorage` | content-addressed **freeze (dedup/idempotency, new revision on value change)** + **orphan prune** against file metadata |
| `noteStorage` | fileName-indexed list, size-cap guard, events (pure helpers were already covered) |
| `graphPrefsStorage` | save/load/delete + **channel-key migration on load** |
| `videoStorage` | sync round-trip + **legacy→new overlay-settings migration** |
| `videoFileStorage` | blob save/load, blob-free metadata readers, existence check, delete |

## Coverage
**~46% → 53.4% lines** (49% functions, 52% statements). Threshold floors in `vitest.config.ts` ratcheted up a few points below the new actuals (lines 41→50, functions 33→45, branches 40→45, statements 40→49).

Per-file highlights: engine/kart/vehicle/snapshot storage now **100% lines**; fileStorage 83%, setupStorage 81%, templateStorage 93%, setupRevisionStorage 84%.

## Verification
- `npm run test:run` — 83 files, **1151 tests** pass
- `npm run lint` / `npm run typecheck` — clean
- `npm run test:coverage` — passes the new thresholds

## Notes / next
- `dbUtils.ts` is at ~58% — the gap is the v8 legacy-DB **upgrade-migration** path, which only fires when opening an old on-disk schema (hard to exercise under a fresh fake DB); left for a follow-up if we want to simulate it.
- Remaining storage at 0% is **localStorage**-backed (`trackStorage`, `submittedTracksStorage`) — a different mechanism, separate follow-up.
- **Next up per discussion: cloud-sync plugin tests.**

https://claude.ai/code/session_01RvEau9ZFKJocvKyTsChx7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvEau9ZFKJocvKyTsChx7m)_