### PR TITLE
perf: playback loop, follow-cam, video-export memory, bundle slimming (H-7…H-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Playback now runs at real time.** The playback loop no longer tears itself
+  down and re-anchors its clock on every cursor tick, so high-rate (60 Hz)
+  data plays at full speed instead of capping at half the display rate. The
+  playback Hz readout is also no longer recomputed (a full sort of the visible
+  window) on every render.
+- **MiniMap follow-cam stopped fighting itself.** The Pro-mode map re-centers
+  only when the position arrow leaves the middle of the view, without
+  animation — instead of issuing an animated pan every tick that perpetually
+  interrupted itself.
+- **Video export no longer holds the whole MP4 in memory.** Long exports
+  (estimated > 350 MB — e.g. 20 min at high quality ≈ 2.2 GB) stream the
+  output in ~16 MB chunks (fragmented MP4) instead of one giant buffer, which
+  was a guaranteed out-of-memory crash on mobile. Both the video and audio
+  encoders now run with bounded queues (backpressure), so encoding can't
+  buffer unbounded raw frames when the encoder falls behind.
+- **~40% smaller landing page.** The initial payload dropped from ~1.13 MB raw
+  / ~334 kB gzip to ~684 kB / ~207 kB: the map stack (Leaflet + the Simple
+  view) now loads when a session opens rather than up front, and the Supabase
+  client is completely off the eager path — offline-first builds (cloud/admin
+  flags off) never download it at all, and flag-on builds load it off the
+  critical path.
+
+### Changed
 - **Map heatmap rendering rebuilt for large sessions.** The race-line speed
   heatmap (Simple view and the Pro MiniMap) now renders as ~20 canvas-drawn
   color-bucket polylines instead of one SVG DOM element per GPS segment, which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -928,7 +928,9 @@ re-merges it into the main chunk.
 
 **Lazy-loaded (off the initial path) — loaded on first use:**
 - Routes: `Login`, `Admin`, `Register`, `Privacy` (`App.tsx`, wrapped in `<Suspense>`)
-- Pro view: `GraphViewTab` and `LabsTab` (`Index.tsx`)
+- View tabs: `RaceLineTab` (the Simple tab — keeps `vendor-leaflet` + the
+  telemetry chart off the landing page; loads the moment a session opens),
+  `GraphViewTab`, and `LabsTab` (`Index.tsx`)
 - `FileManagerDrawer` (slide-out drawer, `Index.tsx`)
 - `DataloggerDownload` (BLE entry point; keeps `lib/ble/*` out of initial bundle — `FileImport.tsx`, `drawer/FilesTab.tsx`)
 - `VisualEditor` (Leaflet drawing tools; `TrackEditor.tsx`, `track-editor/AddCourseDialog.tsx`, `admin/CoursesTab.tsx`). The shared map editor for **all** track managers — start/finish + sector lines (drag-to-place, auto-saved on release) and the course-outline Draw/Generate tools (auto-saved on each edit; no Done/Close button). There is no manual coordinate-entry mode — visual is the only editor.
@@ -937,13 +939,21 @@ re-merges it into the main chunk.
 `vendor-query`, `vendor-leaflet`, `vendor-supabase`, `vendor-radix`. These cache
 independently across deploys so app-only changes don't re-download vendor code.
 
+**`vendor-supabase` is fully off the eager graph.** The Supabase client's only
+static importers are lazy/flag-gated modules: `contexts/authBackend.ts` (the
+auth bootstrap, dynamically imported by `AuthContext` **only when
+`VITE_ENABLE_ADMIN` or `VITE_ENABLE_CLOUD` is on** — flag-off builds never
+fetch it at all), the lazy auth/admin pages, and cloud-sync's lazy panels.
+Everything that rides the eager graph (`SubmitTrackDialog`, `PricingCards`,
+`useStripePrices`/`useSubscription`) reaches `billingClient`/the client via
+dynamic import at the call site. Don't add a static
+`@/integrations/supabase/client` (or `lib/billingClient`) import to anything
+eagerly reachable from `Index.tsx`/`LandingPage` — it re-merges 172 kB of
+Supabase into the offline-first landing payload.
+
 > Lazy components must be rendered inside a `<Suspense>` boundary. Use
 > `lazy(() => import('…').then((m) => ({ default: m.Named })))` for the
 > named-export components in this codebase.
->
-> **Known follow-up:** `vendor-supabase` is still on the initial path because
-> `AuthProvider` (`App.tsx`) and `SubmitTrackDialog` import the client eagerly.
-> Deferring it would require gating the auth bootstrap on `VITE_ENABLE_ADMIN`.
 
 ---
 

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -14,7 +14,6 @@ import {
   pricingCta,
   tiersWithPrices,
 } from "@/lib/billing";
-import { createCheckout, createPortal } from "@/lib/billingClient";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -244,6 +243,9 @@ export function PricingCards({ className, variant = "home" }: { className?: stri
   const onUpgrade = async (slug: PaidSlug) => {
     setBusy(slug);
     try {
+      // Dynamic import: billingClient pulls the Supabase client, which must
+      // stay off the eager graph (these cards ride the landing page).
+      const { createCheckout } = await import("@/lib/billingClient");
       const url = await createCheckout(slug, cardInterval, window.location.href);
       window.location.href = url;
     } catch (e) {
@@ -258,6 +260,7 @@ export function PricingCards({ className, variant = "home" }: { className?: stri
   const onManage = async (slug: PaidSlug) => {
     setBusy(slug);
     try {
+      const { createPortal } = await import("@/lib/billingClient");
       const url = await createPortal(window.location.href);
       window.location.href = url;
     } catch (e) {

--- a/src/components/SubmitTrackDialog.tsx
+++ b/src/components/SubmitTrackDialog.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from '@/components/ui/dialog';
 import { toast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
 import { Send, ShieldCheck, ArrowRight, ArrowLeft, Loader2, CheckCircle2, AlertTriangle, Check } from 'lucide-react';
 import { loadTracks, loadDefaultTracks } from '@/lib/trackStorage';
 import { buildSubmissionPlan, type SubmissionPlan, type SubmissionCourse } from '@/lib/trackSubmission';
@@ -143,6 +142,10 @@ export function SubmitTrackDialog({ trigger, onSubmitted }: SubmitTrackDialogPro
         layout_data: c.layout,
       }));
 
+      // Dynamic import: submitting is online-only and rare, so the Supabase
+      // client stays out of the initial bundle (this dialog rides the eager
+      // TrackEditor on the landing page).
+      const { supabase } = await import('@/integrations/supabase/client');
       const { data, error } = await supabase.functions.invoke('submit-track', {
         body: { submissions, turnstile_token: turnstileToken },
       });

--- a/src/components/graphview/MiniMap.tsx
+++ b/src/components/graphview/MiniMap.tsx
@@ -217,12 +217,20 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], course, bo
     });
   }, [brakingZones, showBrakingZones, brakingZoneSettings?.color, brakingZoneSettings?.width]);
 
-  // Arrow marker (created once, moved/rotated per tick) + follow-pan
+  // Arrow marker (created once, moved/rotated per tick) + follow-pan.
+  // Re-center only when the marker leaves the middle half of the view, and
+  // without animation — an animated panTo issued per 16 ms tick perpetually
+  // interrupts itself and burns the frame budget on aborted pan animations.
   useEffect(() => {
     const map = mapRef.current; if (!map) return;
     markerRef.current = updatePositionMarker(map, markerRef.current, samples, currentIndex);
     const sample = samples[currentIndex];
-    if (sample) map.panTo([sample.lat, sample.lon], { animate: true, duration: 0.15 });
+    if (!sample) return;
+    const p = map.latLngToContainerPoint([sample.lat, sample.lon]);
+    const size = map.getSize();
+    if (p.x < size.x * 0.25 || p.x > size.x * 0.75 || p.y < size.y * 0.25 || p.y > size.y * 0.75) {
+      map.panTo([sample.lat, sample.lon], { animate: false });
+    }
   }, [currentIndex, samples]);
 
   const cycleMapStyle = () => setMapStyle(p => p === 'dark' ? 'satellite' : p === 'satellite' ? 'none' : 'dark');

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { createContext, useContext, useState, useEffect, useMemo, type ReactNode } from 'react';
 import type { User, Session } from '@supabase/supabase-js';
 
 interface AuthContextValue {
@@ -16,136 +15,68 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// The Supabase auth bootstrap only exists when an account-facing feature is
+// on. Flag-off builds never load the backend chunk, keeping vendor-supabase
+// entirely off the offline-first initial path (it was the single biggest dead
+// weight on the landing page). The dynamic import starts at module evaluation
+// on flag-on builds, so it's in flight before the provider even mounts.
+const enableAuthBackend =
+  import.meta.env.VITE_ENABLE_ADMIN === 'true' || import.meta.env.VITE_ENABLE_CLOUD === 'true';
+
+const backendPromise = enableAuthBackend ? import('./authBackend') : null;
+
+const disabledError = () =>
+  Promise.resolve({ error: new Error('Accounts are not enabled in this build') });
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [loading, setLoading] = useState(true);
+  // Flag-off builds are immediately "settled signed-out"; flag-on builds stay
+  // loading until the backend chunk reports the initial session.
+  const [loading, setLoading] = useState(enableAuthBackend);
 
   useEffect(() => {
+    if (!backendPromise) return;
     let cancelled = false;
-    let initialResolved = false;
-
-    // Resolve the admin role. MUST run outside the onAuthStateChange callback:
-    // supabase-js holds the GoTrue Web Lock (navigator.locks) for the duration
-    // of that callback, and any awaited Supabase call inside it needs the same
-    // lock — which deadlocks token refresh and spuriously signs the user out on
-    // reload. So updateAuth sets session/user synchronously and defers this.
-    const resolveRole = async (s: Session | null) => {
-      if (!s?.user) {
-        if (!cancelled) setIsAdmin(false);
-        return;
-      }
-      try {
-        const { data } = await supabase.rpc('has_role', {
-          _user_id: s.user.id,
-          _role: 'admin',
-        });
-        if (!cancelled) setIsAdmin(!!data);
-      } catch {
-        if (!cancelled) setIsAdmin(false);
-      }
-    };
-
-    const updateAuth = (s: Session | null) => {
+    let unsubscribe: (() => void) | undefined;
+    backendPromise.then((backend) => {
       if (cancelled) return;
-      setSession(s);
-      setUser(s?.user ?? null);
-      if (!s?.user) setIsAdmin(false);
-      initialResolved = true;
-      setLoading(false);
-      // Deferred so we never await a Supabase call while the auth lock is held.
-      setTimeout(() => { void resolveRole(s); }, 0);
-    };
-
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (_event, session) => {
-        if (cancelled) return;
-        updateAuth(session);
-      }
-    );
-
-    // Fallback: getSession as backup for initial load
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (!initialResolved) updateAuth(session);
-    }).catch(() => {
-      if (!cancelled && !initialResolved) {
-        initialResolved = true;
-        setLoading(false);
-      }
+      unsubscribe = backend.subscribeAuthState({ setUser, setSession, setIsAdmin, setLoading });
     });
-
-    // Safety timeout: never stay loading forever
-    const timeout = setTimeout(() => {
-      if (!initialResolved && !cancelled) {
-        console.warn('Auth loading timed out');
-        initialResolved = true;
-        setLoading(false);
-      }
-    }, 5000);
-
     return () => {
       cancelled = true;
-      clearTimeout(timeout);
-      subscription.unsubscribe();
+      unsubscribe?.();
     };
   }, []);
 
-  const login = useCallback(async (email: string, password: string) => {
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    return { error };
-  }, []);
-
-  const logout = useCallback(async () => {
-    await supabase.auth.signOut();
-    setUser(null);
-    setSession(null);
-    setIsAdmin(false);
-  }, []);
-
-  const resetPassword = useCallback(async (email: string) => {
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: window.location.origin + '/reset-password',
-    });
-    return { error };
-  }, []);
-
-  const signUp = useCallback(async (email: string, password: string, displayName?: string, captchaToken?: string) => {
-    const trimmed = displayName?.trim();
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: window.location.origin + '/auth/callback',
-        // Picked up by the handle_new_user trigger; blank → a random name is
-        // generated server-side. A taken name is auto-suffixed there too.
-        data: trimmed ? { display_name: trimmed } : {},
-        // Verified server-side when Turnstile is enabled in the Supabase Auth
-        // settings; ignored otherwise (graceful fallback when no key is set).
-        ...(captchaToken ? { captchaToken } : {}),
-      },
-    });
-    return { error };
-  }, []);
-
-  const signInWithGoogle = useCallback(async () => {
-    try {
-      // Lazy import keeps the Lovable auth SDK out of the main chunk; this
-      // module is only imported in cloud-flagged builds, but the dynamic
-      // import doubles as belt-and-suspenders.
-      const { lovable } = await import('@/integrations/lovable/index');
-      const result = await lovable.auth.signInWithOAuth('google', {
-        redirect_uri: window.location.origin + '/auth/callback',
-      });
-      if (result.error) return { error: result.error as Error };
-      return { error: null };
-    } catch (e) {
-      return { error: e instanceof Error ? e : new Error(String(e)) };
-    }
-  }, []);
+  const value = useMemo<AuthContextValue>(() => ({
+    user,
+    session,
+    isAdmin,
+    loading,
+    // Actions await the backend chunk, so a click racing the initial load
+    // still lands on the real implementation.
+    login: backendPromise
+      ? async (email, password) => (await backendPromise).login(email, password)
+      : disabledError,
+    signUp: backendPromise
+      ? async (email, password, displayName, captchaToken) =>
+          (await backendPromise).signUp(email, password, displayName, captchaToken)
+      : disabledError,
+    signInWithGoogle: backendPromise
+      ? async () => (await backendPromise).signInWithGoogle()
+      : disabledError,
+    logout: backendPromise
+      ? async () => (await backendPromise).logout()
+      : async () => {},
+    resetPassword: backendPromise
+      ? async (email) => (await backendPromise).resetPassword(email)
+      : disabledError,
+  }), [user, session, isAdmin, loading]);
 
   return (
-    <AuthContext.Provider value={{ user, session, isAdmin, loading, login, signUp, signInWithGoogle, logout, resetPassword }}>
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/contexts/authBackend.ts
+++ b/src/contexts/authBackend.ts
@@ -1,0 +1,145 @@
+/**
+ * The Supabase-backed half of AuthContext, loaded as a separate chunk.
+ *
+ * This module owns the only auth-path static import of the Supabase client.
+ * AuthContext dynamically imports it — and only when VITE_ENABLE_ADMIN or
+ * VITE_ENABLE_CLOUD is on — so flag-off (pure offline-first) builds never
+ * fetch vendor-supabase on the landing page at all, and flag-on builds load
+ * it off the critical path.
+ */
+
+import { supabase } from '@/integrations/supabase/client';
+import type { User, Session } from '@supabase/supabase-js';
+
+export interface AuthStateListeners {
+  setUser: (user: User | null) => void;
+  setSession: (session: Session | null) => void;
+  setIsAdmin: (isAdmin: boolean) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+/**
+ * Wire the Supabase auth state into React state. Returns an unsubscribe.
+ */
+export function subscribeAuthState(listeners: AuthStateListeners): () => void {
+  const { setUser, setSession, setIsAdmin, setLoading } = listeners;
+  let cancelled = false;
+  let initialResolved = false;
+
+  // Resolve the admin role. MUST run outside the onAuthStateChange callback:
+  // supabase-js holds the GoTrue Web Lock (navigator.locks) for the duration
+  // of that callback, and any awaited Supabase call inside it needs the same
+  // lock — which deadlocks token refresh and spuriously signs the user out on
+  // reload. So updateAuth sets session/user synchronously and defers this.
+  const resolveRole = async (s: Session | null) => {
+    if (!s?.user) {
+      if (!cancelled) setIsAdmin(false);
+      return;
+    }
+    try {
+      const { data } = await supabase.rpc('has_role', {
+        _user_id: s.user.id,
+        _role: 'admin',
+      });
+      if (!cancelled) setIsAdmin(!!data);
+    } catch {
+      if (!cancelled) setIsAdmin(false);
+    }
+  };
+
+  const updateAuth = (s: Session | null) => {
+    if (cancelled) return;
+    setSession(s);
+    setUser(s?.user ?? null);
+    if (!s?.user) setIsAdmin(false);
+    initialResolved = true;
+    setLoading(false);
+    // Deferred so we never await a Supabase call while the auth lock is held.
+    setTimeout(() => { void resolveRole(s); }, 0);
+  };
+
+  const { data: { subscription } } = supabase.auth.onAuthStateChange(
+    (_event, session) => {
+      if (cancelled) return;
+      updateAuth(session);
+    }
+  );
+
+  // Fallback: getSession as backup for initial load
+  supabase.auth.getSession().then(({ data: { session } }) => {
+    if (!initialResolved) updateAuth(session);
+  }).catch(() => {
+    if (!cancelled && !initialResolved) {
+      initialResolved = true;
+      setLoading(false);
+    }
+  });
+
+  // Safety timeout: never stay loading forever
+  const timeout = setTimeout(() => {
+    if (!initialResolved && !cancelled) {
+      console.warn('Auth loading timed out');
+      initialResolved = true;
+      setLoading(false);
+    }
+  }, 5000);
+
+  return () => {
+    cancelled = true;
+    clearTimeout(timeout);
+    subscription.unsubscribe();
+  };
+}
+
+// ── Actions: plain async functions; state updates arrive via the
+//    onAuthStateChange subscription above, so they need no React access. ──
+
+export async function login(email: string, password: string) {
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  return { error };
+}
+
+export async function logout(): Promise<void> {
+  await supabase.auth.signOut();
+}
+
+export async function resetPassword(email: string) {
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: window.location.origin + '/reset-password',
+  });
+  return { error };
+}
+
+export async function signUp(email: string, password: string, displayName?: string, captchaToken?: string) {
+  const trimmed = displayName?.trim();
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: window.location.origin + '/auth/callback',
+      // Picked up by the handle_new_user trigger; blank → a random name is
+      // generated server-side. A taken name is auto-suffixed there too.
+      data: trimmed ? { display_name: trimmed } : {},
+      // Verified server-side when Turnstile is enabled in the Supabase Auth
+      // settings; ignored otherwise (graceful fallback when no key is set).
+      ...(captchaToken ? { captchaToken } : {}),
+    },
+  });
+  return { error };
+}
+
+export async function signInWithGoogle() {
+  try {
+    // Lazy import keeps the Lovable auth SDK out of the main chunk; this
+    // module is only imported in cloud-flagged builds, but the dynamic
+    // import doubles as belt-and-suspenders.
+    const { lovable } = await import('@/integrations/lovable/index');
+    const result = await lovable.auth.signInWithOAuth('google', {
+      redirect_uri: window.location.origin + '/auth/callback',
+    });
+    if (result.error) return { error: result.error as Error };
+    return { error: null };
+  } catch (e) {
+    return { error: e instanceof Error ? e : new Error(String(e)) };
+  }
+}

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { GpsSample } from '@/types/racing';
 
 interface UsePlaybackOptions {
@@ -19,6 +19,12 @@ interface UsePlaybackReturn {
 /**
  * Hook to manage playback of telemetry data at realistic speed.
  * Animates through samples based on their actual timestamps.
+ *
+ * The rAF loop reads its inputs through refs and is (re)subscribed only when
+ * playback starts/stops — never per index change. The old loop depended on
+ * `currentIndex`, so every tick cancelled and recreated the rAF and reset the
+ * timing anchors: playback advanced at most one frame per two rAF frames and
+ * constantly re-anchored its clock, so 60 Hz data could not play at real time.
  */
 export function usePlayback({
   samples,
@@ -27,17 +33,24 @@ export function usePlayback({
   visibleRange,
 }: UsePlaybackOptions): UsePlaybackReturn {
   const [isPlaying, setIsPlaying] = useState(false);
-  const animationRef = useRef<number | null>(null);
-  const lastFrameTimeRef = useRef<number>(0);
-  const startPlaybackIndexRef = useRef<number>(0);
-  const playbackStartTimeRef = useRef<number>(0);
-  const baseDataTimeRef = useRef<number>(0);
 
-  // Calculate average frame rate from sample timestamps
-  const averageFrameRate = useCallback((): number | null => {
+  // Latest inputs, readable from inside the loop without re-subscribing it.
+  const samplesRef = useRef(samples);
+  samplesRef.current = samples;
+  const onIndexChangeRef = useRef(onIndexChange);
+  onIndexChangeRef.current = onIndexChange;
+  const visibleRangeRef = useRef(visibleRange);
+  visibleRangeRef.current = visibleRange;
+  const currentIndexRef = useRef(currentIndex);
+  currentIndexRef.current = currentIndex;
+
+  // Calculate average frame rate from sample timestamps. Memoized on the
+  // sample window — the old useCallback(...)() IIFE memoized the *function*
+  // and re-diffed + re-sorted the whole window on every render (every
+  // playback tick) for a constant value.
+  const averageFrameRate = useMemo((): number | null => {
     if (samples.length < 2) return null;
 
-    // Calculate time differences between consecutive samples
     const timeDiffs: number[] = [];
     for (let i = 1; i < samples.length; i++) {
       const diff = samples[i].t - samples[i - 1].t;
@@ -45,126 +58,100 @@ export function usePlayback({
         timeDiffs.push(diff);
       }
     }
-
     if (timeDiffs.length === 0) return null;
 
-    // Calculate median to be robust against outliers
+    // Median to be robust against outliers
     timeDiffs.sort((a, b) => a - b);
     const medianInterval = timeDiffs[Math.floor(timeDiffs.length / 2)];
-
-    // Convert to Hz (frames per second)
     return 1000 / medianInterval;
-  }, [samples])();
-
-  // Stop playback when component unmounts or samples change significantly
-  useEffect(() => {
-    return () => {
-      if (animationRef.current !== null) {
-        cancelAnimationFrame(animationRef.current);
-        animationRef.current = null;
-      }
-    };
-  }, []);
+  }, [samples]);
 
   // Stop playback when visible range changes
   const rangeStart = visibleRange[0];
   const rangeEnd = visibleRange[1];
   useEffect(() => {
-    if (isPlaying) {
-      setIsPlaying(false);
-      if (animationRef.current !== null) {
-        cancelAnimationFrame(animationRef.current);
-        animationRef.current = null;
-      }
-    }
-    // Intentional: react only to range edits. Including `isPlaying` would
-    // fire the effect when playback starts and immediately stop it.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setIsPlaying(false);
   }, [rangeStart, rangeEnd]);
 
-  const animate = useCallback((timestamp: number) => {
-    if (!isPlaying) return;
-
-    // Initialize on first frame
-    if (lastFrameTimeRef.current === 0) {
-      lastFrameTimeRef.current = timestamp;
-      playbackStartTimeRef.current = timestamp;
-      startPlaybackIndexRef.current = currentIndex;
-      baseDataTimeRef.current = samples[currentIndex]?.t ?? 0;
-      animationRef.current = requestAnimationFrame(animate);
-      return;
-    }
-
-    // Calculate how much real time has passed since playback started
-    const elapsedRealTime = timestamp - playbackStartTimeRef.current;
-
-    // Find the sample that matches this elapsed time
-    const targetDataTime = baseDataTimeRef.current + elapsedRealTime;
-
-    // Find the index of the sample closest to this time
-    let targetIndex = startPlaybackIndexRef.current;
-    const maxIndex = visibleRange[1] - visibleRange[0];
-
-    for (let i = startPlaybackIndexRef.current; i <= maxIndex; i++) {
-      if (samples[i].t >= targetDataTime) {
-        targetIndex = i;
-        break;
-      }
-      targetIndex = i;
-    }
-
-    // Check if we've reached the end
-    if (targetIndex >= maxIndex) {
-      onIndexChange(maxIndex);
-      setIsPlaying(false);
-      animationRef.current = null;
-      lastFrameTimeRef.current = 0;
-      return;
-    }
-
-    // Update index if it changed
-    if (targetIndex !== currentIndex) {
-      onIndexChange(targetIndex);
-    }
-
-    lastFrameTimeRef.current = timestamp;
-    animationRef.current = requestAnimationFrame(animate);
-  }, [isPlaying, currentIndex, samples, onIndexChange, visibleRange]);
-
-  // Start animation loop when playing
+  // The playback loop. Subscribed once per play; all per-tick state lives in
+  // locals/refs. An external scrub mid-playback (currentIndex changing to a
+  // value the loop didn't emit) re-anchors the clock at the new position.
   useEffect(() => {
-    if (isPlaying && samples.length > 0) {
-      lastFrameTimeRef.current = 0; // Reset to trigger initialization
-      animationRef.current = requestAnimationFrame(animate);
+    if (!isPlaying) return;
+    if (samplesRef.current.length === 0) {
+      setIsPlaying(false);
+      return;
     }
 
-    return () => {
-      if (animationRef.current !== null) {
-        cancelAnimationFrame(animationRef.current);
-        animationRef.current = null;
+    let raf: number;
+    let startTimestamp = 0;
+    let baseDataTime = 0;
+    let emittedIndex = currentIndexRef.current;
+
+    const step = (timestamp: number) => {
+      const samples = samplesRef.current;
+      const maxIndex = Math.min(
+        samples.length - 1,
+        visibleRangeRef.current[1] - visibleRangeRef.current[0],
+      );
+      if (maxIndex < 0) {
+        setIsPlaying(false);
+        return;
       }
+
+      // First frame, or the user scrubbed while playing → anchor the clock
+      // at the current position.
+      if (startTimestamp === 0 || currentIndexRef.current !== emittedIndex) {
+        emittedIndex = Math.min(currentIndexRef.current, maxIndex);
+        startTimestamp = timestamp;
+        baseDataTime = samples[emittedIndex]?.t ?? 0;
+        raf = requestAnimationFrame(step);
+        return;
+      }
+
+      // Advance to the sample matching the elapsed real time.
+      const targetDataTime = baseDataTime + (timestamp - startTimestamp);
+      let idx = emittedIndex;
+      while (idx < maxIndex && samples[idx + 1] && samples[idx + 1].t <= targetDataTime) {
+        idx++;
+      }
+
+      if (idx >= maxIndex) {
+        emittedIndex = maxIndex;
+        currentIndexRef.current = maxIndex;
+        onIndexChangeRef.current(maxIndex);
+        setIsPlaying(false);
+        return;
+      }
+
+      if (idx !== emittedIndex) {
+        emittedIndex = idx;
+        currentIndexRef.current = idx;
+        onIndexChangeRef.current(idx);
+      }
+
+      raf = requestAnimationFrame(step);
     };
-  }, [isPlaying, animate, samples.length]);
+
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [isPlaying]);
 
   const play = useCallback(() => {
-    if (samples.length === 0) return;
+    if (samplesRef.current.length === 0) return;
 
     // If at the end, restart from beginning
-    const maxIndex = visibleRange[1] - visibleRange[0];
-    if (currentIndex >= maxIndex) {
-      onIndexChange(0);
+    const maxIndex = visibleRangeRef.current[1] - visibleRangeRef.current[0];
+    if (currentIndexRef.current >= maxIndex) {
+      currentIndexRef.current = 0;
+      onIndexChangeRef.current(0);
     }
 
     setIsPlaying(true);
-  }, [samples.length, currentIndex, visibleRange, onIndexChange]);
+  }, []);
 
   const pause = useCallback(() => {
     setIsPlaying(false);
-    if (animationRef.current !== null) {
-      cancelAnimationFrame(animationRef.current);
-      animationRef.current = null;
-    }
-    lastFrameTimeRef.current = 0;
   }, []);
 
   const toggle = useCallback(() => {

--- a/src/hooks/useStripePrices.ts
+++ b/src/hooks/useStripePrices.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import type { StripeConfig } from "@/lib/billing";
-import { fetchStripeConfig } from "@/lib/billingClient";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -31,7 +30,10 @@ export function useStripePrices(): StripePricesState {
     }
     let cancelled = false;
     setLoading(true);
-    fetchStripeConfig()
+    // Dynamic import: billingClient pulls the Supabase client, which must
+    // stay off the eager graph (PricingCards rides the landing page).
+    import("@/lib/billingClient")
+      .then(({ fetchStripeConfig }) => fetchStripeConfig())
       .then((c) => {
         if (!cancelled) setConfig(c);
       })

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { effectiveTier, type SubscriptionTierRow, type UserSubscriptionRow } from "@/lib/billing";
-import { fetchMySubscription, fetchTiers } from "@/lib/billingClient";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -40,6 +39,8 @@ export function useSubscription(): SubscriptionState {
     }
     setLoading(true);
     try {
+      // Dynamic import keeps the Supabase client off the eager graph.
+      const { fetchTiers, fetchMySubscription } = await import("@/lib/billingClient");
       const [t, s] = await Promise.all([fetchTiers(), fetchMySubscription(user.id)]);
       setTiers(t);
       setSubscription(s);

--- a/src/lib/videoExport.ts
+++ b/src/lib/videoExport.ts
@@ -9,13 +9,37 @@
  * Audio is extracted from the source video via Web Audio API, encoded with
  * AudioEncoder (AAC), and muxed alongside the video track.
  *
+ * Memory: both encoders run with bounded queues (backpressure), and exports
+ * whose estimated size exceeds the streaming threshold mux into chunked
+ * streamed parts (fragmented MP4) instead of one contiguous ArrayBuffer —
+ * see lib/videoExportTarget.ts.
+ *
  * Falls back to MediaRecorder (WebM) if WebCodecs is unavailable.
  */
 
-import { Muxer, ArrayBufferTarget } from "mp4-muxer";
+import { Muxer, ArrayBufferTarget, StreamTarget } from "mp4-muxer";
 import type { ExportOptions } from "@/components/video-overlays/VideoExportDialog";
 import type { OverlayInstance, OverlayRenderContext } from "@/components/video-overlays/types";
 import { renderOverlaysToCanvas } from "@/lib/overlayCanvasRenderer";
+import { shouldStreamExport, writeStreamChunk, type StreamedPart } from "@/lib/videoExportTarget";
+
+/** A muxer over either export target (in-memory buffer or chunked stream). */
+type ExportMuxer = Muxer<ArrayBufferTarget | StreamTarget>;
+
+// Encoder backpressure: cap the number of frames in flight inside the
+// encoders. Without this the frame loop queues raw frames as fast as it can
+// seek — unbounded memory on slow encoders.
+const MAX_ENCODE_QUEUE = 4;
+const MAX_AUDIO_ENCODE_QUEUE = 32;
+
+async function waitForEncoderQueue(
+  encoder: { encodeQueueSize: number },
+  max: number,
+): Promise<void> {
+  while (encoder.encodeQueueSize > max) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+}
 
 export interface ExportController {
   cancel: () => void;
@@ -123,37 +147,38 @@ async function extractAudioBuffer(
  */
 async function encodeAudioToMuxer(
   audioBuffer: AudioBuffer,
-  muxer: Muxer<ArrayBufferTarget>,
+  muxer: ExportMuxer,
 ): Promise<boolean> {
   if (typeof AudioEncoder === "undefined") {
     console.log("AudioEncoder not available, skipping audio");
     return false;
   }
 
-  return new Promise<boolean>((resolve) => {
-    let hadError = false;
+  let hadError = false;
 
-    const encoder = new AudioEncoder({
-      output: (chunk, meta) => {
-        muxer.addAudioChunk(chunk, meta ?? undefined);
-      },
-      error: (e) => {
-        console.warn("AudioEncoder error:", e);
-        hadError = true;
-      },
-    });
+  const encoder = new AudioEncoder({
+    output: (chunk, meta) => {
+      muxer.addAudioChunk(chunk, meta ?? undefined);
+    },
+    error: (e) => {
+      console.warn("AudioEncoder error:", e);
+      hadError = true;
+    },
+  });
 
-    const sampleRate = audioBuffer.sampleRate;
-    const channels = audioBuffer.numberOfChannels;
+  const sampleRate = audioBuffer.sampleRate;
+  const channels = audioBuffer.numberOfChannels;
 
-    encoder.configure({
-      codec: "mp4a.40.2", // AAC-LC
-      sampleRate,
-      numberOfChannels: channels,
-      bitrate: 128_000,
-    });
+  encoder.configure({
+    codec: "mp4a.40.2", // AAC-LC
+    sampleRate,
+    numberOfChannels: channels,
+    bitrate: 128_000,
+  });
 
-    // Feed audio in chunks of ~1024 samples (standard AAC frame size)
+  try {
+    // Feed audio in chunks of ~1024 samples (standard AAC frame size), with
+    // backpressure — the old loop queued the whole track in one tight pass.
     const frameSize = 1024;
     const totalSamples = audioBuffer.length;
 
@@ -173,16 +198,19 @@ async function encodeAudioToMuxer(
 
       encoder.encode(audioData);
       audioData.close();
+
+      if (encoder.encodeQueueSize > MAX_AUDIO_ENCODE_QUEUE) {
+        await waitForEncoderQueue(encoder, MAX_AUDIO_ENCODE_QUEUE);
+      }
     }
 
-    encoder.flush().then(() => {
-      encoder.close();
-      resolve(!hadError);
-    }).catch(() => {
-      try { encoder.close(); } catch { /* encoder already closed during error handling */ }
-      resolve(false);
-    });
-  });
+    await encoder.flush();
+    encoder.close();
+    return !hadError;
+  } catch {
+    try { encoder.close(); } catch { /* encoder already closed during error handling */ }
+    return false;
+  }
 }
 
 /**
@@ -255,15 +283,31 @@ async function runWebCodecsExport(
     const audioBuffer = await audioPromise;
     if (isCancelled()) return;
 
+    // Pick a bitrate
+    const bitrate = options.quality === "standard" ? 5_000_000 : 15_000_000;
+
+    // Target: short exports keep the single in-memory buffer (classic MP4,
+    // max compatibility). Long ones stream ~16 MiB chunks into a part list
+    // and produce fragmented MP4 — a 20-min 15 Mbps export would otherwise
+    // need one contiguous ~2.2 GB ArrayBuffer (guaranteed mobile OOM).
+    const useStreaming = shouldStreamExport(duration, bitrate);
+    const streamedParts: StreamedPart[] = [];
+    const target = useStreaming
+      ? new StreamTarget({
+          chunked: true,
+          onData: (data, position) => writeStreamChunk(streamedParts, data, position),
+        })
+      : new ArrayBufferTarget();
+
     // mp4-muxer setup — include audio track if we have audio
-    const muxerConfig = {
-      target: new ArrayBufferTarget(),
+    const muxer: ExportMuxer = new Muxer({
+      target,
       video: {
         codec: "avc" as const,
         width: targetW,
         height: targetH,
       },
-      fastStart: "in-memory" as const,
+      fastStart: useStreaming ? ("fragmented" as const) : ("in-memory" as const),
       ...(audioBuffer ? {
         audio: {
           codec: "aac" as const,
@@ -271,9 +315,7 @@ async function runWebCodecsExport(
           sampleRate: audioBuffer.sampleRate,
         },
       } : {}),
-    };
-
-    const muxer = new Muxer<ArrayBufferTarget>(muxerConfig);
+    });
 
     // VideoEncoder setup
     let encoderError: string | null = null;
@@ -285,9 +327,6 @@ async function runWebCodecsExport(
         encoderError = e.message;
       },
     });
-
-    // Pick a bitrate
-    const bitrate = options.quality === "standard" ? 5_000_000 : 15_000_000;
 
     encoder.configure({
       codec: "avc1.42001f", // Baseline profile, level 3.1 — wide compat
@@ -329,12 +368,17 @@ async function runWebCodecsExport(
         }
       }
 
-      // Create VideoFrame and encode
+      // Create VideoFrame and encode, with backpressure: never let more than
+      // a few frames queue inside the encoder (unbounded queueing buffers raw
+      // frames in memory whenever encoding is slower than seeking).
       const timestamp = Math.round(i * frameInterval * 1_000_000); // microseconds
       const frame = new VideoFrame(canvas, { timestamp });
       const keyFrame = i % keyFrameInterval === 0;
       encoder.encode(frame, { keyFrame });
       frame.close();
+      if (encoder.encodeQueueSize > MAX_ENCODE_QUEUE) {
+        await waitForEncoderQueue(encoder, MAX_ENCODE_QUEUE);
+      }
 
       callbacks.onProgress((i + 1) / totalFrames);
     }
@@ -356,8 +400,12 @@ async function runWebCodecsExport(
 
     muxer.finalize();
 
-    const buf = (muxer.target as ArrayBufferTarget).buffer;
-    const blob = new Blob([buf], { type: "video/mp4" });
+    // Many small parts → Blob lets the browser keep the result off-heap;
+    // the in-memory path keeps its single buffer (short exports only).
+    const blob = useStreaming
+      ? new Blob(streamedParts.map((p) => p.data), { type: "video/mp4" })
+      : new Blob([(target as ArrayBufferTarget).buffer], { type: "video/mp4" });
+    streamedParts.length = 0;
 
     video.muted = wasMuted;
     if (wasPlaying) video.play();

--- a/src/lib/videoExportTarget.test.ts
+++ b/src/lib/videoExportTarget.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the video-export target choice + streamed chunk store.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  estimateExportBytes,
+  shouldStreamExport,
+  writeStreamChunk,
+  streamedPartsLength,
+  STREAMING_SIZE_THRESHOLD_BYTES,
+  type StreamedPart,
+} from "./videoExportTarget";
+
+/** Assemble the parts into one byte array (what the Blob constructor sees). */
+function assemble(parts: StreamedPart[]): Uint8Array {
+  const out = new Uint8Array(streamedPartsLength(parts));
+  for (const p of parts) out.set(p.data, p.position);
+  return out;
+}
+
+// ─── shouldStreamExport ─────────────────────────────────────────────────────
+
+describe("shouldStreamExport", () => {
+  it("keeps short exports on the in-memory path", () => {
+    // 2 minutes at 5 Mbps ≈ 79 MB — well under the threshold.
+    expect(shouldStreamExport(120, 5_000_000)).toBe(false);
+  });
+
+  it("streams a 20-minute high-quality export (the OOM case)", () => {
+    // 20 min at 15 Mbps ≈ 2.2 GB.
+    expect(shouldStreamExport(20 * 60, 15_000_000)).toBe(true);
+  });
+
+  it("uses the size estimate against the threshold", () => {
+    const justUnder = (STREAMING_SIZE_THRESHOLD_BYTES * 8) / 15_128_000 / 1.05 - 1;
+    expect(estimateExportBytes(justUnder, 15_000_000)).toBeLessThan(STREAMING_SIZE_THRESHOLD_BYTES);
+    expect(shouldStreamExport(justUnder, 15_000_000)).toBe(false);
+    expect(shouldStreamExport(justUnder + 10, 15_000_000)).toBe(true);
+  });
+});
+
+// ─── writeStreamChunk ───────────────────────────────────────────────────────
+
+describe("writeStreamChunk", () => {
+  it("appends sequential writes", () => {
+    const parts: StreamedPart[] = [];
+    writeStreamChunk(parts, new Uint8Array([1, 2, 3]), 0);
+    writeStreamChunk(parts, new Uint8Array([4, 5]), 3);
+    expect(streamedPartsLength(parts)).toBe(5);
+    expect(Array.from(assemble(parts))).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("applies an in-place back-patch over existing parts", () => {
+    const parts: StreamedPart[] = [];
+    writeStreamChunk(parts, new Uint8Array([1, 2, 3, 4]), 0);
+    writeStreamChunk(parts, new Uint8Array([5, 6]), 4);
+    // Patch bytes 2..5 (spans both parts).
+    writeStreamChunk(parts, new Uint8Array([9, 9, 9]), 2);
+    expect(Array.from(assemble(parts))).toEqual([1, 2, 9, 9, 9, 6]);
+    expect(streamedPartsLength(parts)).toBe(6);
+  });
+
+  it("handles a write that overlaps the end and extends the file", () => {
+    const parts: StreamedPart[] = [];
+    writeStreamChunk(parts, new Uint8Array([1, 2, 3]), 0);
+    writeStreamChunk(parts, new Uint8Array([7, 8, 9]), 2); // overwrites byte 2, appends 2 more
+    expect(Array.from(assemble(parts))).toEqual([1, 2, 7, 8, 9]);
+  });
+
+  it("zero-fills a gap so the file stays well-formed", () => {
+    const parts: StreamedPart[] = [];
+    writeStreamChunk(parts, new Uint8Array([1]), 0);
+    writeStreamChunk(parts, new Uint8Array([5]), 3);
+    expect(Array.from(assemble(parts))).toEqual([1, 0, 0, 5]);
+  });
+
+  it("copies the incoming buffer (muxer may reuse it)", () => {
+    const parts: StreamedPart[] = [];
+    const buf = new Uint8Array([1, 2, 3]);
+    writeStreamChunk(parts, buf, 0);
+    buf[0] = 99;
+    expect(Array.from(assemble(parts))).toEqual([1, 2, 3]);
+  });
+});

--- a/src/lib/videoExportTarget.ts
+++ b/src/lib/videoExportTarget.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure helpers for the video-export muxer target choice and the streamed
+ * chunk store behind it.
+ *
+ * Short exports keep the old in-memory path (single buffer, in-memory
+ * fastStart → maximally compatible MP4). Long exports would need that single
+ * contiguous ArrayBuffer to grow to the full file size (a 20-min 15 Mbps
+ * export ≈ 2.2 GB — guaranteed mobile OOM), so they switch to a chunked
+ * stream target with fragmented MP4 output: the muxer emits ~16 MiB pieces
+ * that are collected and handed to the Blob constructor, which lets the
+ * browser back the result with disk instead of one giant heap allocation.
+ */
+
+/** Estimated output size above which the export streams instead of buffering. */
+export const STREAMING_SIZE_THRESHOLD_BYTES = 350 * 1024 * 1024;
+
+/** Audio bitrate used by the export pipeline (AAC-LC). */
+const AUDIO_BITRATE = 128_000;
+
+/** Rough output size for a given duration and video bitrate, in bytes. */
+export function estimateExportBytes(durationSec: number, videoBitrate: number): number {
+  // ~5% container overhead on top of the elementary streams.
+  return ((videoBitrate + AUDIO_BITRATE) / 8) * durationSec * 1.05;
+}
+
+/** Whether an export of this duration/bitrate should use the streamed target. */
+export function shouldStreamExport(
+  durationSec: number,
+  videoBitrate: number,
+  thresholdBytes: number = STREAMING_SIZE_THRESHOLD_BYTES,
+): boolean {
+  return estimateExportBytes(durationSec, videoBitrate) > thresholdBytes;
+}
+
+/** One contiguous piece of the streamed output file. */
+export interface StreamedPart {
+  position: number;
+  data: Uint8Array;
+}
+
+/**
+ * Apply a muxer write to the part list. Fragmented MP4 writes are
+ * append-only in practice, but this also handles in-place back-patches and
+ * (defensively) zero-fills gaps, so the assembled file is always well-formed.
+ * Parts are kept contiguous from position 0 in ascending order.
+ */
+export function writeStreamChunk(parts: StreamedPart[], data: Uint8Array, position: number): void {
+  const last = parts[parts.length - 1];
+  const total = last ? last.position + last.data.length : 0;
+
+  // Overwrite any overlap with already-stored parts (back-patch).
+  if (position < total) {
+    for (const part of parts) {
+      const start = Math.max(position, part.position);
+      const end = Math.min(position + data.length, part.position + part.data.length);
+      if (start >= end) continue;
+      part.data.set(data.subarray(start - position, end - position), start - part.position);
+    }
+  }
+
+  // Zero-fill a gap (should not happen with fragmented output, but never
+  // produce a corrupt file if it does).
+  if (position > total) {
+    parts.push({ position: total, data: new Uint8Array(position - total) });
+  }
+
+  // Append whatever extends beyond the current end.
+  const writeEnd = position + data.length;
+  if (writeEnd > total) {
+    const tailStart = Math.max(position, total);
+    parts.push({ position: tailStart, data: data.slice(tailStart - position) });
+  }
+}
+
+/** Total assembled size of the part list, in bytes. */
+export function streamedPartsLength(parts: StreamedPart[]): number {
+  const last = parts[parts.length - 1];
+  return last ? last.position + last.data.length : 0;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,12 +2,16 @@ import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react
 import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, AlertCircle } from "lucide-react";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
-import { RaceLineTab } from "@/components/tabs/RaceLineTab";
 import { LapTimesTab } from "@/components/tabs/LapTimesTab";
 // Heavy tabs lazy-loaded so the initial bundle doesn't carry their deps.
-// GraphView pulls in the multi-series canvas chart + InfoBox + MiniMap; Labs is
-// behind a settings flag and almost never opened. Both load on first user click
-// of their respective tab.
+// RaceLine pulls in Leaflet (vendor-leaflet, ~150 kB) + the telemetry chart —
+// lazy keeps the whole mapping stack off the landing page; it loads the moment
+// a session is opened (the default tab). GraphView pulls in the multi-series
+// canvas chart + InfoBox + MiniMap; Labs is behind a settings flag and almost
+// never opened. All load on first render of their respective tab.
+const RaceLineTab = lazy(() =>
+  import("@/components/tabs/RaceLineTab").then((m) => ({ default: m.RaceLineTab })),
+);
 const GraphViewTab = lazy(() =>
   import("@/components/tabs/GraphViewTab").then((m) => ({ default: m.GraphViewTab })),
 );
@@ -613,9 +617,9 @@ export default function Index() {
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
-          {topPanelView === "raceline" && <RaceLineTab showOverlays={showOverlays} />}
           {topPanelView === "laptable" && <LapTimesTab />}
           <Suspense fallback={null}>
+            {topPanelView === "raceline" && <RaceLineTab showOverlays={showOverlays} />}
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "labs" && showLabs && <LabsTab />}
             {topPanelView === "coach" && showCoach && <CoachTab />}


### PR DESCRIPTION
Resolves the **performance** highs from the professional review (H-7 … H-12). Sibling PR to #183 (data correctness); both are independent branches off BETA — whichever merges second will have a trivial CHANGELOG conflict.

## H-7 — `averageFrameRate` sorted the sample window on every render
Now a `useMemo` on the sample window. The old `useCallback(...)()` IIFE memoized the *function* and re-diffed + re-sorted the whole visible window (~10–20 ms at 100k samples) on every playback tick for a constant value.

## H-8 — `usePlayback`'s rAF loop tore itself down every tick
The loop reads samples/range/index/callback through refs and is (re)subscribed **only on play/pause** — never per index change. Previously `animate` depended on `currentIndex`, so every tick cancelled + recreated the rAF and reset the timing anchors: playback advanced at most one frame per two rAF frames and 60 Hz data couldn't play at real time. Also:
- index advancement is incremental from the last emitted index (the old loop rescanned from the playback start index every frame), and
- an external scrub mid-playback is detected (emitted ≠ rendered index) and re-anchors the clock at the new position.

## H-9 — per-tick marker destruction + animated `panTo`
The destroy/recreate marker path was already fixed in #182 (markers are created once, then `setLatLng` + a CSS rotation per tick). This PR fixes the remainder: the MiniMap follow-pan now re-centers **only when the arrow leaves the middle half of the view**, with `animate: false` — the old animated `panTo` per 16 ms tick perpetually interrupted its own animation.

## H-10 — O(glitches × n) allocation in SingleSeriesChart
Already fixed in #182 (the speeds array is hoisted out of the draw loop and built at most once per redraw). Verified on BETA; nothing further needed.

## H-11 — video export held the whole MP4 + decoded audio in memory, no backpressure
- **Streamed target for big exports** (new pure `lib/videoExportTarget.ts`, unit-tested): when the estimated output exceeds 350 MB (a 20-min 15 Mbps export ≈ 2.2 GB — guaranteed mobile OOM), the muxer writes through a chunked `StreamTarget` with `fastStart: 'fragmented'` into a part list, and the final file is a `Blob` built from ~16 MB pieces — no single contiguous allocation, and the browser can back the Blob with disk. The chunk store handles append, in-place back-patch, and (defensively) gap zero-fill. Short exports keep the old in-memory fastStart path for maximum container compatibility.
- **Encoder backpressure**: the frame loop awaits whenever `VideoEncoder.encodeQueueSize` exceeds 4, and the audio loop does the same at 32 — encoding can no longer queue unbounded raw frames when the encoder is slower than seeking.
- Audio still decodes via `decodeAudioData` (a WebCodecs streaming decode would need an in-house MP4 demuxer — left as the documented remaining limitation), but it now feeds the AAC encoder with backpressure instead of one tight full-track loop.

## H-12 — landing page payload cut ~40% (measured)
**Before → after (real builds): ~1,130 kB raw / ~334 kB gzip → 684 kB raw / 207 kB gzip.**
- `RaceLineTab` (→ `RaceLineView` + `TelemetryChart` + **vendor-leaflet**, 148 kB) is now lazy via the existing tab pattern; it loads the moment a session opens (it's the default tab), never on the landing page.
- **vendor-supabase (172 kB) is fully off the eager graph.** The auth bootstrap moved to `contexts/authBackend.ts`, dynamically imported by `AuthContext` *only when* `VITE_ENABLE_ADMIN`/`VITE_ENABLE_CLOUD` is on — flag-off offline-first builds **never download it at all**; flag-on builds load it off the critical path (auth actions `await` the chunk so a click can't race the load, and `loading` semantics are preserved). The remaining eager-graph importers were converted to call-site dynamic imports: `SubmitTrackDialog` (submit handler), `PricingCards` (checkout/portal clicks), `useStripePrices`/`useSubscription` (cloud-gated fetches).
- Verified post-build that `index.html`'s module graph contains neither vendor chunk and the entry has no static Supabase import. CLAUDE.md's "known follow-up" note replaced with the new invariant + a don't-regress warning.

## Tests
`videoExportTarget` suite (size-threshold decision incl. the 20-min OOM case; chunk-store append/back-patch/overlap-extend/gap-fill/buffer-copy). `npm run lint`, `npm run typecheck`, `npm run test:run` (1432 tests / 106 files), and `npm run build` all pass. Changelog + CLAUDE.md updated.

https://claude.ai/code/session_01F4NRCkHHGTmiQRcS8ogxXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4NRCkHHGTmiQRcS8ogxXY)_