### PR TITLE
v2.5.0: Tools tab + kart seat-position visualizer, icons-only mobile tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new first-party `tools` plugin. The tab self-gates like Coach (it shows only
   when a plugin contributes to the new `tools` panel slot) and opens on a
   picker of tools — icon + one-line description — that you click into.
-- **Kart seat position visualizer** — the first tool: a side-view rigid-body
+- **Kart seat position visualizer** — the first tool (tagged *super
+  experimental* on its picker card): a side-view rigid-body
   statics model showing how a fore/aft seat slide (±1", 1/16" detents) and a
   seat tilt (±5°, or rear-mount mm) shift front/rear weight distribution and
   CoG height relative to a user-set zero point. A stick-figure driver with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [Unreleased]
+
+> Wearing in as the `2.5.0` beta.
+
+### Added
+- **Tools tab** — a new main-view tab to the right of Coach, contributed by a
+  new first-party `tools` plugin. The tab self-gates like Coach (it shows only
+  when a plugin contributes to the new `tools` panel slot) and opens on a
+  picker of tools — icon + one-line description — that you click into.
+- **Kart seat position visualizer** — the first tool: a side-view rigid-body
+  statics model showing how a fore/aft seat slide (±1", 1/16" detents) and a
+  seat tilt (±5°, or rear-mount mm) shift front/rear weight distribution and
+  CoG height relative to a user-set zero point. A stick-figure driver with
+  feet-on-pedals knee IK makes the leg-coupling model visible. Readouts:
+  signed Δrear %, per-axle weight in lb/kg, CoG height change, local
+  sensitivities (%/inch and %/degree), and a 1.5 g lateral-transfer indicator
+  (rigid-frame approximation). An advanced panel tunes the leg-coupling factor
+  and seat/driver geometry, and a corner-scale calibration flow anchors the
+  baseline to your kart and fits the leg coupling from a measured seat slide.
+  Fully offline; settings persist in the tools plugin's own IndexedDB store.
+
+### Changed
+- **The main tab bar is icons-only on phones.** Every view tab (Simple, Pro,
+  Lap Times, Labs, Coach, Tools) and the Simple-view Overlay toggle now show
+  just their icon at phone widths; labels return at tablet width and up.
+
 ## [2.4.0] - 2026-6-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 ├── components/
 │   ├── ui/                # shadcn/ui primitives
 │   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, BannedIps, Tools, Messages)
-│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach; Profile is mounted in the drawer)
+│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach, Tools; Profile is mounted in the drawer)
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Notes, Setups, Device*)
 │   ├── track-editor/      # Track editor sub-components (VisualEditor is lazy — see Bundle Splitting)
@@ -152,6 +152,8 @@ src/
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section
 │   ├── (framework)        # types, registry, index, panels, mounts, storage + PluginPanelHost/PluginMount
 │   ├── cloud-sync/         # ★ First-party plugin: Supabase file + garage sync — see docs/backend.md
+│   ├── tools/              # ★ First-party plugin: Tools tab (lazy tool picker; kart seat-position
+│   │                      #   visualizer — pure rigid-body model.ts + SVG view, corner-scale calibration)
 │   └── coaching/           # Gitignored slot for the AI coach (npm pkg in production)
 ├── types/racing.ts        # ★ Core types: GpsSample, ParsedData, Lap, Course, Track, …
 ├── contexts/              # SettingsContext, SessionContext, PlaybackContext, DeviceContext (BLE), AuthContext (admin)
@@ -217,19 +219,22 @@ A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 
 **UI panels:** the first concrete extension point. A plugin contributes
 `PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
-Three slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`; no
+Four slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`; no
 first-party panel targets it now — it shows only when the experimental
 `enableLabs` setting is on or another plugin contributes), `PanelSlot.Coach`
 (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home for the
-`@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
+`@perchwerks/eye-in-the-sky` coaching plugin), `PanelSlot.Tools`
+(rendered by `ToolsTab.tsx` — the Tools tab right of Coach; the first-party
+`tools` plugin contributes its chromeless tool-picker panel there), and
+`PanelSlot.Profile`
 (rendered by `ProfileTab.tsx` — mounted as a tab **inside the file-manager
 drawer**, between Garage and Device, not in the main view tab bar; cloud-sync
 contributes the merged Account panel (sign-in/out + display name + plan +
 storage, working signed out against local storage), lap-snapshot management, and
 cloud-log management). All render contributed
 panels via `PluginPanelHost` and are
-**self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showProfile`
-from `getPanelsForSlot`, so a tab appears only when a
+**self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showTools`/
+`showProfile` from `getPanelsForSlot`, so a tab appears only when a
 plugin contributes a panel to it (Labs additionally shows when the experimental
 `enableLabs` setting is on). New slots are just new strings — no framework change.
 `PluginPanelHost` wraps each panel in an error boundary **and** a `Suspense`
@@ -275,6 +280,21 @@ the incremental engine. Backs the IndexedDB stores up to Supabase: structured
 stores → `sync_records` jsonb docs, raw blobs → the private `user-files` bucket.
 **Full data model, sync engine, conflict resolution, and backend live in
 `docs/backend.md`.**
+
+**Tools (first-party plugin, `src/plugins/tools/`):** contributes one chromeless
+panel to `PanelSlot.Tools`: a picker of trackside tools (icon + one-line
+description, catalog in `toolList.ts`) that opens the selected tool with a back
+bar. Everything is lazy (`ToolsPanel` and each tool component), so nothing rides
+the initial bundle, and fully offline. Tool state persists via
+`getPluginStore("tools")`. First tool: the **kart seat position visualizer**
+(`seat-position/`) — a pure, unit-tested rigid-body statics model (`model.ts`:
+4-element mass model with a feet-on-pedals leg-coupling factor, slide + tilt
+about the front anchor, closed-form + central-difference sensitivities, knee IK,
+corner-scale calibration that fits `kLegs`, and `rebaseline()` for
+"set current as zero") rendered as a side-view SVG (`SeatDiagram.tsx`) with
+controls/readouts in `SeatPositionTool.tsx`. The user plans to split this plugin
+into its own repo later — keep it free of deep host imports (it touches only the
+plugin contracts + `components/ui`).
 
 **AI coach (npm package):** published to the public npm registry as
 `@perchwerks/eye-in-the-sky` and listed in `optionalDependencies`. The loader in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doves-dataviewer",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doves-dataviewer",
-      "version": "2.3.0",
+      "version": "2.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@lovable.dev/cloud-auth-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.3.1",
+  "version": "2.5.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/components/tabs/ToolsTab.tsx
+++ b/src/components/tabs/ToolsTab.tsx
@@ -1,0 +1,39 @@
+import { memo } from "react";
+import { Wrench } from "lucide-react";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { useSettingsContext } from "@/contexts/SettingsContext";
+import { PluginPanelHost } from "@/plugins/PluginPanelHost";
+import { PanelSlot } from "@/plugins/panels";
+
+export const ToolsTab = memo(function ToolsTab() {
+  const { data, laps, selectedLapNumber, course, activeSnapshot, sessionSetup } = useSessionContext();
+  const { useKph } = useSettingsContext();
+
+  return (
+    <PluginPanelHost
+      slot={PanelSlot.Tools}
+      data={data}
+      laps={laps}
+      selectedLapNumber={selectedLapNumber}
+      course={course}
+      useKph={useKph}
+      sessionSetup={sessionSetup}
+      activeSnapshot={activeSnapshot}
+      fallback={<ToolsEmpty />}
+    />
+  );
+});
+
+function ToolsEmpty() {
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="max-w-sm space-y-5 text-center px-4">
+        <Wrench className="w-10 h-10 text-muted-foreground/40 mx-auto" />
+        <p className="text-sm font-medium text-foreground">Tools</p>
+        <p className="text-xs text-muted-foreground">
+          No tools plugin is loaded in this build.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, AlertCircle } from "lucide-react";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, AlertCircle, Wrench } from "lucide-react";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { LapTimesTab } from "@/components/tabs/LapTimesTab";
@@ -20,6 +20,9 @@ const LabsTab = lazy(() =>
 );
 const CoachTab = lazy(() =>
   import("@/components/tabs/CoachTab").then((m) => ({ default: m.CoachTab })),
+);
+const ToolsTab = lazy(() =>
+  import("@/components/tabs/ToolsTab").then((m) => ({ default: m.ToolsTab })),
 );
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SettingsModal } from "@/components/SettingsModal";
@@ -65,7 +68,7 @@ import { snapshotLapSamples } from "@/lib/lapSnapshot";
 import type { PluginSnapshot } from "@/plugins/panels";
 
 
-type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach";
+type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach" | "tools";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
@@ -141,6 +144,9 @@ export default function Index() {
   // The Coach tab is self-gating: it appears only when a plugin contributes a
   // panel to the Coach slot (i.e. the coach package is installed).
   const showCoach = usePanelsForSlot(PanelSlot.Coach).length > 0;
+  // Tools tab is self-gating like Coach: it appears only when a plugin
+  // contributes a panel to the Tools slot (the first-party tools plugin does).
+  const showTools = usePanelsForSlot(PanelSlot.Tools).length > 0;
   // Profile tab is self-gating too: appears only when a plugin (cloud-sync)
   // contributes a Profile panel (i.e. the cloud build flag is on).
   const showProfile = usePanelsForSlot(PanelSlot.Profile).length > 0;
@@ -613,7 +619,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} setupIndicator={setupIndicator} onSetupIndicatorClick={() => setupIndicator && fileManager.open(setupIndicator.target)} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} showTools={showTools} setupIndicator={setupIndicator} onSetupIndicatorClick={() => setupIndicator && fileManager.open(setupIndicator.target)} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -623,6 +629,7 @@ export default function Index() {
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "labs" && showLabs && <LabsTab />}
             {topPanelView === "coach" && showCoach && <CoachTab />}
+            {topPanelView === "tools" && showTools && <ToolsTab />}
           </Suspense>
         </div>
       </main>
@@ -655,7 +662,7 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, setupIndicator, onSetupIndicatorClick }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, showTools, setupIndicator, onSetupIndicatorClick }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
@@ -663,6 +670,7 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   onToggleOverlays: () => void;
   showLabs: boolean;
   showCoach: boolean;
