### PR TITLE
beta: pull AI coach from coach repo BETA branch (git dep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,29 @@ plugin contracts + `components/ui`).
 The coach shares the public stub's `id` with a higher `priority` to override it.
 See `src/plugins/README.md` for the full publish/wire workflow.
 
+> ## ⚠️ SUPER IMPORTANT — coach source differs by branch (DO NOT MERGE BLINDLY)
+>
+> **The `BETA` branch does NOT use the published npm package.** On `BETA` the
+> coach is pulled **straight from the coach repo's `BETA` branch** as a git
+> `optionalDependency` so beta builds always track the latest coach beta without
+> tagging/publishing per iteration:
+> - `package.json` → `"@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"`
+> - `vite.config.ts` → `DEFAULT_PLUGIN_PACKAGES = "@theangryraven/eye-in-the-sky"`
+>
+> **`main` stays on the published npm package** (`@perchwerks/eye-in-the-sky`,
+> tilde-pinned). These are the **only two lines** that differ.
+>
+> **🛑 This must NOT ride a BETA → main merge.** The product-cut dance, **only
+> when the maintainer asks for it**:
+> 1. On `BETA`, flip both lines back to the **published, tagged npm release**
+>    (e.g. `"@theangryraven/eye-in-the-sky": "~X.Y.Z"` + matching
+>    `DEFAULT_PLUGIN_PACKAGES`), run `bun install`, test, **merge to `main`**.
+> 2. After the merge, flip `BETA` back to the `github:…#BETA` git dep above.
+>
+> Re-pin note: a git dep records the resolved **commit SHA** in `bun.lock`, so a
+> new push to the coach's `BETA` does not auto-update — run
+> `bun update @theangryraven/eye-in-the-sky` to pull the latest beta.
+
 Offline-first note: plugins are bundled internal code. Only a plugin's runtime
 network calls (e.g. AI model APIs) go online — the accepted compromise. Supabase
 cloud is purely file-sync.

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "~0.4.1",
+        "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA",
       },
     },
   },
@@ -383,8 +383,6 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
-    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.4.1", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0" } }, "sha512-SKjiObU+r+fKe28+B0oUEGmASpIG6ZDKRTERRqjFJ1LWmXNs7A2J1BtQE3cx2SI4wURI+H0ie0KeXUXfAYS8yg=="],
-
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
@@ -600,6 +598,8 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
+
+    "@theangryraven/eye-in-the-sky": ["@theangryraven/eye-in-the-sky@github:TheAngryRaven/DataViewer_coach#a867b3f", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "TheAngryRaven-DataViewer_coach-a867b3f", "sha512-lwxiq6M9UoHCQpt4dNxgwiOdd/aKSXKi0ith9DVIoC5fHx8s9Tbv1CtcvHbpFfqzZ3VHXfyuM2Aa5zcCcgnBJQ=="],
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "~0.4.1"
+    "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"
   }
 }

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -179,10 +179,21 @@ automated in the coach repo via a GitHub Actions workflow that runs
    are picked up automatically on the next install, while a minor/major bump
    (`0.5.0`+) stays an explicit, reviewed change — bump the tilde base when you
    intend to adopt a new minor.
-2. The loader in `vite.config.ts` defaults to `@perchwerks/eye-in-the-sky`, so
+2. The loader in `vite.config.ts` defaults to the coach package name, so
    the standard build picks it up with no env configuration. Override the
    candidate list via the `DOVE_PLUGIN_PACKAGES` env var (comma-separated) if
    you want to load different/additional packages.
+
+> **BETA branch override.** On the `BETA` branch the coach is pulled **directly
+> from the coach repo's `BETA` branch** as a git `optionalDependency`
+> (`"@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"`),
+> with `DEFAULT_PLUGIN_PACKAGES` set to that name — so beta builds always track
+> the latest coach beta without cutting a tag/npm release for every iteration.
+> This is deliberately not on `main` (which stays pinned to the published npm
+> package). Note the tradeoff: a git dep records the resolved **commit SHA** in
+> `bun.lock`, so a new push to the coach's `BETA` does **not** auto-update — run
+> `bun update @theangryraven/eye-in-the-sky` (or re-install) to re-pin. When this
+> stabilizes, switch back to a tagged npm release before merging to `main`.
 
 Outcomes:
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,7 @@ export default defineConfig(({ mode }) => {
   const branch = gitBranch();
   const commitDate = gitCommitDate();
 
-  const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
+  const DEFAULT_PLUGIN_PACKAGES = "@theangryraven/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)
     .split(",")
     .map((s) => s.trim())


### PR DESCRIPTION
## What

On the **BETA** branch only, source the AI coach (`@theangryraven/eye-in-the-sky`) **directly from the coach repo's `BETA` branch** as a git `optionalDependency`, instead of the published npm package. Beta builds now always track the latest coach beta without cutting a tag/npm release per iteration.

## Changes
- **`package.json`** — `optionalDependencies`: `@perchwerks/eye-in-the-sky` `~0.4.1` → `@theangryraven/eye-in-the-sky` `github:TheAngryRaven/DataViewer_coach#BETA`. (The BETA coach package was renamed to the `@theangryraven` scope — verified against the repo's `package.json`.)
- **`vite.config.ts`** — `DEFAULT_PLUGIN_PACKAGES` retargeted to the new package name so the external-plugins loader discovers and bundles it (no `DOVE_PLUGIN_PACKAGES` env needed).
- **`bun.lock`** — re-pinned to the resolved BETA commit (`a867b3f`).
- **`src/plugins/README.md`** — documents the BETA-only git-dep arrangement and the re-pin tradeoff.

## Scope / things to know
- **Beta-only.** This lives on `BETA`; `main` stays pinned to the published npm package. The "only in beta builds" scoping is branch-scoped — nothing about `main`'s coach wiring changes.
- **Name match is required & satisfied.** A git `optionalDependency` key must equal the `name` in the target repo's `package.json`; the coach's `BETA` branch declares `@theangryraven/eye-in-the-sky`, so install resolves cleanly.
- **No build step in the dep.** The coach has no `prepare`/`postinstall` and ships `main: index.ts` — it's consumed as source and compiled by the host's Vite, so the git install needs no toolchain.
- **New peer deps satisfied.** The BETA coach adds `i18next` + `react-i18next` peers (the npm `0.4.1` didn't have these); the host already provides both on `BETA`, plus `uplot`.
- **Re-pin tradeoff (the "tags are cumbersome" tradeoff).** A git dep records the resolved **commit SHA** in `bun.lock`, so a new push to the coach's `BETA` does **not** auto-update. Run `bun update @theangryraven/eye-in-the-sky` (or re-install) to re-pin to the latest beta. When this stabilizes, switch back to a tagged npm release before merging to `main`.
- **Install-time network.** The git dep requires git + network access to GitHub at install time (the coach repo must be reachable to the build env). Because it's `optionalDependencies`, a failed fetch won't break `npm/bun install` — the coach just silently won't load.

## Verification
- `bun install` ✅ (coach resolved from `github:…#a867b3f`)
- `bun run build` ✅ (`CoachDashboard` chunk present → coach bundles + loads)
- `bun run typecheck` ✅
- `bun run lint` ✅

https://claude.ai/code/session_01VdVrGSHuBjmmMgZG8BsBDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdVrGSHuBjmmMgZG8BsBDU)_