### PR TITLE
release: bump version to 2.2.2 + list iRacing .ibt in Supported Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-06-05
+
 ### Added
 - **iRacing telemetry (`.ibt`) import.** You can now drop iRacing's native binary
   telemetry file straight into the viewer — no third-party conversion to CSV or
   MoTeC needed. The `.ibt` is parsed directly (in-browser, offline) into the same
   GPS-first session as every other format: position/speed/altitude drive the map
   and laps, with throttle, brake, gear, steering, RPM, water/oil temp and native
-  lateral/longitudinal g available as channels.
+  lateral/longitudinal g available as channels. It's also listed in the
+  **Supported Files** dialog (under the AiM binary format).
+
 ### Fixed
 - **AiM RaceStudio 3 CSV files now import.** RS3 exports (e.g. MyChron via Race
   Studio 3) use space-delimited channel names (`GPS Speed`) and put the channel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doves-dataviewer",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doves-dataviewer",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@lovable.dev/cloud-auth-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/components/SupportedFilesDialog.tsx
+++ b/src/components/SupportedFilesDialog.tsx
@@ -18,6 +18,10 @@ const PRIMARY_FORMATS = [
     body: <>AiM's native binary telemetry from MyChron / SoloDL loggers, including the zlib-compressed <code className="text-primary">.xrz</code> variant. Parsed entirely in your browser by <a href="https://github.com/m3rlin45/libxrk" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">libxrk</a> compiled to WebAssembly — fast and fully offline, like every other format. Extensions: <code className="text-primary">.xrk</code>, <code className="text-primary">.xrz</code></>,
   },
   {
+    name: "iRacing Telemetry (Binary)",
+    body: <>iRacing's native binary telemetry export — the same data the sim's live irsdk API serves, no third-party CSV/MoTeC conversion needed. Read directly in your browser (fully offline): GPS position, speed and altitude drive the map and laps, with throttle, brake, gear, steering, RPM, water/oil temp and native lateral/longitudinal g along for the ride. Extension: <code className="text-primary">.ibt</code></>,
+  },
+  {
     name: "NMEA / CSV (Tab-Delimited)",
     body: <>Tab-delimited CSV with NMEA sentences — the legacy format used by our earlier custom dataloggers. Extensions: <code className="text-primary">.nmea</code>, <code className="text-primary">.csv</code>, <code className="text-primary">.txt</code></>,
   },


### PR DESCRIPTION
The release-prep change for **2.2.2** (into BETA).

## What

- **Version bump 2.2.1 → 2.2.2** — `package.json` + `package-lock.json` (root version, 2 refs). `bun.lock` doesn't track the root workspace version (only `name`), so `bun install` produces no lock diff — confirmed, nothing to change there.
- **Supported Files dialog** — adds an **iRacing Telemetry (Binary)** entry (`.ibt`) right under the AiM XRK/XRZ binary format, so the dialog reflects the parser that landed in this release.
- **CHANGELOG** — cuts the `[Unreleased]` section to `## [2.2.2] - 2026-06-05`.

## Checks

- ✅ `npm run lint`
- ✅ `npm run typecheck`
- ✅ `npm run test:run` — 96 files, 1259 tests
- ✅ `npm run build`

https://claude.ai/code/session_01FvkZiPbudNEtubiMgPu9Lu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvkZiPbudNEtubiMgPu9Lu)_