+  showTools: boolean;
   setupIndicator: SetupIndicator | null;
   onSetupIndicatorClick: () => void;
 }) {
@@ -676,13 +684,13 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   return (
     <div className="flex items-center border-b border-border shrink-0">
       <button onClick={() => setTopPanelView("raceline")} className={tabClass("raceline")}>
-        <Map className="w-4 h-4" /> Simple
+        <Map className="w-4 h-4" /> <span className="hidden sm:inline">Simple</span>
       </button>
       <button onClick={() => setTopPanelView("graphview")} className={tabClass("graphview")}>
         <BarChart3 className="w-4 h-4" /> <span className="hidden sm:inline">Pro</span>
       </button>
       <button onClick={() => setTopPanelView("laptable")} className={tabClass("laptable")}>
-        <ListOrdered className="w-4 h-4" /> Lap Times
+        <ListOrdered className="w-4 h-4" /> <span className="hidden sm:inline">Lap Times</span>
         {laps.length > 0 && (
           <span className="ml-1 px-1.5 py-0.5 text-xs bg-primary/20 text-primary rounded">{laps.length}</span>
         )}
@@ -695,6 +703,11 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
       {showCoach && (
         <button onClick={() => setTopPanelView("coach")} className={tabClass("coach")}>
           <Gauge className="w-4 h-4" /> <span className="hidden sm:inline">Coach</span>
+        </button>
+      )}
+      {showTools && (
+        <button onClick={() => setTopPanelView("tools")} className={tabClass("tools")}>
+          <Wrench className="w-4 h-4" /> <span className="hidden sm:inline">Tools</span>
         </button>
       )}
       {setupIndicator && (
@@ -727,7 +740,7 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
         <div className="ml-auto mr-3">
           <Button variant="ghost" size="sm" onClick={onToggleOverlays} className="h-7 px-2 gap-1.5">
             {showOverlays ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-            <span className="text-xs">Overlay</span>
+            <span className="text-xs hidden sm:inline">Overlay</span>
           </Button>
         </div>
       )}

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -23,6 +23,8 @@ export const PanelSlot = {
   Labs: "labs",
   /** The dedicated AI Coach tab in the main view. */
   Coach: "coach",
+  /** The Tools tab in the main view (utility tools, e.g. the seat-position visualizer). */
+  Tools: "tools",
   /** The user profile tab (storage usage, account) in the file-manager drawer. */
   Profile: "profile",
 } as const;

--- a/src/plugins/tools/ToolsPanel.tsx
+++ b/src/plugins/tools/ToolsPanel.tsx
@@ -30,7 +30,14 @@ export default function ToolsPanel(props: PluginPanelProps) {
                 >
                   <Icon className="w-6 h-6 text-primary shrink-0 mt-0.5" />
                   <span>
-                    <span className="block text-sm font-medium text-foreground">{tool.name}</span>
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-sm font-medium text-foreground">{tool.name}</span>
+                      {tool.badge && (
+                        <span className="rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
+                          {tool.badge}
+                        </span>
+                      )}
+                    </span>
                     <span className="mt-1 block text-xs text-muted-foreground">{tool.description}</span>
                   </span>
                 </button>

--- a/src/plugins/tools/ToolsPanel.tsx
+++ b/src/plugins/tools/ToolsPanel.tsx
@@ -1,0 +1,62 @@
+// The Tools tab body: a picker of available tools, and the opened tool with a
+// back bar. Chromeless panel — it owns the full tab surface.
+
+import { Suspense, useState } from "react";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { TOOLS } from "./toolList";
+
+export default function ToolsPanel(props: PluginPanelProps) {
+  const [activeToolId, setActiveToolId] = useState<string | null>(null);
+  const activeTool = TOOLS.find((t) => t.id === activeToolId) ?? null;
+
+  if (!activeTool) {
+    return (
+      <div className="h-full overflow-auto p-4">
+        <div className="max-w-3xl mx-auto space-y-4">
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Tools</h2>
+            <p className="text-xs text-muted-foreground">Trackside calculators and utilities.</p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {TOOLS.map((tool) => {
+              const Icon = tool.icon;
+              return (
+                <button
+                  key={tool.id}
+                  onClick={() => setActiveToolId(tool.id)}
+                  className="flex items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-primary/50 hover:bg-primary/5"
+                >
+                  <Icon className="w-6 h-6 text-primary shrink-0 mt-0.5" />
+                  <span>
+                    <span className="block text-sm font-medium text-foreground">{tool.name}</span>
+                    <span className="mt-1 block text-xs text-muted-foreground">{tool.description}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const ToolBody = activeTool.component;
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-1.5 border-b border-border px-2 py-1.5 shrink-0">
+        <Button variant="ghost" size="sm" className="h-7 px-2 gap-1" onClick={() => setActiveToolId(null)}>
+          <ChevronLeft className="w-4 h-4" />
+          <span className="text-xs">Tools</span>
+        </Button>
+        <span className="text-sm font-medium text-foreground">{activeTool.name}</span>
+      </div>
+      <div className="flex-1 min-h-0">
+        <Suspense fallback={<p className="p-4 text-xs text-muted-foreground">Loading tool…</p>}>
+          <ToolBody {...props} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/tools/index.ts
+++ b/src/plugins/tools/index.ts
@@ -1,0 +1,32 @@
+// First-party Tools plugin.
+//
+// Contributes the Tools tab (a self-gating main-view tab, like Coach): a
+// chromeless panel that shows a picker of utility tools and renders the one
+// the user opens. The tools themselves live under this folder and are lazy —
+// nothing here rides the initial bundle. Fully offline.
+
+import { lazy } from "react";
+import { Wrench } from "lucide-react";
+import type { DataViewerPlugin } from "@/plugins/types";
+import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
+
+const ToolsPanel = lazy(() => import("./ToolsPanel"));
+
+const plugin: DataViewerPlugin = {
+  id: "tools",
+  name: "Track Tools",
+  version: "0.1.0",
+  setup(ctx) {
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "tools-home",
+      title: "Tools",
+      slot: PanelSlot.Tools,
+      icon: Wrench,
+      component: ToolsPanel,
+      // The panel owns its full layout (picker grid / opened tool).
+      chromeless: true,
+    } satisfies PluginPanel);
+  },
+};
+
+export default plugin;

--- a/src/plugins/tools/seat-position/SeatDiagram.tsx
+++ b/src/plugins/tools/seat-position/SeatDiagram.tsx
@@ -1,0 +1,158 @@
+// Side-view SVG of the kart: chassis, wheels, seat profile, and a three-
+// segment stick driver whose knee is solved by 2-link IK so the feet stay on
+// the pedals — the leg-coupling model made visible. The baseline (zero point)
+// renders as a gray ghost behind the current position.
+
+import { useMemo } from "react";
+import {
+  ZERO_ADJUSTMENTS,
+  computeMassElements,
+  computeCoM,
+  hipPoint,
+  rotateOffset,
+  solveKneeIK,
+  type Point,
+  type SeatAdjustments,
+  type SeatModelParams,
+} from "./model";
+
+// Visual-only proportions (mm). The mass model doesn't depend on these.
+const THIGH_MM = 370;
+const SHANK_MM = 385;
+const HEAD_R_MM = 52;
+const SHOULDER_DX = -276; // from the anchor, rigid with the seat
+const SHOULDER_DZ = 583;
+// Seat profile polyline, offsets from the front-bottom anchor.
+const SEAT_PROFILE: Array<[number, number]> = [
+  [15, -5],
+  [-70, 12],
+  [-160, 42],
+  [-225, 85],
+  [-258, 140],
+  [-290, 275],
+  [-312, 405],
+];
+
+interface FigureGeometry {
+  seat: Point[];
+  hip: Point;
+  knee: Point;
+  foot: Point;
+  shoulder: Point;
+  head: Point;
+  com: Point;
+}
+
+function buildFigure(p: SeatModelParams, adj: SeatAdjustments): FigureGeometry {
+  const anchor: Point = { x: p.anchorXMm + adj.slideMm, z: p.anchorZMm };
+  const place = (dx: number, dz: number): Point => {
+    const r = rotateOffset(dx, dz, adj.tiltDeg);
+    return { x: anchor.x + r.x, z: anchor.z + r.z };
+  };
+  const seat = SEAT_PROFILE.map(([dx, dz]) => place(dx, dz));
+  const hip = hipPoint(p, adj);
+  const foot: Point = { x: p.wheelbaseMm - 80, z: 140 };
+  const knee = solveKneeIK(hip, foot, THIGH_MM, SHANK_MM);
+  const shoulder = place(SHOULDER_DX, SHOULDER_DZ);
+  const len = Math.hypot(shoulder.x - hip.x, shoulder.z - hip.z) || 1;
+  const head: Point = {
+    x: shoulder.x + ((shoulder.x - hip.x) / len) * (HEAD_R_MM + 25),
+    z: shoulder.z + ((shoulder.z - hip.z) / len) * (HEAD_R_MM + 25),
+  };
+  const com = computeCoM(computeMassElements(p, adj));
+  return { seat, hip, knee, foot, shoulder, head, com: { x: com.xMm, z: com.zMm } };
+}
+
+function Figure({ g, ghost }: { g: FigureGeometry; ghost?: boolean }) {
+  const cls = ghost ? "text-muted-foreground/40" : "text-foreground";
+  const pts = (list: Point[]) => list.map((q) => `${q.x},${-q.z}`).join(" ");
+  return (
+    <g className={cls} stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
+      {/* seat profile */}
+      <polyline points={pts(g.seat)} strokeWidth={ghost ? 14 : 18} className={ghost ? undefined : "text-primary"} />
+      {/* legs: shank then thigh (foot stays on the pedals) */}
+      <polyline points={pts([g.foot, g.knee, g.hip])} strokeWidth={12} />
+      {/* torso */}
+      <line x1={g.hip.x} y1={-g.hip.z} x2={g.shoulder.x} y2={-g.shoulder.z} strokeWidth={12} />
+      <circle cx={g.head.x} cy={-g.head.z} r={HEAD_R_MM} strokeWidth={10} />
+    </g>
+  );
+}
+
+function ComCrosshair({ p, ghost }: { p: Point; ghost?: boolean }) {
+  const cls = ghost ? "text-muted-foreground/50" : "text-warning";
+  return (
+    <g className={cls} stroke="currentColor" fill="none" strokeWidth={6}>
+      <circle cx={p.x} cy={-p.z} r={26} />
+      <line x1={p.x - 40} y1={-p.z} x2={p.x + 40} y2={-p.z} />
+      <line x1={p.x} y1={-p.z - 40} x2={p.x} y2={-p.z + 40} />
+    </g>
+  );
+}
+
+export function SeatDiagram({ params, adjustments }: { params: SeatModelParams; adjustments: SeatAdjustments }) {
+  const current = useMemo(() => buildFigure(params, adjustments), [params, adjustments]);
+  const baseline = useMemo(() => buildFigure(params, ZERO_ADJUSTMENTS), [params]);
+  const isAtZero = adjustments.slideMm === 0 && adjustments.tiltDeg === 0;
+
+  const L = params.wheelbaseMm;
+  const rearR = 139;
+  const frontR = 129;
+  const minX = -260;
+  const width = L + 540;
+  const topZ = 820;
+
+  return (
+    <svg
+      viewBox={`${minX} ${-topZ} ${width} ${topZ + 70}`}
+      className="w-full h-auto"
+      role="img"
+      aria-label="Side view of the kart showing seat position and centre of mass"
+    >
+      {/* ground */}
+      <line x1={minX} y1={0} x2={minX + width} y2={0} className="text-border" stroke="currentColor" strokeWidth={6} />
+
+      {/* chassis rail + steering column + pedal (decorative) */}
+      <g className="text-muted-foreground" stroke="currentColor" fill="none" strokeLinecap="round">
+        <line x1={-110} y1={-62} x2={L - 110} y2={-62} strokeWidth={14} />
+        <line x1={L - 360} y1={-90} x2={L - 520} y2={-400} strokeWidth={10} />
+        <circle cx={L - 540} cy={-430} r={55} strokeWidth={10} />
+        <line x1={current.foot.x + 25} y1={-70} x2={current.foot.x - 5} y2={-200} strokeWidth={10} />
+      </g>
+
+      {/* wheels: rear axle at x = 0, front axle at x = L */}
+      <g className="text-foreground/70" stroke="currentColor" fill="none" strokeWidth={12}>
+        <circle cx={0} cy={-rearR} r={rearR} />
+        <circle cx={0} cy={-rearR} r={48} />
+        <circle cx={L} cy={-frontR} r={frontR} />
+        <circle cx={L} cy={-frontR} r={42} />
+      </g>
+      <g className="text-muted-foreground" fill="currentColor" fontSize={42} textAnchor="middle">
+        <text x={0} y={52}>R</text>
+        <text x={L} y={52}>F</text>
+      </g>
+
+      {/* baseline ghost (zero point) */}
+      {!isAtZero && (
+        <>
+          <Figure g={baseline} ghost />
+          <ComCrosshair p={baseline.com} ghost />
+        </>
+      )}
+
+      {/* current position */}
+      <Figure g={current} />
+      {/* tilt anchor — the rotation pivot at the front-bottom seat edge */}
+      <circle
+        cx={params.anchorXMm + adjustments.slideMm}
+        cy={-params.anchorZMm}
+        r={14}
+        className="text-warning"
+        fill="currentColor"
+      />
+      <ComCrosshair p={current.com} />
+    </svg>
+  );
+}
+
+export default SeatDiagram;

--- a/src/plugins/tools/seat-position/SeatPositionTool.tsx
+++ b/src/plugins/tools/seat-position/SeatPositionTool.tsx
@@ -1,0 +1,492 @@
+// Kart seat-position weight-shift visualizer.
+//
+// All physics lives in the pure `model.ts`; this file is rendering + state.
+// Settings (kart/driver numbers, baseline, calibration) persist to the tools
+// plugin's own IndexedDB store, so a calibrated setup survives reloads and
+// works fully offline trackside.
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, RotateCcw, Crosshair } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { getPluginStore } from "@/plugins/storage";
+import { SeatDiagram } from "./SeatDiagram";
+import {
+  DEFAULT_PARAMS,
+  KG_PER_LB,
+  LB_PER_KG,
+  MM_PER_INCH,
+  ZERO_ADJUSTMENTS,
+  computeState,
+  fitKLegs,
+  lateralTransferKg,
+  legMassKg,
+  rearMountMmFromTiltDeg,
+  rebaseline,
+  sensitivity,
+  slideSensitivityPctPerMm,
+  tiltDegFromRearMountMm,
+  torsoMassKg,
+  totalsFromCorners,
+  type SeatAdjustments,
+  type SeatModelParams,
+} from "./model";
+
+const STORE_KEY = "seat-position:v1";
+
+type TiltMode = "deg" | "mm";
+
+interface PersistedState {
+  params: SeatModelParams;
+  adj: SeatAdjustments;
+  useLb: boolean;
+  tiltMode: TiltMode;
+}
+
+/** ±1" slide range in 1/16" detents; ±5° tilt; ±30 mm rear-mount range. */
+const SLIDE_MAX_MM = MM_PER_INCH;
+const SLIDE_STEP_MM = MM_PER_INCH / 16;
+const TILT_MAX_DEG = 5;
+const MOUNT_MAX_MM = 30;
+
+function formatSlideInches(mm: number): string {
+  const sixteenths = Math.round((mm / MM_PER_INCH) * 16);
+  if (sixteenths === 0) return '0"';
+  const sign = sixteenths < 0 ? "−" : "+";
+  let n = Math.abs(sixteenths);
+  let d = 16;
+  while (n % 2 === 0 && d > 1) {
+    n /= 2;
+    d /= 2;
+  }
+  const whole = Math.floor(n / d);
+  const rem = n % d;
+  const frac = rem ? `${rem}/${d}` : "";
+  return `${sign}${whole ? whole + (frac ? " " : "") : ""}${frac}"`;
+}
+
+function signed(value: number, digits: number): string {
+  const r = value.toFixed(digits);
+  return value >= 0 ? `+${r}` : r.replace("-", "−");
+}
+
+/** Number field that doesn't fight the keyboard: commits parseable input, resyncs on outside change. */
+function NumRow({ label, value, onChange, unit, step = 1, className }: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  unit?: string;
+  step?: number;
+  className?: string;
+}) {
+  const display = useMemo(() => String(Number(value.toFixed(2))), [value]);
+  const [text, setText] = useState(display);
+  const editing = useRef(false);
+  useEffect(() => {
+    if (!editing.current) setText(display);
+  }, [display]);
+  return (
+    <div className={className}>
+      <Label className="text-xs text-muted-foreground">
+        {label}
+        {unit ? ` (${unit})` : ""}
+      </Label>
+      <NumberInput
+        className="h-8 mt-1 text-sm"
+        step={step}
+        value={text}
+        onFocus={() => {
+          editing.current = true;
+        }}
+        onBlur={() => {
+          editing.current = false;
+          setText(display);
+        }}
+        onValueChange={(raw) => {
+          setText(raw);
+          const v = parseFloat(raw);
+          if (Number.isFinite(v)) onChange(v);
+        }}
+      />
+    </div>
+  );
+}
+
+function Section({ title, defaultOpen, children }: { title: string; defaultOpen?: boolean; children: ReactNode }) {
+  const [open, setOpen] = useState(!!defaultOpen);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-border bg-card">
+      <CollapsibleTrigger className="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium text-foreground">
+        {title}
+        <ChevronDown className={`w-4 h-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`} />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="border-t border-border p-4">{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export default function SeatPositionTool(_props: PluginPanelProps) {
+  const store = useMemo(() => getPluginStore("tools"), []);
+  const [params, setParams] = useState<SeatModelParams>(DEFAULT_PARAMS);
+  const [adj, setAdj] = useState<SeatAdjustments>(ZERO_ADJUSTMENTS);
+  const [useLb, setUseLb] = useState(true);
+  const [tiltMode, setTiltMode] = useState<TiltMode>("deg");
+  const [loaded, setLoaded] = useState(false);
+
+  // Calibration scratchpad (kg internally, displayed in the chosen unit).
+  const [cal, setCal] = useState({ fl: 0, fr: 0, rl: 0, rr: 0, slideMm: 20, movedFrontKg: 0 });
+
+  useEffect(() => {
+    let active = true;
+    store
+      .get<PersistedState>(STORE_KEY)
+      .then((saved) => {
+        if (active && saved) {
+          setParams({ ...DEFAULT_PARAMS, ...saved.params });
+          setAdj({ ...ZERO_ADJUSTMENTS, ...saved.adj });
+          setUseLb(saved.useLb ?? true);
+          setTiltMode(saved.tiltMode ?? "deg");
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (active) setLoaded(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [store]);
+
+  useEffect(() => {
+    if (!loaded) return;
+    const t = setTimeout(() => {
+      void store.set(STORE_KEY, { params, adj, useLb, tiltMode } satisfies PersistedState).catch(() => undefined);
+    }, 400);
+    return () => clearTimeout(t);
+  }, [params, adj, useLb, tiltMode, loaded, store]);
+
+  const state = useMemo(() => computeState(params, adj), [params, adj]);
+  const zeroState = useMemo(() => computeState(params, ZERO_ADJUSTMENTS), [params]);
+  const sens = useMemo(() => sensitivity(params, adj), [params, adj]);
+  const naivePctPerInch = useMemo(
+    () => slideSensitivityPctPerMm({ ...params, kLegs: 1 }) * MM_PER_INCH,
+    [params],
+  );
+
+  const deltaRearPct = state.loads.rearPct - zeroState.loads.rearPct;
+  const deltaCogZ = state.com.zMm - zeroState.com.zMm;
+  const atZero = adj.slideMm === 0 && adj.tiltDeg === 0;
+  const latTransfer = lateralTransferKg(state.com, params.trackWidthMm, 1.5);
+  const latTransferDelta = latTransfer - lateralTransferKg(zeroState.com, params.trackWidthMm, 1.5);
+
+  const fmtW = (kg: number) =>
+    useLb ? `${(kg * LB_PER_KG).toFixed(1)} lb (${kg.toFixed(1)} kg)` : `${kg.toFixed(1)} kg (${(kg * LB_PER_KG).toFixed(1)} lb)`;
+  const fmtWShort = (kg: number) => (useLb ? `${(kg * LB_PER_KG).toFixed(1)} lb` : `${kg.toFixed(1)} kg`);
+  const toUnit = (kg: number) => (useLb ? kg * LB_PER_KG : kg);
+  const fromUnit = (v: number) => (useLb ? v * KG_PER_LB : v);
+  const wUnit = useLb ? "lb" : "kg";
+
+  const cornerTotals = totalsFromCorners({ fl: cal.fl, fr: cal.fr, rl: cal.rl, rr: cal.rr });
+  const canApplyBaseline = cornerTotals.totalKg > params.driverMassKg + params.fuelKg + params.seatMassKg;
+  const canFitKLegs = cornerTotals.frontKg > 0 && cal.movedFrontKg > 0 && cal.slideMm !== 0;
+
+  const setParam = <K extends keyof SeatModelParams>(key: K, value: SeatModelParams[K]) =>
+    setParams((p) => ({ ...p, [key]: value }));
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="max-w-5xl mx-auto p-4 space-y-4">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+          {/* Diagram + adjustment sliders */}
+          <div className="space-y-4 min-w-0">
+            <div className="rounded-lg border border-border bg-card p-3">
+              <SeatDiagram params={params} adjustments={adj} />
+              <p className="mt-1 text-[11px] text-muted-foreground text-center">
+                Gray ghost = zero point · crosshair = combined CoG · dot = tilt anchor
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 space-y-5">
+              <div>
+                <div className="flex items-baseline justify-between">
+                  <Label className="text-xs">Seat slide (fore/aft)</Label>
+                  <span className="text-sm font-medium tabular-nums">
+                    {formatSlideInches(adj.slideMm)} <span className="text-muted-foreground">({signed(adj.slideMm, 1)} mm)</span>
+                  </span>
+                </div>
+                <Slider
+                  className="mt-2"
+                  min={-SLIDE_MAX_MM}
+                  max={SLIDE_MAX_MM}
+                  step={SLIDE_STEP_MM}
+                  value={[adj.slideMm]}
+                  onValueChange={([v]) => setAdj((a) => ({ ...a, slideMm: v }))}
+                />
+                <div className="flex justify-between text-[10px] text-muted-foreground mt-1">
+                  <span>−1" (rear)</span>
+                  <span>+1" (front)</span>
+                </div>
+              </div>
+
+              <div>
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs">Seat tilt</Label>
+                    <button
+                      onClick={() => setTiltMode((m) => (m === "deg" ? "mm" : "deg"))}
+                      className="text-[10px] text-primary underline-offset-2 hover:underline"
+                    >
+                      {tiltMode === "deg" ? "use rear-mount mm" : "use degrees"}
+                    </button>
+                  </div>
+                  <span className="text-sm font-medium tabular-nums">
+                    {signed(adj.tiltDeg, 2)}°{" "}
+                    <span className="text-muted-foreground">
+                      (mount {signed(rearMountMmFromTiltDeg(adj.tiltDeg, params.rearMountArmMm), 1)} mm)
+                    </span>
+                  </span>
+                </div>
+                {tiltMode === "deg" ? (
+                  <Slider
+                    className="mt-2"
+                    min={-TILT_MAX_DEG}
+                    max={TILT_MAX_DEG}
+                    step={0.25}
+                    value={[adj.tiltDeg]}
+                    onValueChange={([v]) => setAdj((a) => ({ ...a, tiltDeg: v }))}
+                  />
+                ) : (
+                  <Slider
+                    className="mt-2"
+                    min={-MOUNT_MAX_MM}
+                    max={MOUNT_MAX_MM}
+                    step={1}
+                    value={[Math.round(rearMountMmFromTiltDeg(adj.tiltDeg, params.rearMountArmMm))]}
+                    onValueChange={([v]) => setAdj((a) => ({ ...a, tiltDeg: tiltDegFromRearMountMm(v, params.rearMountArmMm) }))}
+                  />
+                )}
+                <div className="flex justify-between text-[10px] text-muted-foreground mt-1">
+                  <span>{tiltMode === "deg" ? "−5° (upright)" : "−30 mm (raise mount)"}</span>
+                  <span>{tiltMode === "deg" ? "+5° (recline)" : "+30 mm (lower mount)"}</span>
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" className="h-8 gap-1.5" disabled={atZero} onClick={() => setAdj(ZERO_ADJUSTMENTS)}>
+                  <RotateCcw className="w-3.5 h-3.5" /> Reset sliders
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5"
+                  disabled={atZero}
+                  onClick={() => {
+                    setParams((p) => rebaseline(p, adj));
+                    setAdj(ZERO_ADJUSTMENTS);
+                  }}
+                >
+                  <Crosshair className="w-3.5 h-3.5" /> Set current as zero
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Readouts */}
+          <div className="space-y-3">
+            <div className="rounded-lg border border-border bg-card p-4 text-center">
+              <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Weight shift vs zero</p>
+              <p
+                className={`mt-1 text-3xl font-bold tabular-nums ${
+                  deltaRearPct > 0.005 ? "text-warning" : deltaRearPct < -0.005 ? "text-primary" : "text-foreground"
+                }`}
+              >
+                {signed(deltaRearPct, 2)}% rear
+              </p>
+              <p className="text-[11px] text-muted-foreground mt-1">
+                {deltaRearPct > 0.005 ? "rear bias added" : deltaRearPct < -0.005 ? "forward bias added" : "at the zero point"}
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+              <div className="flex h-3 overflow-hidden rounded">
+                <div className="bg-primary/70" style={{ width: `${state.loads.frontPct}%` }} />
+                <div className="flex-1 bg-warning/70" />
+              </div>
+              <div className="flex justify-between text-xs">
+                <div>
+                  <p className="font-medium text-foreground">Front {state.loads.frontPct.toFixed(1)}%</p>
+                  <p className="text-muted-foreground">{fmtW(state.loads.frontKg)}</p>
+                </div>
+                <div className="text-right">
+                  <p className="font-medium text-foreground">Rear {state.loads.rearPct.toFixed(1)}%</p>
+                  <p className="text-muted-foreground">{fmtW(state.loads.rearKg)}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 text-xs space-y-1.5">
+              <p className="font-medium text-foreground">Centre of gravity</p>
+              <p className="text-muted-foreground tabular-nums">
+                {state.com.xMm.toFixed(0)} mm fwd of rear axle · {state.com.zMm.toFixed(0)} mm high
+              </p>
+              <p className="tabular-nums">
+                <span className="text-muted-foreground">Δ height: </span>
+                <span className={deltaCogZ < -0.05 ? "text-primary font-medium" : deltaCogZ > 0.05 ? "text-warning font-medium" : "text-foreground"}>
+                  {signed(deltaCogZ, 1)} mm
+                </span>
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 text-xs space-y-1.5">
+              <p className="font-medium text-foreground">Sensitivity (here)</p>
+              <p className="text-muted-foreground tabular-nums">{signed(sens.pctPerInch, 2)}% front per inch of slide</p>
+              <p className="text-muted-foreground tabular-nums">{signed(sens.pctPerDeg, 2)}% front per degree of recline</p>
+              <p className="text-[10px] text-muted-foreground/70">
+                Naive "whole driver moves" estimate: {signed(naivePctPerInch, 2)}%/in — feet-on-pedals model is the lower number.
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 text-xs space-y-1.5">
+              <p className="font-medium text-foreground">Cornering transfer @ 1.5 g</p>
+              <p className="text-muted-foreground tabular-nums">
+                {fmtWShort(latTransfer)} across the kart{" "}
+                <span className={latTransferDelta < -0.005 ? "text-primary" : latTransferDelta > 0.005 ? "text-warning" : ""}>
+                  ({signed(toUnit(latTransferDelta), 1)} {wUnit} vs zero)
+                </span>
+              </p>
+              <p className="text-[10px] text-muted-foreground/70">
+                Rigid-frame approximation — karts corner on frame jacking, so treat as a relative indicator.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <Section title="Kart & driver" defaultOpen>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <div className="col-span-2 sm:col-span-3 flex items-center gap-2">
+              <Label htmlFor="seat-tool-units" className="text-xs text-muted-foreground">kg</Label>
+              <Switch id="seat-tool-units" checked={useLb} onCheckedChange={setUseLb} />
+              <Label htmlFor="seat-tool-units" className="text-xs text-muted-foreground">lb</Label>
+            </div>
+            <NumRow label="Driver (with gear)" unit={wUnit} value={toUnit(params.driverMassKg)} onChange={(v) => setParam("driverMassKg", Math.max(fromUnit(v), 1))} />
+            <NumRow label="Kart (no driver/fuel)" unit={wUnit} value={toUnit(params.kartMassKg)} onChange={(v) => setParam("kartMassKg", Math.max(fromUnit(v), params.seatMassKg + 1))} />
+            <NumRow label="Fuel" unit={wUnit} value={toUnit(params.fuelKg)} onChange={(v) => setParam("fuelKg", Math.max(fromUnit(v), 0))} step={useLb ? 1 : 0.5} />
+            <NumRow label="Wheelbase" unit="mm" value={params.wheelbaseMm} onChange={(v) => setParam("wheelbaseMm", Math.max(v, 500))} step={5} />
+            <NumRow label="Baseline front weight" unit="%" value={params.baselineFrontPct} onChange={(v) => setParam("baselineFrontPct", Math.min(Math.max(v, 20), 70))} step={0.5} />
+            <NumRow label="Baseline CoG height" unit="mm" value={params.baselineCogZMm} onChange={(v) => setParam("baselineCogZMm", Math.max(v, 50))} step={5} />
+          </div>
+          <p className="mt-3 text-[11px] text-muted-foreground">
+            The baseline is your kart at the zero point — most sprint setups target 43% front (some run 40). Corner scales beat guesses: see Calibration.
+          </p>
+        </Section>
+
+        <Section title="Advanced model">
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-baseline justify-between">
+                <Label className="text-xs">Leg coupling k<sub>legs</sub></Label>
+                <span className="text-sm font-medium tabular-nums">{params.kLegs.toFixed(2)}</span>
+              </div>
+              <Slider className="mt-2" min={0} max={1} step={0.05} value={[params.kLegs]} onValueChange={([v]) => setParam("kLegs", v)} />
+              <p className="mt-1 text-[10px] text-muted-foreground">
+                How much of the seat's movement the leg CoM follows (feet stay on the pedals). 0.4 is a sane default — calibrate it on scales.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <NumRow label="Torso fraction of driver" unit="0–1" value={params.torsoFraction} onChange={(v) => setParam("torsoFraction", Math.min(Math.max(v, 0.4), 0.9))} step={0.01} />
+              <NumRow label="Seat mass" unit={wUnit} value={toUnit(params.seatMassKg)} onChange={(v) => setParam("seatMassKg", Math.min(Math.max(fromUnit(v), 0.5), params.kartMassKg - 1))} step={useLb ? 1 : 0.5} />
+              <NumRow label="Anchor fwd of rear axle" unit="mm" value={params.anchorXMm} onChange={(v) => setParam("anchorXMm", v)} step={5} />
+              <NumRow label="Anchor height" unit="mm" value={params.anchorZMm} onChange={(v) => setParam("anchorZMm", v)} step={5} />
+              <NumRow label="Torso CoM distance" unit="mm" value={params.torsoRMm} onChange={(v) => setParam("torsoRMm", Math.max(v, 100))} step={10} />
+              <NumRow label="Torso CoM angle" unit="° from fwd" value={params.torsoAlphaDeg} onChange={(v) => setParam("torsoAlphaDeg", v)} />
+              <NumRow label="Anchor → rear mount" unit="mm" value={params.rearMountArmMm} onChange={(v) => setParam("rearMountArmMm", Math.max(v, 50))} step={10} />
+              <NumRow label="Rear track width" unit="mm" value={params.trackWidthMm} onChange={(v) => setParam("trackWidthMm", Math.max(v, 600))} step={10} />
+            </div>
+            <Button variant="outline" size="sm" className="h-8" onClick={() => setParams(DEFAULT_PARAMS)}>
+              Restore defaults
+            </Button>
+          </div>
+        </Section>
+
+        <Section title="Calibration (corner scales)">
+          <div className="space-y-4 text-xs">
+            <p className="text-muted-foreground">
+              Default numbers are ±20% per driver. Two scale sessions anchor the model to <em>your</em> kart: weigh at the zero point, then slide the seat a
+              known amount and re-weigh to fit the leg coupling.
+            </p>
+            <div>
+              <p className="font-medium text-foreground mb-2">1 · Corner weights at the zero point (driver seated)</p>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <NumRow label="Front left" unit={wUnit} value={toUnit(cal.fl)} onChange={(v) => setCal((c) => ({ ...c, fl: Math.max(fromUnit(v), 0) }))} />
+                <NumRow label="Front right" unit={wUnit} value={toUnit(cal.fr)} onChange={(v) => setCal((c) => ({ ...c, fr: Math.max(fromUnit(v), 0) }))} />
+                <NumRow label="Rear left" unit={wUnit} value={toUnit(cal.rl)} onChange={(v) => setCal((c) => ({ ...c, rl: Math.max(fromUnit(v), 0) }))} />
+                <NumRow label="Rear right" unit={wUnit} value={toUnit(cal.rr)} onChange={(v) => setCal((c) => ({ ...c, rr: Math.max(fromUnit(v), 0) }))} />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  disabled={!canApplyBaseline}
+                  onClick={() =>
+                    setParams((p) => ({
+                      ...p,
+                      kartMassKg: Math.max(cornerTotals.totalKg - p.driverMassKg - p.fuelKg, p.seatMassKg + 1),
+                      baselineFrontPct: cornerTotals.frontPct,
+                    }))
+                  }
+                >
+                  Apply baseline
+                </Button>
+                {cornerTotals.totalKg > 0 && (
+                  <span className="text-muted-foreground tabular-nums">
+                    Total {fmtWShort(cornerTotals.totalKg)} · front {cornerTotals.frontPct.toFixed(1)}%
+                  </span>
+                )}
+              </div>
+            </div>
+            <div>
+              <p className="font-medium text-foreground mb-2">2 · Slide the seat a known amount and re-weigh the front pair</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                <NumRow label="Seat slid by (+fwd)" unit="mm" value={cal.slideMm} onChange={(v) => setCal((c) => ({ ...c, slideMm: v }))} step={5} />
+                <NumRow label="New front-axle total" unit={wUnit} value={toUnit(cal.movedFrontKg)} onChange={(v) => setCal((c) => ({ ...c, movedFrontKg: Math.max(fromUnit(v), 0) }))} />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  disabled={!canFitKLegs}
+                  onClick={() =>
+                    setParam(
+                      "kLegs",
+                      Math.round(
+                        fitKLegs({
+                          baselineFrontKg: cornerTotals.frontKg,
+                          movedFrontKg: cal.movedFrontKg,
+                          slideMm: cal.slideMm,
+                          wheelbaseMm: params.wheelbaseMm,
+                          torsoMassKg: torsoMassKg(params),
+                          seatMassKg: params.seatMassKg,
+                          legMassKg: legMassKg(params),
+                        }) * 100,
+                      ) / 100,
+                    )
+                  }
+                >
+                  Fit leg coupling
+                </Button>
+                <span className="text-muted-foreground tabular-nums">current k = {params.kLegs.toFixed(2)}</span>
+              </div>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/tools/seat-position/model.test.ts
+++ b/src/plugins/tools/seat-position/model.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PARAMS,
+  ZERO_ADJUSTMENTS,
+  axleLoads,
+  computeCoM,
+  computeMassElements,
+  computeState,
+  fitKLegs,
+  hipPoint,
+  legMassKg,
+  lateralTransferKg,
+  rearMountMmFromTiltDeg,
+  rebaseline,
+  sensitivity,
+  slideSensitivityPctPerMm,
+  solveKneeIK,
+  tiltDegFromRearMountMm,
+  torsoMassKg,
+  totalMassKg,
+  totalsFromCorners,
+  type SeatModelParams,
+} from "./model";
+
+const p: SeatModelParams = DEFAULT_PARAMS;
+
+describe("seat position model — statics", () => {
+  it("moments balance: front + rear === total exactly", () => {
+    const { loads } = computeState(p, { slideMm: 13, tiltDeg: 2.5 });
+    expect(loads.frontKg + loads.rearKg).toBeCloseTo(loads.totalKg, 12);
+    expect(loads.frontPct + loads.rearPct).toBeCloseTo(100, 12);
+  });
+
+  it("CoM is linear: translating every element by Δ translates the CoM by Δ", () => {
+    const elements = computeMassElements(p, { slideMm: -10, tiltDeg: 1 });
+    const com = computeCoM(elements);
+    const shifted = computeCoM(elements.map((e) => ({ ...e, xMm: e.xMm + 37, zMm: e.zMm - 12 })));
+    expect(shifted.xMm).toBeCloseTo(com.xMm + 37, 9);
+    expect(shifted.zMm).toBeCloseTo(com.zMm - 12, 9);
+    expect(shifted.massKg).toBeCloseTo(com.massKg, 12);
+  });
+
+  it("zero adjustments reproduce the baseline front% and CoG height exactly", () => {
+    const { loads, com } = computeState(p, ZERO_ADJUSTMENTS);
+    expect(loads.frontPct).toBeCloseTo(p.baselineFrontPct, 9);
+    expect(com.zMm).toBeCloseTo(p.baselineCogZMm, 9);
+  });
+
+  it("mass bookkeeping: elements sum to the class weight", () => {
+    const { com } = computeState(p, ZERO_ADJUSTMENTS);
+    expect(com.massKg).toBeCloseTo(totalMassKg(p), 12);
+    expect(torsoMassKg(p) + legMassKg(p)).toBeCloseTo(p.driverMassKg, 12);
+  });
+});
+
+describe("seat position model — slide", () => {
+  it("numeric slide sensitivity matches the closed-form Section 5 formula", () => {
+    const closedForm = slideSensitivityPctPerMm(p);
+    const f1 = computeState(p, { slideMm: 10, tiltDeg: 0 }).loads.frontPct;
+    const f0 = computeState(p, { slideMm: -10, tiltDeg: 0 }).loads.frontPct;
+    expect((f1 - f0) / 20).toBeCloseTo(closedForm, 9);
+  });
+
+  it("defaults land near the karting rule of thumb: ~1% F/R per inch of slide", () => {
+    const pctPerInch = slideSensitivityPctPerMm(p) * 25.4;
+    expect(pctPerInch).toBeGreaterThan(0.8);
+    expect(pctPerInch).toBeLessThan(1.3);
+  });
+
+  it("slide does not change the CoG height", () => {
+    const z0 = computeState(p, ZERO_ADJUSTMENTS).com.zMm;
+    const z1 = computeState(p, { slideMm: 25.4, tiltDeg: 0 }).com.zMm;
+    expect(z1).toBeCloseTo(z0, 9);
+  });
+
+  it("kLegs = 1 degenerates to the naive whole-driver-moves model", () => {
+    const naive: SeatModelParams = { ...p, kLegs: 1 };
+    const moved = torsoMassKg(p) + p.seatMassKg + legMassKg(p);
+    expect(slideSensitivityPctPerMm(naive)).toBeCloseTo(
+      (100 * moved) / (totalMassKg(p) * p.wheelbaseMm),
+      12,
+    );
+  });
+});
+
+describe("seat position model — tilt", () => {
+  it("zero tilt is the identity", () => {
+    const a = computeState(p, ZERO_ADJUSTMENTS);
+    const b = computeState(p, { slideMm: 0, tiltDeg: 0 });
+    expect(b.com.xMm).toBeCloseTo(a.com.xMm, 12);
+    expect(b.com.zMm).toBeCloseTo(a.com.zMm, 12);
+  });
+
+  it("recline shifts weight rearward AND lowers the CoG (default geometry)", () => {
+    const zero = computeState(p, ZERO_ADJUSTMENTS);
+    const reclined = computeState(p, { slideMm: 0, tiltDeg: 5 });
+    expect(reclined.loads.frontPct).toBeLessThan(zero.loads.frontPct);
+    expect(reclined.com.zMm).toBeLessThan(zero.com.zMm);
+  });
+
+  it("small-angle tilt matches the analytic linearization within 2%", () => {
+    // d(x')/dφ at φ=0 for a rotated offset (dx, dz) is −dz (per radian); legs
+    // couple through the hip with factor kLegs.
+    const DEG = Math.PI / 180;
+    const torsoDz = p.torsoRMm * Math.sin(p.torsoAlphaDeg * DEG);
+    const M = totalMassKg(p);
+    const linearPerDeg =
+      ((-DEG * (torsoMassKg(p) * torsoDz + p.seatMassKg * p.seatComDzMm + p.kLegs * legMassKg(p) * p.hipDzMm)) / M) *
+      (100 / p.wheelbaseMm);
+
+    const phi = 0.5;
+    const f1 = computeState(p, { slideMm: 0, tiltDeg: phi }).loads.frontPct;
+    const f0 = computeState(p, { slideMm: 0, tiltDeg: -phi }).loads.frontPct;
+    const numericPerDeg = (f1 - f0) / (2 * phi);
+    expect(Math.abs(numericPerDeg - linearPerDeg)).toBeLessThan(Math.abs(linearPerDeg) * 0.02);
+  });
+
+  it("rear-mount mm ⇄ degrees round-trips", () => {
+    const deg = tiltDegFromRearMountMm(15, p.rearMountArmMm);
+    expect(rearMountMmFromTiltDeg(deg, p.rearMountArmMm)).toBeCloseTo(15, 9);
+    expect(deg).toBeGreaterThan(0); // lowering the rear mount = recline
+  });
+
+  it("sensitivity readout reports both axes with sane signs", () => {
+    const s = sensitivity(p, ZERO_ADJUSTMENTS);
+    expect(s.pctPerInch).toBeGreaterThan(0); // forward slide adds front weight
+    expect(s.pctPerDeg).toBeLessThan(0); // recline removes front weight
+  });
+});
+
+describe("seat position model — knee IK", () => {
+  const hip = { x: 290, z: 180 };
+  const foot = { x: 950, z: 130 };
+
+  it("preserves both segment lengths when the foot is reachable", () => {
+    const knee = solveKneeIK(hip, foot, 420, 430);
+    expect(Math.hypot(knee.x - hip.x, knee.z - hip.z)).toBeCloseTo(420, 9);
+    expect(Math.hypot(knee.x - foot.x, knee.z - foot.z)).toBeCloseTo(430, 9);
+  });
+
+  it("picks the knee-up solution", () => {
+    const knee = solveKneeIK(hip, foot, 420, 430);
+    expect(knee.z).toBeGreaterThan(Math.max(hip.z, foot.z));
+  });
+
+  it("clamps onto the hip→foot line when out of reach", () => {
+    const knee = solveKneeIK(hip, { x: hip.x + 2000, z: hip.z }, 420, 430);
+    expect(knee.x).toBeCloseTo(hip.x + 420, 9);
+    expect(knee.z).toBeCloseTo(hip.z, 9);
+  });
+});
+
+describe("seat position model — calibration", () => {
+  it("corner totals", () => {
+    const t = totalsFromCorners({ fl: 35, fr: 34, rl: 46, rr: 47 });
+    expect(t.totalKg).toBeCloseTo(162, 12);
+    expect(t.frontKg).toBeCloseTo(69, 12);
+    expect(t.frontPct).toBeCloseTo((100 * 69) / 162, 12);
+  });
+
+  it("round-trips kLegs from synthetic scale data", () => {
+    const truth: SeatModelParams = { ...p, kLegs: 0.55 };
+    const slideMm = 20;
+    const baseline = computeState(truth, ZERO_ADJUSTMENTS).loads;
+    const moved = computeState(truth, { slideMm, tiltDeg: 0 }).loads;
+    const fitted = fitKLegs({
+      baselineFrontKg: baseline.frontKg,
+      movedFrontKg: moved.frontKg,
+      slideMm,
+      wheelbaseMm: truth.wheelbaseMm,
+      torsoMassKg: torsoMassKg(truth),
+      seatMassKg: truth.seatMassKg,
+      legMassKg: legMassKg(truth),
+    });
+    expect(fitted).toBeCloseTo(0.55, 9);
+  });
+
+  it("clamps a nonsense fit into [0, 1]", () => {
+    const args = {
+      slideMm: 20,
+      wheelbaseMm: p.wheelbaseMm,
+      torsoMassKg: torsoMassKg(p),
+      seatMassKg: p.seatMassKg,
+      legMassKg: legMassKg(p),
+    };
+    expect(fitKLegs({ ...args, baselineFrontKg: 69, movedFrontKg: 69 - 5 })).toBe(0);
+    expect(fitKLegs({ ...args, baselineFrontKg: 69, movedFrontKg: 69 + 50 })).toBe(1);
+  });
+});
+
+describe("seat position model — dynamic context", () => {
+  it("lateral transfer scales with CoG height", () => {
+    const com = computeState(p, ZERO_ADJUSTMENTS).com;
+    const low = lateralTransferKg({ ...com, zMm: com.zMm - 10 }, p.trackWidthMm, 1.5);
+    const base = lateralTransferKg(com, p.trackWidthMm, 1.5);
+    expect(low).toBeLessThan(base);
+    expect(base).toBeCloseTo((com.massKg * 1.5 * com.zMm) / p.trackWidthMm, 12);
+  });
+
+  it("axleLoads is consistent with front% = 100·x/L", () => {
+    const loads = axleLoads({ xMm: 447.2, zMm: 250, massKg: 162 }, 1040);
+    expect(loads.frontPct).toBeCloseTo((100 * 447.2) / 1040, 12);
+  });
+
+  it("rebaseline folds adjustments in exactly: new params at zero === old params at adj", () => {
+    const adj = { slideMm: 15, tiltDeg: 3 };
+    const before = computeState(p, adj);
+    const rebased = computeState(rebaseline(p, adj), ZERO_ADJUSTMENTS);
+    expect(rebased.loads.frontPct).toBeCloseTo(before.loads.frontPct, 9);
+    expect(rebased.com.xMm).toBeCloseTo(before.com.xMm, 9);
+    expect(rebased.com.zMm).toBeCloseTo(before.com.zMm, 9);
+  });
+
+  it("hipPoint moves 1:1 with slide", () => {
+    const h0 = hipPoint(p, ZERO_ADJUSTMENTS);
+    const h1 = hipPoint(p, { slideMm: 12, tiltDeg: 0 });
+    expect(h1.x - h0.x).toBeCloseTo(12, 12);
+    expect(h1.z).toBeCloseTo(h0.z, 12);
+  });
+});

--- a/src/plugins/tools/seat-position/model.ts
+++ b/src/plugins/tools/seat-position/model.ts
@@ -1,0 +1,398 @@
+// Pure rigid-body statics model for the kart seat-position visualizer.
+//
+// A kart has no suspension, so static axle loads are pure moments: track the
+// longitudinal position (x) and height (z) of the combined centre of mass as
+// the seat slides fore/aft and tilts about its front-bottom anchor, and every
+// readout falls out of `front% = 100 · x_cm / wheelbase`.
+//
+// Coordinate system: origin at the rear-axle contact line, x positive toward
+// the front axle, z up from the ground. All lengths in mm, masses in kg.
+//
+// The mass model is four elements:
+//   - fixed lump   — chassis + engine + fuel, everything that never moves.
+//     Its position is *solved* so that the zero point (slide 0, tilt 0) lands
+//     exactly on the user's baseline front% / CoG height. The baseline is the
+//     measured (or assumed) truth; the lump is virtual bookkeeping.
+//   - seat         — moves rigidly with both adjustments.
+//   - torso group  — pelvis/torso/head/arms (~66% of the driver), rigid with
+//     the seat.
+//   - leg group    — thighs/shanks/feet. The feet stay on the pedals, so the
+//     leg CoM only follows a fraction `kLegs` of the hip's displacement (the
+//     knees absorb the rest). This is the single biggest modelling choice and
+//     why naive "whole CoG moves with the seat" estimates overstate the effect.
+
+export interface Point {
+  x: number;
+  z: number;
+}
+
+export interface SeatModelParams {
+  /** Rear axle (x=0) to front axle, mm. */
+  wheelbaseMm: number;
+  /** Driver mass incl. gear, kg. */
+  driverMassKg: number;
+  /** Kart mass incl. seat, excl. driver and fuel, kg. */
+  kartMassKg: number;
+  /** Seat mass (part of kartMassKg, but it moves), kg. */
+  seatMassKg: number;
+  /** Fuel load, kg. */
+  fuelKg: number;
+  /** Static front weight % at the zero point (slide 0, tilt 0). */
+  baselineFrontPct: number;
+  /** Combined CoG height at the zero point, mm. */
+  baselineCogZMm: number;
+  /** Fraction of seat/hip displacement the leg-group CoM follows (0..1). */
+  kLegs: number;
+  /** Fraction of driver mass in the seat-rigid torso group (rest is legs). */
+  torsoFraction: number;
+  /** Tilt anchor P — front-bottom seat edge / front mount bolt. */
+  anchorXMm: number;
+  anchorZMm: number;
+  /** Torso-group CoM polar offset from the anchor (deg above +x axis). */
+  torsoRMm: number;
+  torsoAlphaDeg: number;
+  /** Seat CoM offset from the anchor (dx, dz). */
+  seatComDxMm: number;
+  seatComDzMm: number;
+  /** Hip point offset from the anchor (dx, dz) — drives the leg coupling. */
+  hipDxMm: number;
+  hipDzMm: number;
+  /** Leg-group CoM at the zero point (absolute, fwd of rear axle). */
+  legComXMm: number;
+  legComZMm: number;
+  /** Anchor → rear seat mount distance, mm (tilt mm ⇄ deg conversion). */
+  rearMountArmMm: number;
+  /** Rear track width, mm (lateral load-transfer readout). */
+  trackWidthMm: number;
+}
+
+/** Seat adjustments relative to the zero point. */
+export interface SeatAdjustments {
+  /** Fore/aft slide, mm. Positive = forward. */
+  slideMm: number;
+  /** Tilt about the front anchor, deg. Positive = recline (driver back). */
+  tiltDeg: number;
+}
+
+export interface MassElement {
+  id: "fixed" | "seat" | "torso" | "legs";
+  massKg: number;
+  xMm: number;
+  zMm: number;
+}
+
+export interface CoM {
+  xMm: number;
+  zMm: number;
+  massKg: number;
+}
+
+export interface AxleLoads {
+  totalKg: number;
+  frontKg: number;
+  rearKg: number;
+  frontPct: number;
+  rearPct: number;
+}
+
+export const ZERO_ADJUSTMENTS: SeatAdjustments = { slideMm: 0, tiltDeg: 0 };
+
+/**
+ * Defaults for a ~162 kg class weight (80 kg driver + 80 kg kart + 2 kg fuel)
+ * sprint kart at a 43/57 baseline. Geometry puts the torso-group CoM up and
+ * *behind* the front-bottom anchor, so recline moves it rearward AND down —
+ * matching real seat-angle practice (a more reclined back lowers the CoG).
+ */
+export const DEFAULT_PARAMS: SeatModelParams = {
+  wheelbaseMm: 1040,
+  driverMassKg: 80,
+  kartMassKg: 80,
+  seatMassKg: 4,
+  fuelKg: 2,
+  baselineFrontPct: 43,
+  baselineCogZMm: 250,
+  kLegs: 0.4,
+  torsoFraction: 0.66,
+  anchorXMm: 330,
+  anchorZMm: 60,
+  torsoRMm: 450,
+  torsoAlphaDeg: 115,
+  seatComDxMm: -60,
+  seatComDzMm: 140,
+  hipDxMm: -40,
+  hipDzMm: 120,
+  legComXMm: 650,
+  legComZMm: 150,
+  rearMountArmMm: 300,
+  trackWidthMm: 1200,
+};
+
+const DEG = Math.PI / 180;
+
+/** Driver torso-group mass (rigid with the seat), kg. */
+export function torsoMassKg(p: SeatModelParams): number {
+  return p.torsoFraction * p.driverMassKg;
+}
+
+/** Driver leg-group mass, kg. */
+export function legMassKg(p: SeatModelParams): number {
+  return (1 - p.torsoFraction) * p.driverMassKg;
+}
+
+/** Total system mass, kg. */
+export function totalMassKg(p: SeatModelParams): number {
+  return p.kartMassKg + p.driverMassKg + p.fuelKg;
+}
+
+/**
+ * Rotate an (dx, dz) offset by `deg` counter-clockwise in the x-forward /
+ * z-up plane. Positive = recline: a point above the anchor moves rearward.
+ */
+export function rotateOffset(dx: number, dz: number, deg: number): Point {
+  const c = Math.cos(deg * DEG);
+  const s = Math.sin(deg * DEG);
+  return { x: dx * c - dz * s, z: dx * s + dz * c };
+}
+
+/** Hip point (absolute) at the given adjustments — rigid with the seat. */
+export function hipPoint(p: SeatModelParams, adj: SeatAdjustments): Point {
+  const r = rotateOffset(p.hipDxMm, p.hipDzMm, adj.tiltDeg);
+  return { x: p.anchorXMm + adj.slideMm + r.x, z: p.anchorZMm + r.z };
+}
+
+/**
+ * The virtual fixed lump (chassis + engine + fuel): mass is whatever isn't in
+ * the moving groups; position is solved so the zero point reproduces the
+ * baseline front% and CoG height exactly.
+ */
+export function solveFixedElement(p: SeatModelParams): MassElement {
+  const M = totalMassKg(p);
+  const mTorso = torsoMassKg(p);
+  const mLegs = legMassKg(p);
+  const mFixed = Math.max(M - mTorso - mLegs - p.seatMassKg, 0.001);
+
+  const torso = rotateOffset(p.torsoRMm * Math.cos(p.torsoAlphaDeg * DEG), p.torsoRMm * Math.sin(p.torsoAlphaDeg * DEG), 0);
+  const movingMomentX =
+    mTorso * (p.anchorXMm + torso.x) +
+    p.seatMassKg * (p.anchorXMm + p.seatComDxMm) +
+    mLegs * p.legComXMm;
+  const movingMomentZ =
+    mTorso * (p.anchorZMm + torso.z) +
+    p.seatMassKg * (p.anchorZMm + p.seatComDzMm) +
+    mLegs * p.legComZMm;
+
+  const targetXcm = (p.baselineFrontPct / 100) * p.wheelbaseMm;
+  return {
+    id: "fixed",
+    massKg: mFixed,
+    xMm: (targetXcm * M - movingMomentX) / mFixed,
+    zMm: (p.baselineCogZMm * M - movingMomentZ) / mFixed,
+  };
+}
+
+/** All four mass elements at the given adjustments. */
+export function computeMassElements(p: SeatModelParams, adj: SeatAdjustments): MassElement[] {
+  const anchorX = p.anchorXMm + adj.slideMm;
+  const anchorZ = p.anchorZMm;
+
+  const torsoOffset0: Point = {
+    x: p.torsoRMm * Math.cos(p.torsoAlphaDeg * DEG),
+    z: p.torsoRMm * Math.sin(p.torsoAlphaDeg * DEG),
+  };
+  const torsoOffset = rotateOffset(torsoOffset0.x, torsoOffset0.z, adj.tiltDeg);
+  const seatOffset = rotateOffset(p.seatComDxMm, p.seatComDzMm, adj.tiltDeg);
+
+  // Legs: the feet stay on the pedals, so the leg CoM follows only a fraction
+  // of the hip's displacement (slide + tilt combined).
+  const hip0 = hipPoint(p, ZERO_ADJUSTMENTS);
+  const hip = hipPoint(p, adj);
+  const legX = p.legComXMm + p.kLegs * (hip.x - hip0.x);
+  const legZ = p.legComZMm + p.kLegs * (hip.z - hip0.z);
+
+  return [
+    solveFixedElement(p),
+    { id: "seat", massKg: p.seatMassKg, xMm: anchorX + seatOffset.x, zMm: anchorZ + seatOffset.z },
+    { id: "torso", massKg: torsoMassKg(p), xMm: anchorX + torsoOffset.x, zMm: anchorZ + torsoOffset.z },
+    { id: "legs", massKg: legMassKg(p), xMm: legX, zMm: legZ },
+  ];
+}
+
+/** Combined centre of mass of a set of elements. */
+export function computeCoM(elements: MassElement[]): CoM {
+  let m = 0;
+  let mx = 0;
+  let mz = 0;
+  for (const e of elements) {
+    m += e.massKg;
+    mx += e.massKg * e.xMm;
+    mz += e.massKg * e.zMm;
+  }
+  return { xMm: mx / m, zMm: mz / m, massKg: m };
+}
+
+/** Static axle loads from the CoM position (moments about the rear axle). */
+export function axleLoads(com: CoM, wheelbaseMm: number): AxleLoads {
+  const frontKg = (com.massKg * com.xMm) / wheelbaseMm;
+  const frontPct = (100 * com.xMm) / wheelbaseMm;
+  return {
+    totalKg: com.massKg,
+    frontKg,
+    rearKg: com.massKg - frontKg,
+    frontPct,
+    rearPct: 100 - frontPct,
+  };
+}
+
+export interface SeatModelState {
+  elements: MassElement[];
+  com: CoM;
+  loads: AxleLoads;
+}
+
+/** Convenience: elements → CoM → axle loads for one (slide, tilt) point. */
+export function computeState(p: SeatModelParams, adj: SeatAdjustments): SeatModelState {
+  const elements = computeMassElements(p, adj);
+  const com = computeCoM(elements);
+  return { elements, com, loads: axleLoads(com, p.wheelbaseMm) };
+}
+
+/**
+ * Local sensitivities at the current settings, by central difference (the
+ * readout the spec asks for numerically, not from the linearization).
+ */
+export function sensitivity(p: SeatModelParams, adj: SeatAdjustments): { pctPerInch: number; pctPerDeg: number } {
+  const hS = 5; // mm
+  const fS1 = computeState(p, { ...adj, slideMm: adj.slideMm + hS }).loads.frontPct;
+  const fS0 = computeState(p, { ...adj, slideMm: adj.slideMm - hS }).loads.frontPct;
+  const hT = 0.25; // deg
+  const fT1 = computeState(p, { ...adj, tiltDeg: adj.tiltDeg + hT }).loads.frontPct;
+  const fT0 = computeState(p, { ...adj, tiltDeg: adj.tiltDeg - hT }).loads.frontPct;
+  return {
+    pctPerInch: ((fS1 - fS0) / (2 * hS)) * 25.4,
+    pctPerDeg: (fT1 - fT0) / (2 * hT),
+  };
+}
+
+/**
+ * Closed-form slide sensitivity (%/mm) — Section 5 of the design doc. The
+ * model is exactly linear in slide, so this matches the numeric value.
+ */
+export function slideSensitivityPctPerMm(p: SeatModelParams): number {
+  const moved = torsoMassKg(p) + p.seatMassKg + p.kLegs * legMassKg(p);
+  return (100 * moved) / (totalMassKg(p) * p.wheelbaseMm);
+}
+
+/**
+ * Lateral load transfer (kg per side) at a given lateral acceleration —
+ * `ΔW = M · a_y · z_cm / track`. Rigid-frame approximation: karts corner on
+ * frame jacking, so treat this as a relative indicator, not gospel.
+ */
+export function lateralTransferKg(com: CoM, trackWidthMm: number, latG: number): number {
+  return (com.massKg * latG * com.zMm) / trackWidthMm;
+}
+
+/** Most karts tilt via rear-mount spacers: mm the rear mount is LOWERED → recline deg. */
+export function tiltDegFromRearMountMm(loweredMm: number, armMm: number): number {
+  return Math.atan2(loweredMm, armMm) / DEG;
+}
+
+/** Inverse of `tiltDegFromRearMountMm`. */
+export function rearMountMmFromTiltDeg(tiltDeg: number, armMm: number): number {
+  return Math.tan(tiltDeg * DEG) * armMm;
+}
+
+/**
+ * Two-link knee IK for the stick figure: knee position given hip and foot
+ * (foot fixed on the pedals — this *is* the leg-coupling model made visible).
+ * Picks the knee-up solution; clamps gracefully when the foot is out of reach.
+ */
+export function solveKneeIK(hip: Point, foot: Point, thighMm: number, shankMm: number): Point {
+  const dx = foot.x - hip.x;
+  const dz = foot.z - hip.z;
+  const d = Math.hypot(dx, dz);
+  if (d < 1e-9) return { x: hip.x + thighMm, z: hip.z };
+  const ux = dx / d;
+  const uz = dz / d;
+  // Out of reach (or fully folded): put the knee on the hip→foot line.
+  if (d >= thighMm + shankMm) return { x: hip.x + ux * thighMm, z: hip.z + uz * thighMm };
+  if (d <= Math.abs(thighMm - shankMm)) return { x: hip.x + ux * thighMm, z: hip.z + uz * thighMm };
+  const a = (thighMm * thighMm - shankMm * shankMm + d * d) / (2 * d);
+  const h = Math.sqrt(Math.max(thighMm * thighMm - a * a, 0));
+  const bx = hip.x + ux * a;
+  const bz = hip.z + uz * a;
+  // Two solutions: base ± h·perpendicular. Knees point up in a kart.
+  const k1 = { x: bx - uz * h, z: bz + ux * h };
+  const k2 = { x: bx + uz * h, z: bz - ux * h };
+  return k1.z >= k2.z ? k1 : k2;
+}
+
+/**
+ * "Set current as zero": fold the live adjustments into the params so the
+ * current seat position becomes the new baseline and the sliders re-read 0.
+ * Exact — the returned params at zero adjustments reproduce the state the
+ * old params had at `adj` (same front%, same CoG).
+ */
+export function rebaseline(p: SeatModelParams, adj: SeatAdjustments): SeatModelParams {
+  const st = computeState(p, adj);
+  const hip0 = hipPoint(p, ZERO_ADJUSTMENTS);
+  const hip = hipPoint(p, adj);
+  const seatR = rotateOffset(p.seatComDxMm, p.seatComDzMm, adj.tiltDeg);
+  const hipR = rotateOffset(p.hipDxMm, p.hipDzMm, adj.tiltDeg);
+  return {
+    ...p,
+    anchorXMm: p.anchorXMm + adj.slideMm,
+    torsoAlphaDeg: p.torsoAlphaDeg + adj.tiltDeg,
+    seatComDxMm: seatR.x,
+    seatComDzMm: seatR.z,
+    hipDxMm: hipR.x,
+    hipDzMm: hipR.z,
+    legComXMm: p.legComXMm + p.kLegs * (hip.x - hip0.x),
+    legComZMm: p.legComZMm + p.kLegs * (hip.z - hip0.z),
+    baselineFrontPct: st.loads.frontPct,
+    baselineCogZMm: st.com.zMm,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Calibration (corner scales)
+// ---------------------------------------------------------------------------
+
+export interface CornerWeightsKg {
+  fl: number;
+  fr: number;
+  rl: number;
+  rr: number;
+}
+
+/** Totals from a four-pad corner-scale reading. */
+export function totalsFromCorners(c: CornerWeightsKg): { totalKg: number; frontKg: number; frontPct: number } {
+  const frontKg = c.fl + c.fr;
+  const totalKg = frontKg + c.rl + c.rr;
+  return { totalKg, frontKg, frontPct: totalKg > 0 ? (100 * frontKg) / totalKg : 0 };
+}
+
+/**
+ * Fit the leg-coupling factor from a known seat slide re-weighed on scales.
+ * From Section 5: ΔW_front(kg) = s · (m_torso + m_seat + k·m_legs) / L, so
+ *   k = (ΔW_front · L / s − m_torso − m_seat) / m_legs
+ * Result is clamped to [0, 1] — outside that the measurement is suspect.
+ */
+export function fitKLegs(opts: {
+  baselineFrontKg: number;
+  movedFrontKg: number;
+  /** Seat slide between the two weighings, mm (positive = forward). */
+  slideMm: number;
+  wheelbaseMm: number;
+  torsoMassKg: number;
+  seatMassKg: number;
+  legMassKg: number;
+}): number {
+  const dFront = opts.movedFrontKg - opts.baselineFrontKg;
+  const movedMass = (dFront * opts.wheelbaseMm) / opts.slideMm;
+  const k = (movedMass - opts.torsoMassKg - opts.seatMassKg) / opts.legMassKg;
+  return Math.min(1, Math.max(0, k));
+}
+
+export const KG_PER_LB = 0.45359237;
+export const LB_PER_KG = 1 / KG_PER_LB;
+export const MM_PER_INCH = 25.4;

--- a/src/plugins/tools/toolList.ts
+++ b/src/plugins/tools/toolList.ts
@@ -13,6 +13,8 @@ export interface ToolDef {
   name: string;
   /** One-liner shown on the picker card. */
   description: string;
+  /** Optional bubble tag on the picker card (e.g. maturity warning). */
+  badge?: string;
   icon: ComponentType<{ className?: string }>;
   component: ComponentType<PluginPanelProps>;
 }
@@ -23,6 +25,7 @@ export const TOOLS: ToolDef[] = [
     name: "Seat Position Visualizer",
     description:
       "See how sliding or tilting your kart seat shifts front/rear weight and CoG height — with a calibration mode for corner scales.",
+    badge: "Super experimental",
     icon: Armchair,
     component: lazy(() => import("./seat-position/SeatPositionTool")),
   },

--- a/src/plugins/tools/toolList.ts
+++ b/src/plugins/tools/toolList.ts
@@ -1,0 +1,29 @@
+// The catalog of tools the Tools tab offers. Each tool is a self-contained,
+// lazy-loaded component; adding a tool is adding an entry here. Tools receive
+// the standard `PluginPanelProps` session snapshot so a future tool can read
+// the loaded session, but most are standalone calculators that ignore it.
+
+import { lazy, type ComponentType } from "react";
+import { Armchair } from "lucide-react";
+import type { PluginPanelProps } from "@/plugins/panels";
+
+export interface ToolDef {
+  /** Stable id — also the persistence key prefix in the plugin store. */
+  id: string;
+  name: string;
+  /** One-liner shown on the picker card. */
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  component: ComponentType<PluginPanelProps>;
+}
+
+export const TOOLS: ToolDef[] = [
+  {
+    id: "seat-position",
+    name: "Seat Position Visualizer",
+    description:
+      "See how sliding or tilting your kart seat shifts front/rear weight and CoG height — with a calibration mode for corner scales.",
+    icon: Armchair,
+    component: lazy(() => import("./seat-position/SeatPositionTool")),
+  },
+];


### PR DESCRIPTION
First changes wearing in the **2.5.0** beta (package version bumped, changelog recorded under `[Unreleased]` as we go).

## 1 · Icons-only tab bar on phones (small task)

At phone widths every main-view tab — Simple, Pro, Lap Times, Labs, Coach, Tools — and the Simple-view **Overlay** toggle now show just their icon (`hidden sm:inline` on the labels, matching the existing Pro/Labs/Coach pattern). Tablet (`sm`) and up are unchanged. The lap-count badge stays on mobile since it's data, not a label.

## 2 · Tools tab + first-party `tools` plugin (big task)

- New `PanelSlot.Tools` + `ToolsTab.tsx` host; the tab sits **right of Coach** and self-gates exactly like Coach — it appears only when a plugin contributes a panel to the slot.
- New first-party plugin `src/plugins/tools/`: contributes one **chromeless lazy panel** — a picker of tools (icon + one-line description, catalog in `toolList.ts`) that opens the chosen tool with a back bar. Everything is code-split (`ToolsTab` / `ToolsPanel` / each tool are separate chunks), so the initial bundle is untouched. The plugin only touches the plugin contracts + `components/ui`, so it can be broken out to its own repo later.

### First tool: Kart Seat Position Visualizer

Built from the supplied spec sheet, adapted to house conventions (pure model + Vitest, plugin storage instead of URL params, semantic color tokens):

- **Pure model** (`seat-position/model.ts`, 24 unit tests): rigid-body statics over a 4-element mass model (virtual fixed lump solved to hit the user's baseline, seat, torso group, leg group with a feet-on-pedals coupling factor `kLegs`). Fore/aft slide ±1" in 1/16" detents; tilt ±5° about the front anchor (or rear-mount mm, converted via the mount arm). Closed-form slide sensitivity matches the numeric central difference to 1e-9; defaults land on the ~1 %/inch karting rule of thumb, and recline both adds rear and **lowers** the CoG, matching real seat-angle practice.
- **Side-view SVG** (`SeatDiagram.tsx`): wheels/chassis, seat profile, three-segment stick driver with 2-link knee IK (the leg-coupling model made visible), per-state CoG crosshair, gray baseline ghost, marked tilt anchor.
- **Readouts**: big signed Δrear% (color-coded), front/rear bar with per-axle lb *and* kg, CoG x/height + Δheight, local %/inch + %/degree sensitivities (with the naive whole-driver figure as a footnote), and a 1.5 g lateral-transfer indicator with the rigid-frame disclaimer.
- **Calibration**: corner weights at the zero point set true mass + baseline front%; a known slide + re-weigh fits `kLegs` (round-trip unit-tested). "Set current as zero" folds the live adjustments into the params exactly (`rebaseline()`, unit-tested).
- **Persistence**: params/sliders/units survive reloads via the plugin's own IndexedDB store (`getPluginStore("tools")`). Fully offline.

## Verification

Lint / typecheck / 1468 tests / build all green. Also driven end-to-end in headless Chromium against the production build: sample session → Tools → seat tool; slide/tilt deltas match hand calcs (+1" → −1.02% rear; +5° recline → +1.19% back), set-as-zero + reload persistence verified, empty-input probe doesn't NaN the model, and the 390 px viewport shows the icons-only bar (820 px keeps labels).

Docs updated: `CHANGELOG.md` (`[Unreleased]`), `CLAUDE.md` (slot list, plugin section, architecture map).

https://claude.ai/code/session_01Dp6CeGcBoGSB9AvsDAjjR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp6CeGcBoGSB9AvsDAjjR3)_