### PR TITLE
i18n: translate the file drop zone (Open a datalog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sync/export status messages, and the **Tools** tab — the tool picker and the
   kart seat-position visualizer, and the **account pages** — sign in, create
   account, forgot/reset password, and the sign-in callback — and the home-screen
-  **About**, **Supported Files**, **Credits**, **Contact** and
-  **browser-compatibility** dialogs. More of the app follows in later updates.
+  **file drop zone** ("Open a datalog") plus the **About**, **Supported Files**,
+  **Credits**, **Contact** and **browser-compatibility** dialogs. More of the app
+  follows in later updates.
   (Open-source library names and GitHub link names stay in English by design, as
   do the legal pages.)
 - **Log type bubble in the file browser.** Each session row (shown by date/time)

--- a/docs/plans/i18n-translation-system.md
+++ b/docs/plans/i18n-translation-system.md
@@ -1,6 +1,12 @@
 # Plan: Internationalization (i18n) / translation system
 
-Status: **Phase 7 — auth pages + all landing dialogs complete** · current branch: `claude/i18n-landing-dialogs` → PR into `BETA`
+Status: **Phase 7 — auth pages + entire landing page complete** · current branch: `claude/i18n-file-import` → PR into `BETA`
+
+> **Phase 7d (this PR):** the landing page's primary **file drop zone**
+> (`FileImport`, "Open a datalog") — heading, drag/drop prompt, the
+> locally-processed format note (`<Trans>`; format list stays literal), progress
+> + error/loaded lines — in the `landing` namespace (`fileImport.*`). With this
+> the whole landing page is localized. **Remaining overall:** the **admin** panel.
 
 > **Phase 7c (this PR):** the last three landing-page dialogs — **Credits**
 > (`CreditsDialog`), **Contact** (`ContactDialog`), and **browser-compatibility**

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useTranslation, Trans } from "react-i18next";
 import { Upload, Loader2 } from "lucide-react";
 import { parseDatalogFile } from "@/lib/datalogParser";
 import { ParsedData } from "@/types/racing";
@@ -16,6 +17,7 @@ interface FileImportProps {
  * own tiles in LandingPage rather than bundled inside this dropzone.
  */
 export function FileImport({ onDataLoaded, autoSave, autoSaveFile }: FileImportProps) {
+  const { t } = useTranslation("landing");
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -39,14 +41,14 @@ export function FileImport({ onDataLoaded, autoSave, autoSaveFile }: FileImportP
         const data = await parseDatalogFile(file, (p) => setProgress(p.message));
         onDataLoaded(data, file.name);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : "Failed to parse file";
-        setError(autoSave ? `${msg} — file was saved and can be found in Browse Files.` : msg);
+        const msg = e instanceof Error ? e.message : t("fileImport.parseFailed");
+        setError(autoSave ? t("fileImport.parseErrorSaved", { message: msg }) : msg);
       } finally {
         setIsLoading(false);
         setProgress(null);
       }
     },
-    [onDataLoaded, autoSave, autoSaveFile],
+    [onDataLoaded, autoSave, autoSaveFile, t],
   );
 
   const handleFileChange = useCallback(
@@ -106,21 +108,20 @@ export function FileImport({ onDataLoaded, autoSave, autoSaveFile }: FileImportP
           </span>
         )}
         <span className="text-xl font-semibold text-foreground">
-          {isLoading ? (progress ?? "Processing...") : "Open a datalog"}
+          {isLoading ? (progress ?? t("fileImport.processing")) : t("fileImport.title")}
         </span>
         <span className="text-sm text-muted-foreground">
-          Drag &amp; drop a file here, or click to browse
+          {t("fileImport.dragDrop")}
         </span>
         <span className="max-w-md text-xs text-muted-foreground">
-          NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD and more —
-          <i> all processed locally on your device.</i>
+          <Trans t={t} i18nKey="fileImport.formats" components={{ i: <i /> }} />
         </span>
       </label>
 
       {fileName && !error && (
-        <p className="text-center text-sm font-mono text-muted-foreground">Loaded: {fileName}</p>
+        <p className="text-center text-sm font-mono text-muted-foreground">{t("fileImport.loaded", { name: fileName })}</p>
       )}
-      {error && <p className="text-center text-sm font-medium text-destructive">Error: {error}</p>}
+      {error && <p className="text-center text-sm font-medium text-destructive">{t("fileImport.errorLine", { error })}</p>}
     </div>
   );
 }

--- a/src/locales/de/landing.json
+++ b/src/locales/de/landing.json
@@ -204,5 +204,15 @@
       "native": "Nativ",
       "fileInputFallback": "Datei-Eingabe-Fallback"
     }
+  },
+  "fileImport": {
+    "title": "Datalog öffnen",
+    "processing": "Wird verarbeitet...",
+    "dragDrop": "Datei hierher ziehen und ablegen oder zum Durchsuchen klicken",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD und mehr — <i>alles lokal auf deinem Gerät verarbeitet.</i>",
+    "parseFailed": "Datei konnte nicht verarbeitet werden",
+    "parseErrorSaved": "{{message}} — die Datei wurde gespeichert und ist unter „Dateien durchsuchen“ zu finden.",
+    "loaded": "Geladen: {{name}}",
+    "errorLine": "Fehler: {{error}}"
   }
 }

--- a/src/locales/en/landing.json
+++ b/src/locales/en/landing.json
@@ -90,6 +90,16 @@
       "PWA — installable & fully offline"
     ]
   },
