### PR TITLE
Release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new first-party `tools` plugin. The tab self-gates like Coach (it shows only
   when a plugin contributes to the new `tools` panel slot) and opens on a
   picker of tools — icon + one-line description — that you click into.
-- **Kart seat position visualizer** — the first tool: a side-view rigid-body
+- **Kart seat position visualizer** — the first tool (tagged *super
+  experimental* on its picker card): a side-view rigid-body
   statics model showing how a fore/aft seat slide (±1", 1/16" detents) and a
   seat tilt (±5°, or rear-mount mm) shift front/rear weight distribution and
   CoG height relative to a user-set zero point. A stick-figure driver with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and seat/driver geometry, and a corner-scale calibration flow anchors the
   baseline to your kart and fits the leg coupling from a measured seat slide.
   Fully offline; settings persist in the tools plugin's own IndexedDB store.
+- **"Unlimited" course sectors.** A course is no longer limited to three fixed
+  sectors. The course editor now shows an ordered, drag-to-reorder sector list
+  below the map: add sectors, mark exactly three (start/finish + two) as **Major
+  sectors**, and group sub-sectors under each major. Up to 25 timing lines per
+  course. Start/finish, major, and sub-sector lines are drawn on the race-line
+  map in three distinct colors.
+- **Per-sector optimal lap + Full lap-table view.** The optimal (ideal) lap is
+  now computed from the best time in *every* sector, not just the three majors.
+  The lap-times list has a **Simple/Full** toggle — Full shows one column per
+  fine-grained sector (zebra-striped by major group, horizontally scrollable).
+- **Crop to a sector.** The data-crop bar on the Simple and Pro views now pairs
+  the range slider with a sector dropdown — pick a sector to snap the view to
+  that section of the selected lap.
 
 ### Changed
 - **The main tab bar is icons-only on phones.** Every view tab (Simple, Pro,
   Lap Times, Labs, Coach, Tools) and the Simple-view Overlay toggle now show
   just their icon at phone widths; labels return at tablet width and up.
+- The logger track export is unchanged on the wire: only the three major sectors
+  (start/finish + two) are uploaded to the DovesDataLogger, so sub-sectors are an
+  app-only refinement. Track JSON, community submissions, and the admin database
+  carry the full ordered list alongside the legacy two-sector mirror.
+- Removed the per-lap "Map" overlay toggle column from the lap-times list
+  (overlays are still controlled from the header Overlays menu).
 
 ## [2.4.0] - 2026-6-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the per-lap "Map" overlay toggle column from the lap-times list
   (overlays are still controlled from the header Overlays menu).
 
+### Fixed
+- **Pro-mode mini-map no longer re-centers too early.** The camera held the
+  position arrow inside the middle half of the view, so it snapped back to
+  center while the cursor was still well within the visible map. It now re-centers
+  only once the arrow's edge actually reaches the viewport border, so the map
+  stays put while the cursor crosses most of it.
+
 ## [2.4.0] - 2026-6-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now computed from the best time in *every* sector, not just the three majors.
   The lap-times list has a **Simple/Full** toggle — Full shows one column per
   fine-grained sector (zebra-striped by major group, horizontally scrollable).
+  In Full view a colored **"S# Sum"** column precedes each major sector's
+  columns, showing that major's running total (the S1/S2/S3 rollup) per lap with
+  the fastest sum highlighted; a **Sector sums** toggle (default on) shows or
+  hides them.
 - **Crop to a sector.** The data-crop bar on the Simple and Pro views now pairs
   the range slider with a sector dropdown — pick a sector to snap the view to
   that section of the selected lap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [Unreleased]
-
-> Wearing in as the `2.5.0` beta.
+## [2.5.0] - 2026-06-13
 
 ### Added
 - **Tools tab** — a new main-view tab to the right of Coach, contributed by a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   center while the cursor was still well within the visible map. It now re-centers
   only once the arrow's edge actually reaches the viewport border, so the map
   stays put while the cursor crosses most of it.
+- **New sectors drop in the middle of the current map view.** Adding a sector
+  in the course editor previously dropped the line near start/finish (often
+  off-screen if you'd panned away). It now lands in the center of whatever
+  you're looking at, without moving the map.
+- **Sector lines are much easier to see in the course editor.** Unselected
+  timing lines were thin and faint; they're now drawn noticeably thicker (and
+  the selected line thicker still), so all the lines stand out against the
+  satellite imagery.
 
 ## [2.4.0] - 2026-6-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [Unreleased]
+
+> Wearing in as the `2.5.0` beta.
+
+### Added
+- **Tools tab** — a new main-view tab to the right of Coach, contributed by a
+  new first-party `tools` plugin. The tab self-gates like Coach (it shows only
+  when a plugin contributes to the new `tools` panel slot) and opens on a
+  picker of tools — icon + one-line description — that you click into.
+- **Kart seat position visualizer** — the first tool: a side-view rigid-body
+  statics model showing how a fore/aft seat slide (±1", 1/16" detents) and a
+  seat tilt (±5°, or rear-mount mm) shift front/rear weight distribution and
+  CoG height relative to a user-set zero point. A stick-figure driver with
+  feet-on-pedals knee IK makes the leg-coupling model visible. Readouts:
+  signed Δrear %, per-axle weight in lb/kg, CoG height change, local
+  sensitivities (%/inch and %/degree), and a 1.5 g lateral-transfer indicator
+  (rigid-frame approximation). An advanced panel tunes the leg-coupling factor
+  and seat/driver geometry, and a corner-scale calibration flow anchors the
+  baseline to your kart and fits the leg coupling from a measured seat slide.
+  Fully offline; settings persist in the tools plugin's own IndexedDB store.
+
+### Changed
+- **The main tab bar is icons-only on phones.** Every view tab (Simple, Pro,
+  Lap Times, Labs, Coach, Tools) and the Simple-view Overlay toggle now show
+  just their icon at phone widths; labels return at tablet width and up.
+
 ## [2.4.0] - 2026-6-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ will read it tomorrow.
 | Charts | Custom Canvas 2D (not a library — see `TelemetryChart.tsx`, `SingleSeriesChart.tsx`) |
 | Video Export | WebCodecs + [mp4-muxer](https://github.com/Vanilagy/mp4-muxer) (H.264 video + AAC audio → MP4 output) |
 | State | React hooks + React Query (for admin only) |
+| Drag/Reorder | [dnd kit](https://dndkit.com) (`@dnd-kit/core`+`sortable`+`utilities`) — sector-list reorder; lazy-loaded with the track editor |
 | Local Storage | IndexedDB (`dbUtils.ts`) for files/metadata/karts/notes/setups/video-sync/graph-prefs; localStorage for tracks & settings |
 | Backend | None for core features. Optional admin via Supabase (Lovable Cloud) |
 | BLE | Web Bluetooth API for DovesDataLogger device communication |
@@ -82,7 +83,7 @@ src/
 │   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach, Tools; Profile is mounted in the drawer)
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Notes, Setups, Device*)
-│   ├── track-editor/      # Track editor sub-components (VisualEditor is lazy — see Bundle Splitting)
+│   ├── track-editor/      # Track editor sub-components: VisualEditor (lazy Leaflet line placement), SectorListEditor (dnd-kit reorderable sector list — the control surface), CourseSectorEditor (bundles the two), AddCourseDialog/AddTrackDialog
 │   ├── video-overlays/    # Video-export overlay system: registry + themes + per-widget *Overlay,
 │   │                      #   sectorUtils, dataSourceResolver, OverlaySettingsPanel, VideoExportDialog
 │   ├── RaceLineView.tsx   # Leaflet map: race line, speed heatmap, braking zones
@@ -109,7 +110,8 @@ src/
 │   ├── channels.ts        # ★ Canonical channel registry (ids/labels/units/aliases) + normalizeChannels()
 │   ├── fieldResolver.ts   # Settings-facing adapter over channels.ts
 │   ├── courseDetection.ts # ★ Auto track/course/direction detection + waypoint mode
-│   ├── lapCalculation.ts  # Start/finish crossing detection → Lap[]
+│   ├── courseSectors.ts   # ★ Pure sector model: caps (25 lines / 3 majors), normalizeCourseSectors (legacy→array migration at every load boundary), sectorLabels (1/1.1/2…), validateCourseSectors, majorSectorLines + legacyMirror (the logger projection), rollupMajorSectors (fine-grained → S1/S2/S3)
+│   ├── lapCalculation.ts  # Start/finish + per-sector crossing detection → Lap[] (sectorTimes[] + sectorBoundaries[] + major rollup); calculateOptimalLap sums best of EVERY segment
 │   ├── lapDelta.ts        # ★ Position-based lap delta (arc-length resample + segment-projected gap)
 │   ├── fileBrowserTree.ts # ★ Pure file-browser hierarchy: Track→Course→logs, engine/kart filter, breadcrumbs, smart collapse
 │   ├── lapOverlays.ts     # ★ Pure multi-lap overlay logic: id format (lap/snap/file), palette, resolve selections → OverlayLine[], unionBounds
@@ -384,8 +386,9 @@ and **native** lateral/longitudinal g (`LatAccel`/`LongAccel` → `lat_g_native`
 | `ParsedData` | `samples[]`, `fieldMappings[]`, `bounds`, `duration`, `startDate?`, `dovexMetadata?`, `parserStats?` |
 | `ParserStats` | `totalRows`, `acceptedRows`, `rejected: { nanFields, zeroCoords, outOfRange, speedCap, teleportation, incompleteRow }` |
 | `DovexMetadata` | `datetime?`, `driver?`, `course?`, `shortName?`, `bestLapMs?`, `optimalMs?`, `lapTimesMs?[]` |
-| `Lap` | `lapNumber`, `startTime/endTime`, `lapTimeMs`, speed stats, `startIndex/endIndex`, `sectors?` |
-| `Course` | `name`, `lengthFt?`, `startFinishA/B` (lat/lon), optional `sector2/sector3` lines, optional `layout?` (`{lat,lon}[]` user-drawn outline) |
+| `Lap` | `lapNumber`, `startTime/endTime`, `lapTimeMs`, speed stats, `startIndex/endIndex`, `sectors?` (S1/S2/S3 **major rollup**), `sectorTimes?` (fine-grained per-segment), `sectorBoundaries?` (per-line sample indices) |
+| `Course` | `name`, `lengthFt?`, `startFinishA/B` (lat/lon), `sectors?: CourseSector[]` (ordered timing lines after S/F), deprecated `sector2/sector3` (legacy mirror of the 2 majors, kept in sync by `normalizeCourseSectors`), optional `layout?` (`{lat,lon}[]` user-drawn outline) |
+| `CourseSector` | `{ line: SectorLine, major: boolean }` — one timing line after start/finish (the implicit, always-major sector 1) |
 | `Track` | `name`, `shortName?` (max 8 chars), `courses[]` |
 | `CourseDetectionResult` | `track`, `course`, `direction?`, `laps[]`, `isWaypointMode`, `waypointNotice?` |
 | `CourseDirection` | `'forward' \| 'reverse'` |
@@ -550,6 +553,50 @@ Documents, logs, and lap snapshots all draw from **one pooled per-tier byte
 budget** (`subscription_tiers.total_bytes`: free 50 MB / plus 10 GB / premium
 100 GB / pro 500 GB), shown as a single segmented bar on the Profile tab — see
 `docs/backend.md`.
+
+---
+
+## Course Sectors ("Unlimited" sectors — `lib/courseSectors.ts`)
+
+A course's timing lines are **start/finish (the implicit, always-major sector 1)
++ an ordered `Course.sectors` list** (`{line, major}[]`). Exactly three are
+"major" (start/finish + two flagged). Hidden caps: **25 timing lines**, **3
+majors** — both named constants (`MAX_SECTOR_LINES`, `MAX_MAJOR_SECTORS`), raise
+later. `courseSectors.ts` is the single source of truth; the rest of the app
+never reasons about sector geometry directly.
+
+- **One list, two visual groups.** The editor (`SectorListEditor`, dnd-kit
+  reorderable) shows the ordered list below the map; a per-row **Major** switch
+  flags the majors, sub-sectors indent under their owning major, drag order drives
+  numbering (`sectorLabels`: `1, 1.1, 2, 2.1, 3`). Save is blocked unless there
+  are 0 sectors or exactly 3 majors (`validateCourseSectors`). Three line colors
+  on every map: S/F green, major purple, sub sky-blue.
+- **The logger only ever sees the 3 majors.** `majorSectorLines`/`legacyMirror`
+  project the course down to start/finish + `sector2`/`sector3` — **byte-identical**
+  to the pre-overhaul device JSON, submission payload, and content hash.
+  `normalizeCourseSectors` migrates legacy `sector2/3` → the array (and keeps the
+  mirror in sync) at **every load boundary** (track load, device download, admin
+  read). Sub-sectors are app-only.
+- **Lap timing.** `calculateLaps` detects a crossing for every line → `Lap.sectorTimes[]`
+  (one per segment) + `Lap.sectorBoundaries[]` (sample index per line) + `Lap.sectors`
+  (the S1/S2/S3 **major rollup** via `rollupMajorSectors` — so video overlays,
+  snapshots, and the coach plugin keep working unchanged: the **coach receives the
+  major rollup only, for now**). `calculateOptimalLap` now sums the best time of
+  **every** segment (the true ideal lap), excluded-segment → `null`.
+- **Lap table** has a **Simple/Full** toggle (`LapTable.tsx`): Simple = S1/S2/S3,
+  Full = one column per fine-grained sector, zebra-striped by major group,
+  horizontally scrollable (shown only when sub-sectors exist). The per-lap "Map"
+  overlay column was removed.
+- **Crop-to-sector** (`SectorCropSelect`): the data-crop bar pairs the range
+  slider (~80%) with a sector dropdown (~20%) that snaps `visibleRange` to a
+  sector via `Lap.sectorBoundaries` (per-lap; disabled for all-laps view).
+- **Persistence.** Track JSON + community submissions + the admin `courses`/
+  `submissions` tables carry a canonical `sectors` / `sectors_data` array
+  alongside the legacy mirror columns (migration
+  `20260613000000_course_sectors_data.sql`; the generated Supabase types lag — the
+  adapter builds the insert payload as a variable to dodge the excess-property
+  check until regen). `submit-track` edge fn validates the optional `sectors`
+  array (≤24, exactly-2-majors-or-none).
 
 ---
 
@@ -953,7 +1000,7 @@ re-merges it into the main chunk.
   `GraphViewTab`, and `LabsTab` (`Index.tsx`)
 - `FileManagerDrawer` (slide-out drawer, `Index.tsx`)
 - `DataloggerDownload` (BLE entry point; keeps `lib/ble/*` out of initial bundle — `FileImport.tsx`, `drawer/FilesTab.tsx`)
-- `VisualEditor` (Leaflet drawing tools; `TrackEditor.tsx`, `track-editor/AddCourseDialog.tsx`, `admin/CoursesTab.tsx`). The shared map editor for **all** track managers — start/finish + sector lines (drag-to-place, auto-saved on release) and the course-outline Draw/Generate tools (auto-saved on each edit; no Done/Close button). There is no manual coordinate-entry mode — visual is the only editor.
+- `CourseSectorEditor` (lazy; wraps `VisualEditor` + `SectorListEditor`, used by `TrackEditor.tsx`, `track-editor/AddCourseDialog.tsx`, `admin/CoursesTab.tsx`). The shared map+list editor for **all** track managers — start/finish + every sector line (select a row → drag its endpoints on the map, auto-saved on release) and the course-outline Draw/Generate tools (auto-saved on each edit; no Done/Close button). The sector list (dnd-kit) is the control surface; there is no manual coordinate-entry mode. `@dnd-kit/*` rides this lazy boundary, off the initial bundle.
 
 **Vendor chunks** (`manualChunks` in `vite.config.ts`): `vendor-react`,
 `vendor-query`, `vendor-leaflet`, `vendor-supabase`, `vendor-radix`. These cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 ├── components/
 │   ├── ui/                # shadcn/ui primitives
 │   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, BannedIps, Tools, Messages)
-│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach; Profile is mounted in the drawer)
+│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach, Tools; Profile is mounted in the drawer)
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Notes, Setups, Device*)
 │   ├── track-editor/      # Track editor sub-components (VisualEditor is lazy — see Bundle Splitting)
@@ -152,6 +152,8 @@ src/
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see Plugin Framework section
 │   ├── (framework)        # types, registry, index, panels, mounts, storage + PluginPanelHost/PluginMount
 │   ├── cloud-sync/         # ★ First-party plugin: Supabase file + garage sync — see docs/backend.md
+│   ├── tools/              # ★ First-party plugin: Tools tab (lazy tool picker; kart seat-position
+│   │                      #   visualizer — pure rigid-body model.ts + SVG view, corner-scale calibration)
 │   └── coaching/           # Gitignored slot for the AI coach (npm pkg in production)
 ├── types/racing.ts        # ★ Core types: GpsSample, ParsedData, Lap, Course, Track, …
 ├── contexts/              # SettingsContext, SessionContext, PlaybackContext, DeviceContext (BLE), AuthContext (admin)
@@ -217,19 +219,22 @@ A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
 
 **UI panels:** the first concrete extension point. A plugin contributes
 `PluginPanel` descriptors to `PANELS_POINT`, targeting a *slot* (host surface).
-Three slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`; no
+Four slots exist today: `PanelSlot.Labs` (rendered by `LabsTab.tsx`; no
 first-party panel targets it now — it shows only when the experimental
 `enableLabs` setting is on or another plugin contributes), `PanelSlot.Coach`
 (rendered by `CoachTab.tsx` — the dedicated AI Coach tab, home for the
-`@perchwerks/eye-in-the-sky` coaching plugin), and `PanelSlot.Profile`
+`@perchwerks/eye-in-the-sky` coaching plugin), `PanelSlot.Tools`
+(rendered by `ToolsTab.tsx` — the Tools tab right of Coach; the first-party
+`tools` plugin contributes its chromeless tool-picker panel there), and
+`PanelSlot.Profile`
 (rendered by `ProfileTab.tsx` — mounted as a tab **inside the file-manager
 drawer**, between Garage and Device, not in the main view tab bar; cloud-sync
 contributes the merged Account panel (sign-in/out + display name + plan +
 storage, working signed out against local storage), lap-snapshot management, and
 cloud-log management). All render contributed
 panels via `PluginPanelHost` and are
-**self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showProfile`
-from `getPanelsForSlot`, so a tab appears only when a
+**self-gating**: `Index.tsx` computes `hasLabsPanels`/`showCoach`/`showTools`/
+`showProfile` from `getPanelsForSlot`, so a tab appears only when a
 plugin contributes a panel to it (Labs additionally shows when the experimental
 `enableLabs` setting is on). New slots are just new strings — no framework change.
 `PluginPanelHost` wraps each panel in an error boundary **and** a `Suspense`
@@ -275,6 +280,21 @@ the incremental engine. Backs the IndexedDB stores up to Supabase: structured
 stores → `sync_records` jsonb docs, raw blobs → the private `user-files` bucket.
 **Full data model, sync engine, conflict resolution, and backend live in
 `docs/backend.md`.**
+
+**Tools (first-party plugin, `src/plugins/tools/`):** contributes one chromeless
+panel to `PanelSlot.Tools`: a picker of trackside tools (icon + one-line
+description, catalog in `toolList.ts`) that opens the selected tool with a back
+bar. Everything is lazy (`ToolsPanel` and each tool component), so nothing rides
+the initial bundle, and fully offline. Tool state persists via
+`getPluginStore("tools")`. First tool: the **kart seat position visualizer**
+(`seat-position/`) — a pure, unit-tested rigid-body statics model (`model.ts`:
+4-element mass model with a feet-on-pedals leg-coupling factor, slide + tilt
+about the front anchor, closed-form + central-difference sensitivities, knee IK,
+corner-scale calibration that fits `kLegs`, and `rebaseline()` for
+"set current as zero") rendered as a side-view SVG (`SeatDiagram.tsx`) with
+controls/readouts in `SeatPositionTool.tsx`. The user plans to split this plugin
+into its own repo later — keep it free of deep host imports (it touches only the
+plugin contracts + `components/ui`).
 
 **AI coach (npm package):** published to the public npm registry as
 `@perchwerks/eye-in-the-sky` and listed in `optionalDependencies`. The loader in

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ The app includes an optional admin system for managing a community track databas
 
 **The app always reads tracks from `public/tracks.json` — zero database calls on normal page loads.** The database exists solely for the admin workflow.
 
+**Course sectors.** A course may define an ordered list of up to 25 timing
+lines (start/finish + sub-sectors), exactly three of which are "major"
+(start/finish + two). In the track JSON each course carries a canonical
+`sectors` array — `[{ a_lat, a_lng, b_lat, b_lng, major }]` (start/finish
+excluded) — alongside the legacy `sector_2_*`/`sector_3_*` fields, which mirror
+the two major lines for back-compat. **Only the three major sectors are exported
+to the DovesDataLogger** (over the same wire format as before); sub-sectors are
+an app-only refinement used for finer optimal-lap timing and the lap-table "Full"
+view. Older JSON with only `sector_2_*`/`sector_3_*` is read as the two majors.
+
 ### Environment Variables
 
 | Variable | Required | Description |
