### PR TITLE
diag(ble): surface Bluetooth service-access errors during firmware update

### DIFF
--- a/src/components/drawer/FirmwareUpdateSection.tsx
+++ b/src/components/drawer/FirmwareUpdateSection.tsx
@@ -166,7 +166,7 @@ export function FirmwareUpdateSection({ connection }: { connection: BleConnectio
                   <AlertTriangle className="w-5 h-5 text-destructive" />
                   {PHASE_LABEL.error}
                 </DialogTitle>
-                <DialogDescription className="text-left">
+                <DialogDescription className="text-left whitespace-pre-wrap break-words max-h-60 overflow-y-auto">
                   {fw.flashError ?? "Something went wrong during the update."}
                 </DialogDescription>
               </DialogHeader>

--- a/src/hooks/useFirmwareUpdate.ts
+++ b/src/hooks/useFirmwareUpdate.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import type { BleConnection } from "@/lib/bleDatalogger";
 import { useDeviceContext } from "@/contexts/DeviceContext";
 import { isPreviewBuild } from "@/lib/buildInfo";
+import { isDebugEnabled } from "@/lib/debugConsole";
 import {
   connectToDfuDevice,
   evaluateFirmwareUpdate,
@@ -29,6 +30,28 @@ export type FirmwareFlashPhase =
 
 function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
+}
+
+/** Debug log, only when the on-screen console is enabled (?dbg=true). */
+function fwLog(...args: unknown[]): void {
+  if (isDebugEnabled()) console.info("[firmware]", ...args);
+}
+
+/** A Web Bluetooth "Origin is not allowed to access the service" / SecurityError. */
+function isServiceAccessError(e: unknown): boolean {
+  const name = (e as { name?: string } | null)?.name ?? "";
+  const msg = (e instanceof Error ? e.message : String(e)).toLowerCase();
+  return name === "SecurityError" || msg.includes("not allowed to access");
+}
+
+/** Comma-joined UUIDs of the services this origin can currently access (diagnostic). */
+async function listAccessibleServices(server: BluetoothRemoteGATTServer): Promise<string> {
+  try {
+    const services = await server.getPrimaryServices();
+    return services.map((s) => s.uuid).join(", ") || "(none)";
+  } catch {
+    return "(could not enumerate)";
+  }
 }
 
 /**
@@ -136,15 +159,20 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
 
     try {
       setPhase("downloading");
+      fwLog("downloading package", build.name, build.dfuZip);
       const zip = await fetchFirmwarePackage(build.dfuZip);
       const pkg = await parseDfuPackage(zip);
+      fwLog("package ready", { imageBytes: pkg.image.byteLength });
 
       setPhase("rebooting");
+      fwLog("triggering DFU mode (writing to control point)…");
       await triggerDfuMode(connection.server);
       rebooted = true;
 
       setPhase("reconnecting");
+      fwLog("reconnecting to bootloader…");
       const dfu = await connectToDfuDevice(connection.device);
+      fwLog("connected to bootloader; starting transfer");
 
       await flashFirmware(dfu.transport, pkg, {
         onProgress: (p) => {
@@ -172,8 +200,24 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
       setFlashing(false);
       disconnectDevice();
     } catch (e) {
+      fwLog("update failed", { rebooted, name: (e as { name?: string })?.name, error: errorMessage(e) });
+      let message = errorMessage(e);
+      // A SecurityError on a service we *do* whitelist almost always means a
+      // stale browser permission for an already-paired device. Surface what the
+      // page can actually access + how to fix it.
+      if (isServiceAccessError(e) && !rebooted) {
+        const accessible = await listAccessibleServices(connection.server);
+        fwLog("accessible services:", accessible);
+        message =
+          `${errorMessage(e)}\n\n` +
+          "Your browser is blocking the firmware-update service — usually a stale " +
+          "Bluetooth permission from a previous pairing. Fix: disconnect, then remove " +
+          "this device under your browser's Bluetooth permissions " +
+          "(chrome://settings/content/bluetoothDevices), reconnect, and try again.\n\n" +
+          `Services currently accessible: ${accessible}`;
+      }
       setPhase("error");
-      setFlashError(errorMessage(e));
+      setFlashError(message);
       setNeedsDisconnect(rebooted);
       setFlashing(false);
       toast.error(`Firmware update failed: ${errorMessage(e)}`);


### PR DESCRIPTION
## Context

When flashing, the firmware update fails with a Web Bluetooth error:

```
Origin is not allowed to access the service.
Tip: Add the service UUID to 'optionalServices' in requestDevice() options.
```

I verified the code is correct end-to-end and this *shouldn't* happen from our side:
- The firmware (Seeed core `BLEDfu`) exposes the DFU service at `00001530-…-785feabcd123` — **exactly** our `DFU_SERVICE_UUID` (legacy DFU; there is only one legacy DFU UUID).
- That UUID **is** in `connectToDevice()`'s `optionalServices` (alongside DIS), and version-read working proves that grant is live.
- The transport only ever calls `getPrimaryService` with whitelisted UUIDs.

A `SecurityError` despite all that is runtime-specific — the most common cause is a **stale Chrome device-permission grant** from an earlier pairing that predates the DFU service being whitelisted (Chrome doesn't always expand an already-granted device's allowed-services when `optionalServices` later grows).

## What this PR does (diagnostics, not a behavior change)

- Logs each update step (download / reboot / reconnect / transfer) to the on-screen debug console (`?dbg=true`), gated by `isDebugEnabled()` so production stays quiet.
- On a service-access error **before** the reboot, enumerates the services the origin can actually reach (`server.getPrimaryServices()`) and folds that list **plus a fix hint** into the error shown in the dialog:
  > disconnect → remove this device under the browser's Bluetooth permissions (`chrome://settings/content/bluetoothDevices`) → reconnect → retry.
- Renders the error message with line breaks / scrolling.

This turns the opaque Chrome error into actionable data: the "Services currently accessible" line will show whether the DFU service is actually in the grant.

## Likely fix for you to try first
Disconnect, **forget/remove the DovesDataLogger** under your browser's Bluetooth permissions, then reconnect and retry — that refreshes the permission grant to include the DFU service. If it still fails, the new error text (or the `?dbg=true` log) will tell us exactly which services are in the grant.

## Test plan
`npm run lint` · `npm run typecheck` · `npm run test:run` (**1315 passing**) · `npm run build` — all green.

https://claude.ai/code/session_018ZCN5HsjxMdV85wVWZwo6t

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCN5HsjxMdV85wVWZwo6t)_