### PR TITLE
fix: data-correctness highs H-3…H-6 (UBX UTC, course tolerance, Alfano time unit, native g channels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **UBX session start time was shifted by the browser's time zone.** The
+  parser now builds the session date from the receiver's UTC fields with
+  `Date.UTC` (matching the NMEA parser), so file-browser names and the weather
+  lookup hour are no longer off by the local UTC offset.
+- **Course auto-detection now enforces the documented 25% length tolerance.**
+  A course whose known length differs from the driven lap distance by more
+  than 25% is rejected (waypoint-mode fallback) instead of being tagged onto
+  the session with the wrong sector lines. Courses without a stored length
+  remain eligible.
+- **Alfano time units are decided once per file.** The old per-row heuristic
+  flipped a millisecond-based time column to seconds for the first 100 s, then
+  collapsed — time ran backwards and a fake day was added. The unit is now
+  detected from the whole column (value range + median row step).
+- **Native g-force channels are never silently clobbered or dropped.** AiM CSV
+  and MoTeC logger-reported lateral/longitudinal g now land on the dedicated
+  native channels and coexist with the GPS-derived primary pair (like Alfano,
+  VBO, and iRacing already did). When a file supplies only one g axis, that
+  axis is preserved as a native channel instead of being overwritten by the
+  GPS derivation — and the missing axis is now derived instead of absent
+  (previously a MoTeC file with only lateral g got no longitudinal g at all).
+  Same fix applied to AiM XRK imports.
+
 ### Changed
 - **Map heatmap rendering rebuilt for large sessions.** The race-line speed
   heatmap (Simple view and the Pro MiniMap) now renders as ~20 canvas-drawn

--- a/src/lib/aimParser.test.ts
+++ b/src/lib/aimParser.test.ts
@@ -93,11 +93,31 @@ describe("parseAimFile", () => {
     const parsed = parseAimFile(makeAimCsv(4));
     const ef = parsed.samples[0].extraFields;
     expect(ef["RPM"]).toBe(5000);
+    // Logger acc_lat/acc_long land on the native channels; the primary
+    // Lat G / Lon G pair is GPS-derived and coexists.
+    expect(ef["Lat G (Native)"]).toBeCloseTo(0.5, 5);
+    expect(ef["Lon G (Native)"]).toBeCloseTo(0.3, 5);
     expect(ef["Lat G"]).toBeDefined();
     expect(ef["Lon G"]).toBeDefined();
     const names = parsed.fieldMappings.map((m) => m.name);
     expect(names).toContain("Lat G");
+    expect(names).toContain("Lat G (Native)");
     expect(names).toContain("RPM");
+  });
+
+  it("keeps a lone native axis instead of dropping/clobbering it (regression)", () => {
+    // Only Acc_Lat in the file: the old code stored it as the primary 'Lat G'
+    // and the GPS derivation then overwrote BOTH axes, destroying the logger's
+    // lateral channel.
+    const lines = ["Time,GPS_Speed,GPS_Lat,GPS_Long,Acc_Lat"];
+    for (let i = 0; i < 5; i++) {
+      lines.push(`${(i * 0.1).toFixed(1)},60,28.401,${(-81.401 + i * 0.00001).toFixed(6)},0.8`);
+    }
+    const parsed = parseAimFile(lines.join("\n"));
+    const ef = parsed.samples[0].extraFields;
+    expect(ef["Lat G (Native)"]).toBeCloseTo(0.8, 5);
+    expect(ef["Lat G"]).toBeDefined(); // GPS-derived primary still exists
+    expect(ef["Lon G"]).toBeDefined();
   });
 
   it("skips rows with invalid coordinates", () => {

--- a/src/lib/aimParser.ts
+++ b/src/lib/aimParser.ts
@@ -1,5 +1,5 @@
 import { ParsedData, GpsSample, FieldMapping } from '@/types/racing';
-import { applyGForceCalculations } from './gforceCalculation';
+import { ensureDerivedGForcePair } from './gforceCalculation';
 import {
   haversineDistance,
   parseCsvLine,
@@ -330,14 +330,17 @@ export function parseAimFile(content: string): ParsedData {
       if (!isNaN(alt)) extraFields['Altitude'] = alt;
     }
     
+    // Logger-reported g rides the native channels (channels.ts contract); the
+    // primary Lat G / Lon G pair is always GPS-derived below, so the sources
+    // coexist and a lone native axis can't be clobbered by the derivation.
     if (latGCol !== -1) {
       const latG = parseFloat(values[latGCol]);
-      if (!isNaN(latG)) extraFields['Lat G'] = normalizeAccelToG(latG);
+      if (!isNaN(latG)) extraFields['Lat G (Native)'] = normalizeAccelToG(latG);
     }
 
     if (lonGCol !== -1) {
       const lonG = parseFloat(values[lonGCol]);
-      if (!isNaN(lonG)) extraFields['Lon G'] = normalizeAccelToG(lonG);
+      if (!isNaN(lonG)) extraFields['Lon G (Native)'] = normalizeAccelToG(lonG);
     }
     
     if (rpmCol !== -1) {
@@ -389,14 +392,9 @@ export function parseAimFile(content: string): ParsedData {
     throw new Error('No valid GPS samples found in AiM file');
   }
   
-  // Calculate G-forces from GPS if not natively available
-  const hasNativeLatG = samples.some(s => 'Lat G' in s.extraFields);
-  const hasNativeLonG = samples.some(s => 'Lon G' in s.extraFields);
-  
-  if (!hasNativeLatG || !hasNativeLonG) {
-    // Use the improved shared G-force calculation
-    applyGForceCalculations(samples, 5);
-  }
+  // Derive the primary GPS Lat G / Lon G pair (native channels coexist; a
+  // lone primary axis from the file would be preserved as native first).
+  ensureDerivedGForcePair(samples, 5);
   
   // Build field mappings from extra fields
   const fieldNames = new Set<string>();

--- a/src/lib/alfanoParser.test.ts
+++ b/src/lib/alfanoParser.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { isAlfanoFormat, parseAlfanoFile } from "./alfanoParser";
+import { isAlfanoFormat, parseAlfanoFile, detectAlfanoTimeMultiplier } from "./alfanoParser";
 
 // ─── Synthetic fixtures ─────────────────────────────────────────────────────
 
@@ -98,6 +98,23 @@ describe("parseAlfanoFile", () => {
     expect(names).toContain("Lat G (Native)");
   });
 
+  it("treats a millisecond time column uniformly (regression for the per-row heuristic)", () => {
+    // Time in ms at 10 Hz starting from 0: every value below the old 100000
+    // cutoff used to be multiplied by 1000, then collapse at 100 s — time ran
+    // backwards and the midnight patch added a fake day. The unit must be
+    // decided once per file.
+    const lines = [
+      "Driver:,Test",
+      "Time,GPS_Latitude,GPS_Longitude,GPS_Speed",
+    ];
+    for (let i = 0; i < 5; i++) {
+      lines.push(`${i * 100},28.401,${(-81.401 + i * 0.00001).toFixed(6)},50`);
+    }
+    const parsed = parseAlfanoFile(lines.join("\n"));
+    expect(parsed.samples.map((s) => s.t)).toEqual([0, 100, 200, 300, 400]);
+    expect(parsed.duration).toBe(400); // not 400,000 — and no +24 h patch
+  });
+
   it("handles a semicolon-delimited export", () => {
     const parsed = parseAlfanoFile(makeAlfanoCsv(4, ";"));
     expect(parsed.samples).toHaveLength(4);
@@ -118,5 +135,31 @@ describe("parseAlfanoFile", () => {
 
   it("throws when no valid header row is found", () => {
     expect(() => parseAlfanoFile("just\nrandom\ntext")).toThrow();
+  });
+});
+
+// ─── detectAlfanoTimeMultiplier ──────────────────────────────────────────────
+
+describe("detectAlfanoTimeMultiplier", () => {
+  it("detects seconds from sub-second row steps", () => {
+    const values = Array.from({ length: 50 }, (_, i) => i * 0.1); // 10 Hz, seconds
+    expect(detectAlfanoTimeMultiplier(values)).toBe(1000);
+  });
+
+  it("detects milliseconds from large values", () => {
+    const values = Array.from({ length: 50 }, (_, i) => 3_600_000 + i * 100);
+    expect(detectAlfanoTimeMultiplier(values)).toBe(1);
+  });
+
+  it("detects milliseconds from row steps even when all values are small", () => {
+    // A short ms-based session (< 100 s): every value is below the old 100000
+    // cutoff, but 100-unit steps at any sane log rate can only be ms.
+    const values = Array.from({ length: 50 }, (_, i) => i * 100);
+    expect(detectAlfanoTimeMultiplier(values)).toBe(1);
+  });
+
+  it("falls back to seconds for empty or constant columns", () => {
+    expect(detectAlfanoTimeMultiplier([])).toBe(1000);
+    expect(detectAlfanoTimeMultiplier([5, 5, 5])).toBe(1000);
   });
 });

--- a/src/lib/alfanoParser.ts
+++ b/src/lib/alfanoParser.ts
@@ -149,6 +149,35 @@ function detectAlfanoDelimiter(lines: string[]): string {
   return ',';
 }
 
+/**
+ * Decide the generic `time` column's unit for the whole file, returning the
+ * multiplier to milliseconds (1 = already ms, 1000 = seconds).
+ *
+ * - Any value above 100,000 can only be ms (≈27.8 h is impossible as seconds
+ *   since start/midnight).
+ * - Otherwise the median step between consecutive rows decides: at any
+ *   plausible log rate (1–50 Hz) a seconds column advances by ≤ 1 per row,
+ *   while a ms column advances by tens to hundreds.
+ * - An empty/constant column falls back to seconds (the historical default).
+ */
+export function detectAlfanoTimeMultiplier(timeValues: number[]): number {
+  if (timeValues.length === 0) return 1000;
+
+  let max = -Infinity;
+  for (const v of timeValues) if (v > max) max = v;
+  if (max > 100000) return 1;
+
+  const deltas: number[] = [];
+  for (let i = 1; i < timeValues.length; i++) {
+    const d = timeValues[i] - timeValues[i - 1];
+    if (d > 0) deltas.push(d);
+  }
+  if (deltas.length === 0) return 1000;
+  deltas.sort((a, b) => a - b);
+  const median = deltas[Math.floor(deltas.length / 2)];
+  return median >= 5 ? 1 : 1000;
+}
+
 export function parseAlfanoFile(content: string): ParsedData {
   const lines = content.split(/\r?\n/);
   const delimiter = detectAlfanoDelimiter(lines);
@@ -188,19 +217,35 @@ export function parseAlfanoFile(content: string): ParsedData {
     throw new Error('Could not find valid header row in Alfano CSV');
   }
   
+  // Decide the generic time column's unit ONCE for the whole file. The old
+  // per-row heuristic (`> 100000 ? ms : ×1000`) flipped units mid-file: a
+  // ms-based column had its first 100 seconds multiplied by 1000, then
+  // collapsed — time ran backwards and the midnight patch added a fake day.
+  let timeMultiplier = 1000; // seconds → ms (the historical default)
+  if (columnMap['time'] !== undefined && columnMap['time_ms'] === undefined) {
+    const timeValues: number[] = [];
+    for (let i = headerIndex + 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line || ALFANO_METADATA_PATTERNS.some(p => p.test(line))) continue;
+      const v = parseFloat(parseCsvLine(line, delimiter)[columnMap['time']]);
+      if (!isNaN(v)) timeValues.push(v);
+    }
+    timeMultiplier = detectAlfanoTimeMultiplier(timeValues);
+  }
+
   // Parse data rows
   const samples: GpsSample[] = [];
   let baseTimeMs: number | null = null;
   let startDate: Date | undefined;
   let hasNativeG = false;
-  
+
   for (let i = headerIndex + 1; i < lines.length; i++) {
     const line = lines[i].trim();
     if (!line) continue;
-    
+
     // Skip metadata rows that might appear after header
     if (ALFANO_METADATA_PATTERNS.some(p => p.test(line))) continue;
-    
+
     const fields = parseCsvLine(line, delimiter);
     if (fields.length < 3) continue;
 
@@ -217,8 +262,7 @@ export function parseAlfanoFile(content: string): ParsedData {
     } else if (columnMap['time'] !== undefined) {
       const timeVal = parseFloat(fields[columnMap['time']]);
       if (!isNaN(timeVal)) {
-        // Detect if time is in seconds or milliseconds
-        timeMs = timeVal > 100000 ? timeVal : timeVal * 1000;
+        timeMs = timeVal * timeMultiplier;
       }
     }
     

--- a/src/lib/courseDetection.test.ts
+++ b/src/lib/courseDetection.test.ts
@@ -76,7 +76,9 @@ function makeTrack(opts: {
     shortName: opts.shortName ?? "OKC",
     courses: opts.courses ?? [{
       name: "Full",
-      lengthFt: 700, // ~213m perimeter — about right for 4-sample path with samples 0.002° apart
+      // makeRacePathAtTrack's loop is ~2.6 km (~8500 ft) per lap: 0.002° east,
+      // 0.01° north, back. Must sit within the enforced 25% length tolerance.
+      lengthFt: 8500,
       startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
       startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
     }],
@@ -201,10 +203,9 @@ describe("autoDetectCourse - course matching", () => {
     expect(result!.course.name).toBe("Known");
   });
 
-  it("returns a course outside 25% tolerance but flags it via lengthMatchDiff", () => {
-    // Implementation still returns the closest course rather than failing —
-    // intentional UX choice (better to show something than nothing). The
-    // lengthMatchDiff field surfaces the confidence so UI can warn the user.
+  it("rejects a course outside the 25% tolerance and falls back to waypoint mode", () => {
+    // The documented tolerance is enforced: a wildly wrong length means wrong
+    // sector lines, so the session must not be tagged with that course.
     const origin = okcOrigin;
     const badMatchTrack: Track = {
       name: "OKC", shortName: "OKC",
@@ -216,11 +217,26 @@ describe("autoDetectCourse - course matching", () => {
       }],
     };
     const samples = makeRacePathAtTrack(origin, 3, 10000);
-    const result = autoDetectCourse(samples, [badMatchTrack])!;
-    expect(result.course.name).toBe("WayTooLong");
+    const result = autoDetectCourse(samples, [badMatchTrack]);
+    expect(result?.course.name).not.toBe("WayTooLong");
+    expect(result === null || result.isWaypointMode).toBe(true);
+  });
+
+  it("accepts a course just inside the 25% tolerance", () => {
+    const origin = okcOrigin;
+    const nearMissTrack: Track = {
+      name: "OKC", shortName: "OKC",
+      courses: [{
+        name: "NearMiss",
+        lengthFt: 10300, // ~21% above the actual ~8500ft — inside tolerance
+        startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
+        startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
+      }],
+    };
+    const samples = makeRacePathAtTrack(origin, 3, 10000);
+    const result = autoDetectCourse(samples, [nearMissTrack])!;
+    expect(result.course.name).toBe("NearMiss");
     expect(result.isWaypointMode).toBe(false);
-    expect(result.lengthMatchDiff).toBeDefined();
-    expect(result.lengthMatchDiff!).toBeGreaterThan(0.25); // outside documented tolerance
   });
 
   it("populates lengthMatchDiff with the actual fractional difference for good matches", () => {
@@ -288,7 +304,9 @@ describe("autoDetectCourse - direction detection", () => {
       name: "OKC", shortName: "OKC",
       courses: [{
         name: "Full",
-        lengthFt: 1500,
+        // makeSectorLap's loop is ~3.7 km (~12000 ft) per lap; the reverse
+        // sweep fixture is ~13800 ft — both within the 25% tolerance.
+        lengthFt: 12000,
         startFinishA: { lat: origin.lat + 0.0001, lon: origin.lon },
         startFinishB: { lat: origin.lat - 0.0001, lon: origin.lon },
         sector2: { a: { lat: origin.lat + 0.0001, lon: origin.lon + 0.003 }, b: { lat: origin.lat - 0.0001, lon: origin.lon + 0.003 } },

--- a/src/lib/courseDetection.ts
+++ b/src/lib/courseDetection.ts
@@ -132,8 +132,20 @@ export function autoDetectCourse(
     return createWaypointResult(samples);
   }
 
+  // Enforce the documented 25% tolerance: a course whose known length differs
+  // from the driven lap distance by more than that is a wrong match (wrong
+  // sector lines, wrong timing), not a near miss — fall back to waypoint mode
+  // instead of tagging the session with it. Courses without a lengthFt can't
+  // be length-checked and stay eligible.
+  const withinTolerance = candidates.filter(
+    c => c.lengthDiff === Infinity || c.lengthDiff <= LENGTH_MATCH_TOLERANCE
+  );
+  if (withinTolerance.length === 0) {
+    return createWaypointResult(samples);
+  }
+
   // Sort by number of laps (more = better) then by length match
-  candidates.sort((a, b) => {
+  withinTolerance.sort((a, b) => {
     // First prefer candidates with known length match
     if (a.lengthDiff !== Infinity && b.lengthDiff === Infinity) return -1;
     if (a.lengthDiff === Infinity && b.lengthDiff !== Infinity) return 1;
@@ -145,7 +157,7 @@ export function autoDetectCourse(
     return b.laps.length - a.laps.length;
   });
 
-  const best = candidates[0];
+  const best = withinTolerance[0];
 
   const direction = detectDirection(samples, best.course, best.laps);
 

--- a/src/lib/gforceCalculation.test.ts
+++ b/src/lib/gforceCalculation.test.ts
@@ -3,6 +3,7 @@ import {
   calculateAccelerations,
   smoothField,
   applyGForceCalculations,
+  ensureDerivedGForcePair,
 } from "./gforceCalculation";
 import { STANDARD_GRAVITY_MPS2 } from "./parserUtils";
 import type { GpsSample } from "@/types/racing";
@@ -223,5 +224,70 @@ describe("applyGForceCalculations", () => {
   it("handles empty input gracefully", () => {
     const samples: GpsSample[] = [];
     expect(() => applyGForceCalculations(samples)).not.toThrow();
+  });
+});
+
+// ─── ensureDerivedGForcePair ─────────────────────────────────────────────────
+
+describe("ensureDerivedGForcePair", () => {
+  /** A short straight run at constant speed — enough for the derivation to run. */
+  function makeRun(extra: (i: number) => Record<string, number>): GpsSample[] {
+    return Array.from({ length: 10 }, (_, i) =>
+      makeSample({ t: i * 100, speedMps: 20, heading: 90, extra: extra(i) }),
+    );
+  }
+
+  it("leaves a full primary pair from the file untouched (no derivation)", () => {
+    const samples = makeRun(() => ({ "Lateral G": 0.7, "Longitudinal G": -0.3 }));
+    ensureDerivedGForcePair(samples);
+    for (const s of samples) {
+      expect(s.extraFields["Lateral G"]).toBe(0.7);
+      expect(s.extraFields["Longitudinal G"]).toBe(-0.3);
+      // The derivation writes 'Lat G'/'Lon G' — it must not have run.
+      expect(s.extraFields["Lat G"]).toBeUndefined();
+      expect(s.extraFields["Lon G"]).toBeUndefined();
+    }
+  });
+
+  it("preserves a lone lat axis as native instead of clobbering it (regression)", () => {
+    // Old behavior: applyGForceCalculations overwrote BOTH primary keys, so a
+    // lateral-only logger channel was silently destroyed.
+    const samples = makeRun(() => ({ "Lat G": 0.9 }));
+    ensureDerivedGForcePair(samples);
+    for (const s of samples) {
+      expect(s.extraFields["Lat G (Native)"]).toBe(0.9);
+      expect(s.extraFields["Lat G"]).toBeDefined(); // derived, not the logger value
+      expect(s.extraFields["Lon G"]).toBeDefined(); // missing axis now exists
+    }
+  });
+
+  it("preserves a lone lon axis (alias name) as native and derives the pair", () => {
+    const samples = makeRun(() => ({ "Longitudinal G": -0.5 }));
+    ensureDerivedGForcePair(samples);
+    for (const s of samples) {
+      expect(s.extraFields["Lon G (Native)"]).toBe(-0.5);
+      expect(s.extraFields["Lat G"]).toBeDefined();
+      expect(s.extraFields["Lon G"]).toBeDefined();
+      expect(s.extraFields["Longitudinal G"]).toBeUndefined();
+    }
+  });
+
+  it("does not clobber an existing native channel when demoting", () => {
+    const samples = makeRun(() => ({ "Lat G": 0.9, "Lat G (Native)": 0.4 }));
+    ensureDerivedGForcePair(samples);
+    for (const s of samples) {
+      expect(s.extraFields["Lat G (Native)"]).toBe(0.4); // first value wins
+    }
+  });
+
+  it("derives the full pair when the file carried no primary g at all", () => {
+    const samples = makeRun(() => ({ "Lat G (Native)": 0.2, "Lon G (Native)": 0.1 }));
+    ensureDerivedGForcePair(samples);
+    for (const s of samples) {
+      // Natives coexist with the derived primaries.
+      expect(s.extraFields["Lat G (Native)"]).toBe(0.2);
+      expect(s.extraFields["Lat G"]).toBeDefined();
+      expect(s.extraFields["Lon G"]).toBeDefined();
+    }
   });
 });

--- a/src/lib/gforceCalculation.ts
+++ b/src/lib/gforceCalculation.ts
@@ -122,3 +122,45 @@ export function applyGForceCalculations(samples: GpsSample[], smoothingWindow: n
   smoothField(samples, 'Lat G', smoothingWindow);
   smoothField(samples, 'Lon G', smoothingWindow);
 }
+
+// Human names that normalizeChannels maps onto the PRIMARY lat_g / lon_g ids
+// (see channels.ts aliases). The derivation above writes 'Lat G' / 'Lon G'.
+const PRIMARY_LAT_KEYS = ['Lat G', 'Lateral G', 'LatG'];
+const PRIMARY_LON_KEYS = ['Lon G', 'Longitudinal G', 'LonG'];
+const NATIVE_LAT_KEY = 'Lat G (Native)';
+const NATIVE_LON_KEY = 'Lon G (Native)';
+
+/**
+ * Make sure the primary lat/lon g pair exists without clobbering logger data.
+ *
+ * `applyGForceCalculations` unconditionally writes BOTH primary keys, so when
+ * a file supplied only one axis (e.g. a lateral-g-only logger channel), running
+ * it would silently overwrite that axis — and skipping it would leave the
+ * other axis missing entirely. Instead:
+ * - both primary axes present → leave the file's pair untouched
+ * - exactly one present → preserve it under the logger-native channel
+ *   (`lat_g_native`/`lon_g_native` per the channels.ts contract), then derive
+ *   the full primary pair from GPS
+ * - neither present → derive the full pair from GPS
+ * Native "(Native)" channels always coexist with the derived primaries.
+ */
+export function ensureDerivedGForcePair(samples: GpsSample[], smoothingWindow: number = 5): void {
+  const findKey = (keys: string[]) => keys.find(k => samples.some(s => k in s.extraFields));
+  const latKey = findKey(PRIMARY_LAT_KEYS);
+  const lonKey = findKey(PRIMARY_LON_KEYS);
+  if (latKey && lonKey) return;
+
+  const demote = (from: string, to: string) => {
+    for (const s of samples) {
+      if (from in s.extraFields) {
+        // Don't clobber an existing native channel either — first value wins.
+        if (!(to in s.extraFields)) s.extraFields[to] = s.extraFields[from];
+        delete s.extraFields[from];
+      }
+    }
+  };
+  if (latKey) demote(latKey, NATIVE_LAT_KEY);
+  if (lonKey) demote(lonKey, NATIVE_LON_KEY);
+
+  applyGForceCalculations(samples, smoothingWindow);
+}

--- a/src/lib/motecParser.test.ts
+++ b/src/lib/motecParser.test.ts
@@ -84,9 +84,12 @@ describe("parseMotecCsvFile", () => {
     const parsed = parseMotecCsvFile(makeMotecCsv());
     const ef = parsed.samples[0].extraFields;
     expect(ef["RPM"]).toBe(5000);
-    // Native G is present, so it's kept as-is (not overwritten by GPS calc).
-    expect(ef["Lat G"]).toBeCloseTo(0.1, 6);
-    expect(ef["Lon G"]).toBeCloseTo(0.2, 6);
+    // Logger-reported G lands on the native channels (channels.ts contract);
+    // the primary Lat G / Lon G pair is GPS-derived and coexists with it.
+    expect(ef["Lat G (Native)"]).toBeCloseTo(0.1, 6);
+    expect(ef["Lon G (Native)"]).toBeCloseTo(0.2, 6);
+    expect(ef["Lat G"]).toBeDefined();
+    expect(ef["Lon G"]).toBeDefined();
   });
 
   it("throws when GPS latitude/longitude channels are absent", () => {

--- a/src/lib/motecParser.ts
+++ b/src/lib/motecParser.ts
@@ -1,5 +1,5 @@
 import { ParsedData, GpsSample, FieldMapping } from '@/types/racing';
-import { applyGForceCalculations } from './gforceCalculation';
+import { ensureDerivedGForcePair } from './gforceCalculation';
 import {
   haversineDistance,
   parseCsvLine,
@@ -152,8 +152,10 @@ export function parseMotecCsvFile(content: string): ParsedData {
     tryExtra(throttleCol, 'Throttle');
     tryExtra(waterTempCol, 'Water Temp');
     tryExtra(altCol, 'Altitude');
-    tryExtra(latGCol, 'Lat G', v => normalizeAccelToG(v));
-    tryExtra(lonGCol, 'Lon G', v => normalizeAccelToG(v));
+    // Logger-reported g rides the native channels; the primary pair is
+    // GPS-derived below so a lone native axis can't be clobbered.
+    tryExtra(latGCol, 'Lat G (Native)', v => normalizeAccelToG(v));
+    tryExtra(lonGCol, 'Lon G (Native)', v => normalizeAccelToG(v));
 
     let heading: number | undefined;
     if (headingCol >= 0) {
@@ -173,10 +175,8 @@ export function parseMotecCsvFile(content: string): ParsedData {
 
   if (samples.length === 0) throw new Error('No valid GPS samples found in MoTeC CSV');
 
-  // Fill G-forces from GPS if not native
-  if (!samples.some(s => 'Lat G' in s.extraFields)) {
-    applyGForceCalculations(samples, 5);
-  }
+  // Derive the primary GPS Lat G / Lon G pair (native channels coexist).
+  ensureDerivedGForcePair(samples, 5);
 
   const fieldNames = new Set<string>();
   samples.forEach(s => Object.keys(s.extraFields).forEach(k => fieldNames.add(k)));
@@ -416,8 +416,10 @@ export function parseMotecLdFile(buffer: ArrayBuffer): ParsedData {
     tryExtra(throttleCh, 'Throttle');
     tryExtra(waterTempCh, 'Water Temp');
     tryExtra(altCh, 'Altitude');
-    tryExtra(latGCh, 'Lat G', v => normalizeAccelToG(v));
-    tryExtra(lonGCh, 'Lon G', v => normalizeAccelToG(v));
+    // Logger-reported g rides the native channels; the primary pair is
+    // GPS-derived below so a lone native axis can't be clobbered.
+    tryExtra(latGCh, 'Lat G (Native)', v => normalizeAccelToG(v));
+    tryExtra(lonGCh, 'Lon G (Native)', v => normalizeAccelToG(v));
 
     const rawHeading = resample(headingCh, i);
     const heading = rawHeading !== undefined && !isNaN(rawHeading) ? rawHeading : undefined;
@@ -434,9 +436,8 @@ export function parseMotecLdFile(buffer: ArrayBuffer): ParsedData {
 
   if (samples.length === 0) throw new Error('No valid GPS samples found in MoTeC LD file');
 
-  if (!samples.some(s => 'Lat G' in s.extraFields)) {
-    applyGForceCalculations(samples, 5);
-  }
+  // Derive the primary GPS Lat G / Lon G pair (native channels coexist).
+  ensureDerivedGForcePair(samples, 5);
 
   // Collect extra channels not already mapped
   const fieldNames = new Set<string>();

--- a/src/lib/ubxParser.test.ts
+++ b/src/lib/ubxParser.test.ts
@@ -181,6 +181,21 @@ describe("parseUbxFile", () => {
     expect(parsed.startDate).toBeInstanceOf(Date);
     expect(parsed.duration).toBe(100);
   });
+
+  it("builds startDate as UTC, not local time (regression)", () => {
+    // NAV-PVT date/time fields are UTC. The old `new Date(year, …)` constructor
+    // interpreted them in the browser's local zone, shifting the session epoch
+    // by the UTC offset (wrong file-browser names, wrong weather hour) — and
+    // disagreeing with the NMEA parser for the same hardware.
+    const parsed = parseUbxFile(twoSampleFile());
+    const d = parsed.startDate!;
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth() + 1).toBe(3);
+    expect(d.getUTCDate()).toBe(15);
+    expect(d.getUTCHours()).toBe(14);
+    expect(d.getUTCMinutes()).toBe(30);
+    expect(d.getUTCSeconds()).toBe(0);
+  });
 });
 
 // ─── parseUbxFile: reject paths ─────────────────────────────────────────────

--- a/src/lib/ubxParser.ts
+++ b/src/lib/ubxParser.ts
@@ -183,10 +183,12 @@ export function parseUbxFile(buffer: ArrayBuffer): ParsedData {
     // Calculate time in ms since midnight
     const timeMs = (pvt.hour * 3600 + pvt.min * 60 + pvt.sec) * 1000 + Math.floor(pvt.nano / 1e6);
     
-    // Set base time and start date from first valid sample
+    // Set base time and start date from first valid sample.
+    // NAV-PVT date/time fields are UTC — build the epoch with Date.UTC so the
+    // session start doesn't shift by the browser's UTC offset (matches nmeaParser).
     if (baseTimeMs === null) {
       baseTimeMs = timeMs;
-      startDate = new Date(pvt.year, pvt.month - 1, pvt.day, pvt.hour, pvt.min, pvt.sec);
+      startDate = new Date(Date.UTC(pvt.year, pvt.month - 1, pvt.day, pvt.hour, pvt.min, pvt.sec));
     }
     
     // Calculate relative time (handle midnight wrap)

--- a/src/lib/xrk/xrkMapping.ts
+++ b/src/lib/xrk/xrkMapping.ts
@@ -8,7 +8,7 @@
 // everything else lands in `extraFields`.
 
 import { ParsedData, GpsSample, FieldMapping } from "@/types/racing";
-import { applyGForceCalculations } from "../gforceCalculation";
+import { ensureDerivedGForcePair } from "../gforceCalculation";
 import {
   speedTriple,
   calculateBounds,
@@ -150,17 +150,11 @@ export function mapXrkToParsedData(raw: XrkRawResult, _fileName: string): Parsed
     throw new Error("XRK file contains no valid GPS samples");
   }
 
-  // Derive lateral/longitudinal G from GPS when the log carries neither a
-  // GPS-derived nor native g pair — mirrors the CSV AiM parser.
-  const hasLatG = samples.some(
-    (s) => "Lat G" in s.extraFields || "Lateral G" in s.extraFields || "Lat G (Native)" in s.extraFields,
-  );
-  const hasLonG = samples.some(
-    (s) => "Lon G" in s.extraFields || "Longitudinal G" in s.extraFields || "Lon G (Native)" in s.extraFields,
-  );
-  if (!hasLatG || !hasLonG) {
-    applyGForceCalculations(samples, 5);
-  }
+  // Make sure the primary GPS g pair exists — mirrors the CSV AiM parser. The
+  // old check let a lone primary axis be overwritten by the derivation (and
+  // counted "(Native)"-only logs as covered, leaving them without a primary
+  // pair); the shared helper preserves a lone axis as native and derives both.
+  ensureDerivedGForcePair(samples, 5);
 
   // Build field mappings from whatever extraFields ended up present.
   const fieldNames = new Set<string>();


### PR DESCRIPTION
Resolves the four **data-correctness** highs from the professional review (H-3 … H-6).

## H-3 — UBX `startDate` used the local-time Date constructor on UTC fields
`ubxParser` now builds the session epoch with `Date.UTC(...)` from NAV-PVT's UTC date/time fields, matching `nmeaParser`. Previously the epoch shifted by the browser's UTC offset (±14 h worst case) — wrong file-browser display names, wrong weather hour, and the two parsers disagreed for the same hardware. Regression test asserts the UTC fields directly.

## H-4 — the documented 25% course-length tolerance is now enforced
`autoDetectCourse` filters candidates whose known `lengthFt` differs from the driven average lap distance by more than `LENGTH_MATCH_TOLERANCE` (the constant that was declared and never referenced). If nothing survives, it falls back to waypoint mode — as CLAUDE.md and the module docstring always promised — instead of tagging the session with a wildly wrong course and its wrong sector lines. Courses **without** a stored length can't be length-checked and stay eligible (so user-created tracks keep working).

Two test fixtures carried stale `lengthFt` values (700 ft / 1500 ft against synthetic paths that actually measure ~8500 ft / ~12000 ft) that the unenforced tolerance never caught — corrected to the paths' real distances, the old "returns a course outside 25% tolerance" test rewritten to the enforced contract, and a just-inside-tolerance acceptance test added.

## H-5 — Alfano time unit decided per file, not per row
New pure `detectAlfanoTimeMultiplier()` decides the generic `time` column's unit once for the whole file: values > 100,000 can only be ms, otherwise the **median row step** decides (a seconds column advances ≤ 1 per row at any sane log rate; a ms column advances by tens to hundreds). The old `> 100000 ? ms : ×1000` per-row branch multiplied a ms column's first 100 s by 1000, collapsed, ran time backwards, and triggered the +24 h midnight patch. Regression test feeds a ms column entirely below the old cutoff.

## H-6 — native g channels silently clobbered / dropped
New shared helper `ensureDerivedGForcePair()` (gforceCalculation.ts) encodes the channels.ts contract:
- both primary axes present in the file → untouched, no derivation
- exactly one → the lone axis is **preserved under its native channel** (`lat_g_native`/`lon_g_native`) before the full primary pair is GPS-derived (never clobbers an already-present native value)
- neither → full pair derived; native channels always coexist

Applied to:
- **AiM CSV**: `acc_lat`/`acc_long` now land on `Lat G (Native)`/`Lon G (Native)` and the primary pair is always GPS-derived (matching Alfano/VBO/iRacing). A lateral-only file no longer has its logger channel destroyed by the derivation.
- **MoTeC CSV + LD**: same native-channel storage; a file with only lateral g now also gets a longitudinal channel (previously it got none at all).
- **XRK importer**: same helper replaces its hand-rolled check, fixing the identical overwrite path — and "(Native)"-only logs now get a GPS-derived primary pair instead of none.

## Tests
6 new/updated suites: UBX UTC regression, tolerance accept/reject pair + fixture corrections, `detectAlfanoTimeMultiplier` + ms-column end-to-end regression, `ensureDerivedGForcePair` (5 cases incl. the lone-axis clobber regression), AiM lone-axis regression + native-channel assertions, MoTeC native-channel assertions.

`npm run lint`, `npm run typecheck`, `npm run test:run` (1437 tests / 105 files), and `npm run build` all pass. Changelog updated.

https://claude.ai/code/session_01F4NRCkHHGTmiQRcS8ogxXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4NRCkHHGTmiQRcS8ogxXY)_