### PR TITLE
Home page UI edits + cut v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-06-10
+
+### Changed
+- **Home page reshuffle.** The "Try it out!" sample-data panel now sits at the
+  top of the page (above the file import) and the "Build your own datalogger"
+  card moved below it, so new visitors see how to try the viewer first.
+- **Contact button stands out.** The header's Contact button is now a filled
+  primary button instead of a muted outline, so it's easier to find.
+- **About dialog mentions OTA.** The feature list in the About dialog now
+  includes over-the-air firmware updates for the DovesDataLogger.
+
 ## [2.3.0] - 2026-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -51,6 +51,7 @@ const FEATURES = [
   "Session notes per file",
   "BLE device integration (DovesDataLogger)",
   "Device track sync over Bluetooth",
+  "Over-the-air firmware updates — flash your logger straight from the app",
   "Custom track & course editor with community submissions",
   "Local weather lookup",
   "Dark & light mode",

--- a/src/components/ContactDialog.tsx
+++ b/src/components/ContactDialog.tsx
@@ -59,7 +59,7 @@ export function ContactDialog({ variant = "footer" }: { variant?: "header" | "fo
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         {variant === "header" ? (
-          <Button variant="outline" size="sm" className="gap-2">
+          <Button variant="default" size="sm" className="gap-2">
             <Mail className="w-4 h-4" />
             <span className="hidden sm:inline">Contact</span>
           </Button>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -108,6 +108,28 @@ export function LandingPage({
             </h1>
           </div>
 
+          <div className="text-center text-sm text-muted-foreground space-y-3">
+            <div className="p-4 bg-primary/5 rounded-lg border border-primary/20">
+              <h3 className="font-medium text-foreground mb-2">Try it out!</h3>
+              <p className="text-xs mb-3">Load sample data from Orlando Kart Center to see how the viewer works.</p>
+              <Button variant="default" size="sm" onClick={onLoadSample} disabled={isLoadingSample}>
+                {isLoadingSample ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <Play className="w-4 h-4 mr-2" />
+                )}
+                {isLoadingSample ? "Loading..." : "Load Sample Data"}
+              </Button>
+            </div>
+          </div>
+
+          <FileImport
+            onDataLoaded={onDataLoaded}
+            onOpenFileManager={onOpenFileManager}
+            autoSave={autoSave}
+            autoSaveFile={autoSaveFile}
+          />
+
           <a
             href="https://github.com/TheAngryRaven/DovesDataLogger"
             target="_blank"
@@ -126,28 +148,6 @@ export function LandingPage({
               Get Started
             </Button>
           </a>
-
-          <FileImport
-            onDataLoaded={onDataLoaded}
-            onOpenFileManager={onOpenFileManager}
-            autoSave={autoSave}
-            autoSaveFile={autoSaveFile}
-          />
-
-          <div className="text-center text-sm text-muted-foreground space-y-3">
-            <div className="mt-4 p-4 bg-primary/5 rounded-lg border border-primary/20">
-              <h3 className="font-medium text-foreground mb-2">Try it out!</h3>
-              <p className="text-xs mb-3">Load sample data from Orlando Kart Center to see how the viewer works.</p>
-              <Button variant="default" size="sm" onClick={onLoadSample} disabled={isLoadingSample}>
-                {isLoadingSample ? (
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                ) : (
-                  <Play className="w-4 h-4 mr-2" />
-                )}
-                {isLoadingSample ? "Loading..." : "Load Sample Data"}
-              </Button>
-            </div>
-          </div>
         </div>
 
         <PricingCards className="mx-auto w-full max-w-5xl" />


### PR DESCRIPTION
## Summary

Four small UI/release housekeeping changes, branched from `BETA`:

1. **Home page panel swap** — the "Try it out!" sample-data panel now sits at the top of the page (above the file import) and the "Build your own datalogger" promo card moved below the import, so new visitors see how to try the viewer first (`LandingPage.tsx`).
2. **OTA in About** — the About dialog's feature list now includes "Over-the-air firmware updates — flash your logger straight from the app", next to the other device features (`AboutDialog.tsx`).
3. **Contact button stands out** — the header Contact button switched from the muted `outline` variant to the filled primary `default` variant, making it the only filled button in the header (`ContactDialog.tsx`).
4. **Cut v2.3.1** — added a dated `[2.3.1]` section to `CHANGELOG.md` with these changes and bumped `package.json` to `2.3.1` so the footer version stamp matches at release.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (1353 tests, 102 files)
- `npm run build` ✅

No logic changes — presentational reorder, one string list entry, one button variant, and release bookkeeping.

https://claude.ai/code/session_01MyUps5gPhuo2XBPNFYFrhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyUps5gPhuo2XBPNFYFrhc)_