### PR TITLE
feat(ble): in-app "Forget device & reconnect" for firmware permission errors

### DIFF
--- a/src/components/drawer/FirmwareUpdateSection.tsx
+++ b/src/components/drawer/FirmwareUpdateSection.tsx
@@ -170,7 +170,12 @@ export function FirmwareUpdateSection({ connection }: { connection: BleConnectio
                   {fw.flashError ?? "Something went wrong during the update."}
                 </DialogDescription>
               </DialogHeader>
-              <DialogFooter>
+              <DialogFooter className="gap-2 sm:gap-0">
+                {fw.canForgetDevice && (
+                  <Button variant="secondary" onClick={fw.forgetDevice}>
+                    Forget device &amp; reconnect
+                  </Button>
+                )}
                 <Button variant="outline" onClick={fw.dismiss}>
                   Close
                 </Button>

--- a/src/hooks/useFirmwareUpdate.ts
+++ b/src/hooks/useFirmwareUpdate.ts
@@ -211,9 +211,8 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
         message =
           `${errorMessage(e)}\n\n` +
           "Your browser is blocking the firmware-update service — usually a stale " +
-          "Bluetooth permission from a previous pairing. Fix: disconnect, then remove " +
-          "this device under your browser's Bluetooth permissions " +
-          "(chrome://settings/content/bluetoothDevices), reconnect, and try again.\n\n" +
+          "Bluetooth permission from a previous pairing. Tap “Forget device & reconnect” " +
+          "below, then reconnect and try again.\n\n" +
           `Services currently accessible: ${accessible}`;
       }
       setPhase("error");
@@ -237,6 +236,34 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
     }
   }, [needsDisconnect, disconnectDevice]);
 
+  /**
+   * Revoke this device's Web Bluetooth permission and disconnect, so the next
+   * connect re-pairs with a fresh grant (the fix for a stale permission that's
+   * missing the DFU service). Works without the browser's settings page —
+   * `BluetoothDevice.forget()` is supported on Chrome desktop + Android.
+   */
+  const forgetDevice = useCallback(async () => {
+    const device = connection?.device as
+      | (BluetoothDevice & { forget?: () => Promise<void> })
+      | undefined;
+    try {
+      await device?.forget?.();
+      fwLog("device permission forgotten");
+    } catch (e) {
+      fwLog("forget() failed", errorMessage(e));
+    }
+    setPhase(null);
+    setFlashError(null);
+    setPercent(0);
+    setNeedsDisconnect(false);
+    disconnectDevice();
+    toast.message("Bluetooth permission cleared — reconnect to try the update again");
+  }, [connection, disconnectDevice]);
+
+  /** Whether `BluetoothDevice.forget()` is available (to show the recovery button). */
+  const canForgetDevice =
+    typeof (connection?.device as { forget?: unknown } | undefined)?.forget === "function";
+
   return {
     info,
     loadingVersion,
@@ -250,9 +277,11 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
     phase,
     percent,
     flashError,
+    canForgetDevice,
     checkForUpdates,
     cancel,
     startUpdate,
     dismiss,
+    forgetDevice,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #171. The `chrome://settings` Bluetooth page isn't navigable on Android, so the "forget the device to clear a stale permission" recovery step had no mobile path. This adds an **in-app recovery button**.

On a service-access (`SecurityError`) flash failure, the error dialog now shows **"Forget device & reconnect"**, which calls Web Bluetooth's `BluetoothDevice.forget()` to revoke the device's permission and disconnects — so the next connect re-pairs with a **fresh grant** that includes the DFU service. No browser settings page required.

- Button is gated on `forget()` support (Chrome desktop + Android).
- Error copy updated to point at the button instead of the `chrome://settings` URL.

## Test plan

`npm run lint` · `npm run typecheck` · `npm run test:run` (1315 passing) · `npm run build` — all green.

## How to use
Hit Upload → on the permission error, tap **Forget device & reconnect** → reconnect → retry. If it still fails, the dialog's "Services currently accessible" line (from #171) will show whether the DFU service made it into the grant.

https://claude.ai/code/session_018ZCN5HsjxMdV85wVWZwo6t

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCN5HsjxMdV85wVWZwo6t)_