### PR TITLE
i18n: translate the Credits, Contact and browser-compatibility dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sync/export status messages, and the **Tools** tab — the tool picker and the
   kart seat-position visualizer, and the **account pages** — sign in, create
   account, forgot/reset password, and the sign-in callback — and the home-screen
-  **About** and **Supported Files** dialogs. More of the app follows in later
-  updates. (Legal pages remain English by design.)
+  **About**, **Supported Files**, **Credits**, **Contact** and
+  **browser-compatibility** dialogs. More of the app follows in later updates.
+  (Open-source library names and GitHub link names stay in English by design, as
+  do the legal pages.)
 - **Log type bubble in the file browser.** Each session row (shown by date/time)
   now carries a small pill with the log's format — Dove, Dovex, XRK, XRZ,
   iRacing, VBO, MoTeC, UBX, NMEA, CSV, … — derived from the file's extension, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -968,8 +968,10 @@ existing user data keeps resolving without a destructive migration.
 
 Multi-language support built on **i18next + react-i18next**. A phased overhaul
 (full plan: `docs/plans/i18n-translation-system.md`); migrated so far: the
-landing page (incl. the **About** + **Supported Files** dialogs, in the `landing`
-namespace), Settings, the **core in-session UI** (the tab bar + session header
+landing page (incl. the **About**, **Supported Files**, **Credits**, **Contact**
+and **browser-compatibility** dialogs, in the `landing` namespace —
+`browserCompat.ts` returns stable ids the dialog translates), Settings, the
+**core in-session UI** (the tab bar + session header
 in `Index.tsx`, `LapTable`, `LapSnapshotControls`, `OverlaysMenu`,
 `SectorCropSelect`), and the **live analysis views** — the map (`RaceLineView`,
 `MiniMap`) and the pro **GraphView** (`GraphViewPanel`, `GraphPanel`,

--- a/docs/plans/i18n-translation-system.md
+++ b/docs/plans/i18n-translation-system.md
@@ -1,6 +1,15 @@
 # Plan: Internationalization (i18n) / translation system
 
-Status: **Phase 7 — auth pages + landing dialogs complete** · current branch: `claude/i18n-about-supported-files` → PR into `BETA`
+Status: **Phase 7 — auth pages + all landing dialogs complete** · current branch: `claude/i18n-landing-dialogs` → PR into `BETA`
+
+> **Phase 7c (this PR):** the last three landing-page dialogs — **Credits**
+> (`CreditsDialog`), **Contact** (`ContactDialog`), and **browser-compatibility**
+> (`BrowserCompatDialog`) — in the `landing` namespace. Open-source library names
+> + their GitHub links stay literal (Credits data is untranslated by design);
+> contact category **values** stay English (the submitted/admin key) while their
+> labels are translated. `lib/browserCompat.ts` was refactored to return stable
+> feature/status **ids** (typed unions) so the dialog translates them, keeping the
+> lib i18n-free. **Remaining overall:** the **admin** panel only.
 
 > **Phase 7b (this PR):** the two remaining landing-page content dialogs —
 > **About** (`AboutDialog`) and **Supported Files** (`SupportedFilesDialog`) —

--- a/src/components/BrowserCompatDialog.tsx
+++ b/src/components/BrowserCompatDialog.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { Monitor, CheckCircle, AlertTriangle, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,6 +24,7 @@ const levelIcon = (level: CapabilityCheck["level"]) => {
 };
 
 export function BrowserCompatDialog() {
+  const { t } = useTranslation("landing");
   const checks = useMemo(() => detectCapabilities(), []);
   const hasIssues = checks.some((c) => c.level !== "green");
 
@@ -39,17 +41,17 @@ export function BrowserCompatDialog() {
           }
         >
           <Monitor className="w-3.5 h-3.5 mr-1.5" />
-          Browser Compatibility
+          {t("browserCompat.trigger")}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Monitor className="w-5 h-5" />
-            Browser Compatibility
+            {t("browserCompat.title")}
           </DialogTitle>
           <DialogDescription>
-            Feature support for your current browser.
+            {t("browserCompat.description")}
           </DialogDescription>
         </DialogHeader>
 
@@ -61,18 +63,17 @@ export function BrowserCompatDialog() {
             >
               <div className="flex items-center gap-2 min-w-0">
                 {levelIcon(check.level)}
-                <span className="text-sm text-foreground">{check.feature}</span>
+                <span className="text-sm text-foreground">{t(`browserCompat.features.${check.feature}`)}</span>
               </div>
               <span className="text-xs text-muted-foreground shrink-0 font-mono">
-                {check.status}
+                {t(`browserCompat.statuses.${check.status}`)}
               </span>
             </div>
           ))}
         </div>
 
         <p className="text-[11px] text-muted-foreground leading-relaxed mt-2">
-          All core features work across modern browsers. Some advanced features
-          work best in Chrome or Edge.
+          {t("browserCompat.note")}
         </p>
       </DialogContent>
     </Dialog>

--- a/src/components/ContactDialog.tsx
+++ b/src/components/ContactDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Mail } from "lucide-react";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -11,7 +12,17 @@ import { toast } from "@/hooks/use-toast";
 // eslint-disable-next-line react-refresh/only-export-components -- co-located with the dialog that owns the categories
 export const MESSAGE_CATEGORIES = ["Comment", "Feature Request", "Complaint", "Bug Report"] as const;
 
+// The category VALUE submitted to the backend stays the English string above;
+// this only maps it to a locale key for display.
+const CATEGORY_KEYS = {
+  "Comment": "comment",
+  "Feature Request": "featureRequest",
+  "Complaint": "complaint",
+  "Bug Report": "bugReport",
+} as const;
+
 export function ContactDialog({ variant = "footer" }: { variant?: "header" | "footer" }) {
+  const { t } = useTranslation("landing");
   const [open, setOpen] = useState(false);
   const [category, setCategory] = useState<string>("");
   const [email, setEmail] = useState("");
@@ -20,11 +31,11 @@ export function ContactDialog({ variant = "footer" }: { variant?: "header" | "fo
 
   const handleSubmit = async () => {
     if (!category || !message.trim()) {
-      toast({ title: "Missing fields", description: "Please select a category and enter a message.", variant: "destructive" });
+      toast({ title: t("contact.missingFields"), description: t("contact.missingFieldsDesc"), variant: "destructive" });
       return;
     }
     if (message.trim().length > 2000) {
-      toast({ title: "Message too long", description: "Max 2000 characters.", variant: "destructive" });
+      toast({ title: t("contact.tooLong"), description: t("contact.tooLongDesc"), variant: "destructive" });
       return;
     }
 
@@ -39,17 +50,17 @@ export function ContactDialog({ variant = "footer" }: { variant?: "header" | "fo
 
       const data = await resp.json();
       if (!resp.ok) {
-        toast({ title: "Error", description: data.error || "Something went wrong.", variant: "destructive" });
+        toast({ title: t("contact.error"), description: data.error || t("contact.errorGeneric"), variant: "destructive" });
         return;
       }
 
-      toast({ title: "Message sent!", description: "Thanks for your feedback." });
+      toast({ title: t("contact.sent"), description: t("contact.sentDesc") });
       setCategory("");
       setEmail("");
       setMessage("");
       setOpen(false);
     } catch {
-      toast({ title: "Error", description: "Could not send message. Please try again.", variant: "destructive" });
+      toast({ title: t("contact.error"), description: t("contact.errorNetwork"), variant: "destructive" });
     } finally {
       setSubmitting(false);
     }
@@ -61,46 +72,46 @@ export function ContactDialog({ variant = "footer" }: { variant?: "header" | "fo
         {variant === "header" ? (
           <Button variant="default" size="sm" className="gap-2">
             <Mail className="w-4 h-4" />
-            <span className="hidden sm:inline">Contact</span>
+            <span className="hidden sm:inline">{t("contact.trigger")}</span>
           </Button>
         ) : (
           <button className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
             <Mail className="w-3 h-3" />
-            Contact
+            {t("contact.trigger")}
           </button>
         )}
       </DialogTrigger>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>Contact Us</DialogTitle>
-          <DialogDescription>Send us a message — we'll read every one.</DialogDescription>
+          <DialogTitle>{t("contact.title")}</DialogTitle>
+          <DialogDescription>{t("contact.description")}</DialogDescription>
         </DialogHeader>
         <div className="space-y-4 pt-2">
           <div className="space-y-2">
-            <Label>Category *</Label>
+            <Label>{t("contact.categoryLabel")}</Label>
             <Select value={category} onValueChange={setCategory}>
-              <SelectTrigger><SelectValue placeholder="Select a category" /></SelectTrigger>
+              <SelectTrigger><SelectValue placeholder={t("contact.categoryPlaceholder")} /></SelectTrigger>
               <SelectContent>
                 {MESSAGE_CATEGORIES.map(c => (
-                  <SelectItem key={c} value={c}>{c}</SelectItem>
+                  <SelectItem key={c} value={c}>{t(`contact.categories.${CATEGORY_KEYS[c]}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
           <div className="space-y-2">
-            <Label>Email <span className="text-muted-foreground text-xs">(optional, for a reply)</span></Label>
+            <Label>{t("contact.emailLabel")} <span className="text-muted-foreground text-xs">{t("contact.emailOptional")}</span></Label>
             <Input
               type="email"
-              placeholder="your@email.com"
+              placeholder={t("contact.emailPlaceholder")}
               value={email}
               onChange={e => setEmail(e.target.value)}
               maxLength={255}
             />
           </div>
           <div className="space-y-2">
-            <Label>Message *</Label>
+            <Label>{t("contact.messageLabel")}</Label>
             <Textarea
-              placeholder="What's on your mind?"
+              placeholder={t("contact.messagePlaceholder")}
               value={message}
               onChange={e => setMessage(e.target.value)}
               maxLength={2000}
@@ -109,7 +120,7 @@ export function ContactDialog({ variant = "footer" }: { variant?: "header" | "fo
             <p className="text-xs text-muted-foreground text-right">{message.length}/2000</p>
           </div>
           <Button onClick={handleSubmit} disabled={submitting || !category || !message.trim()} className="w-full">
-            {submitting ? "Sending…" : "Send Message"}
+            {submitting ? t("contact.sending") : t("contact.send")}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -1,4 +1,5 @@
 import { BookOpen, ExternalLink } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
@@ -32,20 +33,21 @@ const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
 ];
 
 export function CreditsDialog() {
+  const { t } = useTranslation("landing");
   return (
     <Dialog>
       <DialogTrigger asChild>
         <button className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
           <BookOpen className="w-3 h-3" />
-          Credits
+          {t("credits.trigger")}
         </button>
       </DialogTrigger>
       <DialogContent className="max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Credits</DialogTitle>
+          <DialogTitle>{t("credits.title")}</DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground mb-4">
-          Built on the shoulders of these incredible open-source projects and free services.
+          {t("credits.intro")}
         </p>
         <div className="grid grid-cols-1 gap-2">
           {CREDITS.map(([name, url]) => (

--- a/src/lib/browserCompat.ts
+++ b/src/lib/browserCompat.ts
@@ -1,7 +1,34 @@
+// Pure capability detection. Returns stable string ids (not display text) so the
+// presentation layer (BrowserCompatDialog) can translate them — keeping this
+// module i18n-free. The ids match the `landing.browserCompat.features` /
+// `.statuses` locale keys.
+
+export type CapabilityLevel = "green" | "yellow" | "red";
+
+export type FeatureId =
+  | "gpsFileParsing"
+  | "videoSync"
+  | "videoExport"
+  | "audioInExport"
+  | "bleDatalogger"
+  | "filePicker"
+  | "pwaOffline";
+
+export type StatusId =
+  | "supported"
+  | "notAvailable"
+  | "frameAccurate"
+  | "approximateSync"
+  | "mp4H264"
+  | "webmFallback"
+  | "silentExports"
+  | "native"
+  | "fileInputFallback";
+
 export interface CapabilityCheck {
-  feature: string;
-  status: string;
-  level: "green" | "yellow" | "red";
+  feature: FeatureId;
+  status: StatusId;
+  level: CapabilityLevel;
 }
 
 // `"X" in Y` is a runtime feature check that TypeScript narrows without
@@ -11,50 +38,46 @@ const hasAudioEncoder = "AudioEncoder" in globalThis;
 const hasBluetooth = "bluetooth" in navigator;
 
 export function detectCapabilities(): CapabilityCheck[] {
+  const hasIndexedDb = "indexedDB" in window;
+  const hasFrameCallback = "requestVideoFrameCallback" in HTMLVideoElement.prototype;
+  const hasFilePicker = "showOpenFilePicker" in window;
+  const hasServiceWorker = "serviceWorker" in navigator;
+
   return [
     {
-      feature: "GPS File Parsing",
-      status: "indexedDB" in window ? "Supported" : "Not Available",
-      level: "indexedDB" in window ? "green" : "red",
+      feature: "gpsFileParsing",
+      status: hasIndexedDb ? "supported" : "notAvailable",
+      level: hasIndexedDb ? "green" : "red",
     },
     {
-      feature: "Video Sync",
-      status:
-        "requestVideoFrameCallback" in HTMLVideoElement.prototype
-          ? "Frame-accurate"
-          : "Approximate sync",
-      level:
-        "requestVideoFrameCallback" in HTMLVideoElement.prototype
-          ? "green"
-          : "yellow",
+      feature: "videoSync",
+      status: hasFrameCallback ? "frameAccurate" : "approximateSync",
+      level: hasFrameCallback ? "green" : "yellow",
     },
     {
-      feature: "Video Export (MP4)",
-      status: hasVideoEncoder ? "MP4 (H.264)" : "WebM fallback",
+      feature: "videoExport",
+      status: hasVideoEncoder ? "mp4H264" : "webmFallback",
       level: hasVideoEncoder ? "green" : "yellow",
     },
     {
-      feature: "Audio in Export",
-      status: hasAudioEncoder ? "Supported" : "Silent exports",
+      feature: "audioInExport",
+      status: hasAudioEncoder ? "supported" : "silentExports",
       level: hasAudioEncoder ? "green" : "yellow",
     },
     {
-      feature: "BLE Datalogger",
-      status: hasBluetooth ? "Supported" : "Not Available",
+      feature: "bleDatalogger",
+      status: hasBluetooth ? "supported" : "notAvailable",
       level: hasBluetooth ? "green" : "red",
     },
     {
-      feature: "File Picker",
-      status:
-        "showOpenFilePicker" in window
-          ? "Native"
-          : "File input fallback",
-      level: "showOpenFilePicker" in window ? "green" : "yellow",
+      feature: "filePicker",
+      status: hasFilePicker ? "native" : "fileInputFallback",
+      level: hasFilePicker ? "green" : "yellow",
     },
     {
-      feature: "PWA / Offline",
-      status: "serviceWorker" in navigator ? "Supported" : "Not Available",
-      level: "serviceWorker" in navigator ? "green" : "red",
+      feature: "pwaOffline",
+      status: hasServiceWorker ? "supported" : "notAvailable",
+      level: hasServiceWorker ? "green" : "red",
     },
   ];
 }

--- a/src/locales/de/landing.json
+++ b/src/locales/de/landing.json
@@ -144,5 +144,65 @@
         "body": "CSV-Exporte aus Race Studio 3 (RS2Analysis-Stil) für MyChron 5/6. Erweiterung: <code>.csv</code>"
       }
     }
+  },
+  "credits": {
+    "trigger": "Danksagungen",
+    "title": "Danksagungen",
+    "intro": "Aufgebaut auf den Schultern dieser großartigen Open-Source-Projekte und kostenlosen Dienste."
+  },
+  "contact": {
+    "trigger": "Kontakt",
+    "title": "Kontaktiere uns",
+    "description": "Schreib uns eine Nachricht — wir lesen jede.",
+    "categoryLabel": "Kategorie *",
+    "categoryPlaceholder": "Kategorie auswählen",
+    "categories": {
+      "comment": "Kommentar",
+      "featureRequest": "Funktionswunsch",
+      "complaint": "Beschwerde",
+      "bugReport": "Fehlerbericht"
+    },
+    "emailLabel": "E-Mail",
+    "emailOptional": "(optional, für eine Antwort)",
+    "emailPlaceholder": "deine@email.com",
+    "messageLabel": "Nachricht *",
+    "messagePlaceholder": "Was beschäftigt dich?",
+    "sending": "Wird gesendet…",
+    "send": "Nachricht senden",
+    "missingFields": "Fehlende Felder",
+    "missingFieldsDesc": "Bitte wähle eine Kategorie und gib eine Nachricht ein.",
+    "tooLong": "Nachricht zu lang",
+    "tooLongDesc": "Maximal 2000 Zeichen.",
+    "error": "Fehler",
+    "errorGeneric": "Etwas ist schiefgelaufen.",
+    "errorNetwork": "Nachricht konnte nicht gesendet werden. Bitte versuche es erneut.",
+    "sent": "Nachricht gesendet!",
+    "sentDesc": "Danke für dein Feedback."
+  },
+  "browserCompat": {
+    "trigger": "Browser-Kompatibilität",
+    "title": "Browser-Kompatibilität",
+    "description": "Funktionsunterstützung für deinen aktuellen Browser.",
+    "note": "Alle Kernfunktionen laufen in modernen Browsern. Einige erweiterte Funktionen laufen am besten in Chrome oder Edge.",
+    "features": {
+      "gpsFileParsing": "GPS-Dateiverarbeitung",
+      "videoSync": "Videosynchronisation",
+      "videoExport": "Videoexport (MP4)",
+      "audioInExport": "Audio im Export",
+      "bleDatalogger": "BLE-Datenlogger",
+      "filePicker": "Dateiauswahl",
+      "pwaOffline": "PWA / Offline"
+    },
+    "statuses": {
+      "supported": "Unterstützt",
+      "notAvailable": "Nicht verfügbar",
+      "frameAccurate": "Bildgenau",
+      "approximateSync": "Ungefähre Synchronisation",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "WebM-Fallback",
+      "silentExports": "Stumme Exporte",
+      "native": "Nativ",
+      "fileInputFallback": "Datei-Eingabe-Fallback"
+    }
   }
 }

--- a/src/locales/en/landing.json
+++ b/src/locales/en/landing.json
@@ -90,6 +90,66 @@
       "PWA — installable & fully offline"
     ]
   },
+  "credits": {
+    "trigger": "Credits",
+    "title": "Credits",
+    "intro": "Built on the shoulders of these incredible open-source projects and free services."
+  },
+  "contact": {
+    "trigger": "Contact",
+    "title": "Contact Us",
+    "description": "Send us a message — we'll read every one.",
+    "categoryLabel": "Category *",
+    "categoryPlaceholder": "Select a category",
+    "categories": {
+      "comment": "Comment",
+      "featureRequest": "Feature Request",
+      "complaint": "Complaint",
+      "bugReport": "Bug Report"
+    },
+    "emailLabel": "Email",
+    "emailOptional": "(optional, for a reply)",
+    "emailPlaceholder": "your@email.com",
+    "messageLabel": "Message *",
+    "messagePlaceholder": "What's on your mind?",
+    "sending": "Sending…",
+    "send": "Send Message",
+    "missingFields": "Missing fields",
+    "missingFieldsDesc": "Please select a category and enter a message.",
+    "tooLong": "Message too long",
+    "tooLongDesc": "Max 2000 characters.",
+    "error": "Error",
+    "errorGeneric": "Something went wrong.",
+    "errorNetwork": "Could not send message. Please try again.",
+    "sent": "Message sent!",
+    "sentDesc": "Thanks for your feedback."
+  },
+  "browserCompat": {
+    "trigger": "Browser Compatibility",
+    "title": "Browser Compatibility",
+    "description": "Feature support for your current browser.",
+    "note": "All core features work across modern browsers. Some advanced features work best in Chrome or Edge.",
+    "features": {
+      "gpsFileParsing": "GPS File Parsing",
+      "videoSync": "Video Sync",
+      "videoExport": "Video Export (MP4)",
+      "audioInExport": "Audio in Export",
+      "bleDatalogger": "BLE Datalogger",
+      "filePicker": "File Picker",
+      "pwaOffline": "PWA / Offline"
+    },
+    "statuses": {
+      "supported": "Supported",
+      "notAvailable": "Not Available",
+      "frameAccurate": "Frame-accurate",
+      "approximateSync": "Approximate sync",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "WebM fallback",
+      "silentExports": "Silent exports",
+      "native": "Native",
+      "fileInputFallback": "File input fallback"
+    }
+  },
   "supportedFiles": {
     "trigger": "Supported Files",
     "title": "Supported File Formats",

--- a/src/locales/es/landing.json
+++ b/src/locales/es/landing.json
@@ -144,5 +144,65 @@
         "body": "Exportaciones CSV de Race Studio 3 (estilo RS2Analysis) para MyChron 5/6. Extensión: <code>.csv</code>"
       }
     }
+  },
+  "credits": {
+    "trigger": "Créditos",
+    "title": "Créditos",
+    "intro": "Construido sobre los hombros de estos increíbles proyectos de código abierto y servicios gratuitos."
+  },
+  "contact": {
+    "trigger": "Contacto",
+    "title": "Contáctanos",
+    "description": "Envíanos un mensaje: leemos todos.",
+    "categoryLabel": "Categoría *",
+    "categoryPlaceholder": "Selecciona una categoría",
+    "categories": {
+      "comment": "Comentario",
+      "featureRequest": "Solicitud de función",
+      "complaint": "Queja",
+      "bugReport": "Informe de error"
+    },
+    "emailLabel": "Correo electrónico",
+    "emailOptional": "(opcional, para responderte)",
+    "emailPlaceholder": "tu@correo.com",
+    "messageLabel": "Mensaje *",
+    "messagePlaceholder": "¿Qué tienes en mente?",
+    "sending": "Enviando…",
+    "send": "Enviar mensaje",
+    "missingFields": "Faltan campos",
+    "missingFieldsDesc": "Selecciona una categoría e introduce un mensaje.",
+    "tooLong": "Mensaje demasiado largo",
+    "tooLongDesc": "Máximo 2000 caracteres.",
+    "error": "Error",
+    "errorGeneric": "Algo salió mal.",
+    "errorNetwork": "No se pudo enviar el mensaje. Inténtalo de nuevo.",
+    "sent": "¡Mensaje enviado!",
+    "sentDesc": "Gracias por tus comentarios."
+  },
+  "browserCompat": {
+    "trigger": "Compatibilidad del navegador",
+    "title": "Compatibilidad del navegador",
+    "description": "Soporte de funciones para tu navegador actual.",
+    "note": "Todas las funciones principales funcionan en los navegadores modernos. Algunas funciones avanzadas funcionan mejor en Chrome o Edge.",
+    "features": {
+      "gpsFileParsing": "Análisis de archivos GPS",
+      "videoSync": "Sincronización de vídeo",
+      "videoExport": "Exportación de vídeo (MP4)",
+      "audioInExport": "Audio en la exportación",
+      "bleDatalogger": "Datalogger BLE",
+      "filePicker": "Selector de archivos",
+      "pwaOffline": "PWA / Sin conexión"
+    },
+    "statuses": {
+      "supported": "Compatible",
+      "notAvailable": "No disponible",
+      "frameAccurate": "Precisión de fotograma",
+      "approximateSync": "Sincronización aproximada",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "Alternativa WebM",
+      "silentExports": "Exportaciones sin audio",
+      "native": "Nativo",
+      "fileInputFallback": "Alternativa de entrada de archivo"
+    }
   }
 }

--- a/src/locales/fr/landing.json
+++ b/src/locales/fr/landing.json
@@ -144,5 +144,65 @@
         "body": "Exports CSV de Race Studio 3 (style RS2Analysis) pour MyChron 5/6. Extension : <code>.csv</code>"
       }
     }
+  },
+  "credits": {
+    "trigger": "Crédits",
+    "title": "Crédits",
+    "intro": "Construit sur les épaules de ces incroyables projets open source et services gratuits."
+  },
+  "contact": {
+    "trigger": "Contact",
+    "title": "Contactez-nous",
+    "description": "Envoyez-nous un message — nous les lisons tous.",
+    "categoryLabel": "Catégorie *",
+    "categoryPlaceholder": "Sélectionnez une catégorie",
+    "categories": {
+      "comment": "Commentaire",
+      "featureRequest": "Demande de fonctionnalité",
+      "complaint": "Réclamation",
+      "bugReport": "Rapport de bug"
+    },
+    "emailLabel": "E-mail",
+    "emailOptional": "(facultatif, pour une réponse)",
+    "emailPlaceholder": "votre@email.com",
+    "messageLabel": "Message *",
+    "messagePlaceholder": "Qu'avez-vous en tête ?",
+    "sending": "Envoi…",
+    "send": "Envoyer le message",
+    "missingFields": "Champs manquants",
+    "missingFieldsDesc": "Veuillez sélectionner une catégorie et saisir un message.",
+    "tooLong": "Message trop long",
+    "tooLongDesc": "2000 caractères maximum.",
+    "error": "Erreur",
+    "errorGeneric": "Une erreur s'est produite.",
+    "errorNetwork": "Impossible d'envoyer le message. Veuillez réessayer.",
+    "sent": "Message envoyé !",
+    "sentDesc": "Merci pour votre retour."
+  },
+  "browserCompat": {
+    "trigger": "Compatibilité du navigateur",
+    "title": "Compatibilité du navigateur",
+    "description": "Prise en charge des fonctionnalités pour votre navigateur actuel.",
+    "note": "Toutes les fonctionnalités principales fonctionnent sur les navigateurs modernes. Certaines fonctionnalités avancées fonctionnent mieux dans Chrome ou Edge.",
+    "features": {
+      "gpsFileParsing": "Analyse des fichiers GPS",
+      "videoSync": "Synchronisation vidéo",
+      "videoExport": "Export vidéo (MP4)",
+      "audioInExport": "Audio dans l'export",
+      "bleDatalogger": "Datalogger BLE",
+      "filePicker": "Sélecteur de fichiers",
+      "pwaOffline": "PWA / Hors ligne"
+    },
+    "statuses": {
+      "supported": "Pris en charge",
+      "notAvailable": "Non disponible",
+      "frameAccurate": "Précision à l'image",
+      "approximateSync": "Synchronisation approximative",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "Repli WebM",
+      "silentExports": "Exports muets",
+      "native": "Natif",
+      "fileInputFallback": "Repli sur champ de fichier"
+    }
   }
 }

--- a/src/locales/it/landing.json
+++ b/src/locales/it/landing.json
@@ -144,5 +144,65 @@
         "body": "Esportazioni CSV da Race Studio 3 (stile RS2Analysis) per MyChron 5/6. Estensione: <code>.csv</code>"
       }
     }
+  },
+  "credits": {
+    "trigger": "Crediti",
+    "title": "Crediti",
+    "intro": "Costruito sulle spalle di questi incredibili progetti open source e servizi gratuiti."
+  },
+  "contact": {
+    "trigger": "Contatti",
+    "title": "Contattaci",
+    "description": "Inviaci un messaggio: li leggiamo tutti.",
+    "categoryLabel": "Categoria *",
+    "categoryPlaceholder": "Seleziona una categoria",
+    "categories": {
+      "comment": "Commento",
+      "featureRequest": "Richiesta di funzionalità",
+      "complaint": "Reclamo",
+      "bugReport": "Segnalazione di bug"
+    },
+    "emailLabel": "Email",
+    "emailOptional": "(facoltativa, per una risposta)",
+    "emailPlaceholder": "tua@email.com",
+    "messageLabel": "Messaggio *",
+    "messagePlaceholder": "A cosa stai pensando?",
+    "sending": "Invio…",
+    "send": "Invia messaggio",
+    "missingFields": "Campi mancanti",
+    "missingFieldsDesc": "Seleziona una categoria e inserisci un messaggio.",
+    "tooLong": "Messaggio troppo lungo",
+    "tooLongDesc": "Massimo 2000 caratteri.",
+    "error": "Errore",
+    "errorGeneric": "Qualcosa è andato storto.",
+    "errorNetwork": "Impossibile inviare il messaggio. Riprova.",
+    "sent": "Messaggio inviato!",
+    "sentDesc": "Grazie per il tuo feedback."
+  },
+  "browserCompat": {
+    "trigger": "Compatibilità del browser",
+    "title": "Compatibilità del browser",
+    "description": "Supporto delle funzionalità per il tuo browser attuale.",
+    "note": "Tutte le funzionalità principali funzionano sui browser moderni. Alcune funzionalità avanzate funzionano meglio in Chrome o Edge.",
+    "features": {
+      "gpsFileParsing": "Analisi dei file GPS",
+      "videoSync": "Sincronizzazione video",
+      "videoExport": "Esportazione video (MP4)",
+      "audioInExport": "Audio nell'esportazione",
+      "bleDatalogger": "Datalogger BLE",
+      "filePicker": "Selettore di file",
+      "pwaOffline": "PWA / Offline"
+    },
+    "statuses": {
+      "supported": "Supportato",
+      "notAvailable": "Non disponibile",
+      "frameAccurate": "Precisione al fotogramma",
+      "approximateSync": "Sincronizzazione approssimativa",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "Ripiego WebM",
+      "silentExports": "Esportazioni mute",
+      "native": "Nativo",
+      "fileInputFallback": "Ripiego su campo file"
+    }
   }
 }

--- a/src/locales/ja/landing.json
+++ b/src/locales/ja/landing.json
@@ -144,5 +144,65 @@
         "body": "MyChron 5/6 向けの Race Studio 3（RS2Analysis 形式）からの CSV 書き出し。拡張子: <code>.csv</code>"
       }
     }
+  },
+  "credits": {
+    "trigger": "クレジット",
+    "title": "クレジット",
+    "intro": "これらの素晴らしいオープンソースプロジェクトと無料サービスの上に構築されています。"
+  },
+  "contact": {
+    "trigger": "お問い合わせ",
+    "title": "お問い合わせ",
+    "description": "メッセージをお送りください。すべて目を通します。",
+    "categoryLabel": "カテゴリ *",
+    "categoryPlaceholder": "カテゴリを選択",
+    "categories": {
+      "comment": "コメント",
+      "featureRequest": "機能リクエスト",
+      "complaint": "苦情",
+      "bugReport": "バグ報告"
+    },
+    "emailLabel": "メールアドレス",
+    "emailOptional": "（任意、返信用）",
+    "emailPlaceholder": "your@email.com",
+    "messageLabel": "メッセージ *",
+    "messagePlaceholder": "どうされましたか？",
+    "sending": "送信中…",
+    "send": "メッセージを送信",
+    "missingFields": "未入力の項目があります",
+    "missingFieldsDesc": "カテゴリを選択し、メッセージを入力してください。",
+    "tooLong": "メッセージが長すぎます",
+    "tooLongDesc": "最大2000文字です。",
+    "error": "エラー",
+    "errorGeneric": "問題が発生しました。",
+    "errorNetwork": "メッセージを送信できませんでした。もう一度お試しください。",
+    "sent": "メッセージを送信しました！",
+    "sentDesc": "フィードバックありがとうございます。"
+  },
+  "browserCompat": {
+    "trigger": "ブラウザ互換性",
+    "title": "ブラウザ互換性",
+    "description": "現在のブラウザの機能対応状況。",
+    "note": "すべての主要機能は最新のブラウザで動作します。一部の高度な機能は Chrome または Edge で最も適切に動作します。",
+    "features": {
+      "gpsFileParsing": "GPS ファイル解析",
+      "videoSync": "動画同期",
+      "videoExport": "動画書き出し（MP4）",
+      "audioInExport": "書き出し時の音声",
+      "bleDatalogger": "BLE データロガー",
+      "filePicker": "ファイル選択",
+      "pwaOffline": "PWA / オフライン"
+    },
+    "statuses": {
+      "supported": "対応",
+      "notAvailable": "利用不可",
+      "frameAccurate": "フレーム精度",
+      "approximateSync": "おおよその同期",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "WebM フォールバック",
+      "silentExports": "音声なしの書き出し",
+      "native": "ネイティブ",
+      "fileInputFallback": "ファイル入力フォールバック"
+    }
   }
 }

--- a/src/locales/pt-BR/landing.json
+++ b/src/locales/pt-BR/landing.json
@@ -144,5 +144,65 @@
         "body": "Exportações CSV do Race Studio 3 (estilo RS2Analysis) para MyChron 5/6. Extensão: <code>.csv</code>"
       }
     }
+  },
+  "credits": {
+    "trigger": "Créditos",
+    "title": "Créditos",
+    "intro": "Construído sobre os ombros destes incríveis projetos de código aberto e serviços gratuitos."
+  },
+  "contact": {
+    "trigger": "Contato",
+    "title": "Fale conosco",
+    "description": "Envie-nos uma mensagem — lemos todas.",
+    "categoryLabel": "Categoria *",
+    "categoryPlaceholder": "Selecione uma categoria",
+    "categories": {
+      "comment": "Comentário",
+      "featureRequest": "Solicitação de recurso",
+      "complaint": "Reclamação",
+      "bugReport": "Relatório de bug"
+    },
+    "emailLabel": "E-mail",
+    "emailOptional": "(opcional, para resposta)",
+    "emailPlaceholder": "seu@email.com",
+    "messageLabel": "Mensagem *",
+    "messagePlaceholder": "O que você está pensando?",
+    "sending": "Enviando…",
+    "send": "Enviar mensagem",
+    "missingFields": "Campos faltando",
+    "missingFieldsDesc": "Selecione uma categoria e digite uma mensagem.",
+    "tooLong": "Mensagem muito longa",
+    "tooLongDesc": "Máximo de 2000 caracteres.",
+    "error": "Erro",
+    "errorGeneric": "Algo deu errado.",
+    "errorNetwork": "Não foi possível enviar a mensagem. Tente novamente.",
+    "sent": "Mensagem enviada!",
+    "sentDesc": "Obrigado pelo seu feedback."
+  },
+  "browserCompat": {
+    "trigger": "Compatibilidade do navegador",
+    "title": "Compatibilidade do navegador",
+    "description": "Suporte de recursos para o seu navegador atual.",
+    "note": "Todos os recursos principais funcionam nos navegadores modernos. Alguns recursos avançados funcionam melhor no Chrome ou Edge.",
+    "features": {
+      "gpsFileParsing": "Análise de arquivos GPS",
+      "videoSync": "Sincronização de vídeo",
+      "videoExport": "Exportação de vídeo (MP4)",
+      "audioInExport": "Áudio na exportação",
+      "bleDatalogger": "Datalogger BLE",
+      "filePicker": "Seletor de arquivos",
+      "pwaOffline": "PWA / Offline"
+    },
+    "statuses": {
+      "supported": "Compatível",
+      "notAvailable": "Não disponível",
+      "frameAccurate": "Precisão de quadro",
+      "approximateSync": "Sincronização aproximada",
+      "mp4H264": "MP4 (H.264)",
+      "webmFallback": "Alternativa WebM",
+      "silentExports": "Exportações sem áudio",
+      "native": "Nativo",
+      "fileInputFallback": "Alternativa de entrada de arquivo"
+    }
   }
 }


### PR DESCRIPTION
## The last three landing-page dialogs

Wraps up landing-page i18n by translating the remaining content dialogs into the **`landing`** namespace.

- **Credits** (`CreditsDialog`) — only the trigger/title/intro are translated. The **open-source library names and their GitHub links stay literal** (per request — those are the English names you use for them).
- **Contact** (`ContactDialog`) — the full form (labels, placeholders, buttons) and every toast. The category **values** submitted to the backend stay English (the admin/key), while only their displayed labels are translated.
- **Browser Compatibility** (`BrowserCompatDialog`) — chrome, the per-feature rows and statuses, and the footer note. `lib/browserCompat.ts` was refactored to return stable **feature/status ids** (typed unions) so the dialog does the translating — the lib stays i18n-free. Feature acronyms (GPS, BLE, PWA, MP4/H.264, WebM) stay literal inside the strings.

### Languages
English source; **es/fr/de/it/pt-BR/ja** merged into the existing `landing.json` files (existing keys untouched), markup/placeholders preserved.

### Gates
`typecheck`, `lint`, `build`, full `test:run` (**1728**) pass; i18n parity test (128) green. `browserCompat.ts` has no test and a single consumer (the dialog), both updated together.

### Scope
The landing page is now fully localized. The only remaining surface is the **admin** panel (env-gated, operator-only). Legal pages stay English by design.

https://claude.ai/code/session_01U9pEPejKDiJEWpto8ihNbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9pEPejKDiJEWpto8ihNbh)_