### PR TITLE
release: cut v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-08
+
+### Added
+- **Firmware updates over Bluetooth.** Update your DovesDataLogger's firmware
+  straight from the **Device → Settings** tab — no desktop tools, no cables, no
+  taking the device apart. It shows the installed firmware version with a **Check
+  for updates** button; when a newer build is available, a confirmation dialog
+  (battery / don't-power-off warnings) runs it: download the image, verify it
+  against the published checksum, upload it to the logger's SD card, and the device
+  re-checks the checksum, installs it, and reboots into the new firmware. The image
+  is **CRC-32 verified at every hop** — publisher → download → device control
+  channel → on-device file — so a corrupt or wrong-variant transfer can never be
+  flashed. You get a **"Flash complete"** prompt to reconnect when it's done.
+  Fetching firmware needs a connection; everything else runs in-browser. Beta
+  builds pull from a separate beta firmware channel and always offer the update for
+  testing.
+
 ### Changed
 - **Clearer plans & pricing cards.** The plan cards now lead with bold,
   larger-text titles — **Just the App** (offline) and **Cloud Access** (the
@@ -22,17 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Free** in place of a price, and only the paid plan shows an actual price.
   Storage lines read "cloud storage for datalogs" to make clear what the quota
   covers.
-
-### Added
-- **Firmware updates over Bluetooth.** The Device → Settings tab now shows your
-  logger's installed firmware version with a **Check for updates** button. When a
-  newer build is available for your device, a confirmation dialog (battery /
-  don't-power-off warnings) updates it over BLE — download, upload to the logger
-  (checksum-verified both ways), then the device installs it and reboots, with the
-  app auto-disconnecting when done. No desktop tools needed. Fetching the firmware
-  needs a connection; everything else runs in-browser. On beta/preview builds the
-  version check is bypassed so the update always pushes through for testing (the
-  confirmation dialog says so).
 
 ## [2.2.2] - 2026-06-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doves-dataviewer",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doves-dataviewer",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@lovable.dev/cloud-auth-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",


### PR DESCRIPTION
## Summary

Release cut for **v2.3.0** (firmware OTA over Bluetooth). One commit — gets the version + changelog into BETA so the **#169 release PR (BETA → main)** carries it.

- `package.json` (+ lockfile): **2.2.2 → 2.3.0**
- `CHANGELOG.md`: moved `[Unreleased]` → dated **`[2.3.0]`**, with the firmware-OTA entry polished to match the shipped SD-staged flow (CRC-32 verified at every hop, "Flash complete" reconnect prompt, beta firmware channel on non-main builds).

The actual OTA feature + all its fixes are already in BETA; this is just the version stamp.

## Test plan

Docs/metadata only — build stamps `doves-dataviewer@2.3.0`; full suite (1336 tests) + build green.

https://claude.ai/code/session_018ZCN5HsjxMdV85wVWZwo6t

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCN5HsjxMdV85wVWZwo6t)_