### PR TITLE
feat(settings): split units into speed/distance/weather imperial-metric toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   covers.
 
 ### Added
+- **Independent imperial/metric unit toggles.** Settings now has three separate
+  unit switches instead of just one speed toggle: **Speed** (MPH ⇄ KPH),
+  **Distance** (ft/mi ⇄ m/km — track lengths, lap/chart distance axis, and the
+  range-crop labels), and **Weather** (°F/mph/inHg/ft ⇄ °C/(km/h)/hPa/m —
+  temperature, dew point, wind, pressure, and density/pressure altitude). Each is
+  app-wide and remembered per device; all default to imperial.
 - **Firmware updates over Bluetooth.** The Device → Settings tab now shows your
   logger's installed firmware version with a **Check for updates** button. When a
   newer build is available for your device, a confirmation dialog (battery /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Independent imperial/metric unit toggles.** Settings now has three separate
   unit switches instead of just one speed toggle: **Speed** (MPH ⇄ KPH),
-  **Distance** (ft/mi ⇄ m/km — track lengths, lap/chart distance axis, and the
-  range-crop labels), and **Weather** (°F/mph/inHg/ft ⇄ °C/(km/h)/hPa/m —
+  **Distance** (ft/mi ⇄ m/km — track lengths, lap/chart distance axis, the
+  range-crop labels, and meters-based telemetry channels like Distance &
+  Altitude in the graphs and video overlays), and **Weather**
+  (°F/mph/inHg/ft ⇄ °C/(km/h)/hPa/m —
   temperature, dew point, wind, pressure, and density/pressure altitude). Each is
   app-wide and remembered per device; all default to imperial.
 - **Firmware updates over Bluetooth.** The Device → Settings tab now shows your

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -738,7 +738,7 @@ Key settings: `useKph`, `gForceSmoothing`, `gForceSmoothingStrength`, `brakingZo
 
 **Units are three independent imperial/metric toggles** (all default imperial), one per measurement family, each a Switch in `SettingsModal`:
 - `useKph` (speed) — MPH ⇄ KPH. Picks `speedMph`/`speedKph` on every sample + speed axis labels.
-- `useMetricDistance` (distance) — ft/mi ⇄ m/km. Drives the chart distance axis (`buildChartAxis` `opts.useMetricDistance`), the range-crop labels, and `TrackEditor` course lengths.
+- `useMetricDistance` (distance) — ft/mi ⇄ m/km. Drives the chart distance axis (`buildChartAxis` `opts.useMetricDistance`), the range-crop labels, `TrackEditor` course lengths, and the meters-based **distance-family telemetry channels** (`distance`, `altitude` — `isDistanceUnitChannel`; converted to a single continuous m/ft unit in the graph charts + video overlays. GPS accuracy `h_acc`/`v_acc` stays in meters).
 - `useMetricWeather` (weather) — °F/mph/inHg/ft ⇄ °C/(km/h)/hPa/m. Drives `WeatherPanel` + `LocalWeatherDialog` (temp, dew point, wind, pressure, density/pressure altitude).
 
 All conversions + display formatters live in **`lib/units.ts`** (pure, unit-tested in `units.test.ts`): canonical internal values (distance→meters, temp→Celsius, wind→knots, pressure→inHg, altitude→feet) convert only at display time. `chartAxis.formatAxisDistance` is a re-export of `units.formatDistance`. Weather/track-length surfaces read the flag via `useOptionalSettingsContext()` so they also render outside the provider (landing page).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ src/
 │   ├── weatherService.ts  # Historical weather (online-only): US → NWS station + IEM ASOS METAR; else → Open-Meteo reanalysis fallback (keyless, global). fetchSessionWeather orchestrates.
 │   ├── buildInfo.ts       # Build version/hash/branch/commit-date stamp (landing footer "what changed" marker; main → version+hash, other branches → branch+hash+commit time + amber preview-DB warning via isPreviewBuild(); values injected by vite define)
 │   ├── debugConsole.ts    # ★ On-screen debug console (`?dbg=true`): pure flag-parse + log ring-buffer + console/global-error capture (mobile/PWA has no dev tools) — rendered by components/DebugConsole.tsx
+│   ├── units.ts           # ★ Pure unit conversions + display formatters for the 3 imperial/metric toggles (speed/distance/weather) — single home for every conversion constant
 │   └── utils.ts           # Tailwind cn() helper
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section
 │   ├── (framework)        # types, registry, index, panels, mounts, storage + PluginPanelHost/PluginMount
@@ -735,6 +736,13 @@ Global BLE connection state is managed by `DeviceContext.tsx`, wrapping the app 
 
 Key settings: `useKph`, `gForceSmoothing`, `gForceSmoothingStrength`, `brakingZoneSettings` (thresholds, duration, smoothing, color, width), `enableLabs` (hidden when no labs features), `darkMode`, `deltaMethod` (`'position'` default | `'distance'` legacy), `deltaSampleMeters` (arc-length resample spacing for position delta, default 2), `chartXAxis` (`'distance'` default | `'time'`) — the analysis-chart X-axis scale.
 
+**Units are three independent imperial/metric toggles** (all default imperial), one per measurement family, each a Switch in `SettingsModal`:
+- `useKph` (speed) — MPH ⇄ KPH. Picks `speedMph`/`speedKph` on every sample + speed axis labels.
+- `useMetricDistance` (distance) — ft/mi ⇄ m/km. Drives the chart distance axis (`buildChartAxis` `opts.useMetricDistance`), the range-crop labels, and `TrackEditor` course lengths.
+- `useMetricWeather` (weather) — °F/mph/inHg/ft ⇄ °C/(km/h)/hPa/m. Drives `WeatherPanel` + `LocalWeatherDialog` (temp, dew point, wind, pressure, density/pressure altitude).
+
+All conversions + display formatters live in **`lib/units.ts`** (pure, unit-tested in `units.test.ts`): canonical internal values (distance→meters, temp→Celsius, wind→knots, pressure→inHg, altitude→feet) convert only at display time. `chartAxis.formatAxisDistance` is a re-export of `units.formatDistance`. Weather/track-length surfaces read the flag via `useOptionalSettingsContext()` so they also render outside the provider (landing page).
+
 `useReferenceLap.ts` routes pace through `computeLapPace` (`lapDelta.ts`), which
 switches on `deltaMethod`. The position method is the issue #29 port; `distance`
 falls back to the legacy `calculatePace` in `referenceUtils.ts`.
@@ -743,8 +751,8 @@ falls back to the legacy `calculatePace` in `referenceUtils.ts`.
 charts (`TelemetryChart`, `SingleSeriesChart`) via `lib/chartAxis.ts`
 (`buildChartAxis`): a pure, unit-tested helper that maps each sample to an
 x-fraction (elapsed-time fraction, or cumulative-distance fraction via
-`calculateDistanceArray`), supplies tick labels (distance unit follows `useKph`:
-MPH→ft/mi, KPH→m/km), and an `indexAt` inverse for scrubbing. Distance is the
+`calculateDistanceArray`), supplies tick labels (distance unit follows
+`useMetricDistance`: imperial→ft/mi, metric→m/km), and an `indexAt` inverse for scrubbing. Distance is the
 default so laps line up by track position; the reference/pace overlays already
 align by distance, so they sit correctly on either axis.
 

--- a/src/components/LocalWeatherDialog.tsx
+++ b/src/components/LocalWeatherDialog.tsx
@@ -15,9 +15,14 @@ import {
   WeatherStation,
   WeatherData,
 } from "@/lib/weatherService";
-import { toast } from "@/hooks/use-toast";
-
-const knotsToMph = (kts: number) => Math.round(kts * 1.15078);
+import { useOptionalSettingsContext } from "@/contexts/SettingsContext";
+import {
+  formatTemperature,
+  formatPressure,
+  formatAltitudeFt,
+  windSpeedValue,
+  windSpeedUnit,
+} from "@/lib/units";
 
 interface LocalWeatherDialogProps {
   /** If provided, renders in session read-only mode (no search UI) */
@@ -222,6 +227,8 @@ export function LocalWeatherDialog({ sessionWeather, externalOpen, onExternalOpe
 
 /** Extracted weather results display */
 function WeatherResultsView({ weather, resolvedLocation, showTuningNote = true }: { weather: WeatherData; resolvedLocation?: string | null; showTuningNote?: boolean }) {
+  const metric = useOptionalSettingsContext()?.useMetricWeather ?? false;
+
   // Compute dew point from temp and humidity (Magnus formula)
   const dewPointC = (() => {
     const a = 17.27;
@@ -230,14 +237,13 @@ function WeatherResultsView({ weather, resolvedLocation, showTuningNote = true }
     return Math.round(((b * alpha) / (a - alpha)) * 10) / 10;
   })();
 
-  const dewPointF = Math.round((dewPointC * 9) / 5 + 32);
   const pressureAltFt = Math.round((29.92 - weather.altimeterInHg) * 1000);
 
   const windValue = weather.windSpeedKts !== null
     ? (() => {
-        const mph = knotsToMph(weather.windSpeedKts);
-        const gustStr = weather.windGustKts ? ` G${knotsToMph(weather.windGustKts)}` : "";
-        return `${weather.windDirectionDeg ?? "VRB"}° @ ${mph} mph${gustStr}`;
+        const spd = windSpeedValue(weather.windSpeedKts, metric);
+        const gustStr = weather.windGustKts ? ` G${windSpeedValue(weather.windGustKts, metric)}` : "";
+        return `${weather.windDirectionDeg ?? "VRB"}° @ ${spd} ${windSpeedUnit(metric)}${gustStr}`;
       })()
     : "Calm";
 
@@ -272,7 +278,7 @@ function WeatherResultsView({ weather, resolvedLocation, showTuningNote = true }
         <WeatherItem
           icon={<Thermometer className="w-4 h-4" />}
           label="Temperature"
-          value={`${weather.temperatureF}°F (${weather.temperatureC}°C)`}
+          value={formatTemperature(weather.temperatureC, metric)}
         />
         <WeatherItem
           icon={<Droplets className="w-4 h-4" />}
@@ -282,12 +288,12 @@ function WeatherResultsView({ weather, resolvedLocation, showTuningNote = true }
         <WeatherItem
           icon={<Thermometer className="w-4 h-4" />}
           label="Dew Point"
-          value={`${dewPointF}°F (${dewPointC}°C)`}
+          value={formatTemperature(dewPointC, metric)}
         />
         <WeatherItem
           icon={<Gauge className="w-4 h-4" />}
           label="Barometer"
-          value={`${weather.altimeterInHg} inHg`}
+          value={formatPressure(weather.altimeterInHg, metric)}
         />
         <WeatherItem
           icon={<Wind className="w-4 h-4" />}
@@ -305,12 +311,12 @@ function WeatherResultsView({ weather, resolvedLocation, showTuningNote = true }
         <WeatherItem
           icon={<Mountain className="w-4 h-4" />}
           label="Pressure Alt"
-          value={`${pressureAltFt.toLocaleString()} ft`}
+          value={formatAltitudeFt(pressureAltFt, metric)}
         />
         <WeatherItem
           icon={<Mountain className="w-4 h-4" />}
           label="Density Alt"
-          value={`${weather.densityAltitudeFt.toLocaleString()} ft`}
+          value={formatAltitudeFt(weather.densityAltitudeFt, metric)}
           highlight
         />
       </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Settings, Eye, EyeOff, Gauge, Activity, Circle, HardDrive, FlaskConical, Sun, Moon, RefreshCw, Timer, Ruler, ChevronDown } from "lucide-react";
+import { Settings, Eye, EyeOff, Gauge, Activity, Circle, HardDrive, FlaskConical, Sun, Moon, RefreshCw, Timer, Ruler, ChevronDown, Map, CloudSun } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -112,6 +112,63 @@ export function SettingsModal({
                 />
                 <span className={`text-xs ${settings.useKph ? "text-foreground font-medium" : "text-muted-foreground"}`}>
                   KPH
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Distance Unit */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Map className="w-4 h-4 text-muted-foreground" />
+              <h3 className="font-medium">Distance Unit</h3>
+            </div>
+            <div className="flex items-center justify-between pl-6">
+              <Label htmlFor="settings-distance-unit" className="text-sm text-muted-foreground">
+                Track length, lap distance &amp; chart distance axis
+              </Label>
+              <div className="flex items-center gap-2">
+                <span className={`text-xs ${!settings.useMetricDistance ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                  ft/mi
+                </span>
+                <Switch
+                  id="settings-distance-unit"
+                  checked={settings.useMetricDistance}
+                  onCheckedChange={(checked) => onSettingsChange({ useMetricDistance: checked })}
+                />
+                <span className={`text-xs ${settings.useMetricDistance ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                  m/km
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Weather Units */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <CloudSun className="w-4 h-4 text-muted-foreground" />
+              <h3 className="font-medium">Weather Units</h3>
+            </div>
+            <div className="flex items-center justify-between pl-6">
+              <div>
+                <Label htmlFor="settings-weather-units" className="text-sm text-muted-foreground">
+                  Temperature, wind, pressure &amp; altitude
+                </Label>
+                <p className="text-xs text-muted-foreground/70 mt-0.5">
+                  Imperial = °F, mph, inHg, ft · Metric = °C, km/h, hPa, m
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className={`text-xs ${!settings.useMetricWeather ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                  Imp
+                </span>
+                <Switch
+                  id="settings-weather-units"
+                  checked={settings.useMetricWeather}
+                  onCheckedChange={(checked) => onSettingsChange({ useMetricWeather: checked })}
+                />
+                <span className={`text-xs ${settings.useMetricWeather ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                  Met
                 </span>
               </div>
             </div>

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -4,6 +4,7 @@ import { G_FORCE_FIELDS, G_FORCE_FIELDS_GPS, G_FORCE_FIELDS_HW, applySmoothingTo
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
 import { buildChartAxis } from '@/lib/chartAxis';
+import { isDistanceUnitChannel, distanceChannelValue, distanceChannelUnit } from '@/lib/units';
 import { alignByDistance } from '@/lib/referenceUtils';
 import type { OverlayLine } from '@/lib/lapOverlays';
 
@@ -479,13 +480,17 @@ export function TelemetryChart({
           const mappingIndex = fieldMappings.findIndex(f => f.name === field.name);
           const colorIndex = ((mappingIndex === -1 ? 0 : mappingIndex) + 1) % COLORS.length;
           ctx.fillStyle = COLORS[colorIndex];
-          ctx.fillText(`${field.label ?? field.name}: ${val.toFixed(1)}`, boxX + 8, boxY + 14 + fieldOffset * 16);
+          // Distance-family channels (distance, altitude) follow the distance unit toggle.
+          const isDist = isDistanceUnitChannel(field.name);
+          const shown = isDist ? distanceChannelValue(val, useMetricDistance) : val;
+          const unitSuffix = isDist ? ` ${distanceChannelUnit(useMetricDistance)}` : '';
+          ctx.fillText(`${field.label ?? field.name}: ${shown.toFixed(1)}${unitSuffix}`, boxX + 8, boxY + 14 + fieldOffset * 16);
           fieldOffset++;
         }
       });
     }
 
-  }, [samples, currentIndex, dimensions, enabledFields, useKph, speedUnit, paceData, referenceSpeedData, hasReference, showReferenceSpeed, showPace, smoothedGForceData, chartColors, fieldMappings, getSpeed, axis, overlaySpeed]);
+  }, [samples, currentIndex, dimensions, enabledFields, useKph, useMetricDistance, speedUnit, paceData, referenceSpeedData, hasReference, showReferenceSpeed, showPace, smoothedGForceData, chartColors, fieldMappings, getSpeed, axis, overlaySpeed]);
 
   // Scrub handling
   const handleScrub = useCallback((clientX: number) => {

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -51,11 +51,11 @@ export function TelemetryChart({
   rangeStart,
   overlayLines = [],
 }: TelemetryChartProps) {
-  const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, gForceSource, chartXAxis } = useSettingsContext();
+  const { useKph, useMetricDistance, gForceSmoothing, gForceSmoothingStrength, darkMode, gForceSource, chartXAxis } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
   const axis = useMemo(
-    () => buildChartAxis(samples, chartXAxis, { useKph, fullSamples: allSamples, rangeStart }),
-    [samples, chartXAxis, useKph, allSamples, rangeStart],
+    () => buildChartAxis(samples, chartXAxis, { useMetricDistance, fullSamples: allSamples, rangeStart }),
+    [samples, chartXAxis, useMetricDistance, allSamples, rangeStart],
   );
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -37,6 +37,8 @@ import {
 } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTrackEditorForm } from '@/hooks/useTrackEditorForm';
+import { useOptionalSettingsContext } from '@/contexts/SettingsContext';
+import { formatTrackLength } from '@/lib/units';
 // Lazy — VisualEditor pulls in Leaflet drawing logic; only loads when the
 // track editor dialog is opened.
 const VisualEditor = lazy(() =>
@@ -88,6 +90,9 @@ export function TrackEditor({
   // Courses that still differ from the community DB (drives the always-visible
   // "Submit to DB" button: greyed out when there's nothing new to send).
   const [pendingSubmissionCount, setPendingSubmissionCount] = useState(0);
+  // Track length follows the distance unit setting; falls back to imperial when
+  // rendered outside the provider (e.g. the landing-page "Manage Tracks" entry).
+  const useMetricDistance = useOptionalSettingsContext()?.useMetricDistance ?? false;
 
   const form = useTrackEditorForm();
 /** Mini SVG preview of a course drawing outline */
@@ -486,7 +491,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
                       {course.sector2 && course.sector3 && <span className="ml-2 text-xs text-accent-foreground/60">(sectors)</span>}
                       {course.lengthFt != null && course.lengthFt > 0 && (
                         <span className="ml-2 text-xs text-muted-foreground">
-                          {course.lengthFt.toLocaleString()} ft
+                          {formatTrackLength(course.lengthFt, useMetricDistance)}
                         </span>
                       )}
                     </div>

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -232,7 +232,7 @@ export const VideoPlayer = memo(function VideoPlayer({
   course = null, referenceSamples = [], paceData = [],
   sessionFileName = null,
 }: VideoPlayerProps) {
-  const { useKph, brakingZoneSettings } = useSettingsContext();
+  const { useKph, useMetricDistance, brakingZoneSettings } = useSettingsContext();
   const progressRef = useRef<HTMLDivElement>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -269,8 +269,8 @@ export const VideoPlayer = memo(function VideoPlayer({
   // Build data sources for overlays
   const hasReference = referenceSamples.length > 0;
   const dataSources = useMemo(() =>
-    buildDataSources(fieldMappings, useKph, hasReference),
-    [fieldMappings, useKph, hasReference]
+    buildDataSources(fieldMappings, useKph, hasReference, useMetricDistance),
+    [fieldMappings, useKph, hasReference, useMetricDistance]
   );
 
   // Build render context

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -7,8 +7,13 @@ import {
   WeatherData,
   WeatherStation,
 } from "@/lib/weatherService";
-
-const knotsToMph = (kts: number) => Math.round(kts * 1.15078);
+import { useOptionalSettingsContext } from "@/contexts/SettingsContext";
+import {
+  formatTemperature,
+  formatPressure,
+  formatAltitudeFt,
+  windSpeedValue,
+} from "@/lib/units";
 
 function isToday(date: Date): boolean {
   const now = new Date();
@@ -38,6 +43,7 @@ export function WeatherPanel({
   const [weather, setWeather] = useState<WeatherData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  const metric = useOptionalSettingsContext()?.useMetricWeather ?? false;
   const onStationResolvedRef = useRef(onStationResolved);
   onStationResolvedRef.current = onStationResolved;
   const onWeatherLoadedRef = useRef(onWeatherLoaded);
@@ -139,17 +145,17 @@ export function WeatherPanel({
             </div>
           )}
 
-          <WeatherRow icon={<Thermometer className="w-3 h-3" />} label="Temp" value={`${weather.temperatureF}°F (${weather.temperatureC}°C)`} />
+          <WeatherRow icon={<Thermometer className="w-3 h-3" />} label="Temp" value={formatTemperature(weather.temperatureC, metric)} />
           <WeatherRow icon={<Droplets className="w-3 h-3" />} label="Humidity" value={`${weather.humidity}%`} />
-          <WeatherRow icon={<Gauge className="w-3 h-3" />} label="Pressure" value={`${weather.altimeterInHg} inHg`} />
-          <WeatherRow icon={<Gauge className="w-3 h-3" />} label="DA" value={`${weather.densityAltitudeFt.toLocaleString()} ft`} />
+          <WeatherRow icon={<Gauge className="w-3 h-3" />} label="Pressure" value={formatPressure(weather.altimeterInHg, metric)} />
+          <WeatherRow icon={<Gauge className="w-3 h-3" />} label="DA" value={formatAltitudeFt(weather.densityAltitudeFt, metric)} />
 
           {/* Extended fields - detailed only */}
           {detailed && (
             <>
-              <DewPointRow temperatureC={weather.temperatureC} humidity={weather.humidity} />
-              <WindRow weather={weather} />
-              <PressureAltRow altimeterInHg={weather.altimeterInHg} />
+              <DewPointRow temperatureC={weather.temperatureC} humidity={weather.humidity} metric={metric} />
+              <WindRow weather={weather} metric={metric} />
+              <PressureAltRow altimeterInHg={weather.altimeterInHg} metric={metric} />
               {sessionDate && isToday(sessionDate) && (
                 <TuningNote densityAltitudeFt={weather.densityAltitudeFt} humidity={weather.humidity} />
               )}
@@ -173,20 +179,19 @@ function WeatherRow({ icon, label, value }: { icon: React.ReactNode; label: stri
   );
 }
 
-function DewPointRow({ temperatureC, humidity }: { temperatureC: number; humidity: number }) {
+function DewPointRow({ temperatureC, humidity, metric }: { temperatureC: number; humidity: number; metric: boolean }) {
   const a = 17.27, b = 237.7;
   const alpha = (a * temperatureC) / (b + temperatureC) + Math.log(humidity / 100);
   const dewC = Math.round(((b * alpha) / (a - alpha)) * 10) / 10;
-  const dewF = Math.round((dewC * 9) / 5 + 32);
-  return <WeatherRow icon={<Thermometer className="w-3 h-3" />} label="Dew Pt" value={`${dewF}°F (${dewC}°C)`} />;
+  return <WeatherRow icon={<Thermometer className="w-3 h-3" />} label="Dew Pt" value={formatTemperature(dewC, metric)} />;
 }
 
-function WindRow({ weather }: { weather: WeatherData }) {
+function WindRow({ weather, metric }: { weather: WeatherData; metric: boolean }) {
   const windValue = weather.windSpeedKts !== null
     ? (() => {
-        const mph = knotsToMph(weather.windSpeedKts);
-        const gustStr = weather.windGustKts ? ` G${knotsToMph(weather.windGustKts)}` : "";
-        return `${weather.windDirectionDeg ?? "VRB"}° @ ${mph}${gustStr}`;
+        const spd = windSpeedValue(weather.windSpeedKts, metric);
+        const gustStr = weather.windGustKts ? ` G${windSpeedValue(weather.windGustKts, metric)}` : "";
+        return `${weather.windDirectionDeg ?? "VRB"}° @ ${spd}${gustStr}`;
       })()
     : "Calm";
   return (
@@ -205,9 +210,9 @@ function WindRow({ weather }: { weather: WeatherData }) {
   );
 }
 
-function PressureAltRow({ altimeterInHg }: { altimeterInHg: number }) {
+function PressureAltRow({ altimeterInHg, metric }: { altimeterInHg: number; metric: boolean }) {
   const pressureAltFt = Math.round((29.92 - altimeterInHg) * 1000);
-  return <WeatherRow icon={<Mountain className="w-3 h-3" />} label="Press Alt" value={`${pressureAltFt.toLocaleString()} ft`} />;
+  return <WeatherRow icon={<Mountain className="w-3 h-3" />} label="Press Alt" value={formatAltitudeFt(pressureAltFt, metric)} />;
 }
 
 function TuningNote({ densityAltitudeFt, humidity }: { densityAltitudeFt: number; humidity: number }) {

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -8,6 +8,7 @@ import { GpsSample, FieldMapping } from '@/types/racing';
 import type { OverlayLine } from '@/lib/lapOverlays';
 import { calculatePace, calculateReferenceSpeed, calculateDistanceArray } from '@/lib/referenceUtils';
 import { computeBrakingGSeriesSG, gToBrakePercent } from '@/lib/brakingZones';
+import { isDistanceUnitChannel, distanceChannelUnit } from '@/lib/units';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { saveGraphPrefs, loadGraphPrefs } from '@/lib/graphPrefsStorage';
 
@@ -36,7 +37,7 @@ export function GraphPanel({
   samples, filteredSamples, referenceSamples, fieldMappings, currentIndex, onScrub,
   visibleRange, onRangeChange, minRange, formatRangeLabel, sessionFileName, overlayLines = [],
 }: GraphPanelProps) {
-  const { useKph, brakingZoneSettings } = useSettingsContext();
+  const { useKph, useMetricDistance, brakingZoneSettings } = useSettingsContext();
   const [activeGraphs, setActiveGraphs] = useState<string[]>([]);
   const [graphHeights, setGraphHeights] = useState<Record<string, number>>({});
   const loadedFileRef = useRef<string | null>(null);
@@ -169,7 +170,9 @@ export function GraphPanel({
     }
     fieldMappings.forEach(f => {
       const display = f.label ?? f.name;
-      let label = display + (f.unit ? ` (${f.unit})` : '');
+      // Distance-family channels (distance, altitude) follow the distance unit toggle.
+      const unit = isDistanceUnitChannel(f.name) ? distanceChannelUnit(useMetricDistance) : f.unit;
+      let label = display + (unit ? ` (${unit})` : '');
       // Add source indicator when both GPS and HW G-force data exist
       if (hasBothSources) {
         if (f.name === 'lat_g') label = 'Lat G (GPS)';
@@ -181,7 +184,7 @@ export function GraphPanel({
       sources.push({ key: f.name, label });
     });
     return sources;
-  }, [fieldMappings, useKph, hasReference, hasBothSources, hasGForce]);
+  }, [fieldMappings, useKph, useMetricDistance, hasReference, hasBothSources, hasGForce]);
 
   const unusedSources = useMemo(() => {
     return availableSources.filter(s => !activeGraphs.includes(s.key));

--- a/src/components/graphview/SingleSeriesChart.tsx
+++ b/src/components/graphview/SingleSeriesChart.tsx
@@ -42,11 +42,11 @@ export function SingleSeriesChart({
   allSamples, rangeStart, overlayLines = [],
   height, onHeightChange,
 }: SingleSeriesChartProps) {
-  const { useKph, gForceSmoothing, gForceSmoothingStrength, darkMode, chartXAxis, brakingZoneSettings } = useSettingsContext();
+  const { useKph, useMetricDistance, gForceSmoothing, gForceSmoothingStrength, darkMode, chartXAxis, brakingZoneSettings } = useSettingsContext();
   const chartColors = useMemo(() => getChartColors(darkMode), [darkMode]);
   const axis = useMemo(
-    () => buildChartAxis(samples, chartXAxis, { useKph, fullSamples: allSamples, rangeStart }),
-    [samples, chartXAxis, useKph, allSamples, rangeStart],
+    () => buildChartAxis(samples, chartXAxis, { useMetricDistance, fullSamples: allSamples, rangeStart }),
+    [samples, chartXAxis, useMetricDistance, allSamples, rangeStart],
   );
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/graphview/SingleSeriesChart.tsx
+++ b/src/components/graphview/SingleSeriesChart.tsx
@@ -5,6 +5,7 @@ import { G_FORCE_FIELDS, applySmoothingToValues, computeSmoothingWindowSize, det
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { getChartColors } from '@/lib/chartColors';
 import { buildChartAxis } from '@/lib/chartAxis';
+import { isDistanceUnitChannel, distanceChannelValue, distanceChannelUnit } from '@/lib/units';
 import { alignByDistance, alignValuesByDistance } from '@/lib/referenceUtils';
 import { computeBrakingGSeriesSG, gToBrakePercent } from '@/lib/brakingZones';
 import type { OverlayLine } from '@/lib/lapOverlays';
@@ -63,6 +64,13 @@ export function SingleSeriesChart({
   const isPace = seriesKey === '__pace__';
   const isBrakingG = seriesKey === '__braking_g__';
   const isGForce = G_FORCE_FIELDS.includes(seriesKey);
+  // Distance-family channels (distance, altitude) are stored in meters but
+  // follow the distance unit toggle (m ⇄ ft).
+  const isDist = isDistanceUnitChannel(seriesKey);
+  const toDist = useCallback(
+    (v: number | undefined) => (isDist && v !== undefined ? distanceChannelValue(v, useMetricDistance) : v),
+    [isDist, useMetricDistance],
+  );
 
   const smoothingWindowSize = useMemo(() =>
     isGForce ? computeSmoothingWindowSize(gForceSmoothing, gForceSmoothingStrength) : 1,
@@ -79,8 +87,14 @@ export function SingleSeriesChart({
     if (isSpeed) {
       return samples.map(s => useKph ? s.speedKph : s.speedMph);
     }
-    return samples.map(s => s.extraFields[seriesKey]);
-  }, [samples, seriesKey, isSpeed, isPace, isBrakingG, useKph, referenceValues, brakingGValues]);
+    return samples.map(s => toDist(s.extraFields[seriesKey]));
+  }, [samples, seriesKey, isSpeed, isPace, isBrakingG, useKph, referenceValues, brakingGValues, toDist]);
+
+  // Reference values, converted onto the same distance unit as the live series.
+  const refValues = useMemo(() => {
+    if (!referenceValues || !isDist) return referenceValues;
+    return referenceValues.map(v => (v === null ? null : distanceChannelValue(v, useMetricDistance)));
+  }, [referenceValues, isDist, useMetricDistance]);
 
   // Apply smoothing for G-force fields
   const values = useMemo(() => {
@@ -114,7 +128,7 @@ export function SingleSeriesChart({
     }
     const getValue = isSpeed
       ? (s: GpsSample) => (useKph ? s.speedKph : s.speedMph)
-      : (s: GpsSample) => s.extraFields[seriesKey];
+      : (s: GpsSample) => toDist(s.extraFields[seriesKey]);
     return overlayLines.map((line) => {
       let values = alignByDistance(full, line.samples, getValue).slice(start, end);
       if (isGForce && smoothingWindowSize > 1) {
@@ -125,7 +139,7 @@ export function SingleSeriesChart({
       }
       return { id: line.id, color: line.color, label: line.label, values };
     });
-  }, [overlayLines, allSamples, samples, rangeStart, isSpeed, isPace, isBrakingG, isGForce, seriesKey, useKph, smoothingWindowSize, brakingZoneSettings.graphWindow, brakingZoneSettings.brakeMaxG]);
+  }, [overlayLines, allSamples, samples, rangeStart, isSpeed, isPace, isBrakingG, isGForce, seriesKey, useKph, toDist, smoothingWindowSize, brakingZoneSettings.graphWindow, brakingZoneSettings.brakeMaxG]);
 
   // Speed glitch filtering
   const interpolateIndices = useMemo(() => {
@@ -189,8 +203,8 @@ export function SingleSeriesChart({
     let maxVal = Math.max(...numericValues);
 
     // Expand range to fit reference values
-    if (referenceValues && !isPace) {
-      const refNums = referenceValues.filter((v): v is number => v !== null);
+    if (refValues && !isPace) {
+      const refNums = refValues.filter((v): v is number => v !== null);
       if (refNums.length > 0) {
         minVal = Math.min(minVal, ...refNums);
         maxVal = Math.max(maxVal, ...refNums);
@@ -216,14 +230,14 @@ export function SingleSeriesChart({
     const range = maxVal - minVal || 1;
 
     // Draw reference line (behind main line)
-    if (referenceValues && !isPace) {
+    if (refValues && !isPace) {
       ctx.beginPath();
       ctx.strokeStyle = chartColors.refLine;
       ctx.lineWidth = 1.5;
       ctx.setLineDash([4, 3]);
       let refDrawing = false;
       for (let i = 0; i < samples.length; i++) {
-        const rv = referenceValues[i];
+        const rv = refValues[i];
         if (rv === null || rv === undefined) { refDrawing = false; continue; }
         const x = padding.left + axis.fracAt(i) * chartWidth;
         const y = padding.top + (1 - (rv - minVal) / range) * chartHeight;
@@ -324,14 +338,14 @@ export function SingleSeriesChart({
       // Current value tooltip — current lap first, then each overlay lap.
       const displayVal = values[currentIndex];
       if (displayVal !== undefined) {
-        const unit = isPace ? 's' : isBrakingG ? 'G' : isSpeed ? (useKph ? ' kph' : ' mph') : '';
+        const unit = isPace ? 's' : isBrakingG ? 'G' : isSpeed ? (useKph ? ' kph' : ' mph') : isDist ? ` ${distanceChannelUnit(useMetricDistance)}` : '';
         const prefix = (isPace || isBrakingG) && displayVal > 0 ? '+' : '';
         const mainText = `${prefix}${displayVal.toFixed((isPace || isBrakingG) ? 2 : 1)}${unit}`;
 
         // Delta text (difference from reference at same point)
         let deltaText = '';
-        if (referenceValues && !isPace) {
-          const refVal = referenceValues[currentIndex];
+        if (refValues && !isPace) {
+          const refVal = refValues[currentIndex];
           if (refVal !== null && refVal !== undefined) {
             const delta = displayVal - refVal;
             const sign = delta > 0 ? '+' : '';
@@ -381,7 +395,7 @@ export function SingleSeriesChart({
         });
       }
     }
-  }, [samples, values, currentIndex, dimensions, color, isSpeed, isPace, isBrakingG, useKph, interpolateIndices, referenceValues, chartColors, axis, overlaySeries]);
+  }, [samples, values, currentIndex, dimensions, color, isSpeed, isPace, isBrakingG, isDist, useKph, useMetricDistance, interpolateIndices, refValues, chartColors, axis, overlaySeries]);
 
   // Scrub handling
   const handleScrub = useCallback((clientX: number) => {

--- a/src/components/video-overlays/dataSourceResolver.test.ts
+++ b/src/components/video-overlays/dataSourceResolver.test.ts
@@ -92,6 +92,24 @@ describe("buildDataSources", () => {
     expect(rpm.getMin([])).toBe(0);
     expect(rpm.getMax([])).toBe(100);
   });
+
+  it("distance-family channels follow the distance unit toggle", () => {
+    const DIST_FIELD: FieldMapping = { index: 2, name: "distance", label: "Distance", unit: "m", enabled: true };
+    const sample = makeSample({ extraFields: { distance: 1000 } });
+
+    // Imperial (default): meters → feet, unit + label switch to ft.
+    const imperial = buildDataSources([DIST_FIELD], false, false, false).find((s) => s.id === "distance")!;
+    expect(imperial.unit).toBe("ft");
+    expect(imperial.label).toBe("Distance (ft)");
+    expect(imperial.getValue(sample)).toBeCloseTo(3280.84, 1);
+    expect(imperial.getMax([sample])).toBeCloseTo(3280.84, 1);
+
+    // Metric: stays in meters.
+    const metric = buildDataSources([DIST_FIELD], false, false, true).find((s) => s.id === "distance")!;
+    expect(metric.unit).toBe("m");
+    expect(metric.label).toBe("Distance (m)");
+    expect(metric.getValue(sample)).toBe(1000);
+  });
 });
 
 // ─── resolveValue ──────────────────────────────────────────────────────────────

--- a/src/components/video-overlays/dataSourceResolver.ts
+++ b/src/components/video-overlays/dataSourceResolver.ts
@@ -1,5 +1,6 @@
 import type { GpsSample, FieldMapping } from "@/types/racing";
 import { toChannelKey } from "@/lib/channels";
+import { isDistanceUnitChannel, distanceChannelValue, distanceChannelUnit } from "@/lib/units";
 
 /**
  * Find a data source by id, falling back to the canonical key for legacy
@@ -23,6 +24,7 @@ export function buildDataSources(
   fieldMappings: FieldMapping[],
   useKph: boolean,
   hasReference: boolean,
+  useMetricDistance: boolean = false,
 ): DataSourceDef[] {
   const sources: DataSourceDef[] = [];
 
@@ -77,16 +79,24 @@ export function buildDataSources(
 
   // Extra fields from parser
   for (const f of fieldMappings) {
+    // Distance-family channels (distance, altitude) are stored in meters but
+    // follow the distance unit toggle (m ⇄ ft).
+    const isDist = isDistanceUnitChannel(f.name);
+    const conv = (v: number) => (isDist ? distanceChannelValue(v, useMetricDistance) : v);
+    const unit = isDist ? distanceChannelUnit(useMetricDistance) : (f.unit ?? "");
     sources.push({
       id: f.name,
-      label: (f.label ?? f.name) + (f.unit ? ` (${f.unit})` : ""),
-      unit: f.unit ?? "",
-      getValue: (s) => s.extraFields[f.name] ?? null,
+      label: (f.label ?? f.name) + (unit ? ` (${unit})` : ""),
+      unit,
+      getValue: (s) => {
+        const v = s.extraFields[f.name];
+        return v === undefined ? null : conv(v);
+      },
       getMin: (samples) => {
         let min = Infinity;
         for (const s of samples) {
           const v = s.extraFields[f.name];
-          if (v !== undefined && v < min) min = v;
+          if (v !== undefined && conv(v) < min) min = conv(v);
         }
         return min === Infinity ? 0 : min;
       },
@@ -94,7 +104,7 @@ export function buildDataSources(
         let max = -Infinity;
         for (const s of samples) {
           const v = s.extraFields[f.name];
-          if (v !== undefined && v > max) max = v;
+          if (v !== undefined && conv(v) > max) max = conv(v);
         }
         return max === -Infinity ? 100 : max;
       },

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -13,6 +13,8 @@ export interface BrakingZoneSettings {
 
 export interface SettingsContextValue {
   useKph: boolean;
+  useMetricDistance: boolean;
+  useMetricWeather: boolean;
   gForceSmoothing: boolean;
   gForceSmoothingStrength: number;
   brakingZoneSettings: BrakingZoneSettings;

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -2,7 +2,9 @@ import { useState, useEffect, useCallback } from "react";
 import { isFieldHiddenByCanonical, CanonicalFieldId } from "@/lib/fieldResolver";
 
 export interface AppSettings {
-  useKph: boolean;
+  useKph: boolean;                  // Speed unit: false = MPH, true = KPH
+  useMetricDistance: boolean;       // Distance unit: false = ft/mi, true = m/km
+  useMetricWeather: boolean;        // Weather units: false = °F/mph/inHg/ft, true = °C/(km/h)/hPa/m
   gForceSmoothing: boolean;
   gForceSmoothingStrength: number; // 0-100, maps to window size
   defaultHiddenFields: CanonicalFieldId[]; // Canonical field IDs to hide by default
@@ -28,6 +30,8 @@ const SETTINGS_KEY = "dove-dataviewer-settings";
 
 const defaultSettings: AppSettings = {
   useKph: false,
+  useMetricDistance: false,
+  useMetricWeather: false,
   gForceSmoothing: true,
   gForceSmoothingStrength: 50,
   defaultHiddenFields: [],

--- a/src/lib/chartAxis.test.ts
+++ b/src/lib/chartAxis.test.ts
@@ -74,7 +74,7 @@ describe("computeAxisPositions", () => {
 describe("buildChartAxis.indexAt", () => {
   it("inverts fracAt to the nearest sample", () => {
     const samples = [makeSample(0, 0), makeSample(10, 100), makeSample(40, 200)];
-    const axis = buildChartAxis(samples, "distance", { useKph: true });
+    const axis = buildChartAxis(samples, "distance", { useMetricDistance: true });
     // Round-trip every sample's own fraction back to its index.
     samples.forEach((_, i) => expect(axis.indexAt(axis.fracAt(i))).toBe(i));
     // A fraction just past the midpoint snaps to the closer endpoint sample.
@@ -85,7 +85,7 @@ describe("buildChartAxis.indexAt", () => {
 
   it("clamps out-of-range fractions", () => {
     const samples = [makeSample(0, 0), makeSample(10, 100)];
-    const axis = buildChartAxis(samples, "time", { useKph: false });
+    const axis = buildChartAxis(samples, "time", { useMetricDistance: false });
     expect(axis.indexAt(-5)).toBe(0);
     expect(axis.indexAt(5)).toBe(1);
   });
@@ -94,18 +94,18 @@ describe("buildChartAxis.indexAt", () => {
 describe("buildChartAxis.label", () => {
   it("labels time mode as m:ss across the axis", () => {
     const samples = [makeSample(0, 0), makeSample(10, 90_000)]; // 90 s span
-    const axis = buildChartAxis(samples, "time", { useKph: false });
+    const axis = buildChartAxis(samples, "time", { useMetricDistance: false });
     expect(axis.label(0)).toBe("0:00");
     expect(axis.label(1)).toBe("1:30");
   });
 
-  it("labels distance mode in the speed-unit family", () => {
+  it("labels distance mode in the distance-unit family", () => {
     const samples = [makeSample(0, 0), makeSample(100, 1000)]; // 100 m span
-    const metric = buildChartAxis(samples, "distance", { useKph: true });
+    const metric = buildChartAxis(samples, "distance", { useMetricDistance: true });
     expect(metric.label(0)).toBe("0 m");
     expect(metric.label(1)).toBe("100 m");
 
-    const imperial = buildChartAxis(samples, "distance", { useKph: false });
+    const imperial = buildChartAxis(samples, "distance", { useMetricDistance: false });
     expect(imperial.label(1)).toBe("328 ft");
   });
 });
@@ -116,7 +116,7 @@ describe("buildChartAxis absolute labels (fullSamples + rangeStart)", () => {
 
   it("labels a cropped window in absolute distance from the lap start", () => {
     const window = fullLap.slice(3, 7); // 30 m .. 60 m
-    const axis = buildChartAxis(window, "distance", { useKph: true, fullSamples: fullLap, rangeStart: 3 });
+    const axis = buildChartAxis(window, "distance", { useMetricDistance: true, fullSamples: fullLap, rangeStart: 3 });
     // Window still fills the canvas (data fractions span 0..1)...
     expect(axis.fracAt(0)).toBe(0);
     expect(axis.fracAt(3)).toBeCloseTo(1, 6);
@@ -128,14 +128,14 @@ describe("buildChartAxis absolute labels (fullSamples + rangeStart)", () => {
 
   it("labels a cropped window in absolute time from the lap start", () => {
     const window = fullLap.slice(4, 9); // 4 s .. 8 s
-    const axis = buildChartAxis(window, "time", { useKph: false, fullSamples: fullLap, rangeStart: 4 });
+    const axis = buildChartAxis(window, "time", { useMetricDistance: false, fullSamples: fullLap, rangeStart: 4 });
     expect(axis.label(0)).toBe("0:04");
     expect(axis.label(1)).toBe("0:08");
   });
 
   it("anchors at 0 when the window starts at the lap origin", () => {
     const window = fullLap.slice(0, 5); // 0 m .. 40 m
-    const axis = buildChartAxis(window, "distance", { useKph: true, fullSamples: fullLap, rangeStart: 0 });
+    const axis = buildChartAxis(window, "distance", { useMetricDistance: true, fullSamples: fullLap, rangeStart: 0 });
     expect(axis.label(0)).toBe("0 m");
     expect(axis.label(1)).toBe("40 m");
   });

--- a/src/lib/chartAxis.ts
+++ b/src/lib/chartAxis.ts
@@ -17,11 +17,9 @@
 
 import { GpsSample } from '@/types/racing';
 import { calculateDistanceArray } from './referenceUtils';
+import { formatDistance } from './units';
 
 export type ChartXAxisMode = 'time' | 'distance';
-
-const METERS_PER_FOOT = 0.3048;
-const FEET_PER_MILE = 5280;
 
 export interface ChartAxis {
   mode: ChartXAxisMode;
@@ -45,17 +43,11 @@ export function formatAxisTime(seconds: number): string {
 }
 
 /**
- * Format a distance (in meters) using the unit family implied by the speed
- * unit: KPH → meters/km, MPH → feet/miles. Switches to the larger unit once
- * past a full km / mile so long sessions stay readable.
+ * Format a distance (in meters) for the distance unit family: metric → m/km,
+ * imperial → ft/mi. Thin re-export of {@link formatDistance} so chart callers
+ * keep a single import.
  */
-export function formatAxisDistance(meters: number, useKph: boolean): string {
-  if (useKph) {
-    return meters >= 1000 ? `${(meters / 1000).toFixed(2)} km` : `${Math.round(meters)} m`;
-  }
-  const feet = meters / METERS_PER_FOOT;
-  return feet >= FEET_PER_MILE ? `${(feet / FEET_PER_MILE).toFixed(2)} mi` : `${Math.round(feet)} ft`;
-}
+export const formatAxisDistance = formatDistance;
 
 /**
  * Compute the per-sample axis fraction [0..1] for a mode. Falls back to a
@@ -108,8 +100,9 @@ function nearestIndex(positions: number[], frac: number): number {
 }
 
 /**
- * Build the axis helper for a sample set. `useKph` only affects distance-mode
- * tick labels (the unit family); positions are unit-agnostic fractions.
+ * Build the axis helper for a sample set. `useMetricDistance` only affects
+ * distance-mode tick labels (the unit family); positions are unit-agnostic
+ * fractions.
  *
  * Pass `fullSamples` + `rangeStart` to label **absolutely** from the full
  * series' origin (the lap start / start-finish line): the drawn fractions still
@@ -120,7 +113,7 @@ function nearestIndex(positions: number[], frac: number): number {
 export function buildChartAxis(
   samples: GpsSample[],
   mode: ChartXAxisMode,
-  opts: { useKph: boolean; fullSamples?: GpsSample[]; rangeStart?: number },
+  opts: { useMetricDistance: boolean; fullSamples?: GpsSample[]; rangeStart?: number },
 ): ChartAxis {
   const positions = computeAxisPositions(samples, mode);
   const n = samples.length;
@@ -155,7 +148,7 @@ export function buildChartAxis(
     indexAt: (frac: number) => nearestIndex(positions, frac),
     label: (frac: number) =>
       mode === 'distance'
-        ? formatAxisDistance(offset + extent * frac, opts.useKph)
+        ? formatDistance(offset + extent * frac, opts.useMetricDistance)
         : formatAxisTime(offset + extent * frac),
   };
 }

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  speedUnitLabel,
+  formatDistance,
+  formatTrackLength,
+  celsiusToFahrenheit,
+  formatTemperature,
+  knotsToMph,
+  knotsToKph,
+  windSpeedUnit,
+  windSpeedValue,
+  formatPressure,
+  formatAltitudeFt,
+  METERS_PER_FOOT,
+  FEET_PER_MILE,
+} from './units';
+
+describe('speed', () => {
+  it('labels the speed unit family', () => {
+    expect(speedUnitLabel(false)).toBe('MPH');
+    expect(speedUnitLabel(true)).toBe('KPH');
+  });
+});
+
+describe('formatDistance', () => {
+  it('formats metric in m below 1 km, km above', () => {
+    expect(formatDistance(500, true)).toBe('500 m');
+    expect(formatDistance(999, true)).toBe('999 m');
+    expect(formatDistance(1000, true)).toBe('1.00 km');
+    expect(formatDistance(1500, true)).toBe('1.50 km');
+  });
+
+  it('formats imperial in ft below 1 mi, mi above', () => {
+    // 304.8 m = 1000 ft
+    expect(formatDistance(304.8, false)).toBe('1000 ft');
+    // 1 mile in meters
+    expect(formatDistance(FEET_PER_MILE * METERS_PER_FOOT, false)).toBe('1.00 mi');
+  });
+
+  it('rounds metric meters and imperial feet', () => {
+    expect(formatDistance(123.4, true)).toBe('123 m');
+    expect(formatDistance(METERS_PER_FOOT * 50, false)).toBe('50 ft');
+  });
+});
+
+describe('formatTrackLength', () => {
+  it('keeps feet in imperial', () => {
+    expect(formatTrackLength(2640, false)).toBe('2640 ft'); // half mile
+    expect(formatTrackLength(5280, false)).toBe('1.00 mi');
+  });
+
+  it('converts feet to meters/km in metric', () => {
+    expect(formatTrackLength(1000, true)).toBe('305 m'); // 1000 ft ≈ 304.8 m
+    expect(formatTrackLength(5280, true)).toBe('1.61 km'); // 1 mile ≈ 1.609 km
+  });
+});
+
+describe('temperature', () => {
+  it('converts C to F', () => {
+    expect(celsiusToFahrenheit(0)).toBe(32);
+    expect(celsiusToFahrenheit(100)).toBe(212);
+    expect(celsiusToFahrenheit(25)).toBe(77);
+  });
+
+  it('formats per family', () => {
+    expect(formatTemperature(25, true)).toBe('25°C');
+    expect(formatTemperature(23.45, true)).toBe('23.5°C');
+    expect(formatTemperature(25, false)).toBe('77°F');
+    expect(formatTemperature(0, false)).toBe('32°F');
+  });
+});
+
+describe('wind', () => {
+  it('converts knots', () => {
+    expect(knotsToMph(10)).toBeCloseTo(11.5078, 3);
+    expect(knotsToKph(10)).toBeCloseTo(18.52, 3);
+  });
+
+  it('labels and rounds wind speed per family', () => {
+    expect(windSpeedUnit(false)).toBe('mph');
+    expect(windSpeedUnit(true)).toBe('km/h');
+    expect(windSpeedValue(10, false)).toBe(12); // 11.5 → 12
+    expect(windSpeedValue(10, true)).toBe(19); // 18.5 → 19
+  });
+});
+
+describe('pressure', () => {
+  it('keeps inHg in imperial, converts to hPa in metric', () => {
+    expect(formatPressure(29.92, false)).toBe('29.92 inHg');
+    // 29.92 inHg ≈ 1013.2 hPa
+    expect(formatPressure(29.92, true)).toBe('1013 hPa');
+  });
+});
+
+describe('altitude', () => {
+  it('keeps feet in imperial, converts to meters in metric', () => {
+    expect(formatAltitudeFt(1000, false)).toBe('1,000 ft');
+    expect(formatAltitudeFt(1000, true)).toBe('305 m'); // 1000 ft ≈ 304.8 m
+  });
+
+  it('formats large values with thousands separators', () => {
+    expect(formatAltitudeFt(12345, false)).toBe('12,345 ft');
+  });
+});

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -11,8 +11,12 @@ import {
   windSpeedValue,
   formatPressure,
   formatAltitudeFt,
+  isDistanceUnitChannel,
+  distanceChannelValue,
+  distanceChannelUnit,
   METERS_PER_FOOT,
   FEET_PER_MILE,
+  FEET_PER_METER,
 } from './units';
 
 describe('speed', () => {
@@ -100,5 +104,27 @@ describe('altitude', () => {
 
   it('formats large values with thousands separators', () => {
     expect(formatAltitudeFt(12345, false)).toBe('12,345 ft');
+  });
+});
+
+describe('distance-family channels', () => {
+  it('recognizes distance + altitude, not accuracy or other channels', () => {
+    expect(isDistanceUnitChannel('distance')).toBe(true);
+    expect(isDistanceUnitChannel('altitude')).toBe(true);
+    expect(isDistanceUnitChannel('h_acc')).toBe(false);
+    expect(isDistanceUnitChannel('v_acc')).toBe(false);
+    expect(isDistanceUnitChannel('speed')).toBe(false);
+    expect(isDistanceUnitChannel('lat_g')).toBe(false);
+  });
+
+  it('keeps meters in metric, converts to feet in imperial', () => {
+    expect(distanceChannelValue(100, true)).toBe(100);
+    expect(distanceChannelValue(100, false)).toBeCloseTo(100 * FEET_PER_METER, 6);
+    expect(distanceChannelValue(1000, false)).toBeCloseTo(3280.84, 1);
+  });
+
+  it('labels the channel unit per family', () => {
+    expect(distanceChannelUnit(true)).toBe('m');
+    expect(distanceChannelUnit(false)).toBe('ft');
   });
 });

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,102 @@
+/**
+ * Centralized unit conversions + display formatting.
+ *
+ * The app exposes three independent imperial/metric toggles in settings, one per
+ * measurement family:
+ *  - **speed**    (`useKph`)            — MPH ⇄ KPH
+ *  - **distance** (`useMetricDistance`) — ft/mi ⇄ m/km
+ *  - **weather**  (`useMetricWeather`)  — °F, mph, inHg, ft ⇄ °C, km/h, hPa, m
+ *
+ * Every conversion + formatter lives here so the views never reimplement a magic
+ * constant. Everything is pure and React-free for direct unit testing. Each
+ * family stores a canonical internal value (distance → meters, speed → both
+ * mph/kph on the sample, temperature → Celsius, wind → knots, pressure → inHg,
+ * altitude → feet) and converts only at display time.
+ */
+
+// ─── Conversion constants ─────────────────────────────────────────────────────
+export const METERS_PER_FOOT = 0.3048;
+export const FEET_PER_METER = 1 / METERS_PER_FOOT;
+export const FEET_PER_MILE = 5280;
+export const METERS_PER_MILE = 1609.344;
+export const KPH_PER_MPH = 1.60934;
+export const MPH_PER_KNOT = 1.15078;
+export const KPH_PER_KNOT = 1.852;
+/** hectopascals (mbar) per inch of mercury. */
+export const HPA_PER_INHG = 33.8639;
+
+// ─── Speed (useKph) ───────────────────────────────────────────────────────────
+
+/** Unit label for the speed family. */
+export function speedUnitLabel(useKph: boolean): string {
+  return useKph ? 'KPH' : 'MPH';
+}
+
+// ─── Distance (useMetricDistance) ─────────────────────────────────────────────
+
+/**
+ * Format a distance given in **meters** for the distance unit family. Switches
+ * to the larger unit once past a full km / mile so long sessions stay readable:
+ * metric → m / km, imperial → ft / mi.
+ */
+export function formatDistance(meters: number, metric: boolean): string {
+  if (metric) {
+    return meters >= 1000 ? `${(meters / 1000).toFixed(2)} km` : `${Math.round(meters)} m`;
+  }
+  const feet = meters * FEET_PER_METER;
+  return feet >= FEET_PER_MILE ? `${(feet / FEET_PER_MILE).toFixed(2)} mi` : `${Math.round(feet)} ft`;
+}
+
+/**
+ * Format a track/course length stored in **feet** (the on-disk + device unit) for
+ * the distance unit family. Imperial keeps feet (familiar for course lengths);
+ * metric converts to meters.
+ */
+export function formatTrackLength(lengthFt: number, metric: boolean): string {
+  return formatDistance(lengthFt * METERS_PER_FOOT, metric);
+}
+
+// ─── Weather (useMetricWeather) ───────────────────────────────────────────────
+
+/** Celsius → Fahrenheit. */
+export function celsiusToFahrenheit(c: number): number {
+  return (c * 9) / 5 + 32;
+}
+
+/** Format a temperature given in **Celsius** for the weather unit family. */
+export function formatTemperature(tempC: number, metric: boolean): string {
+  return metric
+    ? `${Math.round(tempC * 10) / 10}°C`
+    : `${Math.round(celsiusToFahrenheit(tempC))}°F`;
+}
+
+/** Knots → mph. */
+export function knotsToMph(kts: number): number {
+  return kts * MPH_PER_KNOT;
+}
+
+/** Knots → km/h. */
+export function knotsToKph(kts: number): number {
+  return kts * KPH_PER_KNOT;
+}
+
+/** Unit label for wind speed in the weather family. */
+export function windSpeedUnit(metric: boolean): string {
+  return metric ? 'km/h' : 'mph';
+}
+
+/** Convert a wind speed in **knots** to the weather family's display value (rounded). */
+export function windSpeedValue(kts: number, metric: boolean): number {
+  return Math.round(metric ? knotsToKph(kts) : knotsToMph(kts));
+}
+
+/** Format a pressure given in **inHg** for the weather unit family (inHg ⇄ hPa). */
+export function formatPressure(inHg: number, metric: boolean): string {
+  return metric ? `${Math.round(inHg * HPA_PER_INHG)} hPa` : `${inHg} inHg`;
+}
+
+/** Format an altitude given in **feet** for the weather unit family (ft ⇄ m). */
+export function formatAltitudeFt(feet: number, metric: boolean): string {
+  const value = metric ? Math.round(feet * METERS_PER_FOOT) : Math.round(feet);
+  return `${value.toLocaleString()} ${metric ? 'm' : 'ft'}`;
+}

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -100,3 +100,32 @@ export function formatAltitudeFt(feet: number, metric: boolean): string {
   const value = metric ? Math.round(feet * METERS_PER_FOOT) : Math.round(feet);
   return `${value.toLocaleString()} ${metric ? 'm' : 'ft'}`;
 }
+
+// ─── Distance-family telemetry channels (useMetricDistance) ───────────────────
+//
+// Some logged channels are stored canonically in **meters** but represent a
+// length the user reads in their chosen distance unit (e.g. cumulative distance,
+// GPS altitude). These follow the distance toggle. GPS accuracy (`h_acc`/`v_acc`)
+// is deliberately excluded — it's a technical metric conventionally in meters.
+
+const DISTANCE_UNIT_CHANNELS = new Set(['distance', 'altitude']);
+
+/** Whether a canonical channel id is a meters-based distance-family channel. */
+export function isDistanceUnitChannel(channelId: string): boolean {
+  return DISTANCE_UNIT_CHANNELS.has(channelId);
+}
+
+/**
+ * Convert a meters-based distance-channel value to the distance display unit.
+ * Uses a single continuous unit per system (m or ft) — not the m↔km / ft↔mi
+ * auto-switch of {@link formatDistance} — since channel values feed continuous
+ * chart axes + numeric readouts that can't switch unit mid-scale.
+ */
+export function distanceChannelValue(meters: number, metric: boolean): number {
+  return metric ? meters : meters * FEET_PER_METER;
+}
+
+/** Display unit (`m` / `ft`) for distance-family telemetry channels. */
+export function distanceChannelUnit(metric: boolean): string {
+  return metric ? 'm' : 'ft';
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -72,6 +72,7 @@ export default function Index() {
   const setupManager = useSetupManager();
   const templateManager = useTemplateManager();
   const useKph = settings.useKph;
+  const useMetricDistance = settings.useMetricDistance;
 
   // Sync dark mode class when settings change (global init is in App.tsx)
   useEffect(() => {
@@ -283,15 +284,17 @@ export default function Index() {
     (idx: number) => {
       if (filteredDistances) {
         const d = filteredDistances[idx];
-        return d === undefined ? "" : formatAxisDistance(d, useKph);
+        return d === undefined ? "" : formatAxisDistance(d, useMetricDistance);
       }
       return formatRangeLabelTime(idx);
     },
-    [filteredDistances, useKph, formatRangeLabelTime],
+    [filteredDistances, useMetricDistance, formatRangeLabelTime],
   );
 
   const settingsContextValue = useMemo(() => ({
     useKph,
+    useMetricDistance,
+    useMetricWeather: settings.useMetricWeather,
     gForceSmoothing: settings.gForceSmoothing,
     gForceSmoothingStrength: settings.gForceSmoothingStrength,
     brakingZoneSettings,
@@ -299,7 +302,7 @@ export default function Index() {
     darkMode: settings.darkMode,
     gForceSource: settings.gForceSource,
     chartXAxis: settings.chartXAxis,
-  }), [useKph, settings.gForceSmoothing, settings.gForceSmoothingStrength, brakingZoneSettings, settings.enableLabs, settings.darkMode, settings.gForceSource, settings.chartXAxis]);
+  }), [useKph, useMetricDistance, settings.useMetricWeather, settings.gForceSmoothing, settings.gForceSmoothingStrength, brakingZoneSettings, settings.enableLabs, settings.darkMode, settings.gForceSource, settings.chartXAxis]);
 
   // Memoize sliced data arrays to avoid recreating on every render
   const slicedPaceData = useMemo(


### PR DESCRIPTION
## Summary

A "minor overhaul" of the measurement system in Settings. Previously a single **Speed Unit** (`useKph`) switch controlled speed and — via the chart axis — distance, while track lengths and weather were hardcoded to imperial. This replaces that with **three independent imperial/metric toggles**, one per measurement family, each affecting the entire app:

| Toggle | Setting | Imperial ⇄ Metric | Drives |
|--------|---------|-------------------|--------|
| **Speed** | `useKph` | MPH ⇄ KPH | speed values + speed axis labels (unchanged) |
| **Distance** | `useMetricDistance` | ft/mi ⇄ m/km | chart distance axis, range-crop labels, `TrackEditor` course lengths |
| **Weather** | `useMetricWeather` | °F/mph/inHg/ft ⇄ °C/(km/h)/hPa/m | temp, dew point, wind, pressure, density/pressure altitude |

All three default to imperial and persist per device.

## Implementation

- **New `src/lib/units.ts`** — single home for every conversion constant + display formatter (pure, React-free). Canonical internal values (distance→meters, temp→Celsius, wind→knots, pressure→inHg, altitude→feet) convert only at display time. Fully unit-tested in `units.test.ts`.
- `chartAxis.formatAxisDistance` is now a thin re-export of `units.formatDistance`; `buildChartAxis` takes `useMetricDistance` for distance-mode labels (speed labels still use `useKph`).
- Weather (`WeatherPanel`, `LocalWeatherDialog`) and track-length (`TrackEditor`) surfaces read the flag via `useOptionalSettingsContext()` so they still render outside the provider (landing page → imperial fallback).
- Two new Switch rows in `SettingsModal` next to Speed Unit.
- `AppSettings` + `SettingsContextValue` + the `Index.tsx` context value carry the two new booleans.

## Tests / checks

- New `src/lib/units.test.ts` covers every conversion + formatter (both families, rounding, unit thresholds).
- Updated `chartAxis.test.ts` for the renamed `useMetricDistance` opt.
- `npm run lint`, `npm run typecheck`, `npm run test:run` (1343 passing), `npm run build`, and `npm run test:coverage` (thresholds met) all green.
- `README`/`CLAUDE.md`/`CHANGELOG.md` updated.

https://claude.ai/code/session_01CtyDMGULYU55vAtxW97s4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtyDMGULYU55vAtxW97s4M)_