+  "fileImport": {
+    "title": "Open a datalog",
+    "processing": "Processing...",
+    "dragDrop": "Drag & drop a file here, or click to browse",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD and more — <i>all processed locally on your device.</i>",
+    "parseFailed": "Failed to parse file",
+    "parseErrorSaved": "{{message}} — file was saved and can be found in Browse Files.",
+    "loaded": "Loaded: {{name}}",
+    "errorLine": "Error: {{error}}"
+  },
   "credits": {
     "trigger": "Credits",
     "title": "Credits",

--- a/src/locales/es/landing.json
+++ b/src/locales/es/landing.json
@@ -204,5 +204,15 @@
       "native": "Nativo",
       "fileInputFallback": "Alternativa de entrada de archivo"
     }
+  },
+  "fileImport": {
+    "title": "Abrir un datalog",
+    "processing": "Procesando...",
+    "dragDrop": "Arrastra y suelta un archivo aquí, o haz clic para explorar",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD y más — <i>todo procesado localmente en tu dispositivo.</i>",
+    "parseFailed": "No se pudo analizar el archivo",
+    "parseErrorSaved": "{{message}} — el archivo se guardó y puedes encontrarlo en Explorar archivos.",
+    "loaded": "Cargado: {{name}}",
+    "errorLine": "Error: {{error}}"
   }
 }

--- a/src/locales/fr/landing.json
+++ b/src/locales/fr/landing.json
@@ -204,5 +204,15 @@
       "native": "Natif",
       "fileInputFallback": "Repli sur champ de fichier"
     }
+  },
+  "fileImport": {
+    "title": "Ouvrir un datalog",
+    "processing": "Traitement...",
+    "dragDrop": "Glissez-déposez un fichier ici, ou cliquez pour parcourir",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD et plus encore — <i>tout est traité localement sur votre appareil.</i>",
+    "parseFailed": "Échec de l'analyse du fichier",
+    "parseErrorSaved": "{{message}} — le fichier a été enregistré et se trouve dans Parcourir les fichiers.",
+    "loaded": "Chargé : {{name}}",
+    "errorLine": "Erreur : {{error}}"
   }
 }

--- a/src/locales/it/landing.json
+++ b/src/locales/it/landing.json
@@ -204,5 +204,15 @@
       "native": "Nativo",
       "fileInputFallback": "Ripiego su campo file"
     }
+  },
+  "fileImport": {
+    "title": "Apri un datalog",
+    "processing": "Elaborazione...",
+    "dragDrop": "Trascina un file qui o clicca per sfogliare",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD e altro — <i>tutto elaborato localmente sul tuo dispositivo.</i>",
+    "parseFailed": "Impossibile analizzare il file",
+    "parseErrorSaved": "{{message}} — il file è stato salvato e si trova in Sfoglia file.",
+    "loaded": "Caricato: {{name}}",
+    "errorLine": "Errore: {{error}}"
   }
 }

--- a/src/locales/ja/landing.json
+++ b/src/locales/ja/landing.json
@@ -204,5 +204,15 @@
       "native": "ネイティブ",
       "fileInputFallback": "ファイル入力フォールバック"
     }
+  },
+  "fileImport": {
+    "title": "データログを開く",
+    "processing": "処理中...",
+    "dragDrop": "ここにファイルをドラッグ＆ドロップ、またはクリックして参照",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD など — <i>すべて端末内でローカルに処理されます。</i>",
+    "parseFailed": "ファイルの解析に失敗しました",
+    "parseErrorSaved": "{{message}} — ファイルは保存され、「ファイルを参照」で見つけられます。",
+    "loaded": "読み込み済み: {{name}}",
+    "errorLine": "エラー: {{error}}"
   }
 }

--- a/src/locales/pt-BR/landing.json
+++ b/src/locales/pt-BR/landing.json
@@ -204,5 +204,15 @@
       "native": "Nativo",
       "fileInputFallback": "Alternativa de entrada de arquivo"
     }
+  },
+  "fileImport": {
+    "title": "Abrir um datalog",
+    "processing": "Processando...",
+    "dragDrop": "Arraste e solte um arquivo aqui, ou clique para procurar",
+    "formats": "NMEA, UBX, VBO, Dove, Alfano, AiM (CSV + XRK/XRZ), iRacing, MoTeC CSV/LD e mais — <i>tudo processado localmente no seu dispositivo.</i>",
+    "parseFailed": "Falha ao analisar o arquivo",
+    "parseErrorSaved": "{{message}} — o arquivo foi salvo e pode ser encontrado em Procurar arquivos.",
+    "loaded": "Carregado: {{name}}",
+    "errorLine": "Erro: {{error}}"
   }
 }


### PR DESCRIPTION
## The "Open a datalog" drop zone

The one landing-page surface we'd missed — `FileImport`, the big drag-and-drop panel. Now translated into the **`landing`** namespace (`fileImport.*`):

- Heading ("Open a datalog"), the drag/drop prompt, and the format note (`<Trans>` with `<i>`; the format list — NMEA, UBX, VBO, … — stays literal).
- The progress fallback ("Processing…"), and the `Loaded:` / `Error:` lines (interpolated).
- The two parse-error messages (the bare failure + the "file was saved, find it in Browse Files" variant).

### Languages
English source; **es/fr/de/it/pt-BR/ja** merged into the existing `landing.json` files, markup/placeholders preserved.

### Gates
`typecheck`, `lint`, `build`, full `test:run` (**1728**) pass; i18n parity test (128) green.

With this the **entire landing page** is localized. The only remaining surface is the **admin** panel (env-gated, operator-only). Legal pages stay English by design.

https://claude.ai/code/session_01U9pEPejKDiJEWpto8ihNbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9pEPejKDiJEWpto8ihNbh)_