@@ -521,7 +531,7 @@ Built on the shoulders of these incredible open-source projects and free service
 - [React](https://react.dev) · [Vite](https://vite.dev) · [TypeScript](https://www.typescriptlang.org)
 - [Tailwind CSS](https://tailwindcss.com) · [shadcn/ui](https://ui.shadcn.com) · [Radix UI](https://www.radix-ui.com) · [Lucide Icons](https://lucide.dev)
 - [Leaflet](https://leafletjs.com) · [CARTO basemaps](https://carto.com) · [Esri World Imagery & Wayback](https://livingatlas.arcgis.com/wayback/) (satellite + historical imagery dates)
-- [TanStack Query](https://tanstack.com/query) · [Sonner](https://sonner.emilkowal.dev) · [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels)
+- [TanStack Query](https://tanstack.com/query) · [Sonner](https://sonner.emilkowal.dev) · [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels) · [dnd kit](https://dndkit.com) (sector list drag-to-reorder)
 - [mp4-muxer](https://github.com/Vanilagy/mp4-muxer) · [Savitzky-Golay (ml.js)](https://github.com/mljs/savitzky-golay) · [JSZip](https://stuk.github.io/jszip) · [fix-webm-duration](https://github.com/yusitnikov/fix-webm-duration)
 - [IEM ASOS (Iowa State)](https://mesonet.agron.iastate.edu) · [NWS API](https://www.weather.gov/documentation/services-web-api) · [Open-Meteo](https://open-meteo.com) (global weather fallback, CC-BY 4.0)
 - [MoTeC i2](https://www.motec.com.au) (file format reference)

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "doves-dataviewer",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@lovable.dev/cloud-auth-js": "^1.1.2",
         "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -251,6 +254,14 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/docs/plans/lap-sector-overhaul.md
+++ b/docs/plans/lap-sector-overhaul.md
@@ -1,0 +1,184 @@
+# Lap Sector Overhaul — "Unlimited" Sectors
+
+Goal: replace the fixed Start/Finish + Sector 2 + Sector 3 model with **one ordered
+list of sector lines** (hidden cap: 25 total), where exactly 3 are flagged **major**
+(start/finish always is), while the **BLE logger export stays byte-identical**
+(it only ever receives the 3 major lines). Caps live in named constants so "3 majors"
+and "25 lines" can be raised later without an archaeology dig.
+
+## 1. Data model (`src/types/racing.ts` + new `src/lib/courseSectors.ts`)
+
+- New canonical field on `Course`:
+  ```ts
+  export interface CourseSector {
+    line: SectorLine;      // existing { a: {lat,lon}, b: {lat,lon} }
+    major: boolean;        // true = one of the "traditional" sectors
+  }
+  // Course.sectors?: CourseSector[]  — ordered lines AFTER start/finish.
+  ```
+  Start/finish stays `startFinishA/B` and is implicitly **sector 1, always major**
+  (never stored in the array — matches the UI where it can't be unmarked/deleted).
+- Legacy `sector2`/`sector3` stay on the type as `@deprecated` read-compat fields.
+- New pure module **`lib/courseSectors.ts`** (unit-tested), the single home for:
+  - `MAX_SECTOR_LINES = 25` (total incl. S/F, hidden cap) and `MAX_MAJOR_SECTORS = 3`.
+  - `normalizeCourseSectors(course)` — migrates legacy `sector2`/`sector3` →
+    `sectors: [{line: s2, major: true}, {line: s3, major: true}]`. Applied at every
+    boundary where a `Course` enters memory (trackStorage load, device download,
+    lap-snapshot load, admin read) so the rest of the app only ever sees `sectors`.
+  - `majorLines(course)` — `[startFinish, ...majors]` in order (the logger projection).
+  - `legacyMirror(course)` — derives `sector2`/`sector3` from majors[1]/majors[2]
+    for serializers (rollback / old-PWA safety).
+  - `sectorLabels(course)` — auto numbering: S/F = "1", subs under it = "1.1, 1.2",
+    next major = "2", its subs "2.1"… (drag order ⇒ numbering, per the spec).
+  - `validateCourseSectors(course)` — save rule: **either zero additional sectors,
+    or exactly 3 majors total** (S/F + 2 flagged); plus the 25-line cap.
+  - `rollupMajorSectors(course, sectorTimes)` — sums fine-grained segment times into
+    the classic S1/S2/S3 (sum of each major group's sub-segments).
+  - `courseHasSectors()` (racing.ts) → true when the course has 3 majors.
+
+## 2. Lap calculation (`src/lib/lapCalculation.ts`)
+
+- Generalize crossing detection: `LineCrossing.lineType: 'sf' | 's2' | 's3'` →
+  `'sf' | number` (sector index). Detect crossings for **every** line in
+  `course.sectors`; same 1s sector debounce.
+- Per lap, walk crossings in course order between the two S/F crossings:
+  - `Lap.sectorTimes?: (number | undefined)[]` — N lines ⇒ N segments
+    (segment k = line k → line k+1, last wraps to S/F). A skipped/out-of-order
+    crossing leaves that segment (and its neighbor) `undefined` — same spirit as
+    today's partial-sector handling.
+  - `Lap.sectorBoundaries?: number[]` — absolute sample index of each line crossing
+    (powers crop-to-sector and the full lap-table view).
+  - `Lap.sectors` (s1/s2/s3) **kept**, now populated via `rollupMajorSectors` —
+    so the video-overlay sector widgets, `LapSummaryWidget`, snapshots, and the
+    coach plugin keep working untouched (this *is* "send the major sectors to the
+    coach for now").
+- **Optimal lap = sum of best time per fine-grained segment across laps**
+  (`calculateOptimalLap` reworked; laps missing any segment are excluded from that
+  segment's best, lap excluded from "complete" check as today).
+- Direction detection (`detectSectorOrder` + courseDetection): generalize "S2 before
+  S3" → "2nd major before 3rd major". Waypoint mode unchanged (thirds → s1/s2/s3
+  rollup only; no fine-grained list).
+- Tests: N-sector segment times, partial crossings, rollup, all-sector optimal,
+  boundaries, direction.
+
+## 3. Storage & I/O — same wire data for the logger
+
+- **`trackStorage.ts`** — built-in `tracks.json` + localStorage v2:
+  - Load: prefer a new per-course `sectors: [{a_lat,a_lng,b_lat,b_lng,major}]`
+    array; fall back to legacy `sector_2_*`/`sector_3_*` via normalization.
+  - Save (user tracks): write `sectors` **and** the legacy mirror fields.
+- **`deviceTrackSync.ts`** — *unchanged on the wire*: `appCourseToDeviceJson`
+  projects `majorLines()` → `sector_2_*`/`sector_3_*` (byte-identical to today for
+  migrated courses). `coursesMatch` compares only the device-visible projection, so
+  sub-sectors never flag a mismatch. `deviceCourseToAppCourse` → two major entries.
+  Known edge (documented, accepted): overwriting an app course *from* the device
+  drops local sub-sectors — mismatch download already means "replace".
+- **`trackSubmission.ts`** — payload gains the `sectors` array alongside the legacy
+  flat fields. `courseContentHash`: keep the existing 12-coordinate part computed
+  from the **majors** exactly as today and only append sub-sector data when present
+  — already-submitted unchanged courses keep their hash (no mass re-flag); adding or
+  editing a sub-sector re-flags, as it should.
+
+## 4. Course editor UI
+
+- New **`track-editor/SectorListEditor.tsx`** — the ordered list below the map:
+  - Row 0: "Start/finish (Sector 1)" — no switch, no delete, not draggable.
+  - Each sector row: drag handle, auto label (from `sectorLabels`), **Major** switch,
+    delete, and tap-to-select (selects that line on the map for drag-placement).
+  - Rows visually grouped/indented under their owning major; a **+** button at the
+    end of each group inserts a new sub-sector there (placed at map center, like
+    today's `createLineAtMapCenter`).
+  - Helper note under the list: *"Mark the three traditional sectors of the course
+    as a Major sector."* Save is blocked (with that reason) unless majors = 3 or the
+    list is empty. No cap messaging until 25 is hit — then the + buttons disable
+    with a "sector limit reached" hint.
+  - Reorder: **`@dnd-kit/core` + `@dnd-kit/sortable`** (new dep — touch-friendly,
+    actively maintained, tree-shakeable; README credits + `CreditsDialog` updated).
+- **`useTrackEditorForm.ts`**: `formSector2`/`formSector3` → `formSectors:
+  CourseSector[]` (+ selected-sector index); `buildCourse()` writes the array and
+  enforces validation.
+- **`VisualEditor.tsx`**: replace the three fixed buttons with line layers driven by
+  `formSectors` — the list is the control surface; the map keeps per-line draggable
+  endpoint markers for the *selected* line. Colors: S/F green `#22c55e` (as today),
+  majors purple `#a855f7` (as today), **sub-sectors sky-blue `#38bdf8`** (new third
+  color, editor + analysis maps).
+- **Scrolling fix** (confirmed broken): `AddCourseDialog`'s `DialogContent` gets
+  `max-h-[90vh] overflow-y-auto` (+ wider `max-w`) like the manage dialog already
+  has; verify the in-manage edit view scrolls with the list present.
+- Admin `CoursesTab` reuses `SectorListEditor` (replaces its 8 fixed coordinate
+  fields) — see §7.
+
+## 5. Analysis views
+
+- **`RaceLineView.tsx`**: draw *all* sector lines — S/F red (unchanged), majors
+  purple (unchanged), sub-sectors sky-blue, weight 3 / lower opacity so they read as
+  secondary.
+- **`LapTable.tsx`**:
+  1. **Remove the per-lap "Map" overlay column** (overlays remain reachable via the
+     header `OverlaysMenu` and snapshot controls).
+  2. **Simple/Full toggle** (small segmented control in the table header area):
+     - *Simple* (default): today's layout — S1/S2/S3 major rollups + the new
+       all-sector optimal in the summary bar.
+     - *Full*: one column per fine-grained sector labeled `1, 1.1, 1.2, 2, …`,
+       **zebra-striped by major group** (alternating subtle bg per group), wrapped
+       in `overflow-x-auto` for horizontal scrolling; fastest-per-column highlight
+       kept. Toggle hidden when the course has no sub-sectors.
+
+## 6. Crop bar redesign (simple + pro)
+
+- The bottom bar in `RaceLineTab` and `GraphViewPanel` becomes a flex row:
+  **`RangeSlider` at ~80%**, new **`SectorCropSelect` at ~20%** (stacks on small
+  screens).
+- The select lists `Full lap, 1, 1.1, 2, 2.1, …` for the **selected lap**; choosing
+  one sets `visibleRange` from `Lap.sectorBoundaries` (lap-relative indices).
+  Disabled with a placeholder when viewing all laps (sector spans are per-lap).
+  Manually dragging the slider resets the select to "Custom". Selection state lives
+  in `useLapManagement` so simple + pro stay in sync.
+
+## 7. Admin + backend (last phase; gated, online-only)
+
+- Migration: `ALTER TABLE courses ADD COLUMN sectors_data jsonb` (array of
+  `{a_lat,a_lng,b_lat,b_lng,major}`); legacy 8 columns stay populated with the
+  majors mirror on every write.
+- `supabaseAdapter` / `ITrackDatabase` / `DbCourse`: map `sectors_data` ⇄
+  `Course.sectors` (generated Supabase types untouched — cast, as with `batch_id`).
+- `submit-track` edge fn: accept + validate optional `sectors` array (shape, lat/lon
+  ranges, ≤24 entries, exactly-2-majors-or-none); rides `course_data` jsonb.
+  Admin Submissions preview/apply carries it through to `sectors_data`.
+- Admin tracks.json **export** writes `sectors` + legacy mirror; **import** prefers
+  `sectors` (round-trip safe). `CoursesTab` editor reuses `SectorListEditor`.
+
+## 8. Tests, docs, hygiene
+
+- Vitest: `courseSectors.test.ts` (numbering, validation, normalization, rollup,
+  projection, caps), expanded `lapCalculation`, `trackStorage` dual-format,
+  `deviceTrackSync` byte-identical export + subsector-tolerant match,
+  `trackSubmission` hash stability + re-flag on sub edit.
+- `CHANGELOG.md` under `[Unreleased]`; `README.md` (track JSON format, dnd-kit
+  credit), `CreditsDialog.tsx`, `CLAUDE.md` architecture/notes.
+- Green: `npm run lint`, `typecheck`, `test:run`, `build` before push.
+
+## Implementation order
+
+1. `courseSectors.ts` + types + normalization (tests)
+2. `lapCalculation.ts` generalization + optimal (tests)
+3. trackStorage / deviceTrackSync / trackSubmission I/O (tests)
+4. Editor UI: SectorListEditor + dnd-kit + VisualEditor + form hook + scroll fix
+5. RaceLineView lines + LapTable (Map-column removal, Simple/Full toggle)
+6. Crop bar 80/20 + SectorCropSelect
+7. Admin/backend (migration, adapter, CoursesTab, edge fn, submissions, export/import)
+8. Docs/changelog/credits, full CI pass
+
+## Decisions made (flag for review)
+
+- **Cap semantics**: 25 = total timing lines incl. start/finish; majors hard-capped
+  at 3. Both single constants.
+- **`Lap.sectors` (s1/s2/s3) is kept as the major rollup** — keeps coach plugin,
+  video overlays, and snapshots working with zero changes, and *is* the "majors only
+  to the coach" requirement.
+- **dnd-kit** added as the drag-reorder dependency (none exists in the repo; the
+  spec explicitly wants tap-and-drag, not up/down arrows).
+- **Hash stability**: legacy hash input preserved for majors-only courses so
+  existing submission dedupe records stay valid.
+- Sub-sector line color: sky-blue (`#38bdf8`) — distinct from green S/F (editor) /
+  red S/F (analysis) and purple majors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "2.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@lovable.dev/cloud-auth-js": "^1.1.2",
         "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -1593,6 +1596,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doves-dataviewer",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doves-dataviewer",
-      "version": "2.3.0",
+      "version": "2.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@lovable.dev/cloud-auth-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@lovable.dev/cloud-auth-js": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.3.1",
+  "version": "2.5.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -20,6 +20,7 @@ const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
   ["Savitzky-Golay (ml.js)", "https://github.com/mljs/savitzky-golay"],
   ["Sonner", "https://sonner.emilkowal.dev"],
   ["react-resizable-panels", "https://github.com/bvaughn/react-resizable-panels"],
+  ["dnd kit", "https://dndkit.com"],
   ["mp4-muxer", "https://github.com/Vanilagy/mp4-muxer"],
   ["fix-webm-duration", "https://github.com/yusitnikov/fix-webm-duration"],
   ["JSZip", "https://stuk.github.io/jszip"],

--- a/src/components/LapTable.tsx
+++ b/src/components/LapTable.tsx
@@ -1,12 +1,13 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { Lap, courseHasSectors, Course, GpsSample } from '@/types/racing';
 import { formatLapTime, formatSectorTime, calculateOptimalLap } from '@/lib/lapCalculation';
-import { Trophy, Zap, Snail, Target, Spline } from 'lucide-react';
+import { normalizeCourseSectors, sectorLabels } from '@/lib/courseSectors';
+import { Trophy, Zap, Snail, Target } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ExternalRefBar } from '@/components/ExternalRefBar';
 import { LapSnapshotControls } from '@/components/LapSnapshotControls';
 import type { LapSnapshot } from '@/lib/lapSnapshot';
-import { overlayId, type OverlayLine } from '@/lib/lapOverlays';
+import { type OverlayLine } from '@/lib/lapOverlays';
 import type { SaveSnapshotResult } from '@/hooks/useLapSnapshots';
 import { FileEntry } from '@/lib/fileStorage';
 import { useSettingsContext } from '@/contexts/SettingsContext';
@@ -50,6 +51,37 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
   const { useKph } = useSettingsContext();
 
   const showSectors = courseHasSectors(course);
+  const [view, setView] = useState<'simple' | 'full'>('simple');
+
+  // Full view = one column per fine-grained sector. Only offered when the course
+  // has sub-sectors beyond the three majors.
+  const full = useMemo(() => {
+    if (!course) return null;
+    const sectors = normalizeCourseSectors(course).sectors ?? [];
+    const hasSubSectors = sectors.some((s) => !s.major);
+    if (!hasSubSectors) return null;
+
+    const labels = sectorLabels(course); // length = lineCount (incl. start/finish)
+    const lineCount = labels.length;
+    // Major-group index per segment, for zebra striping.
+    const groupOf: number[] = [];
+    let g = 0;
+    for (let k = 0; k < lineCount; k++) {
+      if (k > 0 && sectors[k - 1].major) g++;
+      groupOf.push(g);
+    }
+    // Fastest (min) time per segment across laps.
+    const fastestIdx: (number | null)[] = new Array(lineCount).fill(null);
+    const best: number[] = new Array(lineCount).fill(Infinity);
+    laps.forEach((lap, idx) => {
+      lap.sectorTimes?.forEach((t, k) => {
+        if (t !== undefined && t < best[k]) { best[k] = t; fastestIdx[k] = idx; }
+      });
+    });
+    return { labels, lineCount, groupOf, fastestIdx };
+  }, [course, laps]);
+
+  const showFull = view === 'full' && full !== null;
 
   // Memoize expensive lap statistics computation
   const lapStats = useMemo(() => {
@@ -169,14 +201,41 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
           ) : undefined}
         />
       )}
-      <table className="w-full">
+      {/* Simple/Full toggle — only when the course has sub-sectors. */}
+      {full && (
+        <div className="flex items-center justify-end gap-1 px-2 py-1.5">
+          <div className="inline-flex rounded-md border border-border p-0.5 text-xs">
+            <button
+              className={`rounded px-2 py-0.5 transition-colors ${!showFull ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+              onClick={() => setView('simple')}
+            >
+              Simple
+            </button>
+            <button
+              className={`rounded px-2 py-0.5 transition-colors ${showFull ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+              onClick={() => setView('full')}
+            >
+              Full
+            </button>
+          </div>
+        </div>
+      )}
+      <table className={showFull ? 'min-w-max' : 'w-full'}>
         <thead className="sticky top-0 bg-card">
           <tr className="text-left text-xs text-muted-foreground uppercase tracking-wider">
             <th className="px-2 py-3 font-medium w-16">Ref</th>
-            {onToggleOverlay && <th className="px-1 py-3 font-medium w-10 text-center" title="Show lap line on map">Map</th>}
             <th className="px-4 py-3 font-medium">Lap</th>
             <th className="px-4 py-3 font-medium">Time</th>
-            {showSectors && (
+            {showFull ? (
+              full.labels.map((label, k) => (
+                <th
+                  key={k}
+                  className={`px-3 py-3 font-medium text-center whitespace-nowrap ${full.groupOf[k] % 2 === 1 ? 'bg-muted/40' : ''}`}
+                >
+                  {label}
+                </th>
+              ))
+            ) : showSectors && (
               <>
                 <th className="px-3 py-3 font-medium text-center">S1</th>
                 <th className="px-3 py-3 font-medium text-center">S2</th>
@@ -222,23 +281,6 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
                     {isReference ? 'Ref' : 'Set Ref'}
                   </Button>
                 </td>
-                {onToggleOverlay && (() => {
-                  const ovId = overlayId('lap', lap.lapNumber);
-                  const overlay = overlayLines.find((l) => l.id === ovId);
-                  return (
-                    <td className="px-1 py-3 text-center" onClick={(e) => e.stopPropagation()}>
-                      <button
-                        className="rounded p-1.5 transition-colors hover:bg-muted/50"
-                        style={{ color: overlay ? overlay.color : undefined }}
-                        title={overlay ? 'Hide lap line on map' : 'Show lap line on map'}
-                        aria-pressed={!!overlay}
-                        onClick={() => onToggleOverlay(ovId)}
-                      >
-                        <Spline className={`w-4 h-4 ${overlay ? '' : 'text-muted-foreground'}`} />
-                      </button>
-                    </td>
-                  );
-                })()}
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-sm">{lap.lapNumber}</span>
@@ -250,7 +292,21 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
                 <td className={`px-4 py-3 font-mono text-sm ${isFastest ? 'text-racing-lapBest font-semibold' : ''}`}>
                   {formatLapTime(lap.lapTimeMs)}
                 </td>
-                {showSectors && (
+                {showFull ? (
+                  full.labels.map((_, k) => {
+                    const t = lap.sectorTimes?.[k];
+                    const isFastestSeg = full.fastestIdx[k] === idx;
+                    const zebra = full.groupOf[k] % 2 === 1 ? 'bg-muted/30' : '';
+                    return (
+                      <td
+                        key={k}
+                        className={`px-3 py-3 font-mono text-xs text-center whitespace-nowrap ${isFastestSeg ? 'text-purple-400 font-semibold bg-purple-500/10' : zebra}`}
+                      >
+                        {t !== undefined ? formatSectorTime(t) : '—'}
+                      </td>
+                    );
+                  })
+                ) : showSectors && (
                   <>
                     <td className={`px-3 py-3 font-mono text-xs text-center ${hasFastestS1 ? 'text-purple-400 font-semibold bg-purple-500/10' : ''}`}>
                       {lap.sectors?.s1 !== undefined ? formatSectorTime(lap.sectors.s1) : '—'}

--- a/src/components/LapTable.tsx
+++ b/src/components/LapTable.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react';
+import { Fragment, memo, useMemo, useState } from 'react';
 import { Lap, courseHasSectors, Course, GpsSample } from '@/types/racing';
 import { formatLapTime, formatSectorTime, calculateOptimalLap } from '@/lib/lapCalculation';
 import { normalizeCourseSectors, sectorLabels } from '@/lib/courseSectors';
@@ -52,6 +52,9 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
 
   const showSectors = courseHasSectors(course);
   const [view, setView] = useState<'simple' | 'full'>('simple');
+  // In Full view, an optional colored "S# Sum" column before each major group
+  // showing that major sector's total time (the S1/S2/S3 rollup). Default on.
+  const [showSectorSums, setShowSectorSums] = useState(true);
 
   // Full view = one column per fine-grained sector. Only offered when the course
   // has sub-sectors beyond the three majors.
@@ -78,10 +81,38 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
         if (t !== undefined && t < best[k]) { best[k] = t; fastestIdx[k] = idx; }
       });
     });
-    return { labels, lineCount, groupOf, fastestIdx };
+
+    // Major groups: the segment indices that compose each major sector (S1/S2/S3),
+    // and which segment begins a group (where the "S# Sum" column is inserted).
+    const groupCount = lineCount === 0 ? 0 : groupOf[lineCount - 1] + 1;
+    const segIndicesByGroup: number[][] = Array.from({ length: groupCount }, () => []);
+    for (let k = 0; k < lineCount; k++) segIndicesByGroup[groupOf[k]].push(k);
+    const isGroupStart: boolean[] = groupOf.map((gi, k) => k === 0 || gi !== groupOf[k - 1]);
+    // Sum a lap's segments for major group `gi`; undefined if any segment is missing.
+    const sumForGroup = (lap: Lap, gi: number): number | undefined => {
+      let sum = 0;
+      for (const k of segIndicesByGroup[gi]) {
+        const t = lap.sectorTimes?.[k];
+        if (t === undefined) return undefined;
+        sum += t;
+      }
+      return sum;
+    };
+    // Fastest (min) major-sum per group across laps, for highlighting.
+    const fastestSumIdx: (number | null)[] = new Array(groupCount).fill(null);
+    const bestSum: number[] = new Array(groupCount).fill(Infinity);
+    laps.forEach((lap, idx) => {
+      for (let gi = 0; gi < groupCount; gi++) {
+        const s = sumForGroup(lap, gi);
+        if (s !== undefined && s < bestSum[gi]) { bestSum[gi] = s; fastestSumIdx[gi] = idx; }
+      }
+    });
+
+    return { labels, lineCount, groupOf, fastestIdx, groupCount, isGroupStart, fastestSumIdx, sumForGroup };
   }, [course, laps]);
 
   const showFull = view === 'full' && full !== null;
+  const showSums = showFull && showSectorSums;
 
   // Memoize expensive lap statistics computation
   const lapStats = useMemo(() => {
@@ -201,9 +232,19 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
           ) : undefined}
         />
       )}
-      {/* Simple/Full toggle — only when the course has sub-sectors. */}
+      {/* Simple/Full toggle — only when the course has sub-sectors. The
+          "Sector sums" toggle appears alongside it only in Full view. */}
       {full && (
-        <div className="flex items-center justify-end gap-1 px-2 py-1.5">
+        <div className="flex items-center justify-end gap-2 px-2 py-1.5">
+          {showFull && (
+            <button
+              className={`rounded-md border border-border px-2 py-0.5 text-xs transition-colors ${showSectorSums ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+              onClick={() => setShowSectorSums((v) => !v)}
+              title="Show a running S1/S2/S3 total before each major sector"
+            >
+              Sector sums
+            </button>
+          )}
           <div className="inline-flex rounded-md border border-border p-0.5 text-xs">
             <button
               className={`rounded px-2 py-0.5 transition-colors ${!showFull ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
@@ -228,12 +269,18 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
             <th className="px-4 py-3 font-medium">Time</th>
             {showFull ? (
               full.labels.map((label, k) => (
-                <th
-                  key={k}
-                  className={`px-3 py-3 font-medium text-center whitespace-nowrap ${full.groupOf[k] % 2 === 1 ? 'bg-muted/40' : ''}`}
-                >
-                  {label}
-                </th>
+                <Fragment key={k}>
+                  {showSums && full.isGroupStart[k] && (
+                    <th className="px-3 py-3 font-semibold text-center whitespace-nowrap bg-primary/20 text-primary">
+                      {`S${full.groupOf[k] + 1} Sum`}
+                    </th>
+                  )}
+                  <th
+                    className={`px-3 py-3 font-medium text-center whitespace-nowrap ${full.groupOf[k] % 2 === 1 ? 'bg-muted/40' : ''}`}
+                  >
+                    {label}
+                  </th>
+                </Fragment>
               ))
             ) : showSectors && (
               <>
@@ -297,13 +344,24 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
                     const t = lap.sectorTimes?.[k];
                     const isFastestSeg = full.fastestIdx[k] === idx;
                     const zebra = full.groupOf[k] % 2 === 1 ? 'bg-muted/30' : '';
+                    const g = full.groupOf[k];
+                    const sum = showSums && full.isGroupStart[k] ? full.sumForGroup(lap, g) : undefined;
+                    const isFastestSum = full.fastestSumIdx[g] === idx;
                     return (
-                      <td
-                        key={k}
-                        className={`px-3 py-3 font-mono text-xs text-center whitespace-nowrap ${isFastestSeg ? 'text-purple-400 font-semibold bg-purple-500/10' : zebra}`}
-                      >
-                        {t !== undefined ? formatSectorTime(t) : '—'}
-                      </td>
+                      <Fragment key={k}>
+                        {showSums && full.isGroupStart[k] && (
+                          <td
+                            className={`px-3 py-3 font-mono text-xs text-center whitespace-nowrap font-semibold ${isFastestSum ? 'text-purple-400 bg-purple-500/15' : 'text-primary bg-primary/10'}`}
+                          >
+                            {sum !== undefined ? formatSectorTime(sum) : '—'}
+                          </td>
+                        )}
+                        <td
+                          className={`px-3 py-3 font-mono text-xs text-center whitespace-nowrap ${isFastestSeg ? 'text-purple-400 font-semibold bg-purple-500/10' : zebra}`}
+                        >
+                          {t !== undefined ? formatSectorTime(t) : '—'}
+                        </td>
+                      </Fragment>
                     );
                   })
                 ) : showSectors && (

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useMemo, useState, memo } from 'react';
 import L from 'leaflet';
-import { GpsSample, Course, courseHasSectors, ParserStats } from '@/types/racing';
+import { GpsSample, Course, ParserStats } from '@/types/racing';
+import { normalizeCourseSectors } from '@/lib/courseSectors';
 import { findSpeedEvents, SpeedEvent } from '@/lib/speedEvents';
 import { computeHeatmapSpeedBoundsMph } from '@/lib/speedBounds';
 import { buildHeatmapSegments } from '@/lib/speedHeatmap';
@@ -133,8 +134,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], cours
   const brakingZonesLayerRef = useRef<L.LayerGroup | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
   const startFinishRef = useRef<L.Polyline | null>(null);
-  const sector2Ref = useRef<L.Polyline | null>(null);
-  const sector3Ref = useRef<L.Polyline | null>(null);
+  const sectorsLayerRef = useRef<L.LayerGroup | null>(null);
   const speedEventsLayerRef = useRef<L.LayerGroup | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   
@@ -458,13 +458,9 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], cours
       map.removeLayer(startFinishRef.current);
       startFinishRef.current = null;
     }
-    if (sector2Ref.current) {
-      map.removeLayer(sector2Ref.current);
-      sector2Ref.current = null;
-    }
-    if (sector3Ref.current) {
-      map.removeLayer(sector3Ref.current);
-      sector3Ref.current = null;
+    if (sectorsLayerRef.current) {
+      map.removeLayer(sectorsLayerRef.current);
+      sectorsLayerRef.current = null;
     }
 
     if (!course) return;
@@ -475,17 +471,21 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], cours
       { color: 'hsl(0, 75%, 55%)', weight: 5, opacity: 1 }
     ).addTo(map);
 
-    // Draw sector lines if they exist (purple/magenta)
-    if (courseHasSectors(course) && course.sector2 && course.sector3) {
-      sector2Ref.current = L.polyline(
-        [[course.sector2.a.lat, course.sector2.a.lon], [course.sector2.b.lat, course.sector2.b.lon]],
-        { color: 'hsl(280, 70%, 55%)', weight: 4, opacity: 0.9 }
-      ).addTo(map);
-
-      sector3Ref.current = L.polyline(
-        [[course.sector3.a.lat, course.sector3.a.lon], [course.sector3.b.lat, course.sector3.b.lon]],
-        { color: 'hsl(280, 70%, 55%)', weight: 4, opacity: 0.9 }
-      ).addTo(map);
+    // Draw every sector line: majors purple, sub-sectors sky-blue (secondary).
+    const sectors = normalizeCourseSectors(course).sectors ?? [];
+    if (sectors.length > 0) {
+      const group = L.layerGroup();
+      for (const sec of sectors) {
+        const major = sec.major;
+        L.polyline(
+          [[sec.line.a.lat, sec.line.a.lon], [sec.line.b.lat, sec.line.b.lon]],
+          major
+            ? { color: 'hsl(280, 70%, 55%)', weight: 4, opacity: 0.9 }
+            : { color: 'hsl(199, 89%, 60%)', weight: 3, opacity: 0.7, dashArray: '6 5' }
+        ).addTo(group);
+      }
+      group.addTo(map);
+      sectorsLayerRef.current = group;
     }
   }, [course]);
 

--- a/src/components/SectorCropSelect.tsx
+++ b/src/components/SectorCropSelect.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import { Scissors } from 'lucide-react';
+import { Course, Lap } from '@/types/racing';
+import { normalizeCourseSectors, sectorLabels } from '@/lib/courseSectors';
+
+interface SectorCropSelectProps {
+  course: Course | null;
+  laps: Lap[];
+  selectedLapNumber: number | null;
+  /** Number of samples in the active (lap-filtered) window. */
+  filteredLength: number;
+  visibleRange: [number, number];
+  onRangeChange: (range: [number, number]) => void;
+}
+
+interface CropOption {
+  key: string;
+  label: string;
+  range: [number, number];
+}
+
+/**
+ * Quick crop-to-sector dropdown that sits next to the range slider. Picking a
+ * sector snaps the visible window to that section of the selected lap — handy
+ * for coaches reviewing a specific corner in a predictable way. Disabled when
+ * viewing all laps (sector spans are per-lap) or the course has no sectors.
+ */
+export function SectorCropSelect({
+  course, laps, selectedLapNumber, filteredLength, visibleRange, onRangeChange,
+}: SectorCropSelectProps) {
+  const lap = selectedLapNumber === null ? null : laps.find((l) => l.lapNumber === selectedLapNumber) ?? null;
+
+  const options = useMemo<CropOption[]>(() => {
+    const opts: CropOption[] = [{ key: 'full', label: 'Full lap', range: [0, Math.max(0, filteredLength - 1)] }];
+    if (!course || !lap || !lap.sectorBoundaries || lap.sectorBoundaries.length === 0) return opts;
+
+    const labels = sectorLabels(course);
+    const lineCount = labels.length;
+    const bounds = lap.sectorBoundaries; // absolute sample indices, [0] = lap start
+    const clamp = (n: number) => Math.max(0, Math.min(n, filteredLength - 1));
+
+    for (let k = 0; k < lineCount; k++) {
+      const startAbs = bounds[k];
+      const endAbs = k + 1 < lineCount ? bounds[k + 1] : lap.endIndex;
+      if (startAbs === undefined || endAbs === undefined) continue; // missed crossing
+      const startRel = clamp(startAbs - lap.startIndex);
+      const endRel = clamp(endAbs - lap.startIndex);
+      if (endRel <= startRel) continue;
+      opts.push({ key: `s-${k}`, label: labels[k], range: [startRel, endRel] });
+    }
+    return opts;
+  }, [course, lap, filteredLength]);
+
+  const hasSectorOptions = options.length > 1;
+  const disabled = !hasSectorOptions;
+
+  // Reflect the current window: match it to an option, else "Custom".
+  const currentKey = useMemo(() => {
+    const match = options.find((o) => o.range[0] === visibleRange[0] && o.range[1] === visibleRange[1]);
+    return match ? match.key : 'custom';
+  }, [options, visibleRange]);
+
+  const handleChange = (key: string) => {
+    const opt = options.find((o) => o.key === key);
+    if (opt) onRangeChange(opt.range);
+  };
+
+  return (
+    <label className="flex items-center gap-1.5 text-xs text-muted-foreground" title="Crop to a sector">
+      <Scissors className="w-3.5 h-3.5 shrink-0" />
+      <select
+        value={currentKey}
+        onChange={(e) => handleChange(e.target.value)}
+        disabled={disabled}
+        className="min-w-0 flex-1 cursor-pointer rounded border border-border bg-transparent px-1 py-0.5 text-xs text-foreground/90 outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        title={disabled ? 'Select a lap with sectors to crop' : 'Crop the view to a sector'}
+      >
+        {currentKey === 'custom' && <option value="custom">Custom range</option>}
+        {options.map((o) => (
+          <option key={o.key} value={o.key}>
+            {o.key === 'full' ? o.label : `Sector ${o.label}`}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { Track, TrackCourseSelection } from '@/types/racing';
+import { Track, TrackCourseSelection, courseHasSectors } from '@/types/racing';
+import { legacyMirror, normalizeCourseSectors, validateCourseSectors } from '@/lib/courseSectors';
 import {
   loadTracks,
   loadDefaultTracks,
@@ -39,10 +40,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTrackEditorForm } from '@/hooks/useTrackEditorForm';
 import { useOptionalSettingsContext } from '@/contexts/SettingsContext';
 import { formatTrackLength } from '@/lib/units';
-// Lazy — VisualEditor pulls in Leaflet drawing logic; only loads when the
-// track editor dialog is opened.
-const VisualEditor = lazy(() =>
-  import('@/components/track-editor/VisualEditor').then((m) => ({ default: m.VisualEditor })),
+// Lazy — CourseSectorEditor pulls in Leaflet drawing logic + the sector list;
+// only loads when the track editor dialog is opened.
+const CourseSectorEditor = lazy(() =>
+  import('@/components/track-editor/CourseSectorEditor').then((m) => ({ default: m.CourseSectorEditor })),
 );
 import { AddCourseDialog } from '@/components/track-editor/AddCourseDialog';
 import { AddTrackDialog } from '@/components/track-editor/AddTrackDialog';
@@ -222,18 +223,20 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
         courseData.lengthFt = course.lengthFt;
       }
 
-      if (course.sector2) {
-        courseData.sector_2_a_lat = course.sector2.a.lat;
-        courseData.sector_2_a_lng = course.sector2.a.lon;
-        courseData.sector_2_b_lat = course.sector2.b.lat;
-        courseData.sector_2_b_lng = course.sector2.b.lon;
+      // Device track JSON carries only the three major sectors (start/finish +
+      // the two majors), byte-identical to the pre-overhaul format.
+      const { sector2, sector3 } = legacyMirror(normalizeCourseSectors(course));
+      if (sector2) {
+        courseData.sector_2_a_lat = sector2.a.lat;
+        courseData.sector_2_a_lng = sector2.a.lon;
+        courseData.sector_2_b_lat = sector2.b.lat;
+        courseData.sector_2_b_lng = sector2.b.lon;
       }
-
-      if (course.sector3) {
-        courseData.sector_3_a_lat = course.sector3.a.lat;
-        courseData.sector_3_a_lng = course.sector3.a.lon;
-        courseData.sector_3_b_lat = course.sector3.b.lat;
-        courseData.sector_3_b_lng = course.sector3.b.lon;
+      if (sector3) {
+        courseData.sector_3_a_lat = sector3.a.lat;
+        courseData.sector_3_a_lng = sector3.a.lon;
+        courseData.sector_3_b_lat = sector3.b.lat;
+        courseData.sector_3_b_lng = sector3.b.lon;
       }
 
       result[course.name] = courseData;
@@ -328,6 +331,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
       await updateCourse(trackName, oldCourseName, {
         startFinishA: course.startFinishA,
         startFinishB: course.startFinishB,
+        sectors: course.sectors,
         sector2: course.sector2,
         sector3: course.sector3,
         layout: course.layout,
@@ -371,20 +375,43 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
 
   if (isLoading) return <div className="text-muted-foreground text-sm">Loading tracks...</div>;
 
+  // Shared sector-list editor props (start/finish + sectors + list operations).
+  const sectorEditorProps = {
+    startFinishA: form.visualEditorStartFinishA,
+    startFinishB: form.visualEditorStartFinishB,
+    sectors: form.formSectors,
+    selectedLine: form.selectedLine,
+    onSelectLine: form.setSelectedLine,
+    onStartFinishChange: form.handleVisualStartFinishChange,
+    onSectorLineChange: form.handleVisualSectorLineChange,
+    onAddSector: form.addSector,
+    onRemoveSector: form.removeSector,
+    onToggleMajor: form.toggleSectorMajor,
+    onReorder: form.reorderSectors,
+  } as const;
+
+  // Save is blocked unless the sector layout is valid (0 sectors or 3 majors).
+  const sectorsValid = validateCourseSectors({
+    name: form.formCourseName,
+    startFinishA: form.visualEditorStartFinishA ?? { lat: 0, lon: 0 },
+    startFinishB: form.visualEditorStartFinishB ?? { lat: 0, lon: 0 },
+    sectors: form.formSectors,
+  }).valid;
+
+  const addCourseCanSubmit = Boolean(
+    form.formCourseName.trim() && form.formLatA && form.formLonA && form.formLatB && form.formLonB && sectorsValid,
+  );
+
   // Shared dialog props
   const addCourseDialogProps = {
     open: isAddCourseOpen,
     onOpenChange: (open: boolean) => { setIsAddCourseOpen(open); if (!open) form.resetForm(); },
-    courseFormProps: form.courseFormProps,
+    courseName: form.formCourseName,
+    onCourseNameChange: form.setFormCourseName,
+    canSubmit: addCourseCanSubmit,
     onSubmit: handleAddCourse,
     onCancel: () => { setIsAddCourseOpen(false); form.resetForm(); },
-    startFinishA: form.visualEditorStartFinishA,
-    startFinishB: form.visualEditorStartFinishB,
-    sector2: form.visualEditorSector2,
-    sector3: form.visualEditorSector3,
-    onStartFinishChange: form.handleVisualStartFinishChange,
-    onSector2Change: form.handleVisualSector2Change,
-    onSector3Change: form.handleVisualSector3Change,
+    ...sectorEditorProps,
     layoutPoints: form.formLayout,
     onLayoutChange: form.handleVisualLayoutChange,
     laps,
@@ -394,10 +421,10 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
   const addTrackDialogProps = {
     open: isAddTrackOpen,
     onOpenChange: (open: boolean) => { setIsAddTrackOpen(open); if (!open) form.resetForm(); },
-    trackName: form.courseFormProps.trackName,
-    shortName: form.courseFormProps.trackShortName,
-    onTrackNameChange: form.courseFormProps.onTrackNameChange,
-    onShortNameChange: form.courseFormProps.onTrackShortNameChange,
+    trackName: form.formTrackName,
+    shortName: form.formTrackShortName,
+    onTrackNameChange: form.handleTrackNameChange,
+    onShortNameChange: form.handleTrackShortNameChange,
     onSubmit: handleAddTrack,
     onCancel: () => { setIsAddTrackOpen(false); form.resetForm(); },
   } as const;
@@ -439,14 +466,8 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
           <div className="space-y-4">
             <h4 className="font-medium">Edit Course</h4>
             <Suspense fallback={null}>
-              <VisualEditor
-                startFinishA={form.visualEditorStartFinishA}
-                startFinishB={form.visualEditorStartFinishB}
-                sector2={form.visualEditorSector2}
-                sector3={form.visualEditorSector3}
-                onStartFinishChange={form.handleVisualStartFinishChange}
-                onSector2Change={form.handleVisualSector2Change}
-                onSector3Change={form.handleVisualSector3Change}
+              <CourseSectorEditor
+                {...sectorEditorProps}
                 showDrawTool={true}
                 laps={laps}
                 samples={samples}
@@ -456,7 +477,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
               />
             </Suspense>
             <div className="flex gap-2">
-              <Button onClick={handleUpdateCourse} className="flex-1">
+              <Button onClick={handleUpdateCourse} className="flex-1" disabled={!sectorsValid}>
                 <Check className="w-4 h-4 mr-2" />
                 Update
               </Button>
@@ -488,7 +509,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
                     <div className="flex-1 min-w-0">
                       <span className="font-mono text-sm">{course.name}</span>
                       {!course.isUserDefined && <span className="ml-2 text-xs text-muted-foreground">(default)</span>}
-                      {course.sector2 && course.sector3 && <span className="ml-2 text-xs text-accent-foreground/60">(sectors)</span>}
+                      {courseHasSectors(course) && <span className="ml-2 text-xs text-accent-foreground/60">(sectors)</span>}
                       {course.lengthFt != null && course.lengthFt > 0 && (
                         <span className="ml-2 text-xs text-muted-foreground">
                           {formatTrackLength(course.lengthFt, useMetricDistance)}

--- a/src/components/TrackPromptDialog.tsx
+++ b/src/components/TrackPromptDialog.tsx
@@ -19,6 +19,7 @@ import { Track, TrackCourseSelection, CourseDetectionResult, Lap, GpsSample } fr
 import { AddCourseDialog } from '@/components/track-editor/AddCourseDialog';
 import { AddTrackDialog } from '@/components/track-editor/AddTrackDialog';
 import { useTrackEditorForm } from '@/hooks/useTrackEditorForm';
+import { validateCourseSectors } from '@/lib/courseSectors';
 import { addTrack as addTrackToStorage, addCourse as addCourseToStorage, loadTracks } from '@/lib/trackStorage';
 
 interface TrackPromptDialogProps {
@@ -120,19 +121,35 @@ export function TrackPromptDialog({
     setIsAddCourseOpen(true);
   };
 
+  const addCourseCanSubmit = Boolean(
+    form.formCourseName.trim() && form.formLatA && form.formLonA && form.formLatB && form.formLonB &&
+    validateCourseSectors({
+      name: form.formCourseName,
+      startFinishA: form.visualEditorStartFinishA ?? { lat: 0, lon: 0 },
+      startFinishB: form.visualEditorStartFinishB ?? { lat: 0, lon: 0 },
+      sectors: form.formSectors,
+    }).valid,
+  );
+
   const addCourseDialogProps = {
     open: isAddCourseOpen,
     onOpenChange: (o: boolean) => { setIsAddCourseOpen(o); if (!o) form.resetForm(); },
-    courseFormProps: form.courseFormProps,
+    courseName: form.formCourseName,
+    onCourseNameChange: form.setFormCourseName,
+    canSubmit: addCourseCanSubmit,
     onSubmit: handleAddCourse,
     onCancel: () => { setIsAddCourseOpen(false); form.resetForm(); },
     startFinishA: form.visualEditorStartFinishA,
     startFinishB: form.visualEditorStartFinishB,
-    sector2: form.visualEditorSector2,
-    sector3: form.visualEditorSector3,
+    sectors: form.formSectors,
+    selectedLine: form.selectedLine,
+    onSelectLine: form.setSelectedLine,
     onStartFinishChange: form.handleVisualStartFinishChange,
-    onSector2Change: form.handleVisualSector2Change,
-    onSector3Change: form.handleVisualSector3Change,
+    onSectorLineChange: form.handleVisualSectorLineChange,
+    onAddSector: form.addSector,
+    onRemoveSector: form.removeSector,
+    onToggleMajor: form.toggleSectorMajor,
+    onReorder: form.reorderSectors,
     initialCenter,
     // Carry the drawing through so a generated/drawn outline is saved on the new
     // course (buildCourse reads form.formLayout), and feed laps/samples so the
@@ -146,10 +163,10 @@ export function TrackPromptDialog({
   const addTrackDialogProps = {
     open: isAddTrackOpen,
     onOpenChange: (o: boolean) => { setIsAddTrackOpen(o); if (!o) form.resetForm(); },
-    trackName: form.courseFormProps.trackName,
-    shortName: form.courseFormProps.trackShortName,
-    onTrackNameChange: form.courseFormProps.onTrackNameChange,
-    onShortNameChange: form.courseFormProps.onTrackShortNameChange,
+    trackName: form.formTrackName,
+    shortName: form.formTrackShortName,
+    onTrackNameChange: form.handleTrackNameChange,
+    onShortNameChange: form.handleTrackShortNameChange,
     onSubmit: handleAddTrack,
     onCancel: () => { setIsAddTrackOpen(false); form.resetForm(); },
   } as const;

--- a/src/components/admin/CoursesTab.tsx
+++ b/src/components/admin/CoursesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo, lazy, Suspense } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -277,10 +277,10 @@ export function CoursesTab() {
 
   // Editor bridge helpers
   const [selectedLine, setSelectedLine] = useState<SelectedLine>(null);
-  const visualStartA: GpsPoint | null = form.startALat && form.startALng
-    ? { lat: parseFloat(form.startALat), lon: parseFloat(form.startALng) } : null;
-  const visualStartB: GpsPoint | null = form.startBLat && form.startBLng
-    ? { lat: parseFloat(form.startBLat), lon: parseFloat(form.startBLng) } : null;
+  const visualStartA = useMemo<GpsPoint | null>(() => (form.startALat && form.startALng
+    ? { lat: parseFloat(form.startALat), lon: parseFloat(form.startALng) } : null), [form.startALat, form.startALng]);
+  const visualStartB = useMemo<GpsPoint | null>(() => (form.startBLat && form.startBLng
+    ? { lat: parseFloat(form.startBLat), lon: parseFloat(form.startBLng) } : null), [form.startBLat, form.startBLng]);
 
   const handleVisualStartFinish = useCallback((a: GpsPoint, b: GpsPoint) => {
     setForm(prev => ({ ...prev, startALat: String(a.lat), startALng: String(a.lon), startBLat: String(b.lat), startBLng: String(b.lon) }));

--- a/src/components/admin/CoursesTab.tsx
+++ b/src/components/admin/CoursesTab.tsx
@@ -8,10 +8,15 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/comp
 import { toast } from '@/hooks/use-toast';
 import { getDatabase } from '@/lib/db';
 import type { DbTrack, DbCourse, DbCourseLayout } from '@/lib/db/types';
-import type { SectorLine } from '@/types/racing';
+import type { SectorLine, CourseSector } from '@/types/racing';
 import type { GpsPoint } from '@/components/track-editor/VisualEditor';
-const VisualEditor = lazy(() =>
-  import('@/components/track-editor/VisualEditor').then((m) => ({ default: m.VisualEditor })),
+import type { SelectedLine } from '@/hooks/useTrackEditorForm';
+import {
+  normalizeCourseSectors, legacyMirror, isAtSectorLimit,
+} from '@/lib/courseSectors';
+import { sectorsFromJson, sectorsToJson, type SectorJson } from '@/lib/trackStorage';
+const CourseSectorEditor = lazy(() =>
+  import('@/components/track-editor/CourseSectorEditor').then((m) => ({ default: m.CourseSectorEditor })),
 );
 import { Plus, Edit2, Check, X, Trash2, Star } from 'lucide-react';
 import { calculatePolylineLength, formatTrackLength } from '@/lib/trackUtils';
@@ -35,58 +40,61 @@ interface CourseFormState {
   startALng: string;
   startBLat: string;
   startBLng: string;
-  s2aLat: string;
-  s2aLng: string;
-  s2bLat: string;
-  s2bLng: string;
-  s3aLat: string;
-  s3aLng: string;
-  s3bLat: string;
-  s3bLng: string;
+  sectors: CourseSector[];
 }
 
 const emptyForm: CourseFormState = {
   name: '', startALat: '', startALng: '', startBLat: '', startBLng: '',
-  s2aLat: '', s2aLng: '', s2bLat: '', s2bLng: '',
-  s3aLat: '', s3aLng: '', s3bLat: '', s3bLng: '',
+  sectors: [],
 };
 
 function formFromCourse(c: DbCourse): CourseFormState {
+  // Prefer the canonical sectors_data; fall back to the legacy two-major columns.
+  const fromJson = sectorsFromJson(c.sectors_data as SectorJson[] | undefined);
+  let sectors = fromJson;
+  if (!sectors) {
+    const norm = normalizeCourseSectors({
+      name: c.name,
+      startFinishA: { lat: c.start_a_lat, lon: c.start_a_lng },
+      startFinishB: { lat: c.start_b_lat, lon: c.start_b_lng },
+      sector2: c.sector_2_a_lat != null && c.sector_2_a_lng != null && c.sector_2_b_lat != null && c.sector_2_b_lng != null
+        ? { a: { lat: c.sector_2_a_lat, lon: c.sector_2_a_lng }, b: { lat: c.sector_2_b_lat, lon: c.sector_2_b_lng } } : undefined,
+      sector3: c.sector_3_a_lat != null && c.sector_3_a_lng != null && c.sector_3_b_lat != null && c.sector_3_b_lng != null
+        ? { a: { lat: c.sector_3_a_lat, lon: c.sector_3_a_lng }, b: { lat: c.sector_3_b_lat, lon: c.sector_3_b_lng } } : undefined,
+    });
+    sectors = norm.sectors;
+  }
   return {
     name: c.name,
     startALat: String(c.start_a_lat), startALng: String(c.start_a_lng),
     startBLat: String(c.start_b_lat), startBLng: String(c.start_b_lng),
-    s2aLat: c.sector_2_a_lat != null ? String(c.sector_2_a_lat) : '',
-    s2aLng: c.sector_2_a_lng != null ? String(c.sector_2_a_lng) : '',
-    s2bLat: c.sector_2_b_lat != null ? String(c.sector_2_b_lat) : '',
-    s2bLng: c.sector_2_b_lng != null ? String(c.sector_2_b_lng) : '',
-    s3aLat: c.sector_3_a_lat != null ? String(c.sector_3_a_lat) : '',
-    s3aLng: c.sector_3_a_lng != null ? String(c.sector_3_a_lng) : '',
-    s3bLat: c.sector_3_b_lat != null ? String(c.sector_3_b_lat) : '',
-    s3bLng: c.sector_3_b_lng != null ? String(c.sector_3_b_lng) : '',
+    sectors: sectors ?? [],
   };
 }
 
-function parseOptional(v: string): number | null {
-  const n = parseFloat(v);
-  return isNaN(n) ? null : n;
-}
-
 function formToCourseData(f: CourseFormState) {
+  // Persist the legacy two-major mirror (for DB columns) AND the full sectors_data.
+  const { sector2, sector3 } = legacyMirror({
+    name: f.name,
+    startFinishA: { lat: parseFloat(f.startALat), lon: parseFloat(f.startALng) },
+    startFinishB: { lat: parseFloat(f.startBLat), lon: parseFloat(f.startBLng) },
+    sectors: f.sectors,
+  });
   return {
     name: f.name.trim(),
     start_a_lat: parseFloat(f.startALat),
     start_a_lng: parseFloat(f.startALng),
     start_b_lat: parseFloat(f.startBLat),
     start_b_lng: parseFloat(f.startBLng),
-    sector_2_a_lat: parseOptional(f.s2aLat),
-    sector_2_a_lng: parseOptional(f.s2aLng),
-    sector_2_b_lat: parseOptional(f.s2bLat),
-    sector_2_b_lng: parseOptional(f.s2bLng),
-    sector_3_a_lat: parseOptional(f.s3aLat),
-    sector_3_a_lng: parseOptional(f.s3aLng),
-    sector_3_b_lat: parseOptional(f.s3bLat),
-    sector_3_b_lng: parseOptional(f.s3bLng),
+    sector_2_a_lat: sector2?.a.lat ?? null,
+    sector_2_a_lng: sector2?.a.lon ?? null,
+    sector_2_b_lat: sector2?.b.lat ?? null,
+    sector_2_b_lng: sector2?.b.lon ?? null,
+    sector_3_a_lat: sector3?.a.lat ?? null,
+    sector_3_a_lng: sector3?.a.lon ?? null,
+    sector_3_b_lat: sector3?.b.lat ?? null,
+    sector_3_b_lng: sector3?.b.lon ?? null,
+    sectors_data: sectorsToJson(f.sectors) ?? null,
   };
 }
 
@@ -267,24 +275,50 @@ export function CoursesTab() {
     setLayoutPoints([]); setHasExistingLayout(false);
   };
 
-  // VisualEditor bridge helpers
+  // Editor bridge helpers
+  const [selectedLine, setSelectedLine] = useState<SelectedLine>(null);
   const visualStartA: GpsPoint | null = form.startALat && form.startALng
     ? { lat: parseFloat(form.startALat), lon: parseFloat(form.startALng) } : null;
   const visualStartB: GpsPoint | null = form.startBLat && form.startBLng
     ? { lat: parseFloat(form.startBLat), lon: parseFloat(form.startBLng) } : null;
-  const visualSector2: SectorLine | undefined = form.s2aLat && form.s2aLng && form.s2bLat && form.s2bLng
-    ? { a: { lat: parseFloat(form.s2aLat), lon: parseFloat(form.s2aLng) }, b: { lat: parseFloat(form.s2bLat), lon: parseFloat(form.s2bLng) } } : undefined;
-  const visualSector3: SectorLine | undefined = form.s3aLat && form.s3aLng && form.s3bLat && form.s3bLng
-    ? { a: { lat: parseFloat(form.s3aLat), lon: parseFloat(form.s3aLng) }, b: { lat: parseFloat(form.s3bLat), lon: parseFloat(form.s3bLng) } } : undefined;
 
   const handleVisualStartFinish = useCallback((a: GpsPoint, b: GpsPoint) => {
     setForm(prev => ({ ...prev, startALat: String(a.lat), startALng: String(a.lon), startBLat: String(b.lat), startBLng: String(b.lon) }));
   }, []);
-  const handleVisualSector2 = useCallback((line: SectorLine) => {
-    setForm(prev => ({ ...prev, s2aLat: String(line.a.lat), s2aLng: String(line.a.lon), s2bLat: String(line.b.lat), s2bLng: String(line.b.lon) }));
+  const handleSectorLineChange = useCallback((index: number, line: SectorLine) => {
+    setForm(prev => ({ ...prev, sectors: prev.sectors.map((s, i) => (i === index ? { ...s, line } : s)) }));
   }, []);
-  const handleVisualSector3 = useCallback((line: SectorLine) => {
-    setForm(prev => ({ ...prev, s3aLat: String(line.a.lat), s3aLng: String(line.a.lon), s3bLat: String(line.b.lat), s3bLng: String(line.b.lon) }));
+  const handleAddSector = useCallback((insertIndex?: number) => {
+    setForm(prev => {
+      const course = { name: prev.name, startFinishA: { lat: 0, lon: 0 }, startFinishB: { lat: 0, lon: 0 }, sectors: prev.sectors };
+      if (isAtSectorLimit(course)) return prev;
+      const a = visualStartA, b = visualStartB;
+      const midLat = a && b ? (a.lat + b.lat) / 2 : 28.4123;
+      const midLon = a && b ? (a.lon + b.lon) / 2 : -81.3797;
+      const offset = 0.0003 * (prev.sectors.length + 1);
+      const line: SectorLine = { a: { lat: midLat + offset, lon: midLon - 0.00015 }, b: { lat: midLat + offset, lon: midLon + 0.00015 } };
+      const at = insertIndex === undefined ? prev.sectors.length : Math.max(0, Math.min(insertIndex, prev.sectors.length));
+      const sectors = [...prev.sectors.slice(0, at), { line, major: false }, ...prev.sectors.slice(at)];
+      setSelectedLine(at);
+      return { ...prev, sectors };
+    });
+  }, [visualStartA, visualStartB]);
+  const handleRemoveSector = useCallback((index: number) => {
+    setForm(prev => ({ ...prev, sectors: prev.sectors.filter((_, i) => i !== index) }));
+    setSelectedLine(sel => (typeof sel === 'number' ? null : sel));
+  }, []);
+  const handleToggleMajor = useCallback((index: number) => {
+    setForm(prev => ({ ...prev, sectors: prev.sectors.map((s, i) => (i === index ? { ...s, major: !s.major } : s)) }));
+  }, []);
+  const handleReorder = useCallback((from: number, to: number) => {
+    setForm(prev => {
+      if (from === to || from < 0 || to < 0 || from >= prev.sectors.length || to >= prev.sectors.length) return prev;
+      const sectors = [...prev.sectors];
+      const [moved] = sectors.splice(from, 1);
+      sectors.splice(to, 0, moved);
+      return { ...prev, sectors };
+    });
+    setSelectedLine(null);
   }, []);
 
   const handleLayoutChange = useCallback((points: Array<{ lat: number; lon: number }>) => {
@@ -303,14 +337,18 @@ export function CoursesTab() {
       </div>
 
       <Suspense fallback={null}>
-        <VisualEditor
+        <CourseSectorEditor
           startFinishA={visualStartA}
           startFinishB={visualStartB}
-          sector2={visualSector2}
-          sector3={visualSector3}
+          sectors={form.sectors}
+          selectedLine={selectedLine}
+          onSelectLine={setSelectedLine}
           onStartFinishChange={handleVisualStartFinish}
-          onSector2Change={handleVisualSector2}
-          onSector3Change={handleVisualSector3}
+          onSectorLineChange={handleSectorLineChange}
+          onAddSector={handleAddSector}
+          onRemoveSector={handleRemoveSector}
+          onToggleMajor={handleToggleMajor}
+          onReorder={handleReorder}
           isNewTrack={!editingId}
           showDrawTool={true}
           layoutPoints={layoutPoints}

--- a/src/components/admin/CoursesTab.tsx
+++ b/src/components/admin/CoursesTab.tsx
@@ -289,26 +289,24 @@ export function CoursesTab() {
     setForm(prev => ({ ...prev, sectors: prev.sectors.map((s, i) => (i === index ? { ...s, line } : s)) }));
   }, []);
   const handleAddSector = useCallback((insertIndex?: number, center?: GpsPoint) => {
-    setForm(prev => {
-      const course = { name: prev.name, startFinishA: { lat: 0, lon: 0 }, startFinishB: { lat: 0, lon: 0 }, sectors: prev.sectors };
-      if (isAtSectorLimit(course)) return prev;
-      let line: SectorLine;
-      if (center) {
-        // Drop the new line in the middle of the current map view.
-        line = centeredSectorLine(center);
-      } else {
-        const a = visualStartA, b = visualStartB;
-        const midLat = a && b ? (a.lat + b.lat) / 2 : 28.4123;
-        const midLon = a && b ? (a.lon + b.lon) / 2 : -81.3797;
-        const offset = 0.0003 * (prev.sectors.length + 1);
-        line = { a: { lat: midLat + offset, lon: midLon - 0.00015 }, b: { lat: midLat + offset, lon: midLon + 0.00015 } };
-      }
-      const at = insertIndex === undefined ? prev.sectors.length : Math.max(0, Math.min(insertIndex, prev.sectors.length));
-      const sectors = [...prev.sectors.slice(0, at), { line, major: false }, ...prev.sectors.slice(at)];
-      setSelectedLine(at);
-      return { ...prev, sectors };
-    });
-  }, [visualStartA, visualStartB]);
+    const course = { name: form.name, startFinishA: { lat: 0, lon: 0 }, startFinishB: { lat: 0, lon: 0 }, sectors: form.sectors };
+    if (isAtSectorLimit(course)) return;
+    let line: SectorLine;
+    if (center) {
+      // Drop the new line in the middle of the current map view.
+      line = centeredSectorLine(center);
+    } else {
+      const a = visualStartA, b = visualStartB;
+      const midLat = a && b ? (a.lat + b.lat) / 2 : 28.4123;
+      const midLon = a && b ? (a.lon + b.lon) / 2 : -81.3797;
+      const offset = 0.0003 * (form.sectors.length + 1);
+      line = { a: { lat: midLat + offset, lon: midLon - 0.00015 }, b: { lat: midLat + offset, lon: midLon + 0.00015 } };
+    }
+    const at = insertIndex === undefined ? form.sectors.length : Math.max(0, Math.min(insertIndex, form.sectors.length));
+    const sectors = [...form.sectors.slice(0, at), { line, major: false }, ...form.sectors.slice(at)];
+    setForm(prev => ({ ...prev, sectors }));
+    setSelectedLine(at);
+  }, [visualStartA, visualStartB, form.name, form.sectors]);
   const handleRemoveSector = useCallback((index: number) => {
     setForm(prev => ({ ...prev, sectors: prev.sectors.filter((_, i) => i !== index) }));
     setSelectedLine(sel => (typeof sel === 'number' ? null : sel));

--- a/src/components/admin/CoursesTab.tsx
+++ b/src/components/admin/CoursesTab.tsx
@@ -12,7 +12,7 @@ import type { SectorLine, CourseSector } from '@/types/racing';
 import type { GpsPoint } from '@/components/track-editor/VisualEditor';
 import type { SelectedLine } from '@/hooks/useTrackEditorForm';
 import {
-  normalizeCourseSectors, legacyMirror, isAtSectorLimit,
+  normalizeCourseSectors, legacyMirror, isAtSectorLimit, centeredSectorLine,
 } from '@/lib/courseSectors';
 import { sectorsFromJson, sectorsToJson, type SectorJson } from '@/lib/trackStorage';
 const CourseSectorEditor = lazy(() =>
@@ -288,15 +288,21 @@ export function CoursesTab() {
   const handleSectorLineChange = useCallback((index: number, line: SectorLine) => {
     setForm(prev => ({ ...prev, sectors: prev.sectors.map((s, i) => (i === index ? { ...s, line } : s)) }));
   }, []);
-  const handleAddSector = useCallback((insertIndex?: number) => {
+  const handleAddSector = useCallback((insertIndex?: number, center?: GpsPoint) => {
     setForm(prev => {
       const course = { name: prev.name, startFinishA: { lat: 0, lon: 0 }, startFinishB: { lat: 0, lon: 0 }, sectors: prev.sectors };
       if (isAtSectorLimit(course)) return prev;
-      const a = visualStartA, b = visualStartB;
-      const midLat = a && b ? (a.lat + b.lat) / 2 : 28.4123;
-      const midLon = a && b ? (a.lon + b.lon) / 2 : -81.3797;
-      const offset = 0.0003 * (prev.sectors.length + 1);
-      const line: SectorLine = { a: { lat: midLat + offset, lon: midLon - 0.00015 }, b: { lat: midLat + offset, lon: midLon + 0.00015 } };
+      let line: SectorLine;
+      if (center) {
+        // Drop the new line in the middle of the current map view.
+        line = centeredSectorLine(center);
+      } else {
+        const a = visualStartA, b = visualStartB;
+        const midLat = a && b ? (a.lat + b.lat) / 2 : 28.4123;
+        const midLon = a && b ? (a.lon + b.lon) / 2 : -81.3797;
+        const offset = 0.0003 * (prev.sectors.length + 1);
+        line = { a: { lat: midLat + offset, lon: midLon - 0.00015 }, b: { lat: midLat + offset, lon: midLon + 0.00015 } };
+      }
       const at = insertIndex === undefined ? prev.sectors.length : Math.max(0, Math.min(insertIndex, prev.sectors.length));
       const sectors = [...prev.sectors.slice(0, at), { line, major: false }, ...prev.sectors.slice(at)];
       setSelectedLine(at);

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -2,9 +2,10 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Plus } from 'lucide-react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { RangeSlider } from '@/components/RangeSlider';
+import { SectorCropSelect } from '@/components/SectorCropSelect';
 import { SingleSeriesChart } from './SingleSeriesChart';
 import { GGDiagram } from './GGDiagram';
-import { GpsSample, FieldMapping } from '@/types/racing';
+import { GpsSample, FieldMapping, Course, Lap } from '@/types/racing';
 import type { OverlayLine } from '@/lib/lapOverlays';
 import { calculatePace, calculateReferenceSpeed, calculateDistanceArray } from '@/lib/referenceUtils';
 import { computeBrakingGSeriesSG, gToBrakePercent } from '@/lib/brakingZones';
@@ -30,11 +31,15 @@ interface GraphPanelProps {
   formatRangeLabel: (idx: number) => string;
   sessionFileName: string | null;
   overlayLines?: OverlayLine[];
+  course?: Course | null;
+  laps?: Lap[];
+  selectedLapNumber?: number | null;
 }
 
 export function GraphPanel({
   samples, filteredSamples, referenceSamples, fieldMappings, onScrub,
   visibleRange, onRangeChange, minRange, formatRangeLabel, sessionFileName, overlayLines = [],
+  course = null, laps = [], selectedLapNumber = null,
 }: GraphPanelProps) {
   const { useKph, useMetricDistance, brakingZoneSettings } = useSettingsContext();
   const [activeGraphs, setActiveGraphs] = useState<string[]>([]);
@@ -294,17 +299,29 @@ export function GraphPanel({
         )}
       </div>
 
-      {/* Range slider - fixed at bottom */}
+      {/* Range slider (80%) + crop-to-sector select (20%) - fixed at bottom */}
       {filteredSamples.length > 0 && (
-        <div className="shrink-0 px-4 py-2 border-t border-border bg-muted/30">
-          <RangeSlider
-            min={0}
-            max={filteredSamples.length - 1}
-            value={visibleRange}
-            onChange={onRangeChange}
-            minRange={minRange}
-            formatLabel={formatRangeLabel}
-          />
+        <div className="shrink-0 flex items-center gap-3 px-4 py-2 border-t border-border bg-muted/30">
+          <div className="flex-[4] min-w-0">
+            <RangeSlider
+              min={0}
+              max={filteredSamples.length - 1}
+              value={visibleRange}
+              onChange={onRangeChange}
+              minRange={minRange}
+              formatLabel={formatRangeLabel}
+            />
+          </div>
+          <div className="flex-1 min-w-0">
+            <SectorCropSelect
+              course={course}
+              laps={laps}
+              selectedLapNumber={selectedLapNumber}
+              filteredLength={filteredSamples.length}
+              visibleRange={visibleRange}
+              onRangeChange={onRangeChange}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -186,6 +186,9 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
           formatRangeLabel={props.formatRangeLabel}
           sessionFileName={props.sessionFileName}
           overlayLines={props.overlayLines}
+          course={props.course}
+          laps={props.laps}
+          selectedLapNumber={props.selectedLapNumber}
         />
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/src/components/graphview/MiniMap.tsx
+++ b/src/components/graphview/MiniMap.tsx
@@ -7,7 +7,7 @@ import { buildHeatmapSegments } from '@/lib/speedHeatmap';
 import { detectBrakingZones, BrakingZoneConfig } from '@/lib/brakingZones';
 import { unionBounds, cropOverlayLinesToWindow, type OverlayLine } from '@/lib/lapOverlays';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
-import { updatePositionMarker } from '@/components/map/positionArrowMarker';
+import { updatePositionMarker, ARROW_MARKER_SIZE } from '@/components/map/positionArrowMarker';
 import { useSettingsContext } from '@/contexts/SettingsContext';
 import { usePlaybackContext } from '@/contexts/PlaybackContext';
 import { Moon, Satellite, Square, WifiOff, Zap, Octagon, Map as MapIcon, X, Crosshair, List, ChevronDown, ChevronUp } from 'lucide-react';
@@ -218,8 +218,12 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], course, bo
   }, [brakingZones, showBrakingZones, brakingZoneSettings?.color, brakingZoneSettings?.width]);
 
   // Arrow marker (created once, moved/rotated per tick) + follow-pan.
-  // Re-center only when the marker leaves the middle half of the view, and
-  // without animation — an animated panTo issued per 16 ms tick perpetually
+  // Re-center only once the arrow's edge actually touches the viewport border
+  // (margin = the marker's half-extent), not when it leaves some inner box — so
+  // the camera holds steady while the cursor crosses most of the map and snaps
+  // only at the true edge. Re-centering puts the arrow back at dead-center, so
+  // it has the full half-width to travel before the next snap (no oscillation).
+  // panTo is un-animated — an animated panTo issued per 16 ms tick perpetually
   // interrupts itself and burns the frame budget on aborted pan animations.
   useEffect(() => {
     const map = mapRef.current; if (!map) return;
@@ -228,7 +232,8 @@ export function MiniMap({ samples, allSamples, referenceSamples = [], course, bo
     if (!sample) return;
     const p = map.latLngToContainerPoint([sample.lat, sample.lon]);
     const size = map.getSize();
-    if (p.x < size.x * 0.25 || p.x > size.x * 0.75 || p.y < size.y * 0.25 || p.y > size.y * 0.75) {
+    const margin = ARROW_MARKER_SIZE / 2;
+    if (p.x < margin || p.x > size.x - margin || p.y < margin || p.y > size.y - margin) {
       map.panTo([sample.lat, sample.lon], { animate: false });
     }
   }, [currentIndex, samples]);

--- a/src/components/map/positionArrowMarker.ts
+++ b/src/components/map/positionArrowMarker.ts
@@ -7,10 +7,16 @@ interface PositionSample {
   heading?: number;
 }
 
+/** Side length (px) of the square position-arrow icon. Centered anchor, so its
+ *  half-extent (ARROW_MARKER_SIZE / 2) is how far the marker reaches from its
+ *  GPS point to its visual edge — used by follow-pan to snap when the arrow's
+ *  edge touches the viewport border. */
+export const ARROW_MARKER_SIZE = 20;
+
 /** SVG triangle/arrow marker pointing up; rotated per tick via CSS transform. */
 function createArrowIcon(): L.DivIcon {
   const svg = `
-    <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
+    <svg width="${ARROW_MARKER_SIZE}" height="${ARROW_MARKER_SIZE}" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
          style="transform-origin: center;">
       <polygon
         points="10,2 18,18 10,14 2,18"
@@ -23,8 +29,8 @@ function createArrowIcon(): L.DivIcon {
   return L.divIcon({
     html: svg,
     className: 'arrow-marker',
-    iconSize: [20, 20],
-    iconAnchor: [10, 10],
+    iconSize: [ARROW_MARKER_SIZE, ARROW_MARKER_SIZE],
+    iconAnchor: [ARROW_MARKER_SIZE / 2, ARROW_MARKER_SIZE / 2],
   });
 }
 

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -3,6 +3,7 @@ import { ResizableSplit } from "@/components/ResizableSplit";
 import { RaceLineView } from "@/components/RaceLineView";
 import { TelemetryChart } from "@/components/TelemetryChart";
 import { RangeSlider } from "@/components/RangeSlider";
+import { SectorCropSelect } from "@/components/SectorCropSelect";
 import { useSessionContext } from "@/contexts/SessionContext";
 
 interface RaceLineTabProps {
@@ -63,15 +64,27 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
             />
           </div>
           {s.filteredSamples.length > 0 && (
-            <div className="shrink-0 px-4 py-2 border-t border-border bg-muted/30">
-              <RangeSlider
-                min={0}
-                max={s.filteredSamples.length - 1}
-                value={s.visibleRange}
-                onChange={s.onRangeChange}
-                minRange={s.minRange}
-                formatLabel={s.formatRangeLabel}
-              />
+            <div className="shrink-0 flex items-center gap-3 px-4 py-2 border-t border-border bg-muted/30">
+              <div className="flex-[4] min-w-0">
+                <RangeSlider
+                  min={0}
+                  max={s.filteredSamples.length - 1}
+                  value={s.visibleRange}
+                  onChange={s.onRangeChange}
+                  minRange={s.minRange}
+                  formatLabel={s.formatRangeLabel}
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <SectorCropSelect
+                  course={s.course}
+                  laps={s.laps}
+                  selectedLapNumber={s.selectedLapNumber}
+                  filteredLength={s.filteredSamples.length}
+                  visibleRange={s.visibleRange}
+                  onRangeChange={s.onRangeChange}
+                />
+              </div>
             </div>
           )}
         </div>

--- a/src/components/tabs/ToolsTab.tsx
+++ b/src/components/tabs/ToolsTab.tsx
@@ -1,0 +1,39 @@
+import { memo } from "react";
+import { Wrench } from "lucide-react";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { useSettingsContext } from "@/contexts/SettingsContext";
+import { PluginPanelHost } from "@/plugins/PluginPanelHost";
+import { PanelSlot } from "@/plugins/panels";
+
+export const ToolsTab = memo(function ToolsTab() {
+  const { data, laps, selectedLapNumber, course, activeSnapshot, sessionSetup } = useSessionContext();
+  const { useKph } = useSettingsContext();
+
+  return (
+    <PluginPanelHost
+      slot={PanelSlot.Tools}
+      data={data}
+      laps={laps}
+      selectedLapNumber={selectedLapNumber}
+      course={course}
+      useKph={useKph}
+      sessionSetup={sessionSetup}
+      activeSnapshot={activeSnapshot}
+      fallback={<ToolsEmpty />}
+    />
+  );
+});
+
+function ToolsEmpty() {
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="max-w-sm space-y-5 text-center px-4">
+        <Wrench className="w-10 h-10 text-muted-foreground/40 mx-auto" />
+        <p className="text-sm font-medium text-foreground">Tools</p>
+        <p className="text-xs text-muted-foreground">
+          No tools plugin is loaded in this build.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/track-editor/AddCourseDialog.tsx
+++ b/src/components/track-editor/AddCourseDialog.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from 'react';
 import { Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -10,26 +9,30 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-const VisualEditor = lazy(() =>
-  import('./VisualEditor').then((m) => ({ default: m.VisualEditor })),
-);
-import type { CourseFormProps } from '@/hooks/useTrackEditorForm';
+import { CourseSectorEditor } from './CourseSectorEditor';
 import type { GpsPoint } from './VisualEditor';
-import type { SectorLine, Lap, GpsSample } from '@/types/racing';
+import type { SelectedLine } from '@/hooks/useTrackEditorForm';
+import type { CourseSector, SectorLine, Lap, GpsSample } from '@/types/racing';
 
 interface AddCourseDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  courseFormProps: Omit<CourseFormProps, 'onSubmit' | 'onCancel' | 'submitLabel' | 'showTrackName'>;
+  courseName: string;
+  onCourseNameChange: (value: string) => void;
+  canSubmit: boolean;
   onSubmit: () => void;
   onCancel: () => void;
   startFinishA: GpsPoint | null;
   startFinishB: GpsPoint | null;
-  sector2: SectorLine | undefined;
-  sector3: SectorLine | undefined;
+  sectors: CourseSector[];
+  selectedLine: SelectedLine;
+  onSelectLine: (id: SelectedLine) => void;
   onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
-  onSector2Change: (line: SectorLine) => void;
-  onSector3Change: (line: SectorLine) => void;
+  onSectorLineChange: (index: number, line: SectorLine) => void;
+  onAddSector: (insertIndex?: number) => void;
+  onRemoveSector: (index: number) => void;
+  onToggleMajor: (index: number) => void;
+  onReorder: (from: number, to: number) => void;
   initialCenter?: GpsPoint | null;
   /** Drawing support — draw the outline manually or generate it from a lap. */
   layoutPoints?: Array<{ lat: number; lon: number }>;
@@ -40,47 +43,50 @@ interface AddCourseDialogProps {
 
 export function AddCourseDialog({
   open, onOpenChange,
-  courseFormProps,
+  courseName, onCourseNameChange, canSubmit,
   onSubmit, onCancel,
-  startFinishA, startFinishB, sector2, sector3,
-  onStartFinishChange, onSector2Change, onSector3Change,
+  startFinishA, startFinishB, sectors, selectedLine, onSelectLine,
+  onStartFinishChange, onSectorLineChange,
+  onAddSector, onRemoveSector, onToggleMajor, onReorder,
   initialCenter,
   layoutPoints, onLayoutChange, laps, samples,
 }: AddCourseDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild><span className="sr-only">Add course</span></DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Add New Course</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          <Suspense fallback={null}>
-            <VisualEditor
-              startFinishA={startFinishA}
-              startFinishB={startFinishB}
-              sector2={sector2}
-              sector3={sector3}
-              initialCenter={initialCenter}
-              onStartFinishChange={onStartFinishChange}
-              onSector2Change={onSector2Change}
-              onSector3Change={onSector3Change}
-              isNewTrack={true}
-              showDrawTool={true}
-              layoutPoints={layoutPoints}
-              onLayoutChange={onLayoutChange}
-              laps={laps}
-              samples={samples}
-            />
-          </Suspense>
+          <CourseSectorEditor
+            startFinishA={startFinishA}
+            startFinishB={startFinishB}
+            sectors={sectors}
+            selectedLine={selectedLine}
+            onSelectLine={onSelectLine}
+            onStartFinishChange={onStartFinishChange}
+            onSectorLineChange={onSectorLineChange}
+            onAddSector={onAddSector}
+            onRemoveSector={onRemoveSector}
+            onToggleMajor={onToggleMajor}
+            onReorder={onReorder}
+            isNewTrack
+            initialCenter={initialCenter}
+            showDrawTool
+            layoutPoints={layoutPoints}
+            onLayoutChange={onLayoutChange}
+            laps={laps}
+            samples={samples}
+          />
           <div className="space-y-3">
             <div>
               <Label htmlFor="addCourseName">Course Name</Label>
-              <Input id="addCourseName" value={courseFormProps.courseName} onChange={(e) => courseFormProps.onCourseNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., Full Track" className="font-mono" />
+              <Input id="addCourseName" value={courseName} onChange={(e) => onCourseNameChange(e.target.value)} onKeyDownCapture={(e) => e.stopPropagation()} placeholder="e.g., Full Track" className="font-mono" />
             </div>
           </div>
           <div className="flex gap-2">
-            <Button onClick={onSubmit} className="flex-1" disabled={!courseFormProps.courseName.trim() || !courseFormProps.latA || !courseFormProps.lonA || !courseFormProps.latB || !courseFormProps.lonB}>
+            <Button onClick={onSubmit} className="flex-1" disabled={!canSubmit}>
               <Check className="w-4 h-4 mr-2" />
               Create Course
             </Button>

--- a/src/components/track-editor/AddCourseDialog.tsx
+++ b/src/components/track-editor/AddCourseDialog.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -9,10 +10,15 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { CourseSectorEditor } from './CourseSectorEditor';
 import type { GpsPoint } from './VisualEditor';
 import type { SelectedLine } from '@/hooks/useTrackEditorForm';
 import type { CourseSector, SectorLine, Lap, GpsSample } from '@/types/racing';
+
+// Lazy — CourseSectorEditor pulls in the Leaflet drawing map + the dnd-kit
+// sector list, neither of which belongs in the eager landing bundle.
+const CourseSectorEditor = lazy(() =>
+  import('./CourseSectorEditor').then((m) => ({ default: m.CourseSectorEditor })),
+);
 
 interface AddCourseDialogProps {
   open: boolean;
@@ -59,6 +65,7 @@ export function AddCourseDialog({
           <DialogTitle>Add New Course</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
+          <Suspense fallback={null}>
           <CourseSectorEditor
             startFinishA={startFinishA}
             startFinishB={startFinishB}
@@ -79,6 +86,7 @@ export function AddCourseDialog({
             laps={laps}
             samples={samples}
           />
+          </Suspense>
           <div className="space-y-3">
             <div>
               <Label htmlFor="addCourseName">Course Name</Label>

--- a/src/components/track-editor/AddCourseDialog.tsx
+++ b/src/components/track-editor/AddCourseDialog.tsx
@@ -29,7 +29,7 @@ interface AddCourseDialogProps {
   onSelectLine: (id: SelectedLine) => void;
   onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
   onSectorLineChange: (index: number, line: SectorLine) => void;
-  onAddSector: (insertIndex?: number) => void;
+  onAddSector: (insertIndex?: number, center?: GpsPoint) => void;
   onRemoveSector: (index: number) => void;
   onToggleMajor: (index: number) => void;
   onReorder: (from: number, to: number) => void;

--- a/src/components/track-editor/CourseSectorEditor.tsx
+++ b/src/components/track-editor/CourseSectorEditor.tsx
@@ -1,0 +1,84 @@
+import { lazy, Suspense, useMemo } from 'react';
+import { Course, CourseSector, SectorLine, Lap, GpsSample } from '@/types/racing';
+import { SectorListEditor } from './SectorListEditor';
+import type { GpsPoint, LineId } from './VisualEditor';
+import type { SelectedLine } from '@/hooks/useTrackEditorForm';
+
+const VisualEditor = lazy(() => import('./VisualEditor').then((m) => ({ default: m.VisualEditor })));
+
+interface CourseSectorEditorProps {
+  startFinishA: GpsPoint | null;
+  startFinishB: GpsPoint | null;
+  sectors: CourseSector[];
+  selectedLine: SelectedLine;
+  onSelectLine: (id: SelectedLine) => void;
+  onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
+  onSectorLineChange: (index: number, line: SectorLine) => void;
+  onAddSector: (insertIndex?: number) => void;
+  onRemoveSector: (index: number) => void;
+  onToggleMajor: (index: number) => void;
+  onReorder: (from: number, to: number) => void;
+  isNewTrack?: boolean;
+  initialCenter?: GpsPoint | null;
+  showDrawTool?: boolean;
+  showKnownDrawingToggle?: boolean;
+  layoutPoints?: Array<{ lat: number; lon: number }>;
+  onLayoutChange?: (points: Array<{ lat: number; lon: number }>) => void;
+  laps?: Lap[];
+  samples?: GpsSample[];
+}
+
+/**
+ * The shared course geometry editor: the satellite map (start/finish + sector
+ * line placement) paired with the reorderable sector list below it. The list is
+ * the control surface — selecting a row puts that line into drag-edit on the map.
+ */
+export function CourseSectorEditor({
+  startFinishA, startFinishB, sectors, selectedLine, onSelectLine,
+  onStartFinishChange, onSectorLineChange,
+  onAddSector, onRemoveSector, onToggleMajor, onReorder,
+  isNewTrack, initialCenter, showDrawTool, showKnownDrawingToggle,
+  layoutPoints, onLayoutChange, laps, samples,
+}: CourseSectorEditorProps) {
+  // Minimal course for the list's labels + validation (coords unused there).
+  const course = useMemo<Course>(() => ({
+    name: '',
+    startFinishA: startFinishA ?? { lat: 0, lon: 0 },
+    startFinishB: startFinishB ?? { lat: 0, lon: 0 },
+    sectors,
+  }), [startFinishA, startFinishB, sectors]);
+
+  return (
+    <div className="space-y-3">
+      <Suspense fallback={null}>
+        <VisualEditor
+          startFinishA={startFinishA}
+          startFinishB={startFinishB}
+          sectors={sectors}
+          selectedLine={selectedLine as LineId | null}
+          onSelectLine={(id) => onSelectLine(id)}
+          onStartFinishChange={onStartFinishChange}
+          onSectorLineChange={onSectorLineChange}
+          isNewTrack={isNewTrack}
+          initialCenter={initialCenter}
+          showDrawTool={showDrawTool}
+          showKnownDrawingToggle={showKnownDrawingToggle}
+          layoutPoints={layoutPoints}
+          onLayoutChange={onLayoutChange}
+          laps={laps}
+          samples={samples}
+        />
+      </Suspense>
+      <SectorListEditor
+        course={course}
+        sectors={sectors}
+        selectedLine={selectedLine}
+        onSelectLine={onSelectLine}
+        onAddSector={onAddSector}
+        onRemoveSector={onRemoveSector}
+        onToggleMajor={onToggleMajor}
+        onReorder={onReorder}
+      />
+    </div>
+  );
+}

--- a/src/components/track-editor/CourseSectorEditor.tsx
+++ b/src/components/track-editor/CourseSectorEditor.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo } from 'react';
+import { lazy, Suspense, useMemo, useRef } from 'react';
 import { Course, CourseSector, SectorLine, Lap, GpsSample } from '@/types/racing';
 import { SectorListEditor } from './SectorListEditor';
 import type { GpsPoint, LineId } from './VisualEditor';
@@ -14,7 +14,9 @@ interface CourseSectorEditorProps {
   onSelectLine: (id: SelectedLine) => void;
   onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
   onSectorLineChange: (index: number, line: SectorLine) => void;
-  onAddSector: (insertIndex?: number) => void;
+  /** Add a sector; `center` (when provided) is the live map view center so the
+   *  new line drops in the middle of what the user is looking at. */
+  onAddSector: (insertIndex?: number, center?: GpsPoint) => void;
   onRemoveSector: (index: number) => void;
   onToggleMajor: (index: number) => void;
   onReorder: (from: number, to: number) => void;
@@ -40,6 +42,10 @@ export function CourseSectorEditor({
   isNewTrack, initialCenter, showDrawTool, showKnownDrawingToggle,
   layoutPoints, onLayoutChange, laps, samples,
 }: CourseSectorEditorProps) {
+  // The map's current view center, kept fresh by VisualEditor — read on add so a
+  // new sector drops in the middle of the current view.
+  const viewCenterRef = useRef<GpsPoint | null>(null);
+
   // Minimal course for the list's labels + validation (coords unused there).
   const course = useMemo<Course>(() => ({
     name: '',
@@ -67,6 +73,7 @@ export function CourseSectorEditor({
           onLayoutChange={onLayoutChange}
           laps={laps}
           samples={samples}
+          viewCenterRef={viewCenterRef}
         />
       </Suspense>
       <SectorListEditor
@@ -74,7 +81,7 @@ export function CourseSectorEditor({
         sectors={sectors}
         selectedLine={selectedLine}
         onSelectLine={onSelectLine}
-        onAddSector={onAddSector}
+        onAddSector={(insertIndex) => onAddSector(insertIndex, viewCenterRef.current ?? undefined)}
         onRemoveSector={onRemoveSector}
         onToggleMajor={onToggleMajor}
         onReorder={onReorder}

--- a/src/components/track-editor/SectorListEditor.tsx
+++ b/src/components/track-editor/SectorListEditor.tsx
@@ -1,0 +1,193 @@
+import { useMemo } from 'react';
+import {
+  DndContext, closestCenter, PointerSensor, KeyboardSensor,
+  useSensor, useSensors, type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Flag, GripVertical, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
+import { CourseSector, Course } from '@/types/racing';
+import {
+  sectorLabels, validateCourseSectors, isAtSectorLimit, MAX_SECTOR_LINES,
+} from '@/lib/courseSectors';
+import type { SelectedLine } from '@/hooks/useTrackEditorForm';
+
+interface SectorListEditorProps {
+  /** The course being edited (start/finish + sectors) — for labels + validation. */
+  course: Course;
+  sectors: CourseSector[];
+  selectedLine: SelectedLine;
+  onSelectLine: (id: SelectedLine) => void;
+  onAddSector: (insertIndex?: number) => void;
+  onRemoveSector: (index: number) => void;
+  onToggleMajor: (index: number) => void;
+  onReorder: (from: number, to: number) => void;
+}
+
+function sortableId(index: number): string {
+  return `sector-${index}`;
+}
+function indexFromId(id: string): number {
+  return Number(id.replace('sector-', ''));
+}
+
+export function SectorListEditor({
+  course, sectors, selectedLine, onSelectLine, onAddSector, onRemoveSector, onToggleMajor, onReorder,
+}: SectorListEditorProps) {
+  const labels = useMemo(() => sectorLabels(course), [course]);
+  const validation = useMemo(() => validateCourseSectors(course), [course]);
+  const atLimit = isAtSectorLimit(course);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const ids = useMemo(() => sectors.map((_, i) => sortableId(i)), [sectors]);
+
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    onReorder(indexFromId(String(active.id)), indexFromId(String(over.id)));
+  };
+
+  // The "+" button after the start/finish header — only when SF has no leading
+  // sub-sectors of its own (i.e. the first sector is a major, or the list is empty).
+  const sfHasOwnAddSlot = sectors.length === 0 || sectors[0].major;
+
+  const addButton = (insertIndex: number, key: string) => (
+    <div key={key} className="pl-7">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+        disabled={atLimit}
+        onClick={() => onAddSector(insertIndex)}
+      >
+        <Plus className="w-3.5 h-3.5" />
+        Add sector
+      </Button>
+    </div>
+  );
+
+  return (
+    <div className="space-y-1.5">
+      {/* Start/finish — always sector 1, always major, fixed. */}
+      <button
+        type="button"
+        onClick={() => onSelectLine('sf')}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md border px-2 py-2 text-left transition-colors',
+          selectedLine === 'sf' ? 'border-primary bg-primary/10' : 'border-border bg-card hover:bg-accent/40',
+        )}
+      >
+        <span className="w-4" />
+        <Flag className="h-4 w-4 shrink-0" style={{ color: '#22c55e' }} />
+        <span className="flex-1 text-sm font-semibold">Start/finish (Sector {labels[0]})</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Major</span>
+      </button>
+
+      {sfHasOwnAddSlot && addButton(0, 'add-sf')}
+
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          {sectors.map((sec, i) => {
+            const isLastInGroup = i === sectors.length - 1 || sectors[i + 1].major;
+            return (
+              <div key={sortableId(i)} className="space-y-1.5">
+                <SectorRow
+                  index={i}
+                  label={labels[i + 1] ?? ''}
+                  sector={sec}
+                  selected={selectedLine === i}
+                  onSelect={() => onSelectLine(i)}
+                  onToggleMajor={() => onToggleMajor(i)}
+                  onRemove={() => onRemoveSector(i)}
+                />
+                {isLastInGroup && addButton(i + 1, `add-${i}`)}
+              </div>
+            );
+          })}
+        </SortableContext>
+      </DndContext>
+
+      {/* Validation / guidance note (kept off the line items per the spec). */}
+      {!validation.valid && validation.reason && (
+        <p className="pt-1 text-xs text-warning">{validation.reason}</p>
+      )}
+      {atLimit && (
+        <p className="pt-1 text-xs text-muted-foreground">
+          Sector limit reached ({MAX_SECTOR_LINES} including start/finish).
+        </p>
+      )}
+      {validation.valid && sectors.length === 0 && (
+        <p className="pt-1 text-xs text-muted-foreground">
+          Add a sector to start splitting the lap. Mark exactly three lines (start/finish + two)
+          as Major sectors to save.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface SectorRowProps {
+  index: number;
+  label: string;
+  sector: CourseSector;
+  selected: boolean;
+  onSelect: () => void;
+  onToggleMajor: () => void;
+  onRemove: () => void;
+}
+
+function SectorRow({ index, label, sector, selected, onSelect, onToggleMajor, onRemove }: SectorRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: sortableId(index) });
+  const style = { transform: CSS.Transform.toString(transform), transition };
+  const color = sector.major ? '#a855f7' : '#38bdf8';
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'flex items-center gap-2 rounded-md border px-2 py-1.5 transition-colors',
+        sector.major ? 'font-semibold' : 'ml-5',
+        selected ? 'border-primary bg-primary/10' : 'border-border bg-card hover:bg-accent/40',
+        isDragging && 'opacity-60 shadow-lg',
+      )}
+    >
+      <button
+        type="button"
+        className="cursor-grab touch-none text-muted-foreground active:cursor-grabbing"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <span className="h-3 w-3 shrink-0 rounded-full" style={{ background: color }} />
+      <button type="button" onClick={onSelect} className="flex-1 text-left text-sm">
+        Sector {label}
+      </button>
+      <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        Major
+        <Switch checked={sector.major} onCheckedChange={onToggleMajor} aria-label="Mark as major sector" />
+      </label>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+        aria-label="Delete sector"
+        onClick={onRemove}
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Flag, Timer, Search, Loader2, LocateFixed, Pencil, Undo2, Trash2, Route, Eye, EyeOff, CalendarClock } from 'lucide-react';
+import { Search, Loader2, LocateFixed, Pencil, Undo2, Trash2, Route, Eye, EyeOff, CalendarClock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { toast } from '@/hooks/use-toast';
-import { SectorLine } from '@/types/racing';
+import { SectorLine, CourseSector } from '@/types/racing';
 import type { Lap, GpsSample } from '@/types/racing';
+import { sectorLabels } from '@/lib/courseSectors';
 import { resamplePolyline, calculatePolylineLength, generatedDrawingSpacing } from '@/lib/trackUtils';
 import { useWaybackImagery } from '@/hooks/useWaybackImagery';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
@@ -17,16 +18,24 @@ export interface GpsPoint {
   lon: number;
 }
 
-export type VisualEditorTool = 'startFinish' | 'sector2' | 'sector3' | 'draw' | null;
+/** Identifies an editable timing line: 'sf' = start/finish, number = sectors[index]. */
+export type LineId = 'sf' | number;
+
+// Line colors: start/finish green, major sectors purple, sub-sectors sky-blue.
+const COLOR_SF = '#22c55e';
+const COLOR_MAJOR = '#a855f7';
+const COLOR_SUB = '#38bdf8';
 
 interface VisualEditorProps {
   startFinishA: GpsPoint | null;
   startFinishB: GpsPoint | null;
-  sector2: SectorLine | undefined;
-  sector3: SectorLine | undefined;
+  /** Ordered sector lines after start/finish. */
+  sectors: CourseSector[];
+  /** Currently-selected line (controlled by the sector list), or null. */
+  selectedLine: LineId | null;
+  onSelectLine?: (id: LineId | null) => void;
   onStartFinishChange?: (a: GpsPoint, b: GpsPoint) => void;
-  onSector2Change?: (line: SectorLine) => void;
-  onSector3Change?: (line: SectorLine) => void;
+  onSectorLineChange?: (index: number, line: SectorLine) => void;
   isNewTrack?: boolean;
   /** Initial map center from loaded GPS data */
   initialCenter?: GpsPoint | null;
@@ -45,8 +54,8 @@ interface VisualEditorProps {
 }
 
 interface VisualEditorToolbarProps {
-  activeTool: VisualEditorTool;
-  onToolChange: (tool: VisualEditorTool) => void;
+  drawMode: boolean;
+  onToggleDraw: () => void;
   showDrawTool?: boolean;
   drawPointCount?: number;
   canToggleKnownDrawing?: boolean;
@@ -61,26 +70,10 @@ interface VisualEditorToolbarProps {
   onGenerateFromSession?: () => void;
 }
 
-function VisualEditorToolbar({ activeTool, onToolChange, showDrawTool, drawPointCount = 0, canToggleKnownDrawing = false, showKnownDrawing = true, onToggleKnownDrawing, onUndoDraw, onClearDraw, laps, onGenerateFromLap, hasSamples = false, onGenerateFromSession }: VisualEditorToolbarProps) {
+function VisualEditorToolbar({ drawMode, onToggleDraw, showDrawTool, drawPointCount = 0, canToggleKnownDrawing = false, showKnownDrawing = true, onToggleKnownDrawing, onUndoDraw, onClearDraw, laps, onGenerateFromLap, hasSamples = false, onGenerateFromSession }: VisualEditorToolbarProps) {
   const [showLapPicker, setShowLapPicker] = useState(false);
   const hasLaps = !!laps && laps.length > 0;
   const canGenerate = hasLaps || hasSamples;
-
-  const handleStartFinish = () => {
-    onToolChange(activeTool === 'startFinish' ? null : 'startFinish');
-  };
-
-  const handleSector2 = () => {
-    onToolChange(activeTool === 'sector2' ? null : 'sector2');
-  };
-
-  const handleSector3 = () => {
-    onToolChange(activeTool === 'sector3' ? null : 'sector3');
-  };
-
-  const handleDraw = () => {
-    onToolChange(activeTool === 'draw' ? null : 'draw');
-  };
 
   const handleGenerateClick = () => {
     if (!canGenerate) return;
@@ -109,42 +102,18 @@ function VisualEditorToolbar({ activeTool, onToolChange, showDrawTool, drawPoint
     return mins > 0 ? `${mins}:${secs.padStart(6, '0')}` : `${secs}s`;
   };
 
+  // Nothing to show in the toolbar unless drawing tools are enabled.
+  if (!showDrawTool && !canToggleKnownDrawing) return null;
+
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 p-2 bg-card border border-border rounded-lg flex-wrap">
-        <Button
-          variant={activeTool === 'startFinish' ? 'default' : 'outline'}
-          size="sm"
-          className="h-8 gap-1.5 text-xs"
-          onClick={handleStartFinish}
-        >
-          <Flag className="w-3.5 h-3.5" />
-          Start/Finish
-        </Button>
-        <Button
-          variant={activeTool === 'sector2' ? 'default' : 'outline'}
-          size="sm"
-          className="h-8 gap-1.5 text-xs"
-          onClick={handleSector2}
-        >
-          <Timer className="w-3.5 h-3.5" />
-          Sector 2
-        </Button>
-        <Button
-          variant={activeTool === 'sector3' ? 'default' : 'outline'}
-          size="sm"
-          className="h-8 gap-1.5 text-xs"
-          onClick={handleSector3}
-        >
-          <Timer className="w-3.5 h-3.5" />
-          Sector 3
-        </Button>
         {showDrawTool && (
             <Button
-              variant={activeTool === 'draw' ? 'default' : 'outline'}
+              variant={drawMode ? 'default' : 'outline'}
               size="sm"
               className="h-8 gap-1.5 text-xs"
-              onClick={handleDraw}
+              onClick={onToggleDraw}
             >
               <Pencil className="w-3.5 h-3.5" />
               Draw
@@ -172,7 +141,7 @@ function VisualEditorToolbar({ activeTool, onToolChange, showDrawTool, drawPoint
             Toggle Known Drawing
           </Button>
         )}
-        {activeTool === 'draw' && drawPointCount > 0 && (
+        {drawMode && drawPointCount > 0 && (
           <>
             <Button
               variant="outline"
@@ -231,8 +200,8 @@ function VisualEditorToolbar({ activeTool, onToolChange, showDrawTool, drawPoint
 }
 
 export function VisualEditor({
-  startFinishA, startFinishB, sector2, sector3,
-  onStartFinishChange, onSector2Change, onSector3Change,
+  startFinishA, startFinishB, sectors, selectedLine, onSelectLine,
+  onStartFinishChange, onSectorLineChange,
   isNewTrack = false, initialCenter: initialCenterProp = null,
   showDrawTool = false, layoutPoints: layoutPointsProp, showKnownDrawingToggle = false, onLayoutChange,
   laps, samples,
@@ -240,13 +209,11 @@ export function VisualEditor({
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
-  const [activeTool, setActiveTool] = useState<VisualEditorTool>(null);
+  const [drawMode, setDrawMode] = useState(false);
 
   // Satellite imagery date (Esri Wayback). '' = current best-available mosaic.
   // Lets the user step the basemap back to a cloud-free capture while placing
-  // start/finish + sector lines — often the lines sit on a runway/paddock the
-  // current mosaic happens to have clouded over. Online-only + lazy, mirroring
-  // the race-line map's picker.
+  // start/finish + sector lines. Online-only + lazy, mirroring the race-line map.
   const isOnline = useOnlineStatus();
   const wayback = useWaybackImagery();
   const loadWayback = wayback.load;
@@ -259,14 +226,11 @@ export function VisualEditor({
     return wayback.releases.find((r) => r.date === satelliteDate)?.tileUrl ?? DEFAULT_SATELLITE_TILE_URL;
   }, [satelliteDate, wayback.releases]);
 
-  // Pending coordinates while dragging
-  const [pendingStartFinish, setPendingStartFinish] = useState<{ a: GpsPoint; b: GpsPoint } | null>(null);
-  const [pendingSector2, setPendingSector2] = useState<SectorLine | null>(null);
-  const [pendingSector3, setPendingSector3] = useState<SectorLine | null>(null);
+  // Pending coordinates for the line currently being dragged.
+  const [pendingLine, setPendingLine] = useState<{ id: LineId; coords: { a: GpsPoint; b: GpsPoint } } | null>(null);
 
   // Drawing state. The ref mirrors drawPoints so the draw handlers can read the
-  // latest points synchronously (across rapid clicks) and auto-save each change
-  // to the parent — there's no "Done" button anymore.
+  // latest points synchronously and auto-save each change to the parent.
   const [drawPoints, setDrawPoints] = useState<Array<{ lat: number; lon: number }>>(layoutPointsProp ?? []);
   const drawPointsRef = useRef<Array<{ lat: number; lon: number }>>(layoutPointsProp ?? []);
   const [showKnownDrawing, setShowKnownDrawing] = useState(true);
@@ -280,7 +244,6 @@ export function VisualEditor({
     drawPointsRef.current = incoming;
     setDrawPoints(incoming);
     if (incoming.length > 0) setShowKnownDrawing(true);
-    // Also update the polyline immediately if map exists
     if (mapRef.current && drawPolylineRef.current) {
       if (incoming.length > 0) {
         drawPolylineRef.current.setLatLngs(incoming.map(p => [p.lat, p.lon] as [number, number]));
@@ -296,35 +259,35 @@ export function VisualEditor({
   const activeLineRef = useRef<L.Polyline | null>(null);
   const staticLinesRef = useRef<L.Polyline[]>([]);
 
+  // Latest selection / callbacks for use inside Leaflet event handlers (refs so
+  // the marker-drag closures always see current values without re-binding).
+  const onSelectLineRef = useRef(onSelectLine);
+  onSelectLineRef.current = onSelectLine;
+
   // Location search state (only used when isNewTrack)
   const [searchQuery, setSearchQuery] = useState('');
   const [isLocating, setIsLocating] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
 
-  // Create a new ~30m horizontal line at the map center
-  const createLineAtMapCenter = useCallback((tool: VisualEditorTool): { a: GpsPoint; b: GpsPoint } | null => {
-    const map = mapRef.current;
-    if (!map || !tool) return null;
+  // Color for a given line id.
+  const colorFor = useCallback((id: LineId): string => {
+    if (id === 'sf') return COLOR_SF;
+    return sectors[id]?.major ? COLOR_MAJOR : COLOR_SUB;
+  }, [sectors]);
 
-    const center = map.getCenter();
-    // ~0.00015 degrees longitude ≈ ~15 meters at most latitudes
-    const offset = 0.00015;
-    const newLine = {
-      a: { lat: center.lat, lon: center.lng - offset },
-      b: { lat: center.lat, lon: center.lng + offset },
-    };
-
-    // Set pending state for the line
-    if (tool === 'startFinish') {
-      setPendingStartFinish(newLine);
-    } else if (tool === 'sector2') {
-      setPendingSector2(newLine);
-    } else if (tool === 'sector3') {
-      setPendingSector3(newLine);
+  // Current coordinates for a given line id (pending drag wins).
+  const coordsFor = useCallback((id: LineId): { a: GpsPoint; b: GpsPoint } | null => {
+    if (pendingLine && pendingLine.id === id) return pendingLine.coords;
+    if (id === 'sf') {
+      if (startFinishA && startFinishB) return { a: startFinishA, b: startFinishB };
+      return null;
     }
+    const sec = sectors[id];
+    return sec ? { a: sec.line.a, b: sec.line.b } : null;
+  }, [pendingLine, startFinishA, startFinishB, sectors]);
 
-    return newLine;
-  }, []);
+  // All line ids in course order (start/finish first).
+  const allLineIds = useMemo<LineId[]>(() => ['sf', ...sectors.map((_, i) => i)], [sectors]);
 
   // Location search using Nominatim
   const handleLocationSearch = useCallback(async () => {
@@ -334,11 +297,7 @@ export function VisualEditor({
     try {
       const response = await fetch(
         `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(searchQuery.trim())}`,
-        {
-          headers: {
-            'User-Agent': 'DovesDataViewer/1.0',
-          },
-        }
+        { headers: { 'User-Agent': 'DovesDataViewer/1.0' } }
       );
       const results = await response.json();
 
@@ -347,18 +306,10 @@ export function VisualEditor({
         mapRef.current.setView([parseFloat(lat), parseFloat(lon)], 17, { animate: true });
         setSearchQuery('');
       } else {
-        toast({
-          title: 'Location not found',
-          description: 'Try a different search term',
-          variant: 'destructive',
-        });
+        toast({ title: 'Location not found', description: 'Try a different search term', variant: 'destructive' });
       }
     } catch {
-      toast({
-        title: 'Search failed',
-        description: 'Could not search for location',
-        variant: 'destructive',
-      });
+      toast({ title: 'Search failed', description: 'Could not search for location', variant: 'destructive' });
     } finally {
       setIsSearching(false);
     }
@@ -395,21 +346,6 @@ export function VisualEditor({
     );
   }, []);
 
-  // Get line coordinates for a specific tool
-  const getLineCoords = (tool: VisualEditorTool): { a: GpsPoint; b: GpsPoint } | null => {
-    if (tool === 'startFinish') {
-      if (pendingStartFinish) return pendingStartFinish;
-      if (startFinishA && startFinishB) return { a: startFinishA, b: startFinishB };
-    } else if (tool === 'sector2') {
-      if (pendingSector2) return { a: pendingSector2.a, b: pendingSector2.b };
-      if (sector2) return { a: sector2.a, b: sector2.b };
-    } else if (tool === 'sector3') {
-      if (pendingSector3) return { a: pendingSector3.a, b: pendingSector3.b };
-      if (sector3) return { a: sector3.a, b: sector3.b };
-    }
-    return null;
-  };
-
   // Clear interactive editing layers
   const clearEditingLayers = () => {
     markersRef.current.forEach(m => m.remove());
@@ -420,84 +356,42 @@ export function VisualEditor({
     }
   };
 
-  // Draw static lines (non-active lines, dimmed)
-  const drawStaticLines = (map: L.Map, excludeTool: VisualEditorTool) => {
+  // Draw static lines (all lines except the selected one), dimmed + clickable.
+  const drawStaticLines = useCallback((map: L.Map, excludeId: LineId | null) => {
     staticLinesRef.current.forEach(l => l.remove());
     staticLinesRef.current = [];
 
-    const lines: { coords: GpsPoint[]; color: string; isActive: boolean }[] = [];
-
-    // Start/Finish line
-    if (startFinishA && startFinishB) {
-      const isActive = excludeTool === 'startFinish';
-      const coords = pendingStartFinish && isActive
-        ? [pendingStartFinish.a, pendingStartFinish.b]
-        : [startFinishA, startFinishB];
-      if (!isActive) {
-        lines.push({ coords, color: '#22c55e', isActive });
-      }
-    }
-
-    // Sector 2 line
-    if (sector2) {
-      const isActive = excludeTool === 'sector2';
-      const coords = pendingSector2 && isActive
-        ? [pendingSector2.a, pendingSector2.b]
-        : [sector2.a, sector2.b];
-      if (!isActive) {
-        lines.push({ coords, color: '#a855f7', isActive });
-      }
-    }
-
-    // Sector 3 line
-    if (sector3) {
-      const isActive = excludeTool === 'sector3';
-      const coords = pendingSector3 && isActive
-        ? [pendingSector3.a, pendingSector3.b]
-        : [sector3.a, sector3.b];
-      if (!isActive) {
-        lines.push({ coords, color: '#a855f7', isActive });
-      }
-    }
-
-    lines.forEach(({ coords, color }) => {
+    for (const id of allLineIds) {
+      if (id === excludeId) continue;
+      const coords = coordsFor(id);
+      if (!coords) continue;
       const polyline = L.polyline(
-        coords.map(p => [p.lat, p.lon] as [number, number]),
-        { color, weight: 2, opacity: 0.5 }
+        [[coords.a.lat, coords.a.lon], [coords.b.lat, coords.b.lon]],
+        { color: colorFor(id), weight: 2, opacity: 0.5 }
       ).addTo(map);
+      // Click a static line to select it for editing.
+      polyline.on('click', () => onSelectLineRef.current?.(id));
       staticLinesRef.current.push(polyline);
-    });
-  };
+    }
+  }, [allLineIds, coordsFor, colorFor]);
 
-  // Create draggable markers and active line for the selected tool
-  // If coords is provided, use it directly (avoids async state issues)
-  const createEditingLayersWithCoords = (map: L.Map, tool: VisualEditorTool, coords: { a: GpsPoint; b: GpsPoint }) => {
+  // Create draggable markers + active line for a line id, using known coords.
+  const createEditingLayersWithCoords = useCallback((map: L.Map, id: LineId, coords: { a: GpsPoint; b: GpsPoint }) => {
     clearEditingLayers();
-    if (!tool) return;
+    const color = colorFor(id);
 
-    const color = tool === 'startFinish' ? '#22c55e' : '#a855f7';
-
-    // Create the active polyline
     const polyline = L.polyline(
       [[coords.a.lat, coords.a.lon], [coords.b.lat, coords.b.lon]],
       { color, weight: 4, opacity: 1 }
     ).addTo(map);
     activeLineRef.current = polyline;
 
-    // Create draggable markers
     const createMarker = (point: GpsPoint, isPointA: boolean) => {
       const marker = L.marker([point.lat, point.lon], {
         draggable: true,
         icon: L.divIcon({
           className: 'custom-marker',
-          html: `<div style="
-            width: 16px;
-            height: 16px;
-            background: ${color};
-            border: 3px solid white;
-            border-radius: 50%;
-            box-shadow: 0 2px 6px rgba(0,0,0,0.5);
-          "></div>`,
+          html: `<div style="width:16px;height:16px;background:${color};border:3px solid white;border-radius:50%;box-shadow:0 2px 6px rgba(0,0,0,0.5);"></div>`,
           iconSize: [16, 16],
           iconAnchor: [8, 8],
         }),
@@ -505,8 +399,6 @@ export function VisualEditor({
 
       marker.on('drag', (e: L.LeafletEvent) => {
         const latlng = (e.target as L.Marker).getLatLng();
-
-        // Update polyline in real-time
         if (activeLineRef.current) {
           const otherMarker = markersRef.current.find(m => m !== marker);
           if (otherMarker) {
@@ -525,25 +417,15 @@ export function VisualEditor({
         const otherMarker = markersRef.current.find(m => m !== marker);
         const otherLatLng = otherMarker?.getLatLng();
         const otherPoint = otherLatLng ? { lat: otherLatLng.lat, lon: otherLatLng.lng } : null;
-
         if (!otherPoint) return;
 
         const newA = isPointA ? newPoint : otherPoint;
         const newB = isPointA ? otherPoint : newPoint;
 
-        // Save immediately on release — no separate "Done" step needed. The
-        // pending state keeps the active markers consistent; the parent
-        // callback commits the line straight into the form.
-        if (tool === 'startFinish') {
-          setPendingStartFinish({ a: newA, b: newB });
-          onStartFinishChange?.(newA, newB);
-        } else if (tool === 'sector2') {
-          setPendingSector2({ a: newA, b: newB });
-          onSector2Change?.({ a: newA, b: newB });
-        } else if (tool === 'sector3') {
-          setPendingSector3({ a: newA, b: newB });
-          onSector3Change?.({ a: newA, b: newB });
-        }
+        // Save immediately on release — no separate "Done" step.
+        setPendingLine({ id, coords: { a: newA, b: newB } });
+        if (id === 'sf') onStartFinishChange?.(newA, newB);
+        else onSectorLineChange?.(id, { a: newA, b: newB });
       });
 
       return marker;
@@ -552,15 +434,7 @@ export function VisualEditor({
     const markerA = createMarker(coords.a, true);
     const markerB = createMarker(coords.b, false);
     markersRef.current = [markerA, markerB];
-  };
-
-  // Convenience wrapper that reads coords from state
-  const createEditingLayers = (map: L.Map, tool: VisualEditorTool) => {
-    if (!tool) return;
-    const lineCoords = getLineCoords(tool);
-    if (!lineCoords) return;
-    createEditingLayersWithCoords(map, tool, lineCoords);
-  };
+  }, [colorFor, onStartFinishChange, onSectorLineChange]);
 
   // --- Draw mode helpers ---
   const updateDrawPolyline = useCallback((points: Array<{ lat: number; lon: number }>) => {
@@ -589,9 +463,7 @@ export function VisualEditor({
   const enterDrawMode = useCallback(() => {
     const map = mapRef.current;
     if (!map) return;
-
     clearDrawMode();
-
     const handler = (e: L.LeafletMouseEvent) => {
       const next = [...drawPointsRef.current, { lat: e.latlng.lat, lon: e.latlng.lng }];
       drawPointsRef.current = next;
@@ -612,7 +484,7 @@ export function VisualEditor({
       drawPolylineRef.current.remove();
       drawPolylineRef.current = null;
     }
-    onLayoutChange?.(next); // auto-save
+    onLayoutChange?.(next);
   }, [updateDrawPolyline, onLayoutChange]);
 
   const handleClearDraw = useCallback(() => {
@@ -622,14 +494,10 @@ export function VisualEditor({
       drawPolylineRef.current.remove();
       drawPolylineRef.current = null;
     }
-    onLayoutChange?.([]); // auto-save
+    onLayoutChange?.([]);
   }, [onLayoutChange]);
 
   // Resample a raw GPS trace to an even outline and commit it as the drawing.
-  // The raw points are the full logger rate (10–25 Hz) — far denser than an
-  // outline needs, and unevenly so (more points in slow corners). Arc-length
-  // resample to an even spacing scaled to track length for a clean, compact
-  // polyline (5 m for karting up to 10 m for long road courses).
   const applyGeneratedDrawing = useCallback((rawPoints: Array<{ lat: number; lon: number }>, label: string) => {
     const dbg = isDebugEnabled();
     if (rawPoints.length < 2) {
@@ -641,9 +509,6 @@ export function VisualEditor({
       const spacing = generatedDrawingSpacing(calculatePolylineLength(rawPoints));
       const points = resamplePolyline(rawPoints, spacing);
       if (dbg) console.info('[generate] resampled', { rawPoints: rawPoints.length, spacing, points: points.length, hasMap: !!mapRef.current, hasOnLayoutChange: !!onLayoutChange });
-      // A degenerate resample (e.g. a stationary trace) collapses to <2 points,
-      // which would neither render nor save — surface it instead of silently
-      // committing an empty outline.
       if (points.length < 2) {
         if (dbg) console.warn('[generate] aborted: resampled points < 2', { spacing, points: points.length });
         toast({ title: 'Could not generate outline', description: 'The GPS trace was too short or stationary.', variant: 'destructive' });
@@ -652,52 +517,31 @@ export function VisualEditor({
       drawPointsRef.current = points;
       setDrawPoints(points);
       updateDrawPolyline(points);
-      onLayoutChange?.(points); // auto-save
+      onLayoutChange?.(points);
       if (dbg) console.info('[generate] committed', { drawn: !!drawPolylineRef.current });
-      // Fit map to the generated drawing
       if (mapRef.current && points.length > 1) {
         const bounds = L.latLngBounds(points.map(p => [p.lat, p.lon] as [number, number]));
         mapRef.current.fitBounds(bounds, { padding: [40, 40], animate: true });
       }
       toast({ title: 'Drawing generated', description: `${label} (${points.length} points).` });
     } catch (err) {
-      // Surface failures in the on-screen debug console (?dbg=true) — on mobile
-      // there's no dev-tools console to catch an exception here.
       console.error('Drawing generation failed', err);
       toast({ title: 'Could not generate outline', description: 'See debug log (?dbg=true) for details.', variant: 'destructive' });
     }
   }, [updateDrawPolyline, onLayoutChange]);
 
   const handleGenerateFromLap = useCallback((lapNumber: number) => {
-    if (!samples || !laps) {
-      console.warn('Generate from lap: no samples/laps', { hasSamples: !!samples, hasLaps: !!laps });
-      return;
-    }
+    if (!samples || !laps) return;
     const lap = laps.find(l => l.lapNumber === lapNumber);
-    if (!lap) {
-      console.warn('Generate from lap: lap not found', lapNumber);
-      return;
-    }
+    if (!lap) return;
     const lapSamples = samples.slice(lap.startIndex, lap.endIndex + 1);
-    const rawPoints = lapSamples
-      .filter(s => s.lat !== 0 && s.lon !== 0)
-      .map(s => ({ lat: s.lat, lon: s.lon }));
-    if (isDebugEnabled()) console.info('[generate] from lap', { lapNumber, startIndex: lap.startIndex, endIndex: lap.endIndex, totalSamples: samples.length, lapSamples: lapSamples.length, rawPoints: rawPoints.length });
+    const rawPoints = lapSamples.filter(s => s.lat !== 0 && s.lon !== 0).map(s => ({ lat: s.lat, lon: s.lon }));
     applyGeneratedDrawing(rawPoints, `Generated from Lap ${lapNumber}`);
   }, [samples, laps, applyGeneratedDrawing]);
 
-  // Fresh-track fallback: when no laps were detected (a brand-new venue, or
-  // waypoint timing that never closed a lap) there's nothing to pick from — so
-  // generate the outline straight from the whole session's GPS trace instead.
   const handleGenerateFromSession = useCallback(() => {
-    if (!samples) {
-      console.warn('Generate from session: no samples');
-      return;
-    }
-    const rawPoints = samples
-      .filter(s => s.lat !== 0 && s.lon !== 0)
-      .map(s => ({ lat: s.lat, lon: s.lon }));
-    if (isDebugEnabled()) console.info('[generate] from session', { totalSamples: samples.length, rawPoints: rawPoints.length });
+    if (!samples) return;
+    const rawPoints = samples.filter(s => s.lat !== 0 && s.lon !== 0).map(s => ({ lat: s.lat, lon: s.lon }));
     applyGeneratedDrawing(rawPoints, 'Generated from the full session');
   }, [samples, applyGeneratedDrawing]);
 
@@ -709,9 +553,7 @@ export function VisualEditor({
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
-    // If we're in draw mode, the draw polyline is managed separately
-    if (activeTool === 'draw') return;
-    // Show static layout if we have points and it is enabled
+    if (drawMode) return;
     if (showKnownDrawing && drawPoints.length > 0) {
       if (!drawPolylineRef.current) {
         drawPolylineRef.current = L.polyline(
@@ -727,88 +569,41 @@ export function VisualEditor({
       drawPolylineRef.current.remove();
       drawPolylineRef.current = null;
     }
-  }, [activeTool, drawPoints, showKnownDrawing, mapReady]);
+  }, [drawMode, drawPoints, showKnownDrawing, mapReady]);
 
-  const handleToolChange = (tool: VisualEditorTool) => {
+  // Toggle draw mode on/off.
+  const handleToggleDraw = useCallback(() => {
     const map = mapRef.current;
-
-    // If leaving draw mode, clean up click handler
-    if (activeTool === 'draw' && tool !== 'draw') {
-      clearDrawMode();
-      // Make the polyline dashed/static
-      if (drawPolylineRef.current) {
-        drawPolylineRef.current.setStyle({ opacity: 0.8, dashArray: '10 6' });
+    setDrawMode((prev) => {
+      const next = !prev;
+      if (next) {
+        // Entering draw mode: drop any line editing, deselect, enter draw.
+        onSelectLineRef.current?.(null);
+        if (map) {
+          clearEditingLayers();
+          drawStaticLines(map, null);
+          enterDrawMode();
+          if (drawPolylineRef.current) drawPolylineRef.current.setStyle({ opacity: 0.9, dashArray: undefined });
+        }
+      } else {
+        clearDrawMode();
+        if (drawPolylineRef.current) drawPolylineRef.current.setStyle({ opacity: 0.8, dashArray: '10 6' });
       }
-    }
-
-    // If switching away from a line tool without clicking Done, discard pending changes
-    if (activeTool && activeTool !== tool && activeTool !== 'draw') {
-      if (activeTool === 'startFinish') setPendingStartFinish(null);
-      else if (activeTool === 'sector2') setPendingSector2(null);
-      else if (activeTool === 'sector3') setPendingSector3(null);
-    }
-
-    setActiveTool(tool);
-
-    if (map && tool === 'draw') {
-      clearEditingLayers();
-      drawStaticLines(map, tool);
-      enterDrawMode();
-      // Make draw polyline solid
-      if (drawPolylineRef.current) {
-        drawPolylineRef.current.setStyle({ opacity: 0.9, dashArray: undefined });
-      }
-    } else if (map && tool) {
-      let lineCoords = getLineCoords(tool);
-
-      // If no line exists, create one at map center
-      if (!lineCoords) {
-        lineCoords = createLineAtMapCenter(tool);
-      }
-
-      if (lineCoords) {
-        // Fit map bounds to the selected line with padding
-        const bounds = L.latLngBounds(
-          [lineCoords.a.lat, lineCoords.a.lon],
-          [lineCoords.b.lat, lineCoords.b.lon]
-        );
-        map.fitBounds(bounds, {
-          padding: [80, 80],
-          maxZoom: 20,
-          animate: true
-        });
-
-        // Create layers directly with the known coordinates (avoids async state issue)
-        drawStaticLines(map, tool);
-        createEditingLayersWithCoords(map, tool, lineCoords);
-      }
-    } else if (map && !tool) {
-      // No tool selected, clear editing layers and redraw all static
-      clearEditingLayers();
-      drawStaticLines(map, null);
-    }
-  };
+      return next;
+    });
+  }, [drawStaticLines, enterDrawMode, clearDrawMode]);
 
   // Initialize map
   useEffect(() => {
     if (!mapContainerRef.current || mapRef.current) return;
 
     const center = getInitialCenter();
-    const map = L.map(mapContainerRef.current, {
-      center,
-      zoom: 18,
-      zoomControl: true,
-    });
+    const map = L.map(mapContainerRef.current, { center, zoom: 18, zoomControl: true });
 
-    tileLayerRef.current = L.tileLayer(satelliteTileUrl, {
-      attribution: 'Tiles © Esri',
-      maxZoom: 21,
-    }).addTo(map);
+    tileLayerRef.current = L.tileLayer(satelliteTileUrl, { attribution: 'Tiles © Esri', maxZoom: 21 }).addTo(map);
 
     mapRef.current = map;
     setMapReady(true);
-
-    // Draw initial static lines
     drawStaticLines(map, null);
 
     return () => {
@@ -825,60 +620,81 @@ export function VisualEditor({
       }
       tileLayerRef.current = null;
     };
-    // Mount-only effect — Leaflet setup; helpers used here intentionally not in
-    // deps to avoid map reinit on every helper reference change. Slated for the
-    // Leaflet integration cleanup in the post-Index.tsx roadmap.
+    // Mount-only effect — Leaflet setup; helpers intentionally not in deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Swap the basemap tiles when the Wayback date changes (without re-init).
   useEffect(() => {
-    if (tileLayerRef.current) {
-      tileLayerRef.current.setUrl(satelliteTileUrl);
-    }
+    if (tileLayerRef.current) tileLayerRef.current.setUrl(satelliteTileUrl);
   }, [satelliteTileUrl]);
 
   // Handle resize
   useEffect(() => {
     if (!mapRef.current || !mapContainerRef.current) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      mapRef.current?.invalidateSize();
-    });
-
+    const resizeObserver = new ResizeObserver(() => mapRef.current?.invalidateSize());
     resizeObserver.observe(mapContainerRef.current);
     return () => resizeObserver.disconnect();
   }, []);
 
-  // Update layers when activeTool changes
+  // Render editing layers when the selection (or geometry) changes.
   useEffect(() => {
-    if (!mapRef.current) return;
+    const map = mapRef.current;
+    if (!map || drawMode) return;
 
-    if (activeTool) {
-      drawStaticLines(mapRef.current, activeTool);
-      createEditingLayers(mapRef.current, activeTool);
+    if (selectedLine !== null) {
+      const coords = coordsFor(selectedLine);
+      drawStaticLines(map, selectedLine);
+      if (coords) {
+        createEditingLayersWithCoords(map, selectedLine, coords);
+      } else {
+        clearEditingLayers();
+      }
     } else {
       clearEditingLayers();
-      drawStaticLines(mapRef.current, null);
+      drawStaticLines(map, null);
     }
-    // Helpers omitted intentionally — including them would re-fire the layer
-    // redraw on every parent render. Slated for the Leaflet refactor.
+    // pendingLine intentionally excluded — dragging updates the active polyline
+    // imperatively; re-running here would rebuild markers mid-drag.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTool, pendingStartFinish, pendingSector2, pendingSector3]);
+  }, [selectedLine, sectors, startFinishA, startFinishB, drawMode, mapReady, drawStaticLines, createEditingLayersWithCoords]);
+
+  // Fit the map to the selected line when selection changes.
+  const lastFitRef = useRef<LineId | null>(null);
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || drawMode || selectedLine === null) { lastFitRef.current = null; return; }
+    if (lastFitRef.current === selectedLine) return;
+    lastFitRef.current = selectedLine;
+    const coords = coordsFor(selectedLine);
+    if (!coords) return;
+    map.fitBounds(L.latLngBounds([coords.a.lat, coords.a.lon], [coords.b.lat, coords.b.lon]), {
+      padding: [80, 80], maxZoom: 20, animate: true,
+    });
+    // coordsFor intentionally omitted — fit only when the selected id changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedLine, drawMode]);
+
+  // Clear pending drag state once the committed geometry matches (selection change).
+  useEffect(() => {
+    setPendingLine(null);
+  }, [selectedLine]);
+
+  const labels = useMemo(() => sectorLabels({
+    name: '', startFinishA: { lat: 0, lon: 0 }, startFinishB: { lat: 0, lon: 0 }, sectors,
+  }), [sectors]);
 
   const getHelperText = (): string => {
-    if (!activeTool) return '';
-    if (activeTool === 'draw') {
+    if (drawMode) {
       return drawPoints.length === 0
         ? 'Click on the map to start drawing the track layout'
         : `${drawPoints.length} point${drawPoints.length !== 1 ? 's' : ''} — click to add more, Undo to remove last`;
     }
-    const lineCoords = getLineCoords(activeTool);
-    if (!lineCoords) {
-      return `No ${activeTool === 'startFinish' ? 'Start/Finish' : activeTool === 'sector2' ? 'Sector 2' : 'Sector 3'} line defined`;
-    }
-    const toolName = activeTool === 'startFinish' ? 'Start/Finish' : activeTool === 'sector2' ? 'Sector 2' : 'Sector 3';
-    return `Drag the markers to adjust the ${toolName} line — changes save automatically when you release`;
+    if (selectedLine === null) return '';
+    const name = selectedLine === 'sf' ? 'Start/Finish' : `Sector ${labels[selectedLine + 1] ?? ''}`;
+    const coords = coordsFor(selectedLine);
+    if (!coords) return `No ${name} line defined`;
+    return `Drag the markers to adjust the ${name} line — changes save automatically when you release`;
   };
 
   return (
@@ -896,38 +712,17 @@ export function VisualEditor({
             className="flex-1 h-8 text-sm"
             disabled={isSearching || !mapRef.current}
           />
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 px-3"
-            onClick={handleLocationSearch}
-            disabled={isSearching || !searchQuery.trim() || !mapRef.current}
-          >
-            {isSearching ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <Search className="w-4 h-4" />
-            )}
+          <Button variant="outline" size="sm" className="h-8 px-3" onClick={handleLocationSearch} disabled={isSearching || !searchQuery.trim() || !mapRef.current}>
+            {isSearching ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 px-3"
-            onClick={handleUseMyLocation}
-            disabled={isLocating || !mapRef.current}
-            title="Use my location"
-          >
-            {isLocating ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <LocateFixed className="w-4 h-4" />
-            )}
+          <Button variant="outline" size="sm" className="h-8 px-3" onClick={handleUseMyLocation} disabled={isLocating || !mapRef.current} title="Use my location">
+            {isLocating ? <Loader2 className="w-4 h-4 animate-spin" /> : <LocateFixed className="w-4 h-4" />}
           </Button>
         </div>
       )}
       <VisualEditorToolbar
-        activeTool={activeTool}
-        onToolChange={handleToolChange}
+        drawMode={drawMode}
+        onToggleDraw={handleToggleDraw}
         showDrawTool={showDrawTool}
         drawPointCount={drawPoints.length}
         canToggleKnownDrawing={showKnownDrawingToggle && drawPoints.length > 1}
@@ -969,7 +764,7 @@ export function VisualEditor({
         ref={mapContainerRef}
         className="w-full h-64 sm:h-80 md:h-96 rounded-lg border border-border overflow-hidden"
       />
-      {activeTool && (
+      {(drawMode || selectedLine !== null) && (
         <p className="text-xs text-muted-foreground text-center">
           {getHelperText()}
         </p>
@@ -977,4 +772,3 @@ export function VisualEditor({
     </div>
   );
 }
-

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, type MutableRefObject } from 'react';
 import { Search, Loader2, LocateFixed, Pencil, Undo2, Trash2, Route, Eye, EyeOff, CalendarClock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -51,6 +51,9 @@ interface VisualEditorProps {
   laps?: Lap[];
   /** GPS samples for generating drawing from lap data */
   samples?: GpsSample[];
+  /** Kept in sync with the map's current view center, so an added sector can be
+   *  dropped in the middle of what the user is looking at (without panning). */
+  viewCenterRef?: MutableRefObject<GpsPoint | null>;
 }
 
 interface VisualEditorToolbarProps {
@@ -204,7 +207,7 @@ export function VisualEditor({
   onStartFinishChange, onSectorLineChange,
   isNewTrack = false, initialCenter: initialCenterProp = null,
   showDrawTool = false, layoutPoints: layoutPointsProp, showKnownDrawingToggle = false, onLayoutChange,
-  laps, samples,
+  laps, samples, viewCenterRef,
 }: VisualEditorProps) {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -367,7 +370,7 @@ export function VisualEditor({
       if (!coords) continue;
       const polyline = L.polyline(
         [[coords.a.lat, coords.a.lon], [coords.b.lat, coords.b.lon]],
-        { color: colorFor(id), weight: 2, opacity: 0.5 }
+        { color: colorFor(id), weight: 6, opacity: 0.8 }
       ).addTo(map);
       // Click a static line to select it for editing.
       polyline.on('click', () => onSelectLineRef.current?.(id));
@@ -382,7 +385,7 @@ export function VisualEditor({
 
     const polyline = L.polyline(
       [[coords.a.lat, coords.a.lon], [coords.b.lat, coords.b.lon]],
-      { color, weight: 4, opacity: 1 }
+      { color, weight: 9, opacity: 1 }
     ).addTo(map);
     activeLineRef.current = polyline;
 
@@ -605,6 +608,17 @@ export function VisualEditor({
     mapRef.current = map;
     setMapReady(true);
     drawStaticLines(map, null);
+
+    // Track the live view center so an added sector drops where the user is
+    // looking. Seed it now and keep it current as the map is panned/zoomed.
+    if (viewCenterRef) {
+      const syncCenter = () => {
+        const c = map.getCenter();
+        viewCenterRef.current = { lat: c.lat, lon: c.lng };
+      };
+      syncCenter();
+      map.on('moveend', syncCenter);
+    }
 
     return () => {
       clearEditingLayers();

--- a/src/hooks/useTrackEditorForm.ts
+++ b/src/hooks/useTrackEditorForm.ts
@@ -89,23 +89,20 @@ export function useTrackEditorForm() {
    * start/finish. Either way the user then drags it into place.
    */
   const addSector = useCallback((insertIndex?: number, center?: GpsPoint) => {
-    setFormSectors((prev) => {
-      const course: Course = {
-        name: formCourseName,
-        startFinishA: { lat: parseFloat(formLatA), lon: parseFloat(formLonA) },
-        startFinishB: { lat: parseFloat(formLatB), lon: parseFloat(formLonB) },
-        sectors: prev,
-      };
-      if (isAtSectorLimit(course)) return prev;
-      const line = center
-        ? centeredSectorLine(center)
-        : defaultSectorLine(formLatA, formLonA, formLatB, formLonB, prev.length);
-      const at = insertIndex === undefined ? prev.length : Math.max(0, Math.min(insertIndex, prev.length));
-      const next = [...prev.slice(0, at), { line, major: false }, ...prev.slice(at)];
-      setSelectedLine(at);
-      return next;
-    });
-  }, [formCourseName, formLatA, formLonA, formLatB, formLonB]);
+    const course: Course = {
+      name: formCourseName,
+      startFinishA: { lat: parseFloat(formLatA), lon: parseFloat(formLonA) },
+      startFinishB: { lat: parseFloat(formLatB), lon: parseFloat(formLonB) },
+      sectors: formSectors,
+    };
+    if (isAtSectorLimit(course)) return;
+    const line = center
+      ? centeredSectorLine(center)
+      : defaultSectorLine(formLatA, formLonA, formLatB, formLonB, formSectors.length);
+    const at = insertIndex === undefined ? formSectors.length : Math.max(0, Math.min(insertIndex, formSectors.length));
+    setFormSectors([...formSectors.slice(0, at), { line, major: false }, ...formSectors.slice(at)]);
+    setSelectedLine(at);
+  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSectors]);
 
   const removeSector = useCallback((index: number) => {
     setFormSectors((prev) => prev.filter((_, i) => i !== index));

--- a/src/hooks/useTrackEditorForm.ts
+++ b/src/hooks/useTrackEditorForm.ts
@@ -1,34 +1,11 @@
 import { useState, useCallback } from 'react';
-import { Course, SectorLine } from '@/types/racing';
-import { parseSectorLine, deriveShortName, MAX_SHORT_NAME_LENGTH } from '@/lib/trackUtils';
+import { Course, CourseSector, SectorLine } from '@/types/racing';
+import { deriveShortName, MAX_SHORT_NAME_LENGTH } from '@/lib/trackUtils';
+import { normalizeCourseSectors, isAtSectorLimit } from '@/lib/courseSectors';
 import type { GpsPoint } from '@/components/track-editor/VisualEditor';
 
-export type SectorFormState = { aLat: string; aLon: string; bLat: string; bLon: string };
-
-export interface CourseFormProps {
-  trackName: string;
-  courseName: string;
-  latA: string;
-  lonA: string;
-  latB: string;
-  lonB: string;
-  sector2: SectorFormState;
-  sector3: SectorFormState;
-  trackShortName: string;
-  onTrackNameChange: (value: string) => void;
-  onTrackShortNameChange: (value: string) => void;
-  onCourseNameChange: (value: string) => void;
-  onLatAChange: (value: string) => void;
-  onLonAChange: (value: string) => void;
-  onLatBChange: (value: string) => void;
-  onLonBChange: (value: string) => void;
-  onSector2Change: (field: 'aLat' | 'aLon' | 'bLat' | 'bLon', value: string) => void;
-  onSector3Change: (field: 'aLat' | 'aLon' | 'bLat' | 'bLon', value: string) => void;
-  onSubmit: () => void;
-  onCancel: () => void;
-  submitLabel: string;
-  showTrackName?: boolean;
-}
+/** Selection in the visual editor: 'sf' = start/finish, a number = sectors[index]. */
+export type SelectedLine = 'sf' | number | null;
 
 export function useTrackEditorForm() {
   const [formTrackName, setFormTrackName] = useState('');
@@ -41,8 +18,10 @@ export function useTrackEditorForm() {
   const [formLonA, setFormLonA] = useState('');
   const [formLatB, setFormLatB] = useState('');
   const [formLonB, setFormLonB] = useState('');
-  const [formSector2, setFormSector2] = useState<SectorFormState>({ aLat: '', aLon: '', bLat: '', bLon: '' });
-  const [formSector3, setFormSector3] = useState<SectorFormState>({ aLat: '', aLon: '', bLat: '', bLon: '' });
+  // Ordered sector lines after start/finish (canonical model).
+  const [formSectors, setFormSectors] = useState<CourseSector[]>([]);
+  // Which line the map is currently editing (driven by the sector list).
+  const [selectedLine, setSelectedLine] = useState<SelectedLine>(null);
   // The drawn/generated course outline (polyline). Travels into the created
   // course and rides cloud-sync + community submission.
   const [formLayout, setFormLayout] = useState<Array<{ lat: number; lon: number }>>([]);
@@ -52,8 +31,8 @@ export function useTrackEditorForm() {
     setFormTrackName(''); setFormTrackShortName(''); setShortNameTouched(false);
     setFormCourseName('');
     setFormLatA(''); setFormLonA(''); setFormLatB(''); setFormLonB('');
-    setFormSector2({ aLat: '', aLon: '', bLat: '', bLon: '' });
-    setFormSector3({ aLat: '', aLon: '', bLat: '', bLon: '' });
+    setFormSectors([]);
+    setSelectedLine(null);
     setFormLayout([]);
   }, []);
 
@@ -81,14 +60,14 @@ export function useTrackEditorForm() {
       startFinishB: { lat: latB, lon: lonB },
       isUserDefined: true,
     };
-    const s2 = parseSectorLine(formSector2);
-    const s3 = parseSectorLine(formSector3);
-    if (s2 && s3) { course.sector2 = s2; course.sector3 = s3; }
+    if (formSectors.length > 0) course.sectors = formSectors;
     if (formLayout.length >= 2) course.layout = formLayout;
-    return course;
-  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSector2, formSector3, formLayout]);
+    // Normalize so the legacy mirror (sector2/sector3) is written alongside.
+    return normalizeCourseSectors(course);
+  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSectors, formLayout]);
 
   const openEditCourse = useCallback((trackName: string, course: Course) => {
+    const norm = normalizeCourseSectors(course);
     setEditingCourse({ trackName, courseName: course.name });
     setFormTrackName(trackName);
     setFormCourseName(course.name);
@@ -96,26 +75,56 @@ export function useTrackEditorForm() {
     setFormLonA(course.startFinishA.lon.toString());
     setFormLatB(course.startFinishB.lat.toString());
     setFormLonB(course.startFinishB.lon.toString());
-    setFormSector2(course.sector2 ? {
-      aLat: course.sector2.a.lat.toString(), aLon: course.sector2.a.lon.toString(),
-      bLat: course.sector2.b.lat.toString(), bLon: course.sector2.b.lon.toString()
-    } : { aLat: '', aLon: '', bLat: '', bLon: '' });
-    setFormSector3(course.sector3 ? {
-      aLat: course.sector3.a.lat.toString(), aLon: course.sector3.a.lon.toString(),
-      bLat: course.sector3.b.lat.toString(), bLon: course.sector3.b.lon.toString()
-    } : { aLat: '', aLon: '', bLat: '', bLon: '' });
+    setFormSectors(norm.sectors ?? []);
+    setSelectedLine(null);
     setFormLayout(course.layout ?? []);
   }, []);
 
-  const handleSector2Change = useCallback((field: 'aLat' | 'aLon' | 'bLat' | 'bLon', value: string) => {
-    setFormSector2(prev => ({ ...prev, [field]: value }));
+  // ── Sector-list operations ─────────────────────────────────────────────────
+
+  /**
+   * Add a new sub-sector at `insertIndex` (appended when omitted). Geometry
+   * defaults to a ~30m line near start/finish; the user drags it into place.
+   */
+  const addSector = useCallback((insertIndex?: number) => {
+    setFormSectors((prev) => {
+      const course: Course = {
+        name: formCourseName,
+        startFinishA: { lat: parseFloat(formLatA), lon: parseFloat(formLonA) },
+        startFinishB: { lat: parseFloat(formLatB), lon: parseFloat(formLonB) },
+        sectors: prev,
+      };
+      if (isAtSectorLimit(course)) return prev;
+      const line = defaultSectorLine(formLatA, formLonA, formLatB, formLonB, prev.length);
+      const at = insertIndex === undefined ? prev.length : Math.max(0, Math.min(insertIndex, prev.length));
+      const next = [...prev.slice(0, at), { line, major: false }, ...prev.slice(at)];
+      setSelectedLine(at);
+      return next;
+    });
+  }, [formCourseName, formLatA, formLonA, formLatB, formLonB]);
+
+  const removeSector = useCallback((index: number) => {
+    setFormSectors((prev) => prev.filter((_, i) => i !== index));
+    setSelectedLine((sel) => (typeof sel === 'number' ? null : sel));
   }, []);
 
-  const handleSector3Change = useCallback((field: 'aLat' | 'aLon' | 'bLat' | 'bLon', value: string) => {
-    setFormSector3(prev => ({ ...prev, [field]: value }));
+  const toggleSectorMajor = useCallback((index: number) => {
+    setFormSectors((prev) => prev.map((s, i) => (i === index ? { ...s, major: !s.major } : s)));
   }, []);
 
-  // Memoized VisualEditor callbacks (eliminates 5x duplication)
+  /** Move a sector from one position to another (drag-reorder). */
+  const reorderSectors = useCallback((from: number, to: number) => {
+    setFormSectors((prev) => {
+      if (from === to || from < 0 || to < 0 || from >= prev.length || to >= prev.length) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return next;
+    });
+    setSelectedLine(null);
+  }, []);
+
+  // ── VisualEditor callbacks ──────────────────────────────────────────────────
   const handleVisualStartFinishChange = useCallback((a: GpsPoint, b: GpsPoint) => {
     setFormLatA(a.lat.toString());
     setFormLonA(a.lon.toString());
@@ -123,22 +132,8 @@ export function useTrackEditorForm() {
     setFormLonB(b.lon.toString());
   }, []);
 
-  const handleVisualSector2Change = useCallback((line: SectorLine) => {
-    setFormSector2({
-      aLat: line.a.lat.toString(),
-      aLon: line.a.lon.toString(),
-      bLat: line.b.lat.toString(),
-      bLon: line.b.lon.toString(),
-    });
-  }, []);
-
-  const handleVisualSector3Change = useCallback((line: SectorLine) => {
-    setFormSector3({
-      aLat: line.a.lat.toString(),
-      aLon: line.a.lon.toString(),
-      bLat: line.b.lat.toString(),
-      bLon: line.b.lon.toString(),
-    });
+  const handleVisualSectorLineChange = useCallback((index: number, line: SectorLine) => {
+    setFormSectors((prev) => prev.map((s, i) => (i === index ? { ...s, line } : s)));
   }, []);
 
   const handleVisualLayoutChange = useCallback((points: Array<{ lat: number; lon: number }>) => {
@@ -148,41 +143,53 @@ export function useTrackEditorForm() {
   // Parsed form values for VisualEditor props
   const visualEditorStartFinishA = formLatA && formLonA ? { lat: parseFloat(formLatA), lon: parseFloat(formLonA) } : null;
   const visualEditorStartFinishB = formLatB && formLonB ? { lat: parseFloat(formLatB), lon: parseFloat(formLonB) } : null;
-  const visualEditorSector2 = parseSectorLine(formSector2);
-  const visualEditorSector3 = parseSectorLine(formSector3);
-
-  const courseFormProps = {
-    trackName: formTrackName, trackShortName: formTrackShortName, courseName: formCourseName,
-    latA: formLatA, lonA: formLonA, latB: formLatB, lonB: formLonB,
-    sector2: formSector2, sector3: formSector3,
-    onTrackNameChange: handleTrackNameChange, onTrackShortNameChange: handleTrackShortNameChange,
-    onCourseNameChange: setFormCourseName,
-    onLatAChange: setFormLatA, onLonAChange: setFormLonA,
-    onLatBChange: setFormLatB, onLonBChange: setFormLonB,
-    onSector2Change: handleSector2Change, onSector3Change: handleSector3Change,
-  };
 
   return {
     formTrackName, setFormTrackName,
     formTrackShortName,
+    handleTrackNameChange,
+    handleTrackShortNameChange,
     formCourseName, setFormCourseName,
     formLatA, formLonA, formLatB, formLonB,
-    formSector2, formSector3,
+    formSectors,
+    selectedLine, setSelectedLine,
     formLayout,
     editingCourse, setEditingCourse,
     resetForm,
     buildCourse,
     openEditCourse,
-    handleSector2Change,
-    handleSector3Change,
+    addSector,
+    removeSector,
+    toggleSectorMajor,
+    reorderSectors,
     handleVisualStartFinishChange,
-    handleVisualSector2Change,
-    handleVisualSector3Change,
+    handleVisualSectorLineChange,
     handleVisualLayoutChange,
     visualEditorStartFinishA,
     visualEditorStartFinishB,
-    visualEditorSector2,
-    visualEditorSector3,
-    courseFormProps,
+  };
+}
+
+/**
+ * Default geometry for a freshly-added sector: a ~30m horizontal line offset
+ * north of the start/finish midpoint, fanned out per sector so successive adds
+ * don't stack exactly. The user then drags it onto the track.
+ */
+function defaultSectorLine(
+  latA: string, lonA: string, latB: string, lonB: string, ordinal: number,
+): SectorLine {
+  const aLat = parseFloat(latA); const aLon = parseFloat(lonA);
+  const bLat = parseFloat(latB); const bLon = parseFloat(lonB);
+  if ([aLat, aLon, bLat, bLon].some((n) => isNaN(n))) {
+    // No start/finish yet — fall back to a default near Orlando.
+    return { a: { lat: 28.4123, lon: -81.3797 }, b: { lat: 28.4123, lon: -81.3794 } };
+  }
+  const midLat = (aLat + bLat) / 2;
+  const midLon = (aLon + bLon) / 2;
+  const offset = 0.0003 * (ordinal + 1); // ~33m steps north
+  const half = 0.00015; // ~15m half-length
+  return {
+    a: { lat: midLat + offset, lon: midLon - half },
+    b: { lat: midLat + offset, lon: midLon + half },
   };
 }

--- a/src/hooks/useTrackEditorForm.ts
+++ b/src/hooks/useTrackEditorForm.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Course, CourseSector, SectorLine } from '@/types/racing';
 import { deriveShortName, MAX_SHORT_NAME_LENGTH } from '@/lib/trackUtils';
-import { normalizeCourseSectors, isAtSectorLimit } from '@/lib/courseSectors';
+import { normalizeCourseSectors, isAtSectorLimit, centeredSectorLine } from '@/lib/courseSectors';
 import type { GpsPoint } from '@/components/track-editor/VisualEditor';
 
 /** Selection in the visual editor: 'sf' = start/finish, a number = sectors[index]. */
@@ -83,10 +83,12 @@ export function useTrackEditorForm() {
   // ── Sector-list operations ─────────────────────────────────────────────────
 
   /**
-   * Add a new sub-sector at `insertIndex` (appended when omitted). Geometry
-   * defaults to a ~30m line near start/finish; the user drags it into place.
+   * Add a new sub-sector at `insertIndex` (appended when omitted). When `center`
+   * (the live map view center) is given the line drops there — in the middle of
+   * what the user is looking at; otherwise it falls back to a line near
+   * start/finish. Either way the user then drags it into place.
    */
-  const addSector = useCallback((insertIndex?: number) => {
+  const addSector = useCallback((insertIndex?: number, center?: GpsPoint) => {
     setFormSectors((prev) => {
       const course: Course = {
         name: formCourseName,
@@ -95,7 +97,9 @@ export function useTrackEditorForm() {
         sectors: prev,
       };
       if (isAtSectorLimit(course)) return prev;
-      const line = defaultSectorLine(formLatA, formLonA, formLatB, formLonB, prev.length);
+      const line = center
+        ? centeredSectorLine(center)
+        : defaultSectorLine(formLatA, formLonA, formLatB, formLonB, prev.length);
       const at = insertIndex === undefined ? prev.length : Math.max(0, Math.min(insertIndex, prev.length));
       const next = [...prev.slice(0, at), { line, major: false }, ...prev.slice(at)];
       setSelectedLine(at);

--- a/src/lib/courseSectors.test.ts
+++ b/src/lib/courseSectors.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { Course, SectorLine } from '@/types/racing';
+import {
+  normalizeCourseSectors, majorSectorLines, legacyMirror, sectorLabels,
+  validateCourseSectors, isAtSectorLimit, rollupMajorSectors,
+  MAX_SECTOR_LINES, MAX_MAJOR_SECTORS,
+} from './courseSectors';
+
+const line = (n: number): SectorLine => ({ a: { lat: n, lon: n }, b: { lat: n + 0.001, lon: n + 0.001 } });
+
+function baseCourse(partial: Partial<Course> = {}): Course {
+  return {
+    name: 'Test',
+    startFinishA: { lat: 0, lon: 0 },
+    startFinishB: { lat: 0, lon: 0.001 },
+    ...partial,
+  };
+}
+
+describe('normalizeCourseSectors', () => {
+  it('migrates legacy sector2/sector3 into two major sectors', () => {
+    const c = normalizeCourseSectors(baseCourse({ sector2: line(1), sector3: line(2) }));
+    expect(c.sectors).toHaveLength(2);
+    expect(c.sectors!.every((s) => s.major)).toBe(true);
+    expect(c.sectors![0].line).toEqual(line(1));
+    // Legacy mirror is kept in agreement.
+    expect(c.sector2).toEqual(line(1));
+    expect(c.sector3).toEqual(line(2));
+  });
+
+  it('leaves a course with no sectors untouched', () => {
+    const c = normalizeCourseSectors(baseCourse());
+    expect(c.sectors).toBeUndefined();
+    expect(c.sector2).toBeUndefined();
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeCourseSectors(baseCourse({ sector2: line(1), sector3: line(2) }));
+    const twice = normalizeCourseSectors(once);
+    expect(twice.sectors).toEqual(once.sectors);
+    expect(twice.sector2).toEqual(once.sector2);
+  });
+
+  it('re-derives the legacy mirror from the first two majors', () => {
+    const c = normalizeCourseSectors(baseCourse({
+      sectors: [
+        { line: line(1), major: false },
+        { line: line(2), major: true },
+        { line: line(3), major: false },
+        { line: line(4), major: true },
+      ],
+    }));
+    const { sector2, sector3 } = legacyMirror(c);
+    expect(sector2).toEqual(line(2));
+    expect(sector3).toEqual(line(4));
+  });
+});
+
+describe('majorSectorLines', () => {
+  it('returns only the major lines in order', () => {
+    const c = baseCourse({
+      sectors: [
+        { line: line(1), major: false },
+        { line: line(2), major: true },
+        { line: line(3), major: true },
+      ],
+    });
+    expect(majorSectorLines(c)).toEqual([line(2), line(3)]);
+  });
+});
+
+describe('sectorLabels', () => {
+  it('numbers majors as groups and sub-sectors as group.n', () => {
+    const c = baseCourse({
+      sectors: [
+        { line: line(1), major: false }, // 1.1
+        { line: line(2), major: true },  // 2
+        { line: line(3), major: false }, // 2.1
+        { line: line(4), major: false }, // 2.2
+        { line: line(5), major: true },  // 3
+      ],
+    });
+    expect(sectorLabels(c)).toEqual(['1', '1.1', '2', '2.1', '2.2', '3']);
+  });
+
+  it('labels a bare course as just start/finish', () => {
+    expect(sectorLabels(baseCourse())).toEqual(['1']);
+  });
+});
+
+describe('validateCourseSectors', () => {
+  it('accepts a course with no extra sectors', () => {
+    expect(validateCourseSectors(baseCourse()).valid).toBe(true);
+  });
+
+  it('accepts exactly three majors (start/finish + two)', () => {
+    const c = baseCourse({ sectors: [{ line: line(1), major: true }, { line: line(2), major: true }] });
+    expect(validateCourseSectors(c).valid).toBe(true);
+  });
+
+  it('rejects sectors with the wrong number of majors', () => {
+    const c = baseCourse({ sectors: [{ line: line(1), major: false }, { line: line(2), major: true }] });
+    const v = validateCourseSectors(c);
+    expect(v.valid).toBe(false);
+    expect(v.reason).toMatch(/three traditional sectors/i);
+  });
+
+  it('rejects exceeding the timing-line cap', () => {
+    const many = Array.from({ length: MAX_SECTOR_LINES }, (_, i) => ({ line: line(i), major: i < MAX_MAJOR_SECTORS - 1 }));
+    const c = baseCourse({ sectors: many });
+    expect(validateCourseSectors(c).valid).toBe(false);
+  });
+});
+
+describe('isAtSectorLimit', () => {
+  it('is true once the course holds MAX_SECTOR_LINES - 1 sectors', () => {
+    const sectors = Array.from({ length: MAX_SECTOR_LINES - 1 }, (_, i) => ({ line: line(i), major: false }));
+    expect(isAtSectorLimit(baseCourse({ sectors }))).toBe(true);
+    expect(isAtSectorLimit(baseCourse({ sectors: sectors.slice(0, -1) }))).toBe(false);
+  });
+});
+
+describe('rollupMajorSectors', () => {
+  // Course: S/F, sub(1.1), major(2), sub(2.1), major(3) → 5 timing lines.
+  const course = baseCourse({
+    sectors: [
+      { line: line(1), major: false },
+      { line: line(2), major: true },
+      { line: line(3), major: false },
+      { line: line(4), major: true },
+    ],
+  });
+
+  it('sums fine-grained segments into the three major sectors', () => {
+    // segments: [S/F→1.1, 1.1→2, 2→2.1, 2.1→3, 3→S/F]
+    const times = [1000, 2000, 3000, 4000, 5000];
+    const roll = rollupMajorSectors(course, times)!;
+    expect(roll.s1).toBe(3000);  // 1000 + 2000 (S/F group up to major 2)
+    expect(roll.s2).toBe(7000);  // 3000 + 4000 (major 2 group up to major 3)
+    expect(roll.s3).toBe(5000);  // 5000 (major 3 group to S/F)
+  });
+
+  it('marks a major sector undefined when one of its segments is missing', () => {
+    const times = [1000, undefined, 3000, 4000, 5000];
+    const roll = rollupMajorSectors(course, times)!;
+    expect(roll.s1).toBeUndefined();
+    expect(roll.s2).toBe(7000);
+    expect(roll.s3).toBe(5000);
+  });
+
+  it('returns undefined when there are fewer than three majors', () => {
+    const c = baseCourse({ sectors: [{ line: line(1), major: true }] });
+    expect(rollupMajorSectors(c, [1000, 2000])).toBeUndefined();
+  });
+});

--- a/src/lib/courseSectors.test.ts
+++ b/src/lib/courseSectors.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { Course, SectorLine } from '@/types/racing';
 import {
   normalizeCourseSectors, majorSectorLines, legacyMirror, sectorLabels,
-  validateCourseSectors, isAtSectorLimit, rollupMajorSectors,
-  MAX_SECTOR_LINES, MAX_MAJOR_SECTORS,
+  validateCourseSectors, isAtSectorLimit, rollupMajorSectors, centeredSectorLine,
+  MAX_SECTOR_LINES, MAX_MAJOR_SECTORS, DEFAULT_SECTOR_HALF_LENGTH_DEG,
 } from './courseSectors';
 
 const line = (n: number): SectorLine => ({ a: { lat: n, lon: n }, b: { lat: n + 0.001, lon: n + 0.001 } });
@@ -117,6 +117,24 @@ describe('isAtSectorLimit', () => {
     const sectors = Array.from({ length: MAX_SECTOR_LINES - 1 }, (_, i) => ({ line: line(i), major: false }));
     expect(isAtSectorLimit(baseCourse({ sectors }))).toBe(true);
     expect(isAtSectorLimit(baseCourse({ sectors: sectors.slice(0, -1) }))).toBe(false);
+  });
+});
+
+describe('centeredSectorLine', () => {
+  it('builds a horizontal line centered on the point with the default span', () => {
+    const l = centeredSectorLine({ lat: 28.41, lon: -81.38 });
+    // Same latitude on both ends (horizontal), symmetric about the center lon.
+    expect(l.a.lat).toBe(28.41);
+    expect(l.b.lat).toBe(28.41);
+    expect(l.a.lon).toBeCloseTo(-81.38 - DEFAULT_SECTOR_HALF_LENGTH_DEG, 12);
+    expect(l.b.lon).toBeCloseTo(-81.38 + DEFAULT_SECTOR_HALF_LENGTH_DEG, 12);
+    expect((l.a.lon + l.b.lon) / 2).toBeCloseTo(-81.38, 12);
+  });
+
+  it('honors a custom half-length', () => {
+    const l = centeredSectorLine({ lat: 1, lon: 2 }, 0.001);
+    expect(l.a.lon).toBeCloseTo(1.999, 12);
+    expect(l.b.lon).toBeCloseTo(2.001, 12);
   });
 });
 

--- a/src/lib/courseSectors.ts
+++ b/src/lib/courseSectors.ts
@@ -1,0 +1,148 @@
+import { Course, CourseSector, SectorLine, SectorTimes } from '@/types/racing';
+
+/**
+ * Sector model — the single source of truth for the "unlimited sectors" feature.
+ *
+ * A course's timing lines, in driving order, are: the start/finish line (always
+ * sector 1, always "major") followed by `course.sectors` (zero or more lines).
+ * Exactly three of them are flagged "major" (start/finish + two) — these are the
+ * only lines exported to the BLE logger. Everything else (numbering, validation,
+ * legacy migration, rollup to the classic S1/S2/S3) lives here so the rest of
+ * the app never reasons about sector geometry directly.
+ */
+
+/** Hidden cap on total timing lines (start/finish + sub-sectors). Raise later. */
+export const MAX_SECTOR_LINES = 25;
+/** Hard cap on "major" sectors (start/finish + this-many-minus-one flagged). */
+export const MAX_MAJOR_SECTORS = 3;
+/** Max entries allowed in `course.sectors` (the array excludes start/finish). */
+export const MAX_COURSE_SECTORS = MAX_SECTOR_LINES - 1;
+
+/**
+ * Migrate any course into the canonical `sectors` array and keep the legacy
+ * `sector2`/`sector3` mirror in agreement. Idempotent. Call at every boundary a
+ * Course enters memory (track load, device download, snapshot load, admin read).
+ */
+export function normalizeCourseSectors(course: Course): Course {
+  let sectors = course.sectors;
+
+  if (!sectors || sectors.length === 0) {
+    // Legacy course: sector2/sector3 are the two majors after start/finish.
+    const migrated: CourseSector[] = [];
+    if (course.sector2) migrated.push({ line: course.sector2, major: true });
+    if (course.sector3) migrated.push({ line: course.sector3, major: true });
+    sectors = migrated.length > 0 ? migrated : undefined;
+  }
+
+  const mirror = sectors ? legacyMirror({ ...course, sectors }) : {};
+  return { ...course, sectors, sector2: mirror.sector2, sector3: mirror.sector3 };
+}
+
+/** The major lines among `course.sectors` (excludes the implicit start/finish). */
+export function majorSectorLines(course: Course): SectorLine[] {
+  return (course.sectors ?? []).filter((s) => s.major).map((s) => s.line);
+}
+
+/**
+ * Derive the legacy `sector2`/`sector3` from the first two majors so serializers
+ * (device export, track JSON, content hash) keep emitting the exact same wire
+ * data as before for migrated courses.
+ */
+export function legacyMirror(course: Course): { sector2?: SectorLine; sector3?: SectorLine } {
+  const majors = majorSectorLines(course);
+  return { sector2: majors[0], sector3: majors[1] };
+}
+
+/**
+ * Auto-numbering labels, one per timing line INCLUDING start/finish at index 0.
+ * Drag order drives numbering: each major opens a new group ("1", "2", "3"), and
+ * sub-sectors take "{group}.{n}" since the last major. Example:
+ *   S/F → "1", sub → "1.1", major → "2", sub → "2.1", sub → "2.2", major → "3".
+ */
+export function sectorLabels(course: Course): string[] {
+  const labels: string[] = ['1']; // start/finish is always major group 1
+  let group = 1;
+  let sub = 0;
+  for (const s of course.sectors ?? []) {
+    if (s.major) {
+      group += 1;
+      sub = 0;
+      labels.push(String(group));
+    } else {
+      sub += 1;
+      labels.push(`${group}.${sub}`);
+    }
+  }
+  return labels;
+}
+
+export interface SectorValidation {
+  valid: boolean;
+  /** Human-readable reason a save is blocked, or null when valid. */
+  reason: string | null;
+}
+
+/**
+ * Save rule: a course must have EITHER zero additional sectors, OR exactly three
+ * major sectors total (start/finish + two flagged). The total line count must
+ * also stay within `MAX_SECTOR_LINES`.
+ */
+export function validateCourseSectors(course: Course): SectorValidation {
+  const sectors = course.sectors ?? [];
+  if (sectors.length === 0) return { valid: true, reason: null };
+
+  if (sectors.length > MAX_COURSE_SECTORS) {
+    return { valid: false, reason: `Too many sectors (max ${MAX_SECTOR_LINES} including start/finish).` };
+  }
+
+  const majors = sectors.filter((s) => s.major).length + 1; // + start/finish
+  if (majors !== MAX_MAJOR_SECTORS) {
+    return {
+      valid: false,
+      reason: `Mark the three traditional sectors as a Major sector (start/finish is one — flag ${MAX_MAJOR_SECTORS - 1} more).`,
+    };
+  }
+  return { valid: true, reason: null };
+}
+
+/** True once the course is at the hidden timing-line cap (no more can be added). */
+export function isAtSectorLimit(course: Course): boolean {
+  return (course.sectors ?? []).length >= MAX_COURSE_SECTORS;
+}
+
+/**
+ * Roll the fine-grained per-segment times up into the classic S1/S2/S3, where
+ * each major sector spans from its major line to the next major line. A major
+ * sector is `undefined` if any of its constituent segments is missing.
+ *
+ * `sectorTimes[k]` is the segment beginning at timing line k (index 0 = start/
+ * finish), aligned to the order [startFinish, ...course.sectors].
+ */
+export function rollupMajorSectors(
+  course: Course,
+  sectorTimes: (number | undefined)[],
+): SectorTimes | undefined {
+  // Indices of the major timing lines (line 0 = start/finish is always major).
+  const majorIdx = [0];
+  (course.sectors ?? []).forEach((s, i) => {
+    if (s.major) majorIdx.push(i + 1);
+  });
+  if (majorIdx.length < MAX_MAJOR_SECTORS) return undefined;
+
+  const n = sectorTimes.length;
+  const groupTotal = (from: number, toExclusive: number): number | undefined => {
+    let sum = 0;
+    for (let k = from; k < toExclusive; k++) {
+      const v = sectorTimes[k];
+      if (v === undefined) return undefined;
+      sum += v;
+    }
+    return sum;
+  };
+
+  return {
+    s1: groupTotal(majorIdx[0], majorIdx[1]),
+    s2: groupTotal(majorIdx[1], majorIdx[2]),
+    s3: groupTotal(majorIdx[2], n),
+  };
+}

--- a/src/lib/courseSectors.ts
+++ b/src/lib/courseSectors.ts
@@ -18,6 +18,27 @@ export const MAX_MAJOR_SECTORS = 3;
 /** Max entries allowed in `course.sectors` (the array excludes start/finish). */
 export const MAX_COURSE_SECTORS = MAX_SECTOR_LINES - 1;
 
+/** Default half-length (in degrees longitude) of a freshly-dropped sector line
+ *  — ~15m at mid-latitudes, so the whole line is ~30m. The user drags the
+ *  endpoints onto the track from there. */
+export const DEFAULT_SECTOR_HALF_LENGTH_DEG = 0.00015;
+
+/**
+ * A short horizontal (east-west) timing line centered on `center`. Used when
+ * adding a new sector so it drops in the middle of the current map view rather
+ * than near start/finish; the view is left untouched and the user nudges the
+ * endpoints into place.
+ */
+export function centeredSectorLine(
+  center: { lat: number; lon: number },
+  halfLengthDeg: number = DEFAULT_SECTOR_HALF_LENGTH_DEG,
+): SectorLine {
+  return {
+    a: { lat: center.lat, lon: center.lon - halfLengthDeg },
+    b: { lat: center.lat, lon: center.lon + halfLengthDeg },
+  };
+}
+
 /**
  * Migrate any course into the canonical `sectors` array and keep the legacy
  * `sector2`/`sector3` mirror in agreement. Idempotent. Call at every boundary a

--- a/src/lib/db/supabaseAdapter.ts
+++ b/src/lib/db/supabaseAdapter.ts
@@ -57,7 +57,10 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
   }
 
   async createCourse(input: Omit<DbCourse, 'id' | 'created_at' | 'updated_at'>): Promise<DbCourse> {
-    const { data, error } = await supabase.from('courses').insert({
+    // Built as a variable (not an object literal) so the extra `sectors_data`
+    // column — not yet in the generated Supabase types — isn't flagged as an
+    // excess property. Generated types are regenerated after the migration.
+    const payload = {
       track_id: input.track_id,
       name: input.name.trim(),
       enabled: input.enabled,
@@ -73,8 +76,10 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
       sector_3_a_lng: input.sector_3_a_lng,
       sector_3_b_lat: input.sector_3_b_lat,
       sector_3_b_lng: input.sector_3_b_lng,
+      sectors_data: input.sectors_data ?? null,
       superseded_by: input.superseded_by,
-    }).select().single();
+    };
+    const { data, error } = await supabase.from('courses').insert(payload).select().single();
     if (error) throw error;
     return data as DbCourse;
   }
@@ -218,6 +223,10 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
           obj.sector_3_a_lng = c.sector_3_a_lng;
           obj.sector_3_b_lat = c.sector_3_b_lat;
           obj.sector_3_b_lng = c.sector_3_b_lng;
+        }
+        // Canonical ordered sector list (incl. sub-sectors), when present.
+        if (Array.isArray(c.sectors_data) && c.sectors_data.length > 0) {
+          obj.sectors = c.sectors_data;
         }
         return obj;
       });
@@ -403,6 +412,17 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
           sector_3_b_lat: toNumLat(c.sector_3_b_lat, 'sector_3_b_lat'),
           sector_3_b_lng: toNumLng(c.sector_3_b_lng, 'sector_3_b_lng'),
         };
+
+        // Import the canonical ordered sector list, when present.
+        if (Array.isArray(c.sectors) && c.sectors.length > 0) {
+          courseData.sectors_data = (c.sectors as Array<Record<string, unknown>>).map((s) => ({
+            a_lat: validateLat(s.a_lat, 'sector a_lat'),
+            a_lng: validateLng(s.a_lng, 'sector a_lng'),
+            b_lat: validateLat(s.b_lat, 'sector b_lat'),
+            b_lng: validateLng(s.b_lng, 'sector b_lng'),
+            major: Boolean(s.major),
+          }));
+        }
 
         // Import lengthFt as length_ft_override
         if (c.lengthFt !== undefined && c.lengthFt !== null) {

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -27,6 +27,12 @@ export interface DbCourse {
   sector_3_a_lng: number | null;
   sector_3_b_lat: number | null;
   sector_3_b_lng: number | null;
+  /**
+   * Canonical ordered sector list (start/finish excluded), each entry
+   * `{a_lat,a_lng,b_lat,b_lng,major}`. The legacy `sector_2/3` columns mirror
+   * the two majors for back-compat + device export. Null on legacy rows.
+   */
+  sectors_data: Array<{ a_lat: number; a_lng: number; b_lat: number; b_lng: number; major: boolean }> | null;
   superseded_by: string | null;
   length_ft_override: number | null;
   created_at: string;
@@ -46,6 +52,8 @@ export interface DbSubmission {
   has_layout?: boolean;
   /** The drawn outline polyline, when `has_layout`. */
   layout_data?: Array<{ lat: number; lon: number }> | null;
+  /** Submitted ordered sector list (mirrors courses.sectors_data), when present. */
+  sectors_data?: Array<{ a_lat: number; a_lng: number; b_lat: number; b_lng: number; major: boolean }> | null;
   /** Ties courses uploaded together in one bulk submit. NULL for legacy rows. */
   batch_id: string | null;
   created_at: string;

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -12,7 +12,7 @@ import {
   type DeviceCourseJson,
   type DeviceTrackFile,
 } from "./deviceTrackSync";
-import type { Course, Track } from "@/types/racing";
+import type { Course, Track, SectorLine } from "@/types/racing";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -409,5 +409,39 @@ describe("buildMergedTrackList", () => {
     const deviceFiles: DeviceTrackFile[] = [{ shortName: "OKC", courses: [makeDeviceCourse()] }];
     const merged = buildMergedTrackList(tracks, deviceFiles);
     expect(merged).toHaveLength(1);
+  });
+});
+
+// ─── Unlimited sectors: only the three majors reach the device ───────────────
+
+describe("device export with sub-sectors", () => {
+  const s2: SectorLine = { a: { lat: 35.4002, lon: -97.3002 }, b: { lat: 35.4003, lon: -97.3003 } };
+  const s3: SectorLine = { a: { lat: 35.4004, lon: -97.3004 }, b: { lat: 35.4005, lon: -97.3005 } };
+  const sub: SectorLine = { a: { lat: 35.4006, lon: -97.3006 }, b: { lat: 35.4007, lon: -97.3007 } };
+
+  // Same course expressed legacy (sector2/3) vs new (sectors with extra sub-sector).
+  const legacyCourse = makeAppCourse({ sector2: s2, sector3: s3 });
+  const sectorCourse = makeAppCourse({
+    sectors: [
+      { line: sub, major: false }, // app-only sub-sector before the first major
+      { line: s2, major: true },
+      { line: s3, major: true },
+    ],
+  });
+
+  it("exports byte-identical device JSON whether sub-sectors exist or not", () => {
+    const legacyJson = appCourseToDeviceJson(legacyCourse);
+    const withSubJson = appCourseToDeviceJson(sectorCourse);
+    // The device only ever sees start/finish + the two majors.
+    expect(withSubJson).toEqual(legacyJson);
+    expect("sectors" in withSubJson).toBe(false);
+    expect(withSubJson.sector_2_a_lat).toBe(s2.a.lat);
+    expect(withSubJson.sector_3_a_lat).toBe(s3.a.lat);
+  });
+
+  it("treats a course with extra sub-sectors as synced against the device's two lines", () => {
+    const dev = appCourseToDeviceJson(legacyCourse);
+    // Adding an app-only sub-sector must NOT flag a mismatch.
+    expect(coursesMatch(sectorCourse, dev)).toBe(true);
   });
 });

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -6,6 +6,7 @@
 
 import { Track, Course, SectorLine } from '@/types/racing';
 import { haversineDistance } from '@/lib/parserUtils';
+import { legacyMirror, majorSectorLines, normalizeCourseSectors } from '@/lib/courseSectors';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -78,7 +79,22 @@ function sectorLineFromDevice(
   return undefined;
 }
 
-/** Compare an app Course with a device course JSON. */
+function sectorLinesEqual(a?: SectorLine, b?: SectorLine): boolean {
+  if (!!a !== !!b) return false;
+  if (!a || !b) return true;
+  return (
+    coordsEqual(a.a.lat, b.a.lat) &&
+    coordsEqual(a.a.lon, b.a.lon) &&
+    coordsEqual(a.b.lat, b.b.lat) &&
+    coordsEqual(a.b.lon, b.b.lon)
+  );
+}
+
+/**
+ * Compare an app Course with a device course JSON. Only the device-visible
+ * projection (start/finish + the two major lines) is compared — app-only
+ * sub-sectors never flag a mismatch, since they're never sent to the device.
+ */
 export function coursesMatch(appCourse: Course, dc: DeviceCourseJson): boolean {
   // Compare start/finish
   if (!coordsEqual(appCourse.startFinishA.lat, dc.start_a_lat)) return false;
@@ -86,32 +102,20 @@ export function coursesMatch(appCourse: Course, dc: DeviceCourseJson): boolean {
   if (!coordsEqual(appCourse.startFinishB.lat, dc.start_b_lat)) return false;
   if (!coordsEqual(appCourse.startFinishB.lon, dc.start_b_lng)) return false;
 
-  // Compare sector 2
+  // Compare the two major sectors (mirror) against the device's two sector lines.
+  const { sector2, sector3 } = legacyMirror(normalizeCourseSectors(appCourse));
   const deviceS2 = sectorLineFromDevice(dc.sector_2_a_lat, dc.sector_2_a_lng, dc.sector_2_b_lat, dc.sector_2_b_lng);
-  if (!!appCourse.sector2 !== !!deviceS2) return false;
-  if (appCourse.sector2 && deviceS2) {
-    if (!coordsEqual(appCourse.sector2.a.lat, deviceS2.a.lat)) return false;
-    if (!coordsEqual(appCourse.sector2.a.lon, deviceS2.a.lon)) return false;
-    if (!coordsEqual(appCourse.sector2.b.lat, deviceS2.b.lat)) return false;
-    if (!coordsEqual(appCourse.sector2.b.lon, deviceS2.b.lon)) return false;
-  }
-
-  // Compare sector 3
   const deviceS3 = sectorLineFromDevice(dc.sector_3_a_lat, dc.sector_3_a_lng, dc.sector_3_b_lat, dc.sector_3_b_lng);
-  if (!!appCourse.sector3 !== !!deviceS3) return false;
-  if (appCourse.sector3 && deviceS3) {
-    if (!coordsEqual(appCourse.sector3.a.lat, deviceS3.a.lat)) return false;
-    if (!coordsEqual(appCourse.sector3.a.lon, deviceS3.a.lon)) return false;
-    if (!coordsEqual(appCourse.sector3.b.lat, deviceS3.b.lat)) return false;
-    if (!coordsEqual(appCourse.sector3.b.lon, deviceS3.b.lon)) return false;
-  }
 
-  return true;
+  return sectorLinesEqual(sector2, deviceS2) && sectorLinesEqual(sector3, deviceS3);
 }
 
 // ─── Conversion ───────────────────────────────────────────────────────────────
 
-/** Convert device course JSON to app Course */
+/**
+ * Convert device course JSON to app Course. The device's two sector lines become
+ * the course's two major sectors (the only sectors the device knows about).
+ */
 export function deviceCourseToAppCourse(dc: DeviceCourseJson): Course {
   const course: Course = {
     name: dc.name,
@@ -128,10 +132,14 @@ export function deviceCourseToAppCourse(dc: DeviceCourseJson): Course {
     course.sector3 = s3;
   }
 
-  return course;
+  return normalizeCourseSectors(course);
 }
 
-/** Convert an app Course to device JSON format */
+/**
+ * Convert an app Course to device JSON. Projects the course's three major
+ * sectors down to start/finish + the two legacy sector lines — byte-identical to
+ * the pre-overhaul output. App-only sub-sectors are intentionally dropped.
+ */
 export function appCourseToDeviceJson(course: Course): DeviceCourseJson {
   const dc: DeviceCourseJson = {
     name: course.name,
@@ -145,17 +153,18 @@ export function appCourseToDeviceJson(course: Course): DeviceCourseJson {
     dc.lengthFt = course.lengthFt;
   }
 
-  if (course.sector2) {
-    dc.sector_2_a_lat = course.sector2.a.lat;
-    dc.sector_2_a_lng = course.sector2.a.lon;
-    dc.sector_2_b_lat = course.sector2.b.lat;
-    dc.sector_2_b_lng = course.sector2.b.lon;
+  const { sector2, sector3 } = legacyMirror(normalizeCourseSectors(course));
+  if (sector2) {
+    dc.sector_2_a_lat = sector2.a.lat;
+    dc.sector_2_a_lng = sector2.a.lon;
+    dc.sector_2_b_lat = sector2.b.lat;
+    dc.sector_2_b_lng = sector2.b.lon;
   }
-  if (course.sector3) {
-    dc.sector_3_a_lat = course.sector3.a.lat;
-    dc.sector_3_a_lng = course.sector3.a.lon;
-    dc.sector_3_b_lat = course.sector3.b.lat;
-    dc.sector_3_b_lng = course.sector3.b.lon;
+  if (sector3) {
+    dc.sector_3_a_lat = sector3.a.lat;
+    dc.sector_3_a_lng = sector3.a.lon;
+    dc.sector_3_b_lat = sector3.b.lat;
+    dc.sector_3_b_lng = sector3.b.lon;
   }
 
   return dc;
@@ -298,10 +307,11 @@ export function countDeviceSectors(dc: DeviceCourseJson): number {
   return 0;
 }
 
-/** Count sectors in an app course. */
+/** Count device-visible sectors in an app course (0, 2, or 3 — majors only). */
 export function countAppSectors(course: Course): number {
-  if (course.sector2 && course.sector3) return 3;
-  if (course.sector2) return 2;
+  const majors = majorSectorLines(course).length;
+  if (majors >= 2) return 3;
+  if (majors === 1) return 2;
   return 0;
 }
 

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -309,7 +309,7 @@ export function countDeviceSectors(dc: DeviceCourseJson): number {
 
 /** Count device-visible sectors in an app course (0, 2, or 3 — majors only). */
 export function countAppSectors(course: Course): number {
-  const majors = majorSectorLines(course).length;
+  const majors = majorSectorLines(normalizeCourseSectors(course)).length;
   if (majors >= 2) return 3;
   if (majors === 1) return 2;
   return 0;

--- a/src/lib/lapCalculation.test.ts
+++ b/src/lib/lapCalculation.test.ts
@@ -337,6 +337,37 @@ describe("calculateLaps - sectors", () => {
     expect(laps[0].sectors!.s2).toBeUndefined();
     expect(laps[0].sectors!.s3).toBeUndefined();
   });
+
+  it("computes fine-grained sectorTimes for a sub-sector and rolls them up to the majors", () => {
+    // Same geometry as sectorCourse, but with an extra sub-sector at lon=0.0015
+    // splitting the first major sector. Order: S/F, sub(1.1), major2, major3.
+    const subSectorCourse: Course = {
+      name: "TestSubSectorCourse",
+      startFinishA: { lat: 0.0001, lon: 0 },
+      startFinishB: { lat: -0.0001, lon: 0 },
+      sectors: [
+        { line: { a: { lat: 0.0001, lon: 0.0015 }, b: { lat: -0.0001, lon: 0.0015 } }, major: false },
+        { line: { a: { lat: 0.0001, lon: 0.003 }, b: { lat: -0.0001, lon: 0.003 } }, major: true },
+        { line: { a: { lat: 0.0001, lon: 0.006 }, b: { lat: -0.0001, lon: 0.006 } }, major: true },
+      ],
+    };
+    const samples = [...makeSectorLap(0, 10000), ...makeSectorLap(10000, 10000)];
+    const lap = calculateLaps(samples, subSectorCourse)[0];
+
+    // 4 timing lines → 4 fine-grained segments, all crossed in order.
+    expect(lap.sectorTimes).toHaveLength(4);
+    expect(lap.sectorTimes!.every((t) => t !== undefined && t > 0)).toBe(true);
+    expect(lap.sectorBoundaries).toHaveLength(4);
+
+    // The major rollup matches the plain (no sub-sector) course exactly: the
+    // sub-sector only splits S1 into two segments that sum back to it.
+    const plain = calculateLaps(samples, sectorCourse)[0];
+    expect(lap.sectors!.s1).toBeCloseTo(plain.sectors!.s1!, -1);
+    expect(lap.sectors!.s2).toBeCloseTo(plain.sectors!.s2!, -1);
+    expect(lap.sectors!.s3).toBeCloseTo(plain.sectors!.s3!, -1);
+    // The two sub-segments of S1 sum to S1.
+    expect(lap.sectorTimes![0]! + lap.sectorTimes![1]!).toBeCloseTo(lap.sectors!.s1!, -1);
+  });
 });
 
 // ─── formatLapTime ───────────────────────────────────────────────────────────
@@ -387,6 +418,9 @@ describe("formatSectorTime", () => {
 // ─── calculateOptimalLap ─────────────────────────────────────────────────────
 
 function makeLap(lapNumber: number, lapTimeMs: number, sectors?: { s1?: number; s2?: number; s3?: number }): Lap {
+  // calculateOptimalLap reads the fine-grained sectorTimes; for a classic
+  // 3-major course that is just [s1, s2, s3].
+  const sectorTimes = sectors ? [sectors.s1, sectors.s2, sectors.s3] : undefined;
   return {
     lapNumber, lapTimeMs,
     startTime: 0, endTime: lapTimeMs,
@@ -394,6 +428,7 @@ function makeLap(lapNumber: number, lapTimeMs: number, sectors?: { s1?: number; 
     minSpeedMph: 10, minSpeedKph: 16,
     startIndex: 0, endIndex: 0,
     sectors,
+    sectorTimes,
   };
 }
 
@@ -414,9 +449,7 @@ describe("calculateOptimalLap", () => {
     const laps = [makeLap(1, 60000, { s1: 20000, s2: 18000, s3: 22000 })];
     const result = calculateOptimalLap(laps);
     expect(result).not.toBeNull();
-    expect(result!.bestS1).toBe(20000);
-    expect(result!.bestS2).toBe(18000);
-    expect(result!.bestS3).toBe(22000);
+    expect(result!.bestSegments).toEqual([20000, 18000, 22000]);
     expect(result!.optimalTimeMs).toBe(60000);
   });
 
@@ -427,9 +460,7 @@ describe("calculateOptimalLap", () => {
       makeLap(3, 60000, { s1: 21000, s2: 20000, s3: 19000 }), // best S3
     ];
     const result = calculateOptimalLap(laps)!;
-    expect(result.bestS1).toBe(19000);
-    expect(result.bestS2).toBe(18000);
-    expect(result.bestS3).toBe(19000);
+    expect(result.bestSegments).toEqual([19000, 18000, 19000]);
     expect(result.optimalTimeMs).toBe(19000 + 18000 + 19000);
   });
 
@@ -443,13 +474,24 @@ describe("calculateOptimalLap", () => {
     expect(result.deltaToFastest).toBe(58000 - 56000); // 2000
   });
 
-  it("ignores laps without full sectors when computing optimal", () => {
+  it("takes the best of each segment independently, even from partial laps", () => {
+    // The ideal lap uses the best time achieved in each segment regardless of
+    // whether that lap completed every segment — a real S1 still counts.
     const laps = [
-      makeLap(1, 60000, { s1: 17000, s2: 22000, s3: undefined }), // s3 missing — skipped
+      makeLap(1, 60000, { s1: 17000, s2: 22000, s3: undefined }), // S1 still counts
       makeLap(2, 60000, { s1: 20000, s2: 20000, s3: 20000 }),
     ];
     const result = calculateOptimalLap(laps)!;
-    expect(result.bestS1).toBe(20000); // 17000 from lap 1 ignored
+    expect(result.bestSegments).toEqual([17000, 20000, 20000]);
+    expect(result.optimalTimeMs).toBe(57000);
+  });
+
+  it("returns null when a segment was never completed in any lap", () => {
+    const laps = [
+      makeLap(1, 60000, { s1: 17000, s2: 22000, s3: undefined }),
+      makeLap(2, 60000, { s1: 20000, s2: 20000, s3: undefined }),
+    ];
+    expect(calculateOptimalLap(laps)).toBeNull(); // S3 never completed
   });
 
   it("considers ALL laps for fastest, even those without full sectors", () => {

--- a/src/lib/lapCalculation.ts
+++ b/src/lib/lapCalculation.ts
@@ -1,5 +1,6 @@
-import { GpsSample, Course, Lap, LapCrossing, SectorTimes, SectorLine, CourseDirection, courseHasSectors } from '@/types/racing';
+import { GpsSample, Course, Lap, LapCrossing, SectorTimes, SectorLine, CourseDirection } from '@/types/racing';
 import { EARTH_RADIUS_M } from './parserUtils';
+import { normalizeCourseSectors, majorSectorLines, rollupMajorSectors } from './courseSectors';
 
 interface Point {
   x: number;
@@ -64,7 +65,8 @@ const MIN_CROSSING_INTERVAL_MS = 5000; // 5 seconds for start/finish
 const MIN_SECTOR_CROSSING_INTERVAL_MS = 1000; // 1 second for sector lines
 
 interface LineCrossing {
-  lineType: 'sf' | 's2' | 's3'; // start/finish, sector2, sector3
+  // 'sf' = start/finish; a number is the 0-based index into course.sectors.
+  lineType: 'sf' | number;
   crossingTime: number;
   sampleIndex: number;
   fraction: number;
@@ -82,7 +84,7 @@ function detectLineCrossings(
   lineB: Point,
   centerLat: number,
   centerLon: number,
-  lineType: 'sf' | 's2' | 's3',
+  lineType: 'sf' | number,
   minInterval: number
 ): LineCrossing[] {
   const candidates: LineCrossing[] = [];
@@ -140,40 +142,40 @@ function projectSectorLine(
   };
 }
 
-export function calculateLaps(samples: GpsSample[], course: Course): Lap[] {
+export function calculateLaps(samples: GpsSample[], inputCourse: Course): Lap[] {
   if (samples.length < 2) return [];
-  
+
+  // Operate on the canonical sector model regardless of how the course was stored.
+  const course = normalizeCourseSectors(inputCourse);
+
   // Calculate center for projection
   const centerLat = (course.startFinishA.lat + course.startFinishB.lat) / 2;
   const centerLon = (course.startFinishA.lon + course.startFinishB.lon) / 2;
-  
+
   // Project start/finish line
   const sfA = projectToPlane(course.startFinishA.lat, course.startFinishA.lon, centerLat, centerLon);
   const sfB = projectToPlane(course.startFinishB.lat, course.startFinishB.lon, centerLat, centerLon);
-  
+
   // Detect start/finish crossings
   const sfCrossings = detectLineCrossings(samples, sfA, sfB, centerLat, centerLon, 'sf', MIN_CROSSING_INTERVAL_MS);
-  
+
   // Convert to LapCrossing format for backwards compatibility
   const crossings: LapCrossing[] = sfCrossings.map(c => ({
     sampleIndex: c.sampleIndex,
     crossingTime: c.crossingTime,
     fraction: c.fraction
   }));
-  
-  // Detect sector crossings only if course has both sector lines
-  const hasSectors = courseHasSectors(course);
-  let sector2Crossings: LineCrossing[] = [];
-  let sector3Crossings: LineCrossing[] = [];
-  
-  if (hasSectors && course.sector2 && course.sector3) {
-    const s2Line = projectSectorLine(course.sector2, centerLat, centerLon);
-    const s3Line = projectSectorLine(course.sector3, centerLat, centerLon);
-    
-    sector2Crossings = detectLineCrossings(samples, s2Line.a, s2Line.b, centerLat, centerLon, 's2', MIN_SECTOR_CROSSING_INTERVAL_MS);
-    sector3Crossings = detectLineCrossings(samples, s3Line.a, s3Line.b, centerLat, centerLon, 's3', MIN_SECTOR_CROSSING_INTERVAL_MS);
-  }
-  
+
+  // Detect crossings for every sector line in course order (index-tagged).
+  const courseSectors = course.sectors ?? [];
+  const sectorCrossings: LineCrossing[][] = courseSectors.map((sec, j) => {
+    const line = projectSectorLine(sec.line, centerLat, centerLon);
+    return detectLineCrossings(samples, line.a, line.b, centerLat, centerLon, j, MIN_SECTOR_CROSSING_INTERVAL_MS);
+  });
+  // Number of timing lines = start/finish + course sectors. Segment k spans
+  // line k → line k+1 (last segment wraps back to start/finish).
+  const lineCount = courseSectors.length + 1;
+
   // Calculate laps from crossings
   const laps: Lap[] = [];
   
@@ -233,52 +235,46 @@ export function calculateLaps(samples: GpsSample[], course: Course): Lap[] {
       }
     }
     
-    // Calculate sector times if sectors exist
+    // Compute fine-grained per-segment times when the course defines sectors.
     let sectors: SectorTimes | undefined;
-    
-    if (hasSectors) {
-      // Find sector2 crossing within this lap (after start.crossingTime, before end.crossingTime)
-      const s2Crossing = sector2Crossings.find(c => 
-        c.crossingTime > start.crossingTime && c.crossingTime < end.crossingTime
-      );
-      
-      // Find sector3 crossing within this lap (after sector2 if found, before end.crossingTime)
-      const s3Crossing = sector3Crossings.find(c => 
-        c.crossingTime > (s2Crossing?.crossingTime ?? start.crossingTime) && 
-        c.crossingTime < end.crossingTime
-      );
-      
-      // Only compute sector times if crossings are in correct order
-      if (s2Crossing && s3Crossing && s2Crossing.crossingTime < s3Crossing.crossingTime) {
-        sectors = {
-          s1: s2Crossing.crossingTime - start.crossingTime,
-          s2: s3Crossing.crossingTime - s2Crossing.crossingTime,
-          s3: end.crossingTime - s3Crossing.crossingTime
-        };
-      } else if (s2Crossing && !s3Crossing) {
-        // Only S1 is valid
-        sectors = {
-          s1: s2Crossing.crossingTime - start.crossingTime,
-          s2: undefined,
-          s3: undefined
-        };
-      } else if (!s2Crossing && s3Crossing) {
-        // S1 and S2 missing, S3 can't be computed alone
-        sectors = {
-          s1: undefined,
-          s2: undefined,
-          s3: undefined
-        };
-      } else {
-        // No sector crossings found
-        sectors = {
-          s1: undefined,
-          s2: undefined,
-          s3: undefined
-        };
+    let sectorTimes: (number | undefined)[] | undefined;
+    let sectorBoundaries: (number | undefined)[] | undefined;
+
+    if (courseSectors.length > 0) {
+      // Walk every sector line in order, finding the crossing for this lap. Each
+      // must fall after the previously matched boundary so out-of-order/missed
+      // crossings leave a gap rather than corrupting later sectors.
+      const boundaryTimes: (number | undefined)[] = new Array(lineCount);
+      const boundaryIdx: (number | undefined)[] = new Array(lineCount);
+      boundaryTimes[0] = start.crossingTime; // line 0 = start/finish
+      boundaryIdx[0] = start.sampleIndex;
+      let prevTime = start.crossingTime;
+
+      for (let j = 0; j < courseSectors.length; j++) {
+        const cross = sectorCrossings[j].find(
+          c => c.crossingTime > prevTime && c.crossingTime < end.crossingTime,
+        );
+        if (cross) {
+          boundaryTimes[j + 1] = cross.crossingTime;
+          boundaryIdx[j + 1] = cross.sampleIndex;
+          prevTime = cross.crossingTime;
+        } else {
+          boundaryTimes[j + 1] = undefined;
+          boundaryIdx[j + 1] = undefined;
+        }
       }
+
+      // Segment k = boundary k → boundary k+1 (last segment closes on start/finish).
+      sectorTimes = new Array(lineCount);
+      for (let k = 0; k < lineCount; k++) {
+        const tStart = boundaryTimes[k];
+        const tEnd = k + 1 < lineCount ? boundaryTimes[k + 1] : end.crossingTime;
+        sectorTimes[k] = tStart !== undefined && tEnd !== undefined ? tEnd - tStart : undefined;
+      }
+      sectorBoundaries = boundaryIdx;
+      sectors = rollupMajorSectors(course, sectorTimes);
     }
-    
+
     laps.push({
       lapNumber: i + 1,
       startTime: start.crossingTime,
@@ -290,7 +286,9 @@ export function calculateLaps(samples: GpsSample[], course: Course): Lap[] {
       minSpeedKph: minSpeedKph === Infinity ? 0 : minSpeedKph,
       startIndex: start.sampleIndex,
       endIndex: end.sampleIndex,
-      sectors
+      sectors,
+      sectorTimes,
+      sectorBoundaries
     });
   }
   
@@ -311,37 +309,36 @@ export function formatSectorTime(ms: number): string {
   return seconds.toFixed(3);
 }
 
-// Calculate optimal lap from best sectors
+// Calculate optimal lap from the best time of every fine-grained sector segment.
 export interface OptimalLapResult {
   optimalTimeMs: number;
-  bestS1: number;
-  bestS2: number;
-  bestS3: number;
+  /** Best (min) time for each segment, in course order. */
+  bestSegments: number[];
   deltaToFastest: number; // fastest lap - optimal (should be >= 0)
 }
 
+/**
+ * Optimal lap = sum of the fastest time achieved in each sector segment across
+ * all laps (now over ALL sectors, not just the three majors). Returns null
+ * unless every segment was completed in at least one lap.
+ */
 export function calculateOptimalLap(laps: Lap[]): OptimalLapResult | null {
-  // Filter laps that have all three valid sector times
-  const lapsWithAllSectors = laps.filter(lap => 
-    lap.sectors?.s1 !== undefined && 
-    lap.sectors?.s2 !== undefined && 
-    lap.sectors?.s3 !== undefined
-  );
-  
-  if (lapsWithAllSectors.length === 0) return null;
-  
-  // Find best time for each sector
-  let bestS1 = Infinity;
-  let bestS2 = Infinity;
-  let bestS3 = Infinity;
-  
-  for (const lap of lapsWithAllSectors) {
-    if (lap.sectors!.s1! < bestS1) bestS1 = lap.sectors!.s1!;
-    if (lap.sectors!.s2! < bestS2) bestS2 = lap.sectors!.s2!;
-    if (lap.sectors!.s3! < bestS3) bestS3 = lap.sectors!.s3!;
+  const lapsWithSegments = laps.filter(l => l.sectorTimes && l.sectorTimes.length > 0);
+  if (lapsWithSegments.length === 0) return null;
+
+  const segCount = Math.max(...lapsWithSegments.map(l => l.sectorTimes!.length));
+  const bestSegments = new Array<number>(segCount).fill(Infinity);
+
+  for (const lap of lapsWithSegments) {
+    lap.sectorTimes!.forEach((t, k) => {
+      if (t !== undefined && t < bestSegments[k]) bestSegments[k] = t;
+    });
   }
-  
-  const optimalTimeMs = bestS1 + bestS2 + bestS3;
+
+  // Every segment needs at least one completed lap to form a complete optimal.
+  if (bestSegments.some(b => !isFinite(b))) return null;
+
+  const optimalTimeMs = bestSegments.reduce((a, b) => a + b, 0);
 
   // Find fastest actual lap (single-pass to avoid stack overflow on huge inputs)
   let fastestLapMs = Infinity;
@@ -349,14 +346,8 @@ export function calculateOptimalLap(laps: Lap[]): OptimalLapResult | null {
     if (l.lapTimeMs < fastestLapMs) fastestLapMs = l.lapTimeMs;
   }
   const deltaToFastest = fastestLapMs - optimalTimeMs;
-  
-  return {
-    optimalTimeMs,
-    bestS1,
-    bestS2,
-    bestS3,
-    deltaToFastest
-  };
+
+  return { optimalTimeMs, bestSegments, deltaToFastest };
 }
 
 /**
@@ -374,16 +365,19 @@ export function calculateOptimalLap(laps: Lap[]): OptimalLapResult | null {
  *   - 'reverse' if S3 is crossed before S2
  *   - undefined if either line is never crossed, or the course has no sectors
  */
-export function detectSectorOrder(samples: GpsSample[], course: Course): CourseDirection | undefined {
-  if (!course.sector2 || !course.sector3 || samples.length < 2) {
+export function detectSectorOrder(samples: GpsSample[], inputCourse: Course): CourseDirection | undefined {
+  const course = normalizeCourseSectors(inputCourse);
+  // Direction is inferred from the first two major lines after start/finish.
+  const majors = majorSectorLines(course);
+  if (majors.length < 2 || samples.length < 2) {
     return undefined;
   }
 
   const centerLat = (course.startFinishA.lat + course.startFinishB.lat) / 2;
   const centerLon = (course.startFinishA.lon + course.startFinishB.lon) / 2;
 
-  const s2Line = projectSectorLine(course.sector2, centerLat, centerLon);
-  const s3Line = projectSectorLine(course.sector3, centerLat, centerLon);
+  const s2Line = projectSectorLine(majors[0], centerLat, centerLon);
+  const s3Line = projectSectorLine(majors[1], centerLat, centerLon);
 
   const firstS2Time = findFirstCrossingTime(samples, s2Line, centerLat, centerLon);
   const firstS3Time = findFirstCrossingTime(samples, s3Line, centerLat, centerLon);

--- a/src/lib/trackStorage.test.ts
+++ b/src/lib/trackStorage.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { sectorsFromJson, sectorsToJson, type SectorJson } from './trackStorage';
+import type { CourseSector } from '@/types/racing';
+
+describe('trackStorage sector serialization', () => {
+  const json: SectorJson[] = [
+    { a_lat: 1, a_lng: 2, b_lat: 3, b_lng: 4, major: true },
+    { a_lat: 5, a_lng: 6, b_lat: 7, b_lng: 8, major: false },
+  ];
+  const sectors: CourseSector[] = [
+    { line: { a: { lat: 1, lon: 2 }, b: { lat: 3, lon: 4 } }, major: true },
+    { line: { a: { lat: 5, lon: 6 }, b: { lat: 7, lon: 8 } }, major: false },
+  ];
+
+  it('maps the flat JSON lat/lng shape into the canonical lat/lon CourseSector model', () => {
+    expect(sectorsFromJson(json)).toEqual(sectors);
+  });
+
+  it('serializes CourseSector[] back to the flat lat/lng JSON shape', () => {
+    expect(sectorsToJson(sectors)).toEqual(json);
+  });
+
+  it('round-trips JSON → model → JSON without loss', () => {
+    expect(sectorsToJson(sectorsFromJson(json))).toEqual(json);
+  });
+
+  it('round-trips model → JSON → model without loss', () => {
+    expect(sectorsFromJson(sectorsToJson(sectors))).toEqual(sectors);
+  });
+
+  it('returns undefined for empty/missing input (both directions)', () => {
+    expect(sectorsFromJson(undefined)).toBeUndefined();
+    expect(sectorsFromJson([])).toBeUndefined();
+    expect(sectorsToJson(undefined)).toBeUndefined();
+    expect(sectorsToJson([])).toBeUndefined();
+  });
+
+  it('coerces a truthy/missing `major` flag to a strict boolean on read', () => {
+    const loose = [
+      { a_lat: 1, a_lng: 2, b_lat: 3, b_lng: 4 } as unknown as SectorJson, // major missing
+      { a_lat: 5, a_lng: 6, b_lat: 7, b_lng: 8, major: 1 } as unknown as SectorJson, // truthy non-bool
+    ];
+    const out = sectorsFromJson(loose)!;
+    expect(out[0].major).toBe(false);
+    expect(out[1].major).toBe(true);
+  });
+});

--- a/src/lib/trackStorage.ts
+++ b/src/lib/trackStorage.ts
@@ -1,5 +1,6 @@
-import { Track, Course, LegacyTrack, SectorLine } from '@/types/racing';
+import { Track, Course, CourseSector, LegacyTrack, SectorLine } from '@/types/racing';
 import { emitGarageChange } from '@/lib/garageEvents';
+import { normalizeCourseSectors } from '@/lib/courseSectors';
 
 const STORAGE_KEY = 'racing-datalog-tracks-v2';
 const LEGACY_STORAGE_KEY = 'racing-datalog-tracks';
@@ -11,6 +12,15 @@ const LEGACY_STORAGE_KEY = 'racing-datalog-tracks';
  */
 export const TRACKS_SYNC_STORE = 'tracks';
 
+/** One sector line in the JSON track format (flat lat/lng + major flag). */
+export interface SectorJson {
+  a_lat: number;
+  a_lng: number;
+  b_lat: number;
+  b_lng: number;
+  major: boolean;
+}
+
 interface DefaultCourseJson {
   name: string;
   lengthFt?: number;
@@ -18,6 +28,9 @@ interface DefaultCourseJson {
   start_a_lng: number;
   start_b_lat: number;
   start_b_lng: number;
+  // Canonical ordered sector list (preferred). Excludes start/finish.
+  sectors?: SectorJson[];
+  // Legacy two-major fields — read as a fallback, still written as a mirror.
   sector_2_a_lat?: number;
   sector_2_a_lng?: number;
   sector_2_b_lat?: number;
@@ -26,6 +39,27 @@ interface DefaultCourseJson {
   sector_3_a_lng?: number;
   sector_3_b_lat?: number;
   sector_3_b_lng?: number;
+}
+
+/** Map the JSON sector array into the canonical `CourseSector[]`. */
+export function sectorsFromJson(sectors?: SectorJson[]): CourseSector[] | undefined {
+  if (!Array.isArray(sectors) || sectors.length === 0) return undefined;
+  return sectors.map((s) => ({
+    line: { a: { lat: s.a_lat, lon: s.a_lng }, b: { lat: s.b_lat, lon: s.b_lng } },
+    major: Boolean(s.major),
+  }));
+}
+
+/** Serialize the canonical `CourseSector[]` back to the flat JSON array. */
+export function sectorsToJson(sectors?: CourseSector[]): SectorJson[] | undefined {
+  if (!sectors || sectors.length === 0) return undefined;
+  return sectors.map((s) => ({
+    a_lat: s.line.a.lat,
+    a_lng: s.line.a.lon,
+    b_lat: s.line.b.lat,
+    b_lng: s.line.b.lon,
+    major: s.major,
+  }));
 }
 
 interface DefaultTracksJson {
@@ -93,22 +127,26 @@ export async function loadDefaultTracks(): Promise<Track[]> {
           startFinishB: { lat: c.start_b_lat, lon: c.start_b_lng },
           isUserDefined: false,
         };
-        
-        // Parse sector lines if they exist
-        const sector2 = parseSectorLineFromJson(
-          c.sector_2_a_lat, c.sector_2_a_lng, c.sector_2_b_lat, c.sector_2_b_lng
-        );
-        const sector3 = parseSectorLineFromJson(
-          c.sector_3_a_lat, c.sector_3_a_lng, c.sector_3_b_lat, c.sector_3_b_lng
-        );
-        
-        // Only add sectors if both are present
-        if (sector2 && sector3) {
-          course.sector2 = sector2;
-          course.sector3 = sector3;
+
+        // Prefer the canonical sector array; fall back to the legacy two-major fields.
+        const sectors = sectorsFromJson(c.sectors);
+        if (sectors) {
+          course.sectors = sectors;
+        } else {
+          const sector2 = parseSectorLineFromJson(
+            c.sector_2_a_lat, c.sector_2_a_lng, c.sector_2_b_lat, c.sector_2_b_lng
+          );
+          const sector3 = parseSectorLineFromJson(
+            c.sector_3_a_lat, c.sector_3_a_lng, c.sector_3_b_lat, c.sector_3_b_lng
+          );
+          // Only add sectors if both are present
+          if (sector2 && sector3) {
+            course.sector2 = sector2;
+            course.sector3 = sector3;
+          }
         }
-        
-        return course;
+
+        return normalizeCourseSectors(course);
       });
       tracks.push({
         name: trackName,
@@ -134,7 +172,11 @@ function loadUserTracks(): Track[] {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       const data: StoredData = JSON.parse(stored);
-      return data.tracks || [];
+      // Migrate any legacy-shaped courses into the canonical sector model on read.
+      return (data.tracks || []).map((t) => ({
+        ...t,
+        courses: t.courses.map(normalizeCourseSectors),
+      }));
     }
   } catch (e) {
     console.error('Failed to load user tracks:', e);
@@ -189,7 +231,8 @@ function saveUserTracks(tracks: Track[]): void {
       .filter(t => t.isUserDefined || t.courses.some(c => c.isUserDefined))
       .map(t => ({
         ...t,
-        courses: t.courses.filter(c => c.isUserDefined),
+        // Persist the canonical sectors AND the derived legacy mirror together.
+        courses: t.courses.filter(c => c.isUserDefined).map(normalizeCourseSectors),
       }))
       .filter(t => t.courses.length > 0 || t.isUserDefined);
     

--- a/src/lib/trackSubmission.test.ts
+++ b/src/lib/trackSubmission.test.ts
@@ -75,6 +75,32 @@ describe('courseContentHash', () => {
     const onePoint = course('A', { layout: [{ lat: 28.41, lon: -81.38 }] });
     expect(courseContentHash(onePoint)).toBe(courseContentHash(course('A')));
   });
+
+  it('hashes a legacy sector2/3 course identically to the equivalent sectors array', () => {
+    // A majors-only course must hash the SAME whether stored as legacy
+    // sector2/sector3 or as the canonical two-major sectors array — so existing
+    // submission dedupe records stay valid after the overhaul.
+    const legacy = course('A', sectors);
+    const canonical = course('A', {
+      sectors: [
+        { line: sectors.sector2, major: true },
+        { line: sectors.sector3, major: true },
+      ],
+    });
+    expect(courseContentHash(canonical)).toBe(courseContentHash(legacy));
+  });
+
+  it('re-flags the course when a sub-sector is added', () => {
+    const majorsOnly = course('A', sectors);
+    const withSub = course('A', {
+      sectors: [
+        { line: { a: { lat: 28.4105, lon: -81.3805 }, b: { lat: 28.4106, lon: -81.3806 } }, major: false },
+        { line: sectors.sector2, major: true },
+        { line: sectors.sector3, major: true },
+      ],
+    });
+    expect(courseContentHash(withSub)).not.toBe(courseContentHash(majorsOnly));
+  });
 });
 
 describe('buildSubmissionPlan', () => {

--- a/src/lib/trackSubmission.ts
+++ b/src/lib/trackSubmission.ts
@@ -20,6 +20,8 @@
 
 import type { Course, Track } from '@/types/racing';
 import { deriveShortName } from '@/lib/trackUtils';
+import { legacyMirror, normalizeCourseSectors } from '@/lib/courseSectors';
+import { sectorsToJson, type SectorJson } from '@/lib/trackStorage';
 
 /** Flat snake_case coordinate payload — the shape the edge fn + DB expect. */
 export interface CourseSubmissionData {
@@ -27,6 +29,7 @@ export interface CourseSubmissionData {
   start_a_lng: number;
   start_b_lat: number;
   start_b_lng: number;
+  // Legacy two-major fields — still sent for back-compat with the DB columns.
   sector_2_a_lat?: number;
   sector_2_a_lng?: number;
   sector_2_b_lat?: number;
@@ -35,6 +38,8 @@ export interface CourseSubmissionData {
   sector_3_a_lng?: number;
   sector_3_b_lat?: number;
   sector_3_b_lng?: number;
+  // Canonical ordered sector list (preferred; carries sub-sectors + major flags).
+  sectors?: SectorJson[];
 }
 
 /** Submission type understood by the `submissions` table. */
@@ -102,24 +107,32 @@ function r(n: number): number {
   return Math.round(n * 1e7) / 1e7;
 }
 
-/** Build the flat coordinate payload for a course (sectors only if both set). */
+/**
+ * Build the coordinate payload for a course. Sends the legacy two-major fields
+ * (derived from the majors) for DB back-compat AND the canonical `sectors` array
+ * carrying sub-sectors + major flags.
+ */
 export function courseToSubmissionData(course: Course): CourseSubmissionData {
+  const norm = normalizeCourseSectors(course);
   const data: CourseSubmissionData = {
     start_a_lat: course.startFinishA.lat,
     start_a_lng: course.startFinishA.lon,
     start_b_lat: course.startFinishB.lat,
     start_b_lng: course.startFinishB.lon,
   };
-  if (course.sector2 && course.sector3) {
-    data.sector_2_a_lat = course.sector2.a.lat;
-    data.sector_2_a_lng = course.sector2.a.lon;
-    data.sector_2_b_lat = course.sector2.b.lat;
-    data.sector_2_b_lng = course.sector2.b.lon;
-    data.sector_3_a_lat = course.sector3.a.lat;
-    data.sector_3_a_lng = course.sector3.a.lon;
-    data.sector_3_b_lat = course.sector3.b.lat;
-    data.sector_3_b_lng = course.sector3.b.lon;
+  const { sector2, sector3 } = legacyMirror(norm);
+  if (sector2 && sector3) {
+    data.sector_2_a_lat = sector2.a.lat;
+    data.sector_2_a_lng = sector2.a.lon;
+    data.sector_2_b_lat = sector2.b.lat;
+    data.sector_2_b_lng = sector2.b.lon;
+    data.sector_3_a_lat = sector3.a.lat;
+    data.sector_3_a_lng = sector3.a.lon;
+    data.sector_3_b_lat = sector3.b.lat;
+    data.sector_3_b_lng = sector3.b.lon;
   }
+  const sectors = sectorsToJson(norm.sectors);
+  if (sectors) data.sectors = sectors;
   return data;
 }
 
@@ -145,13 +158,23 @@ function layoutHashInput(layout?: Array<{ lat: number; lon: number }>): string {
  * geometry *or* drawing edits so a freshly-drawn outline re-flags the course.
  */
 export function courseContentHash(course: Course): string {
-  const d = courseToSubmissionData(course);
+  const norm = normalizeCourseSectors(course);
+  const d = courseToSubmissionData(norm);
   const parts = [
     d.start_a_lat, d.start_a_lng, d.start_b_lat, d.start_b_lng,
     d.sector_2_a_lat, d.sector_2_a_lng, d.sector_2_b_lat, d.sector_2_b_lng,
     d.sector_3_a_lat, d.sector_3_a_lng, d.sector_3_b_lat, d.sector_3_b_lng,
   ].map((n) => (n === undefined ? '' : String(r(n))));
   parts.push(layoutHashInput(course.layout));
+  // Only append sub-sector data when present, so a majors-only course hashes
+  // byte-identically to the pre-overhaul hash (existing dedupe records stay valid).
+  const subs = (norm.sectors ?? []).filter((s) => !s.major);
+  if (subs.length > 0) {
+    const seq = (norm.sectors ?? [])
+      .map((s) => `${s.major ? 'M' : 'm'}:${r(s.line.a.lat)} ${r(s.line.a.lon)} ${r(s.line.b.lat)} ${r(s.line.b.lon)}`)
+      .join(';');
+    parts.push(seq);
+  }
   return fnv1a(parts.join(','));
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, AlertCircle } from "lucide-react";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, FlaskConical, AlertCircle, Wrench } from "lucide-react";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { LapTimesTab } from "@/components/tabs/LapTimesTab";
@@ -20,6 +20,9 @@ const LabsTab = lazy(() =>
 );
 const CoachTab = lazy(() =>
   import("@/components/tabs/CoachTab").then((m) => ({ default: m.CoachTab })),
+);
+const ToolsTab = lazy(() =>
+  import("@/components/tabs/ToolsTab").then((m) => ({ default: m.ToolsTab })),
 );
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SettingsModal } from "@/components/SettingsModal";
@@ -65,7 +68,7 @@ import { snapshotLapSamples } from "@/lib/lapSnapshot";
 import type { PluginSnapshot } from "@/plugins/panels";
 
 
-type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach";
+type TopPanelView = "raceline" | "laptable" | "graphview" | "labs" | "coach" | "tools";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === 'true';
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
@@ -141,6 +144,9 @@ export default function Index() {
   // The Coach tab is self-gating: it appears only when a plugin contributes a
   // panel to the Coach slot (i.e. the coach package is installed).
   const showCoach = usePanelsForSlot(PanelSlot.Coach).length > 0;
+  // Tools tab is self-gating like Coach: it appears only when a plugin
+  // contributes a panel to the Tools slot (the first-party tools plugin does).
+  const showTools = usePanelsForSlot(PanelSlot.Tools).length > 0;
   // Profile tab is self-gating too: appears only when a plugin (cloud-sync)
   // contributes a Profile panel (i.e. the cloud build flag is on).
   const showProfile = usePanelsForSlot(PanelSlot.Profile).length > 0;
@@ -613,7 +619,7 @@ export default function Index() {
       </header>
 
       <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
-        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} setupIndicator={setupIndicator} onSetupIndicatorClick={() => setupIndicator && fileManager.open(setupIndicator.target)} />
+        <TabBar topPanelView={topPanelView} setTopPanelView={setTopPanelView} laps={laps} showOverlays={showOverlays} onToggleOverlays={() => setShowOverlays(v => !v)} showLabs={showLabs} showCoach={showCoach} showTools={showTools} setupIndicator={setupIndicator} onSetupIndicatorClick={() => setupIndicator && fileManager.open(setupIndicator.target)} />
 
 
         <div className="flex-1 min-h-0 overflow-hidden">
@@ -623,6 +629,7 @@ export default function Index() {
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "labs" && showLabs && <LabsTab />}
             {topPanelView === "coach" && showCoach && <CoachTab />}
+            {topPanelView === "tools" && showTools && <ToolsTab />}
           </Suspense>
         </div>
       </main>
@@ -655,7 +662,7 @@ export default function Index() {
 }
 
 /** Tab navigation bar for the main data view */
-function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, setupIndicator, onSetupIndicatorClick }: {
+function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOverlays, showLabs, showCoach, showTools, setupIndicator, onSetupIndicatorClick }: {
   topPanelView: TopPanelView;
   setTopPanelView: (view: TopPanelView) => void;
   laps: { lapNumber: number }[];
@@ -663,6 +670,7 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   onToggleOverlays: () => void;
   showLabs: boolean;
   showCoach: boolean;
+  showTools: boolean;
   setupIndicator: SetupIndicator | null;
   onSetupIndicatorClick: () => void;
 }) {
@@ -676,13 +684,13 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   return (
     <div className="flex items-center border-b border-border shrink-0">
       <button onClick={() => setTopPanelView("raceline")} className={tabClass("raceline")}>
-        <Map className="w-4 h-4" /> Simple
+        <Map className="w-4 h-4" /> <span className="hidden sm:inline">Simple</span>
       </button>
       <button onClick={() => setTopPanelView("graphview")} className={tabClass("graphview")}>
         <BarChart3 className="w-4 h-4" /> <span className="hidden sm:inline">Pro</span>
       </button>
       <button onClick={() => setTopPanelView("laptable")} className={tabClass("laptable")}>
-        <ListOrdered className="w-4 h-4" /> Lap Times
+        <ListOrdered className="w-4 h-4" /> <span className="hidden sm:inline">Lap Times</span>
         {laps.length > 0 && (
           <span className="ml-1 px-1.5 py-0.5 text-xs bg-primary/20 text-primary rounded">{laps.length}</span>
         )}
@@ -695,6 +703,11 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
       {showCoach && (
         <button onClick={() => setTopPanelView("coach")} className={tabClass("coach")}>
           <Gauge className="w-4 h-4" /> <span className="hidden sm:inline">Coach</span>
+        </button>
+      )}
+      {showTools && (
+        <button onClick={() => setTopPanelView("tools")} className={tabClass("tools")}>
+          <Wrench className="w-4 h-4" /> <span className="hidden sm:inline">Tools</span>
         </button>
       )}
       {setupIndicator && (
@@ -727,7 +740,7 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
         <div className="ml-auto mr-3">
           <Button variant="ghost" size="sm" onClick={onToggleOverlays} className="h-7 px-2 gap-1.5">
             {showOverlays ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-            <span className="text-xs">Overlay</span>
+            <span className="text-xs hidden sm:inline">Overlay</span>
           </Button>
         </div>
       )}

--- a/src/plugins/panels.ts
+++ b/src/plugins/panels.ts
@@ -23,6 +23,8 @@ export const PanelSlot = {
   Labs: "labs",
   /** The dedicated AI Coach tab in the main view. */
   Coach: "coach",
+  /** The Tools tab in the main view (utility tools, e.g. the seat-position visualizer). */
+  Tools: "tools",
   /** The user profile tab (storage usage, account) in the file-manager drawer. */
   Profile: "profile",
 } as const;

--- a/src/plugins/tools/ToolsPanel.tsx
+++ b/src/plugins/tools/ToolsPanel.tsx
@@ -30,7 +30,14 @@ export default function ToolsPanel(props: PluginPanelProps) {
                 >
                   <Icon className="w-6 h-6 text-primary shrink-0 mt-0.5" />
                   <span>
-                    <span className="block text-sm font-medium text-foreground">{tool.name}</span>
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-sm font-medium text-foreground">{tool.name}</span>
+                      {tool.badge && (
+                        <span className="rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
+                          {tool.badge}
+                        </span>
+                      )}
+                    </span>
                     <span className="mt-1 block text-xs text-muted-foreground">{tool.description}</span>
                   </span>
                 </button>

--- a/src/plugins/tools/ToolsPanel.tsx
+++ b/src/plugins/tools/ToolsPanel.tsx
@@ -1,0 +1,62 @@
+// The Tools tab body: a picker of available tools, and the opened tool with a
+// back bar. Chromeless panel — it owns the full tab surface.
+
+import { Suspense, useState } from "react";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { TOOLS } from "./toolList";
+
+export default function ToolsPanel(props: PluginPanelProps) {
+  const [activeToolId, setActiveToolId] = useState<string | null>(null);
+  const activeTool = TOOLS.find((t) => t.id === activeToolId) ?? null;
+
+  if (!activeTool) {
+    return (
+      <div className="h-full overflow-auto p-4">
+        <div className="max-w-3xl mx-auto space-y-4">
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Tools</h2>
+            <p className="text-xs text-muted-foreground">Trackside calculators and utilities.</p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {TOOLS.map((tool) => {
+              const Icon = tool.icon;
+              return (
+                <button
+                  key={tool.id}
+                  onClick={() => setActiveToolId(tool.id)}
+                  className="flex items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-primary/50 hover:bg-primary/5"
+                >
+                  <Icon className="w-6 h-6 text-primary shrink-0 mt-0.5" />
+                  <span>
+                    <span className="block text-sm font-medium text-foreground">{tool.name}</span>
+                    <span className="mt-1 block text-xs text-muted-foreground">{tool.description}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const ToolBody = activeTool.component;
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-1.5 border-b border-border px-2 py-1.5 shrink-0">
+        <Button variant="ghost" size="sm" className="h-7 px-2 gap-1" onClick={() => setActiveToolId(null)}>
+          <ChevronLeft className="w-4 h-4" />
+          <span className="text-xs">Tools</span>
+        </Button>
+        <span className="text-sm font-medium text-foreground">{activeTool.name}</span>
+      </div>
+      <div className="flex-1 min-h-0">
+        <Suspense fallback={<p className="p-4 text-xs text-muted-foreground">Loading tool…</p>}>
+          <ToolBody {...props} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/tools/index.ts
+++ b/src/plugins/tools/index.ts
@@ -1,0 +1,32 @@
+// First-party Tools plugin.
+//
+// Contributes the Tools tab (a self-gating main-view tab, like Coach): a
+// chromeless panel that shows a picker of utility tools and renders the one
+// the user opens. The tools themselves live under this folder and are lazy —
+// nothing here rides the initial bundle. Fully offline.
+
+import { lazy } from "react";
+import { Wrench } from "lucide-react";
+import type { DataViewerPlugin } from "@/plugins/types";
+import { PANELS_POINT, PanelSlot, type PluginPanel } from "@/plugins/panels";
+
+const ToolsPanel = lazy(() => import("./ToolsPanel"));
+
+const plugin: DataViewerPlugin = {
+  id: "tools",
+  name: "Track Tools",
+  version: "0.1.0",
+  setup(ctx) {
+    ctx.registry.contribute(PANELS_POINT, {
+      id: "tools-home",
+      title: "Tools",
+      slot: PanelSlot.Tools,
+      icon: Wrench,
+      component: ToolsPanel,
+      // The panel owns its full layout (picker grid / opened tool).
+      chromeless: true,
+    } satisfies PluginPanel);
+  },
+};
+
+export default plugin;

--- a/src/plugins/tools/seat-position/SeatDiagram.tsx
+++ b/src/plugins/tools/seat-position/SeatDiagram.tsx
@@ -1,0 +1,158 @@
+// Side-view SVG of the kart: chassis, wheels, seat profile, and a three-
+// segment stick driver whose knee is solved by 2-link IK so the feet stay on
+// the pedals — the leg-coupling model made visible. The baseline (zero point)
+// renders as a gray ghost behind the current position.
+
+import { useMemo } from "react";
+import {
+  ZERO_ADJUSTMENTS,
+  computeMassElements,
+  computeCoM,
+  hipPoint,
+  rotateOffset,
+  solveKneeIK,
+  type Point,
+  type SeatAdjustments,
+  type SeatModelParams,
+} from "./model";
+
+// Visual-only proportions (mm). The mass model doesn't depend on these.
+const THIGH_MM = 370;
+const SHANK_MM = 385;
+const HEAD_R_MM = 52;
+const SHOULDER_DX = -276; // from the anchor, rigid with the seat
+const SHOULDER_DZ = 583;
+// Seat profile polyline, offsets from the front-bottom anchor.
+const SEAT_PROFILE: Array<[number, number]> = [
+  [15, -5],
+  [-70, 12],
+  [-160, 42],
+  [-225, 85],
+  [-258, 140],
+  [-290, 275],
+  [-312, 405],
+];
+
+interface FigureGeometry {
+  seat: Point[];
+  hip: Point;
+  knee: Point;
+  foot: Point;
+  shoulder: Point;
+  head: Point;
+  com: Point;
+}
+
+function buildFigure(p: SeatModelParams, adj: SeatAdjustments): FigureGeometry {
+  const anchor: Point = { x: p.anchorXMm + adj.slideMm, z: p.anchorZMm };
+  const place = (dx: number, dz: number): Point => {
+    const r = rotateOffset(dx, dz, adj.tiltDeg);
+    return { x: anchor.x + r.x, z: anchor.z + r.z };
+  };
+  const seat = SEAT_PROFILE.map(([dx, dz]) => place(dx, dz));
+  const hip = hipPoint(p, adj);
+  const foot: Point = { x: p.wheelbaseMm - 80, z: 140 };
+  const knee = solveKneeIK(hip, foot, THIGH_MM, SHANK_MM);
+  const shoulder = place(SHOULDER_DX, SHOULDER_DZ);
+  const len = Math.hypot(shoulder.x - hip.x, shoulder.z - hip.z) || 1;
+  const head: Point = {
+    x: shoulder.x + ((shoulder.x - hip.x) / len) * (HEAD_R_MM + 25),
+    z: shoulder.z + ((shoulder.z - hip.z) / len) * (HEAD_R_MM + 25),
+  };
+  const com = computeCoM(computeMassElements(p, adj));
+  return { seat, hip, knee, foot, shoulder, head, com: { x: com.xMm, z: com.zMm } };
+}
+
+function Figure({ g, ghost }: { g: FigureGeometry; ghost?: boolean }) {
+  const cls = ghost ? "text-muted-foreground/40" : "text-foreground";
+  const pts = (list: Point[]) => list.map((q) => `${q.x},${-q.z}`).join(" ");
+  return (
+    <g className={cls} stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
+      {/* seat profile */}
+      <polyline points={pts(g.seat)} strokeWidth={ghost ? 14 : 18} className={ghost ? undefined : "text-primary"} />
+      {/* legs: shank then thigh (foot stays on the pedals) */}
+      <polyline points={pts([g.foot, g.knee, g.hip])} strokeWidth={12} />
+      {/* torso */}
+      <line x1={g.hip.x} y1={-g.hip.z} x2={g.shoulder.x} y2={-g.shoulder.z} strokeWidth={12} />
+      <circle cx={g.head.x} cy={-g.head.z} r={HEAD_R_MM} strokeWidth={10} />
+    </g>
+  );
+}
+
+function ComCrosshair({ p, ghost }: { p: Point; ghost?: boolean }) {
+  const cls = ghost ? "text-muted-foreground/50" : "text-warning";
+  return (
+    <g className={cls} stroke="currentColor" fill="none" strokeWidth={6}>
+      <circle cx={p.x} cy={-p.z} r={26} />
+      <line x1={p.x - 40} y1={-p.z} x2={p.x + 40} y2={-p.z} />
+      <line x1={p.x} y1={-p.z - 40} x2={p.x} y2={-p.z + 40} />
+    </g>
+  );
+}
+
+export function SeatDiagram({ params, adjustments }: { params: SeatModelParams; adjustments: SeatAdjustments }) {
+  const current = useMemo(() => buildFigure(params, adjustments), [params, adjustments]);
+  const baseline = useMemo(() => buildFigure(params, ZERO_ADJUSTMENTS), [params]);
+  const isAtZero = adjustments.slideMm === 0 && adjustments.tiltDeg === 0;
+
+  const L = params.wheelbaseMm;
+  const rearR = 139;
+  const frontR = 129;
+  const minX = -260;
+  const width = L + 540;
+  const topZ = 820;
+
+  return (
+    <svg
+      viewBox={`${minX} ${-topZ} ${width} ${topZ + 70}`}
+      className="w-full h-auto"
+      role="img"
+      aria-label="Side view of the kart showing seat position and centre of mass"
+    >
+      {/* ground */}
+      <line x1={minX} y1={0} x2={minX + width} y2={0} className="text-border" stroke="currentColor" strokeWidth={6} />
+
+      {/* chassis rail + steering column + pedal (decorative) */}
+      <g className="text-muted-foreground" stroke="currentColor" fill="none" strokeLinecap="round">
+        <line x1={-110} y1={-62} x2={L - 110} y2={-62} strokeWidth={14} />
+        <line x1={L - 360} y1={-90} x2={L - 520} y2={-400} strokeWidth={10} />
+        <circle cx={L - 540} cy={-430} r={55} strokeWidth={10} />
+        <line x1={current.foot.x + 25} y1={-70} x2={current.foot.x - 5} y2={-200} strokeWidth={10} />
+      </g>
+
+      {/* wheels: rear axle at x = 0, front axle at x = L */}
+      <g className="text-foreground/70" stroke="currentColor" fill="none" strokeWidth={12}>
+        <circle cx={0} cy={-rearR} r={rearR} />
+        <circle cx={0} cy={-rearR} r={48} />
+        <circle cx={L} cy={-frontR} r={frontR} />
+        <circle cx={L} cy={-frontR} r={42} />
+      </g>
+      <g className="text-muted-foreground" fill="currentColor" fontSize={42} textAnchor="middle">
+        <text x={0} y={52}>R</text>
+        <text x={L} y={52}>F</text>
+      </g>
+
+      {/* baseline ghost (zero point) */}
+      {!isAtZero && (
+        <>
+          <Figure g={baseline} ghost />
+          <ComCrosshair p={baseline.com} ghost />
+        </>
+      )}
+
+      {/* current position */}
+      <Figure g={current} />
+      {/* tilt anchor — the rotation pivot at the front-bottom seat edge */}
+      <circle
+        cx={params.anchorXMm + adjustments.slideMm}
+        cy={-params.anchorZMm}
+        r={14}
+        className="text-warning"
+        fill="currentColor"
+      />
+      <ComCrosshair p={current.com} />
+    </svg>
+  );
+}
+
+export default SeatDiagram;

--- a/src/plugins/tools/seat-position/SeatPositionTool.tsx
+++ b/src/plugins/tools/seat-position/SeatPositionTool.tsx
@@ -1,0 +1,492 @@
+// Kart seat-position weight-shift visualizer.
+//
+// All physics lives in the pure `model.ts`; this file is rendering + state.
+// Settings (kart/driver numbers, baseline, calibration) persist to the tools
+// plugin's own IndexedDB store, so a calibrated setup survives reloads and
+// works fully offline trackside.
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, RotateCcw, Crosshair } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import type { PluginPanelProps } from "@/plugins/panels";
+import { getPluginStore } from "@/plugins/storage";
+import { SeatDiagram } from "./SeatDiagram";
+import {
+  DEFAULT_PARAMS,
+  KG_PER_LB,
+  LB_PER_KG,
+  MM_PER_INCH,
+  ZERO_ADJUSTMENTS,
+  computeState,
+  fitKLegs,
+  lateralTransferKg,
+  legMassKg,
+  rearMountMmFromTiltDeg,
+  rebaseline,
+  sensitivity,
+  slideSensitivityPctPerMm,
+  tiltDegFromRearMountMm,
+  torsoMassKg,
+  totalsFromCorners,
+  type SeatAdjustments,
+  type SeatModelParams,
+} from "./model";
+
+const STORE_KEY = "seat-position:v1";
+
+type TiltMode = "deg" | "mm";
+
+interface PersistedState {
+  params: SeatModelParams;
+  adj: SeatAdjustments;
+  useLb: boolean;
+  tiltMode: TiltMode;
+}
+
+/** ±1" slide range in 1/16" detents; ±5° tilt; ±30 mm rear-mount range. */
+const SLIDE_MAX_MM = MM_PER_INCH;
+const SLIDE_STEP_MM = MM_PER_INCH / 16;
+const TILT_MAX_DEG = 5;
+const MOUNT_MAX_MM = 30;
+
+function formatSlideInches(mm: number): string {
+  const sixteenths = Math.round((mm / MM_PER_INCH) * 16);
+  if (sixteenths === 0) return '0"';
+  const sign = sixteenths < 0 ? "−" : "+";
+  let n = Math.abs(sixteenths);
+  let d = 16;
+  while (n % 2 === 0 && d > 1) {
+    n /= 2;
+    d /= 2;
+  }
+  const whole = Math.floor(n / d);
+  const rem = n % d;
+  const frac = rem ? `${rem}/${d}` : "";
+  return `${sign}${whole ? whole + (frac ? " " : "") : ""}${frac}"`;
+}
+
+function signed(value: number, digits: number): string {
+  const r = value.toFixed(digits);
+  return value >= 0 ? `+${r}` : r.replace("-", "−");
+}
+
+/** Number field that doesn't fight the keyboard: commits parseable input, resyncs on outside change. */
+function NumRow({ label, value, onChange, unit, step = 1, className }: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  unit?: string;
+  step?: number;
+  className?: string;
+}) {
+  const display = useMemo(() => String(Number(value.toFixed(2))), [value]);
+  const [text, setText] = useState(display);
+  const editing = useRef(false);
+  useEffect(() => {
+    if (!editing.current) setText(display);
+  }, [display]);
+  return (
+    <div className={className}>
+      <Label className="text-xs text-muted-foreground">
+        {label}
+        {unit ? ` (${unit})` : ""}
+      </Label>
+      <NumberInput
+        className="h-8 mt-1 text-sm"
+        step={step}
+        value={text}
+        onFocus={() => {
+          editing.current = true;
+        }}
+        onBlur={() => {
+          editing.current = false;
+          setText(display);
+        }}
+        onValueChange={(raw) => {
+          setText(raw);
+          const v = parseFloat(raw);
+          if (Number.isFinite(v)) onChange(v);
+        }}
+      />
+    </div>
+  );
+}
+
+function Section({ title, defaultOpen, children }: { title: string; defaultOpen?: boolean; children: ReactNode }) {
+  const [open, setOpen] = useState(!!defaultOpen);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-border bg-card">
+      <CollapsibleTrigger className="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium text-foreground">
+        {title}
+        <ChevronDown className={`w-4 h-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`} />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="border-t border-border p-4">{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export default function SeatPositionTool(_props: PluginPanelProps) {
+  const store = useMemo(() => getPluginStore("tools"), []);
+  const [params, setParams] = useState<SeatModelParams>(DEFAULT_PARAMS);
+  const [adj, setAdj] = useState<SeatAdjustments>(ZERO_ADJUSTMENTS);
+  const [useLb, setUseLb] = useState(true);
+  const [tiltMode, setTiltMode] = useState<TiltMode>("deg");
+  const [loaded, setLoaded] = useState(false);
+
+  // Calibration scratchpad (kg internally, displayed in the chosen unit).
+  const [cal, setCal] = useState({ fl: 0, fr: 0, rl: 0, rr: 0, slideMm: 20, movedFrontKg: 0 });
+
+  useEffect(() => {
+    let active = true;
+    store
+      .get<PersistedState>(STORE_KEY)
+      .then((saved) => {
+        if (active && saved) {
+          setParams({ ...DEFAULT_PARAMS, ...saved.params });
+          setAdj({ ...ZERO_ADJUSTMENTS, ...saved.adj });
+          setUseLb(saved.useLb ?? true);
+          setTiltMode(saved.tiltMode ?? "deg");
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (active) setLoaded(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [store]);
+
+  useEffect(() => {
+    if (!loaded) return;
+    const t = setTimeout(() => {
+      void store.set(STORE_KEY, { params, adj, useLb, tiltMode } satisfies PersistedState).catch(() => undefined);
+    }, 400);
+    return () => clearTimeout(t);
+  }, [params, adj, useLb, tiltMode, loaded, store]);
+
+  const state = useMemo(() => computeState(params, adj), [params, adj]);
+  const zeroState = useMemo(() => computeState(params, ZERO_ADJUSTMENTS), [params]);
+  const sens = useMemo(() => sensitivity(params, adj), [params, adj]);
+  const naivePctPerInch = useMemo(
+    () => slideSensitivityPctPerMm({ ...params, kLegs: 1 }) * MM_PER_INCH,
+    [params],
+  );
+
+  const deltaRearPct = state.loads.rearPct - zeroState.loads.rearPct;
+  const deltaCogZ = state.com.zMm - zeroState.com.zMm;
+  const atZero = adj.slideMm === 0 && adj.tiltDeg === 0;
+  const latTransfer = lateralTransferKg(state.com, params.trackWidthMm, 1.5);
+  const latTransferDelta = latTransfer - lateralTransferKg(zeroState.com, params.trackWidthMm, 1.5);
+
+  const fmtW = (kg: number) =>
+    useLb ? `${(kg * LB_PER_KG).toFixed(1)} lb (${kg.toFixed(1)} kg)` : `${kg.toFixed(1)} kg (${(kg * LB_PER_KG).toFixed(1)} lb)`;
+  const fmtWShort = (kg: number) => (useLb ? `${(kg * LB_PER_KG).toFixed(1)} lb` : `${kg.toFixed(1)} kg`);
+  const toUnit = (kg: number) => (useLb ? kg * LB_PER_KG : kg);
+  const fromUnit = (v: number) => (useLb ? v * KG_PER_LB : v);
+  const wUnit = useLb ? "lb" : "kg";
+
+  const cornerTotals = totalsFromCorners({ fl: cal.fl, fr: cal.fr, rl: cal.rl, rr: cal.rr });
+  const canApplyBaseline = cornerTotals.totalKg > params.driverMassKg + params.fuelKg + params.seatMassKg;
+  const canFitKLegs = cornerTotals.frontKg > 0 && cal.movedFrontKg > 0 && cal.slideMm !== 0;
+
+  const setParam = <K extends keyof SeatModelParams>(key: K, value: SeatModelParams[K]) =>
+    setParams((p) => ({ ...p, [key]: value }));
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="max-w-5xl mx-auto p-4 space-y-4">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+          {/* Diagram + adjustment sliders */}
+          <div className="space-y-4 min-w-0">
+            <div className="rounded-lg border border-border bg-card p-3">
+              <SeatDiagram params={params} adjustments={adj} />
+              <p className="mt-1 text-[11px] text-muted-foreground text-center">
+                Gray ghost = zero point · crosshair = combined CoG · dot = tilt anchor
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 space-y-5">
+              <div>
+                <div className="flex items-baseline justify-between">
+                  <Label className="text-xs">Seat slide (fore/aft)</Label>
+                  <span className="text-sm font-medium tabular-nums">
+                    {formatSlideInches(adj.slideMm)} <span className="text-muted-foreground">({signed(adj.slideMm, 1)} mm)</span>
+                  </span>
+                </div>
+                <Slider
+                  className="mt-2"
+                  min={-SLIDE_MAX_MM}
+                  max={SLIDE_MAX_MM}
+                  step={SLIDE_STEP_MM}
+                  value={[adj.slideMm]}
+                  onValueChange={([v]) => setAdj((a) => ({ ...a, slideMm: v }))}
+                />
+                <div className="flex justify-between text-[10px] text-muted-foreground mt-1">
+                  <span>−1" (rear)</span>
+                  <span>+1" (front)</span>
+                </div>
+              </div>
+
+              <div>
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs">Seat tilt</Label>
+                    <button
+                      onClick={() => setTiltMode((m) => (m === "deg" ? "mm" : "deg"))}
+                      className="text-[10px] text-primary underline-offset-2 hover:underline"
+                    >
+                      {tiltMode === "deg" ? "use rear-mount mm" : "use degrees"}
+                    </button>
+                  </div>
+                  <span className="text-sm font-medium tabular-nums">
+                    {signed(adj.tiltDeg, 2)}°{" "}
+                    <span className="text-muted-foreground">
+                      (mount {signed(rearMountMmFromTiltDeg(adj.tiltDeg, params.rearMountArmMm), 1)} mm)
+                    </span>
+                  </span>
+                </div>
+                {tiltMode === "deg" ? (
+                  <Slider
+                    className="mt-2"
+                    min={-TILT_MAX_DEG}
+                    max={TILT_MAX_DEG}
+                    step={0.25}
+                    value={[adj.tiltDeg]}
+                    onValueChange={([v]) => setAdj((a) => ({ ...a, tiltDeg: v }))}
+                  />
+                ) : (
+                  <Slider
+                    className="mt-2"
+                    min={-MOUNT_MAX_MM}
+                    max={MOUNT_MAX_MM}
+                    step={1}
+                    value={[Math.round(rearMountMmFromTiltDeg(adj.tiltDeg, params.rearMountArmMm))]}
+                    onValueChange={([v]) => setAdj((a) => ({ ...a, tiltDeg: tiltDegFromRearMountMm(v, params.rearMountArmMm) }))}
+                  />
+                )}
+                <div className="flex justify-between text-[10px] text-muted-foreground mt-1">
+                  <span>{tiltMode === "deg" ? "−5° (upright)" : "−30 mm (raise mount)"}</span>
+                  <span>{tiltMode === "deg" ? "+5° (recline)" : "+30 mm (lower mount)"}</span>
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" className="h-8 gap-1.5" disabled={atZero} onClick={() => setAdj(ZERO_ADJUSTMENTS)}>
+                  <RotateCcw className="w-3.5 h-3.5" /> Reset sliders
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5"
+                  disabled={atZero}
+                  onClick={() => {
+                    setParams((p) => rebaseline(p, adj));
+                    setAdj(ZERO_ADJUSTMENTS);
+                  }}
+                >
+                  <Crosshair className="w-3.5 h-3.5" /> Set current as zero
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Readouts */}
+          <div className="space-y-3">
+            <div className="rounded-lg border border-border bg-card p-4 text-center">
+              <p className="text-[11px] text-muted-foreground uppercase tracking-wide">Weight shift vs zero</p>
+              <p
+                className={`mt-1 text-3xl font-bold tabular-nums ${
+                  deltaRearPct > 0.005 ? "text-warning" : deltaRearPct < -0.005 ? "text-primary" : "text-foreground"
+                }`}
+              >
+                {signed(deltaRearPct, 2)}% rear
+              </p>
+              <p className="text-[11px] text-muted-foreground mt-1">
+                {deltaRearPct > 0.005 ? "rear bias added" : deltaRearPct < -0.005 ? "forward bias added" : "at the zero point"}
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+              <div className="flex h-3 overflow-hidden rounded">
+                <div className="bg-primary/70" style={{ width: `${state.loads.frontPct}%` }} />
+                <div className="flex-1 bg-warning/70" />
+              </div>
+              <div className="flex justify-between text-xs">
+                <div>
+                  <p className="font-medium text-foreground">Front {state.loads.frontPct.toFixed(1)}%</p>
+                  <p className="text-muted-foreground">{fmtW(state.loads.frontKg)}</p>
+                </div>
+                <div className="text-right">
+                  <p className="font-medium text-foreground">Rear {state.loads.rearPct.toFixed(1)}%</p>
+                  <p className="text-muted-foreground">{fmtW(state.loads.rearKg)}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 text-xs space-y-1.5">
+              <p className="font-medium text-foreground">Centre of gravity</p>
+              <p className="text-muted-foreground tabular-nums">
+                {state.com.xMm.toFixed(0)} mm fwd of rear axle · {state.com.zMm.toFixed(0)} mm high
+              </p>
+              <p className="tabular-nums">
+                <span className="text-muted-foreground">Δ height: </span>
+                <span className={deltaCogZ < -0.05 ? "text-primary font-medium" : deltaCogZ > 0.05 ? "text-warning font-medium" : "text-foreground"}>
+                  {signed(deltaCogZ, 1)} mm
+                </span>
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 text-xs space-y-1.5">
+              <p className="font-medium text-foreground">Sensitivity (here)</p>
+              <p className="text-muted-foreground tabular-nums">{signed(sens.pctPerInch, 2)}% front per inch of slide</p>
+              <p className="text-muted-foreground tabular-nums">{signed(sens.pctPerDeg, 2)}% front per degree of recline</p>
+              <p className="text-[10px] text-muted-foreground/70">
+                Naive "whole driver moves" estimate: {signed(naivePctPerInch, 2)}%/in — feet-on-pedals model is the lower number.
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4 text-xs space-y-1.5">
+              <p className="font-medium text-foreground">Cornering transfer @ 1.5 g</p>
+              <p className="text-muted-foreground tabular-nums">
+                {fmtWShort(latTransfer)} across the kart{" "}
+                <span className={latTransferDelta < -0.005 ? "text-primary" : latTransferDelta > 0.005 ? "text-warning" : ""}>
+                  ({signed(toUnit(latTransferDelta), 1)} {wUnit} vs zero)
+                </span>
+              </p>
+              <p className="text-[10px] text-muted-foreground/70">
+                Rigid-frame approximation — karts corner on frame jacking, so treat as a relative indicator.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <Section title="Kart & driver" defaultOpen>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <div className="col-span-2 sm:col-span-3 flex items-center gap-2">
+              <Label htmlFor="seat-tool-units" className="text-xs text-muted-foreground">kg</Label>
+              <Switch id="seat-tool-units" checked={useLb} onCheckedChange={setUseLb} />
+              <Label htmlFor="seat-tool-units" className="text-xs text-muted-foreground">lb</Label>
+            </div>
+            <NumRow label="Driver (with gear)" unit={wUnit} value={toUnit(params.driverMassKg)} onChange={(v) => setParam("driverMassKg", Math.max(fromUnit(v), 1))} />
+            <NumRow label="Kart (no driver/fuel)" unit={wUnit} value={toUnit(params.kartMassKg)} onChange={(v) => setParam("kartMassKg", Math.max(fromUnit(v), params.seatMassKg + 1))} />
+            <NumRow label="Fuel" unit={wUnit} value={toUnit(params.fuelKg)} onChange={(v) => setParam("fuelKg", Math.max(fromUnit(v), 0))} step={useLb ? 1 : 0.5} />
+            <NumRow label="Wheelbase" unit="mm" value={params.wheelbaseMm} onChange={(v) => setParam("wheelbaseMm", Math.max(v, 500))} step={5} />
+            <NumRow label="Baseline front weight" unit="%" value={params.baselineFrontPct} onChange={(v) => setParam("baselineFrontPct", Math.min(Math.max(v, 20), 70))} step={0.5} />
+            <NumRow label="Baseline CoG height" unit="mm" value={params.baselineCogZMm} onChange={(v) => setParam("baselineCogZMm", Math.max(v, 50))} step={5} />
+          </div>
+          <p className="mt-3 text-[11px] text-muted-foreground">
+            The baseline is your kart at the zero point — most sprint setups target 43% front (some run 40). Corner scales beat guesses: see Calibration.
+          </p>
+        </Section>
+
+        <Section title="Advanced model">
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-baseline justify-between">
+                <Label className="text-xs">Leg coupling k<sub>legs</sub></Label>
+                <span className="text-sm font-medium tabular-nums">{params.kLegs.toFixed(2)}</span>
+              </div>
+              <Slider className="mt-2" min={0} max={1} step={0.05} value={[params.kLegs]} onValueChange={([v]) => setParam("kLegs", v)} />
+              <p className="mt-1 text-[10px] text-muted-foreground">
+                How much of the seat's movement the leg CoM follows (feet stay on the pedals). 0.4 is a sane default — calibrate it on scales.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <NumRow label="Torso fraction of driver" unit="0–1" value={params.torsoFraction} onChange={(v) => setParam("torsoFraction", Math.min(Math.max(v, 0.4), 0.9))} step={0.01} />
+              <NumRow label="Seat mass" unit={wUnit} value={toUnit(params.seatMassKg)} onChange={(v) => setParam("seatMassKg", Math.min(Math.max(fromUnit(v), 0.5), params.kartMassKg - 1))} step={useLb ? 1 : 0.5} />
+              <NumRow label="Anchor fwd of rear axle" unit="mm" value={params.anchorXMm} onChange={(v) => setParam("anchorXMm", v)} step={5} />
+              <NumRow label="Anchor height" unit="mm" value={params.anchorZMm} onChange={(v) => setParam("anchorZMm", v)} step={5} />
+              <NumRow label="Torso CoM distance" unit="mm" value={params.torsoRMm} onChange={(v) => setParam("torsoRMm", Math.max(v, 100))} step={10} />
+              <NumRow label="Torso CoM angle" unit="° from fwd" value={params.torsoAlphaDeg} onChange={(v) => setParam("torsoAlphaDeg", v)} />
+              <NumRow label="Anchor → rear mount" unit="mm" value={params.rearMountArmMm} onChange={(v) => setParam("rearMountArmMm", Math.max(v, 50))} step={10} />
+              <NumRow label="Rear track width" unit="mm" value={params.trackWidthMm} onChange={(v) => setParam("trackWidthMm", Math.max(v, 600))} step={10} />
+            </div>
+            <Button variant="outline" size="sm" className="h-8" onClick={() => setParams(DEFAULT_PARAMS)}>
+              Restore defaults
+            </Button>
+          </div>
+        </Section>
+
+        <Section title="Calibration (corner scales)">
+          <div className="space-y-4 text-xs">
+            <p className="text-muted-foreground">
+              Default numbers are ±20% per driver. Two scale sessions anchor the model to <em>your</em> kart: weigh at the zero point, then slide the seat a
+              known amount and re-weigh to fit the leg coupling.
+            </p>
+            <div>
+              <p className="font-medium text-foreground mb-2">1 · Corner weights at the zero point (driver seated)</p>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <NumRow label="Front left" unit={wUnit} value={toUnit(cal.fl)} onChange={(v) => setCal((c) => ({ ...c, fl: Math.max(fromUnit(v), 0) }))} />
+                <NumRow label="Front right" unit={wUnit} value={toUnit(cal.fr)} onChange={(v) => setCal((c) => ({ ...c, fr: Math.max(fromUnit(v), 0) }))} />
+                <NumRow label="Rear left" unit={wUnit} value={toUnit(cal.rl)} onChange={(v) => setCal((c) => ({ ...c, rl: Math.max(fromUnit(v), 0) }))} />
+                <NumRow label="Rear right" unit={wUnit} value={toUnit(cal.rr)} onChange={(v) => setCal((c) => ({ ...c, rr: Math.max(fromUnit(v), 0) }))} />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  disabled={!canApplyBaseline}
+                  onClick={() =>
+                    setParams((p) => ({
+                      ...p,
+                      kartMassKg: Math.max(cornerTotals.totalKg - p.driverMassKg - p.fuelKg, p.seatMassKg + 1),
+                      baselineFrontPct: cornerTotals.frontPct,
+                    }))
+                  }
+                >
+                  Apply baseline
+                </Button>
+                {cornerTotals.totalKg > 0 && (
+                  <span className="text-muted-foreground tabular-nums">
+                    Total {fmtWShort(cornerTotals.totalKg)} · front {cornerTotals.frontPct.toFixed(1)}%
+                  </span>
+                )}
+              </div>
+            </div>
+            <div>
+              <p className="font-medium text-foreground mb-2">2 · Slide the seat a known amount and re-weigh the front pair</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                <NumRow label="Seat slid by (+fwd)" unit="mm" value={cal.slideMm} onChange={(v) => setCal((c) => ({ ...c, slideMm: v }))} step={5} />
+                <NumRow label="New front-axle total" unit={wUnit} value={toUnit(cal.movedFrontKg)} onChange={(v) => setCal((c) => ({ ...c, movedFrontKg: Math.max(fromUnit(v), 0) }))} />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  disabled={!canFitKLegs}
+                  onClick={() =>
+                    setParam(
+                      "kLegs",
+                      Math.round(
+                        fitKLegs({
+                          baselineFrontKg: cornerTotals.frontKg,
+                          movedFrontKg: cal.movedFrontKg,
+                          slideMm: cal.slideMm,
+                          wheelbaseMm: params.wheelbaseMm,
+                          torsoMassKg: torsoMassKg(params),
+                          seatMassKg: params.seatMassKg,
+                          legMassKg: legMassKg(params),
+                        }) * 100,
+                      ) / 100,
+                    )
+                  }
+                >
+                  Fit leg coupling
+                </Button>
+                <span className="text-muted-foreground tabular-nums">current k = {params.kLegs.toFixed(2)}</span>
+              </div>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/src/plugins/tools/seat-position/model.test.ts
+++ b/src/plugins/tools/seat-position/model.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PARAMS,
+  ZERO_ADJUSTMENTS,
+  axleLoads,
+  computeCoM,
+  computeMassElements,
+  computeState,
+  fitKLegs,
+  hipPoint,
+  legMassKg,
+  lateralTransferKg,
+  rearMountMmFromTiltDeg,
+  rebaseline,
+  sensitivity,
+  slideSensitivityPctPerMm,
+  solveKneeIK,
+  tiltDegFromRearMountMm,
+  torsoMassKg,
+  totalMassKg,
+  totalsFromCorners,
+  type SeatModelParams,
+} from "./model";
+
+const p: SeatModelParams = DEFAULT_PARAMS;
+
+describe("seat position model — statics", () => {
+  it("moments balance: front + rear === total exactly", () => {
+    const { loads } = computeState(p, { slideMm: 13, tiltDeg: 2.5 });
+    expect(loads.frontKg + loads.rearKg).toBeCloseTo(loads.totalKg, 12);
+    expect(loads.frontPct + loads.rearPct).toBeCloseTo(100, 12);
+  });
+
+  it("CoM is linear: translating every element by Δ translates the CoM by Δ", () => {
+    const elements = computeMassElements(p, { slideMm: -10, tiltDeg: 1 });
+    const com = computeCoM(elements);
+    const shifted = computeCoM(elements.map((e) => ({ ...e, xMm: e.xMm + 37, zMm: e.zMm - 12 })));
+    expect(shifted.xMm).toBeCloseTo(com.xMm + 37, 9);
+    expect(shifted.zMm).toBeCloseTo(com.zMm - 12, 9);
+    expect(shifted.massKg).toBeCloseTo(com.massKg, 12);
+  });
+
+  it("zero adjustments reproduce the baseline front% and CoG height exactly", () => {
+    const { loads, com } = computeState(p, ZERO_ADJUSTMENTS);
+    expect(loads.frontPct).toBeCloseTo(p.baselineFrontPct, 9);
+    expect(com.zMm).toBeCloseTo(p.baselineCogZMm, 9);
+  });
+
+  it("mass bookkeeping: elements sum to the class weight", () => {
+    const { com } = computeState(p, ZERO_ADJUSTMENTS);
+    expect(com.massKg).toBeCloseTo(totalMassKg(p), 12);
+    expect(torsoMassKg(p) + legMassKg(p)).toBeCloseTo(p.driverMassKg, 12);
+  });
+});
+
+describe("seat position model — slide", () => {
+  it("numeric slide sensitivity matches the closed-form Section 5 formula", () => {
+    const closedForm = slideSensitivityPctPerMm(p);
+    const f1 = computeState(p, { slideMm: 10, tiltDeg: 0 }).loads.frontPct;
+    const f0 = computeState(p, { slideMm: -10, tiltDeg: 0 }).loads.frontPct;
+    expect((f1 - f0) / 20).toBeCloseTo(closedForm, 9);
+  });
+
+  it("defaults land near the karting rule of thumb: ~1% F/R per inch of slide", () => {
+    const pctPerInch = slideSensitivityPctPerMm(p) * 25.4;
+    expect(pctPerInch).toBeGreaterThan(0.8);
+    expect(pctPerInch).toBeLessThan(1.3);
+  });
+
+  it("slide does not change the CoG height", () => {
+    const z0 = computeState(p, ZERO_ADJUSTMENTS).com.zMm;
+    const z1 = computeState(p, { slideMm: 25.4, tiltDeg: 0 }).com.zMm;
+    expect(z1).toBeCloseTo(z0, 9);
+  });
+
+  it("kLegs = 1 degenerates to the naive whole-driver-moves model", () => {
+    const naive: SeatModelParams = { ...p, kLegs: 1 };
+    const moved = torsoMassKg(p) + p.seatMassKg + legMassKg(p);
+    expect(slideSensitivityPctPerMm(naive)).toBeCloseTo(
+      (100 * moved) / (totalMassKg(p) * p.wheelbaseMm),
+      12,
+    );
+  });
+});
+
+describe("seat position model — tilt", () => {
+  it("zero tilt is the identity", () => {
+    const a = computeState(p, ZERO_ADJUSTMENTS);
+    const b = computeState(p, { slideMm: 0, tiltDeg: 0 });
+    expect(b.com.xMm).toBeCloseTo(a.com.xMm, 12);
+    expect(b.com.zMm).toBeCloseTo(a.com.zMm, 12);
+  });
+
+  it("recline shifts weight rearward AND lowers the CoG (default geometry)", () => {
+    const zero = computeState(p, ZERO_ADJUSTMENTS);
+    const reclined = computeState(p, { slideMm: 0, tiltDeg: 5 });
+    expect(reclined.loads.frontPct).toBeLessThan(zero.loads.frontPct);
+    expect(reclined.com.zMm).toBeLessThan(zero.com.zMm);
+  });
+
+  it("small-angle tilt matches the analytic linearization within 2%", () => {
+    // d(x')/dφ at φ=0 for a rotated offset (dx, dz) is −dz (per radian); legs
+    // couple through the hip with factor kLegs.
+    const DEG = Math.PI / 180;
+    const torsoDz = p.torsoRMm * Math.sin(p.torsoAlphaDeg * DEG);
+    const M = totalMassKg(p);
+    const linearPerDeg =
+      ((-DEG * (torsoMassKg(p) * torsoDz + p.seatMassKg * p.seatComDzMm + p.kLegs * legMassKg(p) * p.hipDzMm)) / M) *
+      (100 / p.wheelbaseMm);
+
+    const phi = 0.5;
+    const f1 = computeState(p, { slideMm: 0, tiltDeg: phi }).loads.frontPct;
+    const f0 = computeState(p, { slideMm: 0, tiltDeg: -phi }).loads.frontPct;
+    const numericPerDeg = (f1 - f0) / (2 * phi);
+    expect(Math.abs(numericPerDeg - linearPerDeg)).toBeLessThan(Math.abs(linearPerDeg) * 0.02);
+  });
+
+  it("rear-mount mm ⇄ degrees round-trips", () => {
+    const deg = tiltDegFromRearMountMm(15, p.rearMountArmMm);
+    expect(rearMountMmFromTiltDeg(deg, p.rearMountArmMm)).toBeCloseTo(15, 9);
+    expect(deg).toBeGreaterThan(0); // lowering the rear mount = recline
+  });
+
+  it("sensitivity readout reports both axes with sane signs", () => {
+    const s = sensitivity(p, ZERO_ADJUSTMENTS);
+    expect(s.pctPerInch).toBeGreaterThan(0); // forward slide adds front weight
+    expect(s.pctPerDeg).toBeLessThan(0); // recline removes front weight
+  });
+});
+
+describe("seat position model — knee IK", () => {
+  const hip = { x: 290, z: 180 };
+  const foot = { x: 950, z: 130 };
+
+  it("preserves both segment lengths when the foot is reachable", () => {
+    const knee = solveKneeIK(hip, foot, 420, 430);
+    expect(Math.hypot(knee.x - hip.x, knee.z - hip.z)).toBeCloseTo(420, 9);
+    expect(Math.hypot(knee.x - foot.x, knee.z - foot.z)).toBeCloseTo(430, 9);
+  });
+
+  it("picks the knee-up solution", () => {
+    const knee = solveKneeIK(hip, foot, 420, 430);
+    expect(knee.z).toBeGreaterThan(Math.max(hip.z, foot.z));
+  });
+
+  it("clamps onto the hip→foot line when out of reach", () => {
+    const knee = solveKneeIK(hip, { x: hip.x + 2000, z: hip.z }, 420, 430);
+    expect(knee.x).toBeCloseTo(hip.x + 420, 9);
+    expect(knee.z).toBeCloseTo(hip.z, 9);
+  });
+});
+
+describe("seat position model — calibration", () => {
+  it("corner totals", () => {
+    const t = totalsFromCorners({ fl: 35, fr: 34, rl: 46, rr: 47 });
+    expect(t.totalKg).toBeCloseTo(162, 12);
+    expect(t.frontKg).toBeCloseTo(69, 12);
+    expect(t.frontPct).toBeCloseTo((100 * 69) / 162, 12);
+  });
+
+  it("round-trips kLegs from synthetic scale data", () => {
+    const truth: SeatModelParams = { ...p, kLegs: 0.55 };
+    const slideMm = 20;
+    const baseline = computeState(truth, ZERO_ADJUSTMENTS).loads;
+    const moved = computeState(truth, { slideMm, tiltDeg: 0 }).loads;
+    const fitted = fitKLegs({
+      baselineFrontKg: baseline.frontKg,
+      movedFrontKg: moved.frontKg,
+      slideMm,
+      wheelbaseMm: truth.wheelbaseMm,
+      torsoMassKg: torsoMassKg(truth),
+      seatMassKg: truth.seatMassKg,
+      legMassKg: legMassKg(truth),
+    });
+    expect(fitted).toBeCloseTo(0.55, 9);
+  });
+
+  it("clamps a nonsense fit into [0, 1]", () => {
+    const args = {
+      slideMm: 20,
+      wheelbaseMm: p.wheelbaseMm,
+      torsoMassKg: torsoMassKg(p),
+      seatMassKg: p.seatMassKg,
+      legMassKg: legMassKg(p),
+    };
+    expect(fitKLegs({ ...args, baselineFrontKg: 69, movedFrontKg: 69 - 5 })).toBe(0);
+    expect(fitKLegs({ ...args, baselineFrontKg: 69, movedFrontKg: 69 + 50 })).toBe(1);
+  });
+});
+
+describe("seat position model — dynamic context", () => {
+  it("lateral transfer scales with CoG height", () => {
+    const com = computeState(p, ZERO_ADJUSTMENTS).com;
+    const low = lateralTransferKg({ ...com, zMm: com.zMm - 10 }, p.trackWidthMm, 1.5);
+    const base = lateralTransferKg(com, p.trackWidthMm, 1.5);
+    expect(low).toBeLessThan(base);
+    expect(base).toBeCloseTo((com.massKg * 1.5 * com.zMm) / p.trackWidthMm, 12);
+  });
+
+  it("axleLoads is consistent with front% = 100·x/L", () => {
+    const loads = axleLoads({ xMm: 447.2, zMm: 250, massKg: 162 }, 1040);
+    expect(loads.frontPct).toBeCloseTo((100 * 447.2) / 1040, 12);
+  });
+
+  it("rebaseline folds adjustments in exactly: new params at zero === old params at adj", () => {
+    const adj = { slideMm: 15, tiltDeg: 3 };
+    const before = computeState(p, adj);
+    const rebased = computeState(rebaseline(p, adj), ZERO_ADJUSTMENTS);
+    expect(rebased.loads.frontPct).toBeCloseTo(before.loads.frontPct, 9);
+    expect(rebased.com.xMm).toBeCloseTo(before.com.xMm, 9);
+    expect(rebased.com.zMm).toBeCloseTo(before.com.zMm, 9);
+  });
+
+  it("hipPoint moves 1:1 with slide", () => {
+    const h0 = hipPoint(p, ZERO_ADJUSTMENTS);
+    const h1 = hipPoint(p, { slideMm: 12, tiltDeg: 0 });
+    expect(h1.x - h0.x).toBeCloseTo(12, 12);
+    expect(h1.z).toBeCloseTo(h0.z, 12);
+  });
+});

--- a/src/plugins/tools/seat-position/model.ts
+++ b/src/plugins/tools/seat-position/model.ts
@@ -1,0 +1,398 @@
+// Pure rigid-body statics model for the kart seat-position visualizer.
+//
+// A kart has no suspension, so static axle loads are pure moments: track the
+// longitudinal position (x) and height (z) of the combined centre of mass as
+// the seat slides fore/aft and tilts about its front-bottom anchor, and every
+// readout falls out of `front% = 100 · x_cm / wheelbase`.
+//
+// Coordinate system: origin at the rear-axle contact line, x positive toward
+// the front axle, z up from the ground. All lengths in mm, masses in kg.
+//
+// The mass model is four elements:
+//   - fixed lump   — chassis + engine + fuel, everything that never moves.
+//     Its position is *solved* so that the zero point (slide 0, tilt 0) lands
+//     exactly on the user's baseline front% / CoG height. The baseline is the
+//     measured (or assumed) truth; the lump is virtual bookkeeping.
+//   - seat         — moves rigidly with both adjustments.
+//   - torso group  — pelvis/torso/head/arms (~66% of the driver), rigid with
+//     the seat.
+//   - leg group    — thighs/shanks/feet. The feet stay on the pedals, so the
+//     leg CoM only follows a fraction `kLegs` of the hip's displacement (the
+//     knees absorb the rest). This is the single biggest modelling choice and
+//     why naive "whole CoG moves with the seat" estimates overstate the effect.
+
+export interface Point {
+  x: number;
+  z: number;
+}
+
+export interface SeatModelParams {
+  /** Rear axle (x=0) to front axle, mm. */
+  wheelbaseMm: number;
+  /** Driver mass incl. gear, kg. */
+  driverMassKg: number;
+  /** Kart mass incl. seat, excl. driver and fuel, kg. */
+  kartMassKg: number;
+  /** Seat mass (part of kartMassKg, but it moves), kg. */
+  seatMassKg: number;
+  /** Fuel load, kg. */
+  fuelKg: number;
+  /** Static front weight % at the zero point (slide 0, tilt 0). */
+  baselineFrontPct: number;
+  /** Combined CoG height at the zero point, mm. */
+  baselineCogZMm: number;
+  /** Fraction of seat/hip displacement the leg-group CoM follows (0..1). */
+  kLegs: number;
+  /** Fraction of driver mass in the seat-rigid torso group (rest is legs). */
+  torsoFraction: number;
+  /** Tilt anchor P — front-bottom seat edge / front mount bolt. */
+  anchorXMm: number;
+  anchorZMm: number;
+  /** Torso-group CoM polar offset from the anchor (deg above +x axis). */
+  torsoRMm: number;
+  torsoAlphaDeg: number;
+  /** Seat CoM offset from the anchor (dx, dz). */
+  seatComDxMm: number;
+  seatComDzMm: number;
+  /** Hip point offset from the anchor (dx, dz) — drives the leg coupling. */
+  hipDxMm: number;
+  hipDzMm: number;
+  /** Leg-group CoM at the zero point (absolute, fwd of rear axle). */
+  legComXMm: number;
+  legComZMm: number;
+  /** Anchor → rear seat mount distance, mm (tilt mm ⇄ deg conversion). */
+  rearMountArmMm: number;
+  /** Rear track width, mm (lateral load-transfer readout). */
+  trackWidthMm: number;
+}
+
+/** Seat adjustments relative to the zero point. */
+export interface SeatAdjustments {
+  /** Fore/aft slide, mm. Positive = forward. */
+  slideMm: number;
+  /** Tilt about the front anchor, deg. Positive = recline (driver back). */
+  tiltDeg: number;
+}
+
+export interface MassElement {
+  id: "fixed" | "seat" | "torso" | "legs";
+  massKg: number;
+  xMm: number;
+  zMm: number;
+}
+
+export interface CoM {
+  xMm: number;
+  zMm: number;
+  massKg: number;
+}
+
+export interface AxleLoads {
+  totalKg: number;
+  frontKg: number;
+  rearKg: number;
+  frontPct: number;
+  rearPct: number;
+}
+
+export const ZERO_ADJUSTMENTS: SeatAdjustments = { slideMm: 0, tiltDeg: 0 };
+
+/**
+ * Defaults for a ~162 kg class weight (80 kg driver + 80 kg kart + 2 kg fuel)
+ * sprint kart at a 43/57 baseline. Geometry puts the torso-group CoM up and
+ * *behind* the front-bottom anchor, so recline moves it rearward AND down —
+ * matching real seat-angle practice (a more reclined back lowers the CoG).
+ */
+export const DEFAULT_PARAMS: SeatModelParams = {
+  wheelbaseMm: 1040,
+  driverMassKg: 80,
+  kartMassKg: 80,
+  seatMassKg: 4,
+  fuelKg: 2,
+  baselineFrontPct: 43,
+  baselineCogZMm: 250,
+  kLegs: 0.4,
+  torsoFraction: 0.66,
+  anchorXMm: 330,
+  anchorZMm: 60,
+  torsoRMm: 450,
+  torsoAlphaDeg: 115,
+  seatComDxMm: -60,
+  seatComDzMm: 140,
+  hipDxMm: -40,
+  hipDzMm: 120,
+  legComXMm: 650,
+  legComZMm: 150,
+  rearMountArmMm: 300,
+  trackWidthMm: 1200,
+};
+
+const DEG = Math.PI / 180;
+
+/** Driver torso-group mass (rigid with the seat), kg. */
+export function torsoMassKg(p: SeatModelParams): number {
+  return p.torsoFraction * p.driverMassKg;
+}
+
+/** Driver leg-group mass, kg. */
+export function legMassKg(p: SeatModelParams): number {
+  return (1 - p.torsoFraction) * p.driverMassKg;
+}
+
+/** Total system mass, kg. */
+export function totalMassKg(p: SeatModelParams): number {
+  return p.kartMassKg + p.driverMassKg + p.fuelKg;
+}
+
+/**
+ * Rotate an (dx, dz) offset by `deg` counter-clockwise in the x-forward /
+ * z-up plane. Positive = recline: a point above the anchor moves rearward.
+ */
+export function rotateOffset(dx: number, dz: number, deg: number): Point {
+  const c = Math.cos(deg * DEG);
+  const s = Math.sin(deg * DEG);
+  return { x: dx * c - dz * s, z: dx * s + dz * c };
+}
+
+/** Hip point (absolute) at the given adjustments — rigid with the seat. */
+export function hipPoint(p: SeatModelParams, adj: SeatAdjustments): Point {
+  const r = rotateOffset(p.hipDxMm, p.hipDzMm, adj.tiltDeg);
+  return { x: p.anchorXMm + adj.slideMm + r.x, z: p.anchorZMm + r.z };
+}
+
+/**
+ * The virtual fixed lump (chassis + engine + fuel): mass is whatever isn't in
+ * the moving groups; position is solved so the zero point reproduces the
+ * baseline front% and CoG height exactly.
+ */
+export function solveFixedElement(p: SeatModelParams): MassElement {
+  const M = totalMassKg(p);
+  const mTorso = torsoMassKg(p);
+  const mLegs = legMassKg(p);
+  const mFixed = Math.max(M - mTorso - mLegs - p.seatMassKg, 0.001);
+
+  const torso = rotateOffset(p.torsoRMm * Math.cos(p.torsoAlphaDeg * DEG), p.torsoRMm * Math.sin(p.torsoAlphaDeg * DEG), 0);
+  const movingMomentX =
+    mTorso * (p.anchorXMm + torso.x) +
+    p.seatMassKg * (p.anchorXMm + p.seatComDxMm) +
+    mLegs * p.legComXMm;
+  const movingMomentZ =
+    mTorso * (p.anchorZMm + torso.z) +
+    p.seatMassKg * (p.anchorZMm + p.seatComDzMm) +
+    mLegs * p.legComZMm;
+
+  const targetXcm = (p.baselineFrontPct / 100) * p.wheelbaseMm;
+  return {
+    id: "fixed",
+    massKg: mFixed,
+    xMm: (targetXcm * M - movingMomentX) / mFixed,
+    zMm: (p.baselineCogZMm * M - movingMomentZ) / mFixed,
+  };
+}
+
+/** All four mass elements at the given adjustments. */
+export function computeMassElements(p: SeatModelParams, adj: SeatAdjustments): MassElement[] {
+  const anchorX = p.anchorXMm + adj.slideMm;
+  const anchorZ = p.anchorZMm;
+
+  const torsoOffset0: Point = {
+    x: p.torsoRMm * Math.cos(p.torsoAlphaDeg * DEG),
+    z: p.torsoRMm * Math.sin(p.torsoAlphaDeg * DEG),
+  };
+  const torsoOffset = rotateOffset(torsoOffset0.x, torsoOffset0.z, adj.tiltDeg);
+  const seatOffset = rotateOffset(p.seatComDxMm, p.seatComDzMm, adj.tiltDeg);
+
+  // Legs: the feet stay on the pedals, so the leg CoM follows only a fraction
+  // of the hip's displacement (slide + tilt combined).
+  const hip0 = hipPoint(p, ZERO_ADJUSTMENTS);
+  const hip = hipPoint(p, adj);
+  const legX = p.legComXMm + p.kLegs * (hip.x - hip0.x);
+  const legZ = p.legComZMm + p.kLegs * (hip.z - hip0.z);
+
+  return [
+    solveFixedElement(p),
+    { id: "seat", massKg: p.seatMassKg, xMm: anchorX + seatOffset.x, zMm: anchorZ + seatOffset.z },
+    { id: "torso", massKg: torsoMassKg(p), xMm: anchorX + torsoOffset.x, zMm: anchorZ + torsoOffset.z },
+    { id: "legs", massKg: legMassKg(p), xMm: legX, zMm: legZ },
+  ];
+}
+
+/** Combined centre of mass of a set of elements. */
+export function computeCoM(elements: MassElement[]): CoM {
+  let m = 0;
+  let mx = 0;
+  let mz = 0;
+  for (const e of elements) {
+    m += e.massKg;
+    mx += e.massKg * e.xMm;
+    mz += e.massKg * e.zMm;
+  }
+  return { xMm: mx / m, zMm: mz / m, massKg: m };
+}
+
+/** Static axle loads from the CoM position (moments about the rear axle). */
+export function axleLoads(com: CoM, wheelbaseMm: number): AxleLoads {
+  const frontKg = (com.massKg * com.xMm) / wheelbaseMm;
+  const frontPct = (100 * com.xMm) / wheelbaseMm;
+  return {
+    totalKg: com.massKg,
+    frontKg,
+    rearKg: com.massKg - frontKg,
+    frontPct,
+    rearPct: 100 - frontPct,
+  };
+}
+
+export interface SeatModelState {
+  elements: MassElement[];
+  com: CoM;
+  loads: AxleLoads;
+}
+
+/** Convenience: elements → CoM → axle loads for one (slide, tilt) point. */
+export function computeState(p: SeatModelParams, adj: SeatAdjustments): SeatModelState {
+  const elements = computeMassElements(p, adj);
+  const com = computeCoM(elements);
+  return { elements, com, loads: axleLoads(com, p.wheelbaseMm) };
+}
+
+/**
+ * Local sensitivities at the current settings, by central difference (the
+ * readout the spec asks for numerically, not from the linearization).
+ */
+export function sensitivity(p: SeatModelParams, adj: SeatAdjustments): { pctPerInch: number; pctPerDeg: number } {
+  const hS = 5; // mm
+  const fS1 = computeState(p, { ...adj, slideMm: adj.slideMm + hS }).loads.frontPct;
+  const fS0 = computeState(p, { ...adj, slideMm: adj.slideMm - hS }).loads.frontPct;
+  const hT = 0.25; // deg
+  const fT1 = computeState(p, { ...adj, tiltDeg: adj.tiltDeg + hT }).loads.frontPct;
+  const fT0 = computeState(p, { ...adj, tiltDeg: adj.tiltDeg - hT }).loads.frontPct;
+  return {
+    pctPerInch: ((fS1 - fS0) / (2 * hS)) * 25.4,
+    pctPerDeg: (fT1 - fT0) / (2 * hT),
+  };
+}
+
+/**
+ * Closed-form slide sensitivity (%/mm) — Section 5 of the design doc. The
+ * model is exactly linear in slide, so this matches the numeric value.
+ */
+export function slideSensitivityPctPerMm(p: SeatModelParams): number {
+  const moved = torsoMassKg(p) + p.seatMassKg + p.kLegs * legMassKg(p);
+  return (100 * moved) / (totalMassKg(p) * p.wheelbaseMm);
+}
+
+/**
+ * Lateral load transfer (kg per side) at a given lateral acceleration —
+ * `ΔW = M · a_y · z_cm / track`. Rigid-frame approximation: karts corner on
+ * frame jacking, so treat this as a relative indicator, not gospel.
+ */
+export function lateralTransferKg(com: CoM, trackWidthMm: number, latG: number): number {
+  return (com.massKg * latG * com.zMm) / trackWidthMm;
+}
+
+/** Most karts tilt via rear-mount spacers: mm the rear mount is LOWERED → recline deg. */
+export function tiltDegFromRearMountMm(loweredMm: number, armMm: number): number {
+  return Math.atan2(loweredMm, armMm) / DEG;
+}
+
+/** Inverse of `tiltDegFromRearMountMm`. */
+export function rearMountMmFromTiltDeg(tiltDeg: number, armMm: number): number {
+  return Math.tan(tiltDeg * DEG) * armMm;
+}
+
+/**
+ * Two-link knee IK for the stick figure: knee position given hip and foot
+ * (foot fixed on the pedals — this *is* the leg-coupling model made visible).
+ * Picks the knee-up solution; clamps gracefully when the foot is out of reach.
+ */
+export function solveKneeIK(hip: Point, foot: Point, thighMm: number, shankMm: number): Point {
+  const dx = foot.x - hip.x;
+  const dz = foot.z - hip.z;
+  const d = Math.hypot(dx, dz);
+  if (d < 1e-9) return { x: hip.x + thighMm, z: hip.z };
+  const ux = dx / d;
+  const uz = dz / d;
+  // Out of reach (or fully folded): put the knee on the hip→foot line.
+  if (d >= thighMm + shankMm) return { x: hip.x + ux * thighMm, z: hip.z + uz * thighMm };
+  if (d <= Math.abs(thighMm - shankMm)) return { x: hip.x + ux * thighMm, z: hip.z + uz * thighMm };
+  const a = (thighMm * thighMm - shankMm * shankMm + d * d) / (2 * d);
+  const h = Math.sqrt(Math.max(thighMm * thighMm - a * a, 0));
+  const bx = hip.x + ux * a;
+  const bz = hip.z + uz * a;
+  // Two solutions: base ± h·perpendicular. Knees point up in a kart.
+  const k1 = { x: bx - uz * h, z: bz + ux * h };
+  const k2 = { x: bx + uz * h, z: bz - ux * h };
+  return k1.z >= k2.z ? k1 : k2;
+}
+
+/**
+ * "Set current as zero": fold the live adjustments into the params so the
+ * current seat position becomes the new baseline and the sliders re-read 0.
+ * Exact — the returned params at zero adjustments reproduce the state the
+ * old params had at `adj` (same front%, same CoG).
+ */
+export function rebaseline(p: SeatModelParams, adj: SeatAdjustments): SeatModelParams {
+  const st = computeState(p, adj);
+  const hip0 = hipPoint(p, ZERO_ADJUSTMENTS);
+  const hip = hipPoint(p, adj);
+  const seatR = rotateOffset(p.seatComDxMm, p.seatComDzMm, adj.tiltDeg);
+  const hipR = rotateOffset(p.hipDxMm, p.hipDzMm, adj.tiltDeg);
+  return {
+    ...p,
+    anchorXMm: p.anchorXMm + adj.slideMm,
+    torsoAlphaDeg: p.torsoAlphaDeg + adj.tiltDeg,
+    seatComDxMm: seatR.x,
+    seatComDzMm: seatR.z,
+    hipDxMm: hipR.x,
+    hipDzMm: hipR.z,
+    legComXMm: p.legComXMm + p.kLegs * (hip.x - hip0.x),
+    legComZMm: p.legComZMm + p.kLegs * (hip.z - hip0.z),
+    baselineFrontPct: st.loads.frontPct,
+    baselineCogZMm: st.com.zMm,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Calibration (corner scales)
+// ---------------------------------------------------------------------------
+
+export interface CornerWeightsKg {
+  fl: number;
+  fr: number;
+  rl: number;
+  rr: number;
+}
+
+/** Totals from a four-pad corner-scale reading. */
+export function totalsFromCorners(c: CornerWeightsKg): { totalKg: number; frontKg: number; frontPct: number } {
+  const frontKg = c.fl + c.fr;
+  const totalKg = frontKg + c.rl + c.rr;
+  return { totalKg, frontKg, frontPct: totalKg > 0 ? (100 * frontKg) / totalKg : 0 };
+}
+
+/**
+ * Fit the leg-coupling factor from a known seat slide re-weighed on scales.
+ * From Section 5: ΔW_front(kg) = s · (m_torso + m_seat + k·m_legs) / L, so
+ *   k = (ΔW_front · L / s − m_torso − m_seat) / m_legs
+ * Result is clamped to [0, 1] — outside that the measurement is suspect.
+ */
+export function fitKLegs(opts: {
+  baselineFrontKg: number;
+  movedFrontKg: number;
+  /** Seat slide between the two weighings, mm (positive = forward). */
+  slideMm: number;
+  wheelbaseMm: number;
+  torsoMassKg: number;
+  seatMassKg: number;
+  legMassKg: number;
+}): number {
+  const dFront = opts.movedFrontKg - opts.baselineFrontKg;
+  const movedMass = (dFront * opts.wheelbaseMm) / opts.slideMm;
+  const k = (movedMass - opts.torsoMassKg - opts.seatMassKg) / opts.legMassKg;
+  return Math.min(1, Math.max(0, k));
+}
+
+export const KG_PER_LB = 0.45359237;
+export const LB_PER_KG = 1 / KG_PER_LB;
+export const MM_PER_INCH = 25.4;

--- a/src/plugins/tools/toolList.ts
+++ b/src/plugins/tools/toolList.ts
@@ -13,6 +13,8 @@ export interface ToolDef {
   name: string;
   /** One-liner shown on the picker card. */
   description: string;
+  /** Optional bubble tag on the picker card (e.g. maturity warning). */
+  badge?: string;
   icon: ComponentType<{ className?: string }>;
   component: ComponentType<PluginPanelProps>;
 }
@@ -23,6 +25,7 @@ export const TOOLS: ToolDef[] = [
     name: "Seat Position Visualizer",
     description:
       "See how sliding or tilting your kart seat shifts front/rear weight and CoG height — with a calibration mode for corner scales.",
+    badge: "Super experimental",
     icon: Armchair,
     component: lazy(() => import("./seat-position/SeatPositionTool")),
   },

--- a/src/plugins/tools/toolList.ts
+++ b/src/plugins/tools/toolList.ts
@@ -1,0 +1,29 @@
+// The catalog of tools the Tools tab offers. Each tool is a self-contained,
+// lazy-loaded component; adding a tool is adding an entry here. Tools receive
+// the standard `PluginPanelProps` session snapshot so a future tool can read
+// the loaded session, but most are standalone calculators that ignore it.
+
+import { lazy, type ComponentType } from "react";
+import { Armchair } from "lucide-react";
+import type { PluginPanelProps } from "@/plugins/panels";
+
+export interface ToolDef {
+  /** Stable id — also the persistence key prefix in the plugin store. */
+  id: string;
+  name: string;
+  /** One-liner shown on the picker card. */
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  component: ComponentType<PluginPanelProps>;
+}
+
+export const TOOLS: ToolDef[] = [
+  {
+    id: "seat-position",
+    name: "Seat Position Visualizer",
+    description:
+      "See how sliding or tilting your kart seat shifts front/rear weight and CoG height — with a calibration mode for corner scales.",
+    icon: Armchair,
+    component: lazy(() => import("./seat-position/SeatPositionTool")),
+  },
+];

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -17,13 +17,36 @@ export interface SectorLine {
   b: { lat: number; lon: number };
 }
 
+/**
+ * One timing line in a course's ordered sector list. The start/finish line is
+ * always the implicit first sector (always "major") and is NOT stored here —
+ * `Course.sectors` holds only the lines AFTER start/finish, in driving order.
+ *
+ * `major` flags one of the "traditional" sectors familiar to most drivers. A
+ * course either has zero additional sectors, or exactly three majors total
+ * (start/finish + two flagged here). Only the three major lines are exported to
+ * the BLE logger — sub-sectors are app-only. See `lib/courseSectors.ts`.
+ */
+export interface CourseSector {
+  line: SectorLine;
+  major: boolean;
+}
+
 export interface Course {
   name: string;
   lengthFt?: number; // known course length in feet (from track database)
   startFinishA: { lat: number; lon: number };
   startFinishB: { lat: number; lon: number };
-  sector2?: SectorLine; // Optional sector 2 line
-  sector3?: SectorLine; // Optional sector 3 line
+  /**
+   * Ordered sector lines after start/finish (canonical model). Normalized in
+   * from the legacy `sector2`/`sector3` fields at every load boundary via
+   * `normalizeCourseSectors` — the rest of the app reads only this.
+   */
+  sectors?: CourseSector[];
+  /** @deprecated read-compat mirror of the 2nd major line — derived on save. */
+  sector2?: SectorLine;
+  /** @deprecated read-compat mirror of the 3rd major line — derived on save. */
+  sector3?: SectorLine;
   isUserDefined?: boolean; // true if user added/modified this course
   /**
    * User-drawn (or lap-generated) track outline — an ordered polyline of
@@ -34,9 +57,18 @@ export interface Course {
   layout?: Array<{ lat: number; lon: number }>;
 }
 
-// Helper to check if course has valid sector lines
+/**
+ * True when a course produces the classic three major sectors (start/finish +
+ * two flagged majors). Reads the canonical `sectors` array, falling back to the
+ * legacy `sector2`/`sector3` pair for un-normalized courses.
+ */
 export function courseHasSectors(course: Course | null): boolean {
-  return Boolean(course?.sector2 && course?.sector3);
+  if (!course) return false;
+  if (course.sectors && course.sectors.length > 0) {
+    const majors = course.sectors.filter((s) => s.major).length;
+    return majors >= 2; // + the implicit start/finish major = 3 total
+  }
+  return Boolean(course.sector2 && course.sector3);
 }
 
 export interface Track {
@@ -62,11 +94,14 @@ export interface LapCrossing {
   fraction: number; // 0-1 position along segment
 }
 
-// Sector times (only present when course has sector lines)
+// Major-sector rollup times (only present when course has the three major sectors).
+// Derived from the fine-grained `sectorTimes` by `rollupMajorSectors` — kept so the
+// lap-table "Simple" view, video overlays, snapshots, and the coach plugin keep
+// working unchanged.
 export interface SectorTimes {
-  s1?: number; // ms from start/finish to sector2 crossing
-  s2?: number; // ms from sector2 to sector3 crossing
-  s3?: number; // ms from sector3 to next start/finish
+  s1?: number; // ms from start/finish to 2nd major crossing
+  s2?: number; // ms from 2nd major to 3rd major crossing
+  s3?: number; // ms from 3rd major to next start/finish
 }
 
 export interface Lap {
@@ -80,7 +115,20 @@ export interface Lap {
   minSpeedKph: number;
   startIndex: number;
   endIndex: number;
-  sectors?: SectorTimes; // Only present when course has sector lines
+  sectors?: SectorTimes; // Major rollup — present when course has 3 major sectors
+  /**
+   * Fine-grained per-segment times, one entry per timing line in course order
+   * (segment k = line k → line k+1, last wraps back to start/finish). `undefined`
+   * for a segment whose crossing was missed/out-of-order. Present whenever the
+   * course defines any sectors. Length === 1 + course.sectors.length.
+   */
+  sectorTimes?: (number | undefined)[];
+  /**
+   * Absolute sample index of each timing-line crossing within this lap, aligned
+   * to `sectorTimes` (boundary k = where line k was crossed; index 0 === lap
+   * start). `undefined` where the crossing was missed. Powers crop-to-sector.
+   */
+  sectorBoundaries?: (number | undefined)[];
 }
 
 export interface FieldMapping {

--- a/supabase/functions/submit-track/index.ts
+++ b/supabase/functions/submit-track/index.ts
@@ -11,6 +11,8 @@ const MAX_BATCH = 200;
 const MAX_ROWS_PER_HOUR = 300;
 // A drawn outline is a polyline; cap it so one row can't carry an unbounded blob.
 const MAX_LAYOUT_POINTS = 5000;
+// Max sub-sectors (excludes start/finish; app hidden cap is 25 timing lines).
+const MAX_COURSE_SECTORS = 24;
 
 interface SubmissionInput {
   type?: string;
@@ -68,6 +70,26 @@ function validateSubmission(s: SubmissionInput): string | null {
   for (const key of optionalCoords) {
     const v = course_data[key];
     if (v !== undefined && (typeof v !== 'number' || isNaN(v))) return `Invalid coordinate: ${key}`;
+  }
+
+  // Optional ordered sector list (sub-sectors + major flags). Bounded; each
+  // entry must be numeric coords + a boolean major; at most two may be major
+  // (start/finish is the implicit third), or none for a plain course.
+  const sectors = (course_data as { sectors?: unknown }).sectors;
+  if (sectors !== undefined && sectors !== null) {
+    if (!Array.isArray(sectors)) return 'Invalid sectors';
+    if (sectors.length > MAX_COURSE_SECTORS) return 'Too many sectors';
+    let majorCount = 0;
+    for (const sec of sectors) {
+      const e = sec as { a_lat?: unknown; a_lng?: unknown; b_lat?: unknown; b_lng?: unknown; major?: unknown };
+      for (const k of ['a_lat', 'a_lng', 'b_lat', 'b_lng'] as const) {
+        const v = e[k];
+        if (typeof v !== 'number' || isNaN(v)) return `Invalid sector coordinate: ${k}`;
+      }
+      if (typeof e.major !== 'boolean') return 'Invalid sector major flag';
+      if (e.major) majorCount++;
+    }
+    if (majorCount !== 0 && majorCount !== 2) return 'A course must mark exactly two major sectors (plus start/finish), or none';
   }
 
   // Optional drawn outline. Accept undefined/null; otherwise it must be a
@@ -176,6 +198,7 @@ Deno.serve(async (req) => {
 
     const rows = items.map((s) => {
       const hasLayout = Array.isArray(s.layout_data) && s.layout_data.length > 0;
+      const sectors = (s.course_data as { sectors?: unknown }).sectors;
       return {
         type: s.type,
         track_name: s.track_name!.trim(),
@@ -187,6 +210,7 @@ Deno.serve(async (req) => {
         batch_id: batchId,
         has_layout: hasLayout,
         layout_data: hasLayout ? s.layout_data : null,
+        sectors_data: Array.isArray(sectors) && sectors.length > 0 ? sectors : null,
       };
     });
 

--- a/supabase/migrations/20260613000000_course_sectors_data.sql
+++ b/supabase/migrations/20260613000000_course_sectors_data.sql
@@ -1,0 +1,20 @@
+-- Unlimited sectors: store the full ordered sector list on courses + submissions.
+--
+-- The app now supports an ordered list of up to 25 timing lines per course
+-- (start/finish + sub-sectors), of which exactly three are "major". Only the
+-- three majors are exported to the BLE logger, so the existing sector_2/sector_3
+-- columns are kept as a mirror of the two majors for back-compat + device export.
+-- The canonical list rides a new jsonb column.
+--
+-- Shape: jsonb array of { a_lat, a_lng, b_lat, b_lng, major } (start/finish excluded).
+
+ALTER TABLE public.courses
+  ADD COLUMN IF NOT EXISTS sectors_data jsonb;
+
+ALTER TABLE public.submissions
+  ADD COLUMN IF NOT EXISTS sectors_data jsonb;
+
+COMMENT ON COLUMN public.courses.sectors_data IS
+  'Ordered sector lines after start/finish: [{a_lat,a_lng,b_lat,b_lng,major}]. The sector_2/3 columns mirror the two majors for device export.';
+COMMENT ON COLUMN public.submissions.sectors_data IS
+  'Submitted ordered sector lines (mirrors courses.sectors_data shape).';


### PR DESCRIPTION
Staging PR for the **v2.5.0** release — BETA → main. Drafted while the beta wears in; mark ready + merge when it's proven out.

Rolls up everything landing in BETA for 2.5.0.

## Tools, UI & versioning (via #189)
- **Tools tab** (right of Coach, self-gating) backed by the new first-party `tools` plugin, with the **kart seat position visualizer** as the first tool — pure unit-tested statics model, side-view SVG with feet-on-pedals knee IK, corner-scale calibration, offline persistence.
- **Icons-only main tab bar on phones** (labels return at tablet width); includes the Simple-view Overlay toggle.
- Package version bumped to 2.5.0 (the 2.4.0 release never got its `package.json` bump).

## Lap sector overhaul + editor/table polish (via #191)
The headline feature: the fixed 3-sector model is replaced by **one ordered list of timing lines per course** (cap **25 lines / 3 majors**), with start/finish as the implicit always-major sector 1. **The DovesDataLogger export stays byte-identical** — only the three majors ever reach the device; sub-sectors are an app-only refinement.

- **Core model — `lib/courseSectors.ts`** (new, fully unit-tested): `Course.sectors: {line, major}[]` canonical, with the deprecated `sector2/3` kept as a legacy mirror synced by `normalizeCourseSectors` at every load boundary. Auto-numbering (`1, 1.1, 2, 2.1, 3`), validation (0 sectors or exactly 3 majors), `majorSectorLines`/`legacyMirror` (the logger projection), `rollupMajorSectors` (fine → S1/S2/S3).
- **Lap timing:** `calculateLaps` detects a crossing per line → `Lap.sectorTimes[]` + `sectorBoundaries[]` + `Lap.sectors` (the S1/S2/S3 major rollup, so overlays/snapshots/the coach keep working unchanged). `calculateOptimalLap` now sums the best time of **every** segment (the true ideal lap).
- **Course editor:** reorderable `SectorListEditor` (dnd-kit) below the map — add/delete/drag, per-row **Major** switch, grouped sub-sectors, save blocked until valid. Three line colors on every map (S/F green, major purple, sub sky-blue). New sectors now **drop in the middle of the current map view** (not near start/finish), and the editor's timing lines are **drawn much thicker** so unselected lines stand out against the imagery.
- **Lap table:** removed the per-lap Map column; added a **Simple/Full** toggle (Full = one column per fine-grained sector, zebra-striped by major). In Full view a colored **"S# Sum"** column precedes each major sector, showing that major's running total (the S1/S2/S3 rollup) per lap with the fastest sum highlighted; a **Sector sums** toggle (default on) shows/hides them.
- **Crop to a sector:** the data-crop bar (Simple + Pro) pairs the range slider with a sector dropdown that snaps the view to a sector.
- **Pro mini-map follow-pan fix:** the camera held the position arrow inside the middle half of the view and re-centered far too early. It now snaps only once the arrow's edge actually reaches the viewport border.
- **I/O & persistence:** device export, `coursesMatch`, and `courseContentHash` are stable for majors-only courses (existing submission dedupe records stay valid) and regression-tested. Track JSON + community submissions + admin `courses`/`submissions` carry the canonical `sectors`/`sectors_data` array alongside the legacy mirror (migration `20260613000000_course_sectors_data.sql`; `submit-track` validates the optional array).
- **Build:** synced `bun.lock` with the new **dnd-kit** dependency so the Cloudflare Workers build (Bun `--frozen-lockfile`) installs cleanly. New dependency is lazy-loaded with the track editor (off the initial bundle); README Credits + `CreditsDialog` updated.

## Before merging
- Rename the changelog's `[Unreleased]` section to `[2.5.0]` with the release date and cut the tag.
- Confirm CI green across all five workflows + the Cloudflare deploy.

https://claude.ai/code/session_01Dp6CeGcBoGSB9AvsDAjjR3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp6CeGcBoGSB9AvsDAjjR3)_