### PR TITLE
i18n (Phase 8a): admin shell + Messages/Tracks/Tools/Banned IPs tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kart seat-position visualizer, and the **account pages** — sign in, create
   account, forgot/reset password, and the sign-in callback — and the home-screen
   **file drop zone** ("Open a datalog") plus the **About**, **Supported Files**,
-  **Credits**, **Contact** and **browser-compatibility** dialogs. More of the app
-  follows in later updates.
+  **Credits**, **Contact** and **browser-compatibility** dialogs, and most of the
+  **admin panel** (the shell plus the Messages, Tracks, Tools and Banned IPs
+  tabs). More of the app follows in later updates.
   (Open-source library names and GitHub link names stay in English by design, as
   do the legal pages.)
 - **Log type bubble in the file browser.** Each session row (shown by date/time)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1027,8 +1027,11 @@ visualizer), which owns its translations **plugin-locally**
 `registerPluginLocale`, with a plugin-local parity test + typed keys) so they
 travel with the plugin on extraction, and the **auth pages** — sign-in, sign-up,
 forgot/reset password, and the OAuth callback (`Login`, `Register`,
-`ForgotPassword`, `ResetPassword`, `AuthCallback`) — the `auth` namespace. The
-**admin** panel is the last untranslated surface; the framework is whole.
+`ForgotPassword`, `ResetPassword`, `AuthCallback`) — the `auth` namespace, and
+the **admin** panel (env-gated) — the shell + Messages, Tracks, Tools and Banned
+IPs tabs done (the `admin` namespace; `browserCompat`-style id maps keep the
+contact-category badge translated while its DB value stays English). Only the
+admin **Submissions** + **Courses** tabs remain; the framework is whole.
 (Device-setting **labels** still come from
 `deviceSettingsSchema.ts` data — schema-level i18n is a deliberate follow-up so
 unknown device keys keep passing through as raw labels.)
@@ -1054,7 +1057,7 @@ unknown device keys keep passing through as raw labels.)
 - **Keys are typed.** `src/types/i18next.d.ts` augments react-i18next's resources
   with the English JSON shape, so `t("settings:title")` is autocompleted and a
   missing/renamed key fails `tsc -b`. English is the canonical key set.
-- **Namespaces** (`common`, `landing`, `settings`, `session`, `video`, `drawer`, `weather`, `tracks`, `plugins`, `auth`) map to per-language JSON files
+- **Namespaces** (`common`, `landing`, `settings`, `session`, `video`, `drawer`, `weather`, `tracks`, `plugins`, `auth`, `admin`) map to per-language JSON files
   under `src/locales/` and load on demand for their surface. Rich text uses `<Trans>` (e.g. the
   preview-DB warning); interpolation uses `{{var}}`; pluralization uses i18next's
   `count`/CLDR (never hand-rolled `s` suffixes). Unit symbols (`km`, `°C`, …),

--- a/docs/plans/i18n-translation-system.md
+++ b/docs/plans/i18n-translation-system.md
@@ -1,6 +1,14 @@
 # Plan: Internationalization (i18n) / translation system
 
-Status: **Phase 7 — auth pages + entire landing page complete** · current branch: `claude/i18n-file-import` → PR into `BETA`
+Status: **Phase 8 — admin panel (shell + 4 tabs)** · current branch: `claude/i18n-admin-shell` → PR into `BETA`
+
+> **Phase 8a (this PR):** the **admin** panel shell (`Admin.tsx`: login gate, header,
+> tab bar) + the **Messages**, **Tracks**, **Tools** and **Banned IPs** tabs — a
+> new host `admin` namespace (wired into `config.ts`, `index.ts` bundled English,
+> `types/i18next.d.ts`). The contact-category badge in Messages is translated via
+> an English-value→key map (the DB value stays English). `lib/browserCompat.ts`
+> pattern reused only conceptually. **Remaining:** the admin **Submissions** +
+> **Courses** tabs (Phase 8b) — the two biggest. Then i18n is complete.
 
 > **Phase 7d (this PR):** the landing page's primary **file drop zone**
 > (`FileImport`, "Open a datalog") — heading, drag/drop prompt, the

--- a/src/components/admin/BannedIpsTab.tsx
+++ b/src/components/admin/BannedIpsTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -8,6 +9,7 @@ import type { DbBannedIp } from '@/lib/db/types';
 import { Plus, Trash2 } from 'lucide-react';
 
 export function BannedIpsTab() {
+  const { t } = useTranslation('admin');
   const [ips, setIps] = useState<DbBannedIp[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAdd, setShowAdd] = useState(false);
@@ -23,10 +25,10 @@ export function BannedIpsTab() {
     try {
       setIps(await db.getBannedIps());
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
-  }, [db]);
+  }, [db, t]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -39,63 +41,63 @@ export function BannedIpsTab() {
         : undefined;
       await db.banIp(newIp.trim(), newReason.trim() || undefined, expiresAt);
       setNewIp(''); setNewReason(''); setNewDurationDays('90'); setShowAdd(false);
-      toast({ title: 'IP banned' });
+      toast({ title: t('bannedIps.banned') });
       load();
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
   };
 
   const handleUnban = async (id: string) => {
     try {
       await db.unbanIp(id);
-      toast({ title: 'IP unbanned' });
+      toast({ title: t('bannedIps.unbanned') });
       load();
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
   };
 
   return (
     <div className="space-y-4 mt-4">
       <div className="flex justify-between items-center">
-        <h3 className="font-semibold text-foreground">Banned IPs</h3>
-        <Button size="sm" onClick={() => setShowAdd(!showAdd)}><Plus className="w-4 h-4 mr-1" /> Ban IP</Button>
+        <h3 className="font-semibold text-foreground">{t('bannedIps.title')}</h3>
+        <Button size="sm" onClick={() => setShowAdd(!showAdd)}><Plus className="w-4 h-4 mr-1" /> {t('bannedIps.banIp')}</Button>
       </div>
 
       {showAdd && (
         <div className="racing-card p-4 space-y-3">
           <div>
-            <Label>IP Address</Label>
+            <Label>{t('bannedIps.ipAddress')}</Label>
             <Input value={newIp} onChange={e => setNewIp(e.target.value)} placeholder="192.168.1.1" />
           </div>
           <div>
-            <Label>Reason (optional)</Label>
-            <Input value={newReason} onChange={e => setNewReason(e.target.value)} placeholder="Spam submissions" />
+            <Label>{t('bannedIps.reasonOptional')}</Label>
+            <Input value={newReason} onChange={e => setNewReason(e.target.value)} placeholder={t('bannedIps.reasonPlaceholder')} />
           </div>
           <div>
-            <Label>Expires after</Label>
+            <Label>{t('bannedIps.expiresAfter')}</Label>
             <select
               value={newDurationDays}
               onChange={e => setNewDurationDays(e.target.value)}
               className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <option value="1">1 day</option>
-              <option value="7">7 days</option>
-              <option value="30">30 days</option>
-              <option value="90">90 days</option>
-              <option value="365">1 year</option>
-              <option value="0">Permanent</option>
+              <option value="1">{t('bannedIps.duration.oneDay')}</option>
+              <option value="7">{t('bannedIps.duration.sevenDays')}</option>
+              <option value="30">{t('bannedIps.duration.thirtyDays')}</option>
+              <option value="90">{t('bannedIps.duration.ninetyDays')}</option>
+              <option value="365">{t('bannedIps.duration.oneYear')}</option>
+              <option value="0">{t('bannedIps.duration.permanent')}</option>
             </select>
           </div>
-          <Button size="sm" onClick={handleBan}>Ban</Button>
+          <Button size="sm" onClick={handleBan}>{t('bannedIps.ban')}</Button>
         </div>
       )}
 
       {loading ? (
-        <p className="text-muted-foreground">Loading...</p>
+        <p className="text-muted-foreground">{t('common.loading')}</p>
       ) : ips.length === 0 ? (
-        <p className="text-muted-foreground">No banned IPs.</p>
+        <p className="text-muted-foreground">{t('bannedIps.none')}</p>
       ) : (
         <div className="space-y-2">
           {ips.map(ip => (
@@ -103,7 +105,7 @@ export function BannedIpsTab() {
               <div>
                 <span className="font-mono text-sm text-foreground">{ip.ip_address}</span>
                 {ip.reason && <span className="ml-2 text-xs text-muted-foreground">{ip.reason}</span>}
-                {ip.expires_at && <span className="ml-2 text-xs text-muted-foreground">expires: {new Date(ip.expires_at).toLocaleString()}</span>}
+                {ip.expires_at && <span className="ml-2 text-xs text-muted-foreground">{t('bannedIps.expires', { date: new Date(ip.expires_at).toLocaleString() })}</span>}
               </div>
               <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive" onClick={() => handleUnban(ip.id)}>
                 <Trash2 className="w-4 h-4" />

--- a/src/components/admin/MessagesTab.tsx
+++ b/src/components/admin/MessagesTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -25,7 +26,16 @@ const categoryColors: Record<string, string> = {
   "Bug Report": "bg-orange-500/20 text-orange-400 border-orange-500/30",
 };
 
+// Map the English category value stored in the DB to its locale key.
+const categoryKeys = {
+  "Comment": "comment",
+  "Feature Request": "featureRequest",
+  "Complaint": "complaint",
+  "Bug Report": "bugReport",
+} as const;
+
 export function MessagesTab({ onUnreadCount }: { onUnreadCount?: (count: number) => void }) {
+  const { t } = useTranslation("admin");
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<FilterMode>("all");
@@ -41,14 +51,14 @@ export function MessagesTab({ onUnreadCount }: { onUnreadCount?: (count: number)
       .order("created_at", { ascending: false });
 
     if (error) {
-      toast({ title: "Error loading messages", description: error.message, variant: "destructive" });
+      toast({ title: t("messages.loadError"), description: error.message, variant: "destructive" });
     } else {
       setMessages(data || []);
       const unread = (data || []).filter((m: Message) => !m.is_read).length;
       onUnreadCount?.(unread);
     }
     setLoading(false);
-  }, [onUnreadCount]);
+  }, [onUnreadCount, t]);
 
   useEffect(() => { fetchMessages(); }, [fetchMessages]);
 
@@ -64,7 +74,7 @@ export function MessagesTab({ onUnreadCount }: { onUnreadCount?: (count: number)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Supabase types lag schema; remove on next type regen
     const { error } = await (supabase as any).from("messages").delete().eq("id", id);
     if (error) {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
+      toast({ title: t("common.error"), description: error.message, variant: "destructive" });
     } else {
       setMessages(prev => prev.filter(m => m.id !== id));
       if (expandedId === id) setExpandedId(null);
@@ -88,24 +98,30 @@ export function MessagesTab({ onUnreadCount }: { onUnreadCount?: (count: number)
     return true;
   });
 
-  if (loading) return <p className="text-muted-foreground py-4">Loading messages…</p>;
+  if (loading) return <p className="text-muted-foreground py-4">{t("messages.loading")}</p>;
+
+  const filterLabels: Record<FilterMode, string> = {
+    all: t("messages.filterAll"),
+    unread: t("messages.filterUnread"),
+    read: t("messages.filterRead"),
+  };
 
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         {(["all", "unread", "read"] as FilterMode[]).map(f => (
           <Button key={f} size="sm" variant={filter === f ? "default" : "outline"} onClick={() => setFilter(f)}>
-            {f === "all" ? "All" : f === "unread" ? "Unread" : "Read"}
+            {filterLabels[f]}
             {f === "unread" && (
               <span className="ml-1 text-xs">({messages.filter(m => !m.is_read).length})</span>
             )}
           </Button>
         ))}
-        <Button size="sm" variant="ghost" onClick={fetchMessages} className="ml-auto">Refresh</Button>
+        <Button size="sm" variant="ghost" onClick={fetchMessages} className="ml-auto">{t("messages.refresh")}</Button>
       </div>
 
       {filtered.length === 0 ? (
-        <p className="text-muted-foreground py-8 text-center">No messages</p>
+        <p className="text-muted-foreground py-8 text-center">{t("messages.none")}</p>
       ) : (
         <div className="space-y-2">
           {filtered.map(msg => (
@@ -119,7 +135,9 @@ export function MessagesTab({ onUnreadCount }: { onUnreadCount?: (count: number)
                   : <Mail className="w-4 h-4 text-primary shrink-0" />
                 }
                 <Badge variant="outline" className={categoryColors[msg.category] || ""}>
-                  {msg.category}
+                  {msg.category in categoryKeys
+                    ? t(`messages.categories.${categoryKeys[msg.category as keyof typeof categoryKeys]}`)
+                    : msg.category}
                 </Badge>
                 <span className="text-sm truncate flex-1">
                   {msg.message.length > 80 ? msg.message.slice(0, 80) + "…" : msg.message}
@@ -134,11 +152,11 @@ export function MessagesTab({ onUnreadCount }: { onUnreadCount?: (count: number)
                 <div className="px-4 pb-4 space-y-3 border-t border-border pt-3">
                   <p className="text-sm whitespace-pre-wrap">{msg.message}</p>
                   <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                    {msg.email && <span>Email: {msg.email}</span>}
-                    <span>IP: {msg.submitted_by_ip || "unknown"}</span>
+                    {msg.email && <span>{t("messages.emailLine", { email: msg.email })}</span>}
+                    <span>{t("messages.ipLine", { ip: msg.submitted_by_ip || t("messages.unknownIp") })}</span>
                     <span>{new Date(msg.created_at).toLocaleString()}</span>
                     <Button size="sm" variant="destructive" className="ml-auto h-7" onClick={() => deleteMessage(msg.id)}>
-                      <Trash2 className="w-3 h-3 mr-1" /> Delete
+                      <Trash2 className="w-3 h-3 mr-1" /> {t("common.delete")}
                     </Button>
                   </div>
                 </div>

--- a/src/components/admin/ToolsTab.tsx
+++ b/src/components/admin/ToolsTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/hooks/use-toast';
@@ -8,6 +9,7 @@ import { supabase } from '@/integrations/supabase/client';
 import JSZip from 'jszip';
 
 export function ToolsTab() {
+  const { t } = useTranslation('admin');
   const [jsonOutput, setJsonOutput] = useState('');
   const [drawingsOutput, setDrawingsOutput] = useState('');
   const [importJson, setImportJson] = useState('');
@@ -21,9 +23,9 @@ export function ToolsTab() {
     try {
       const json = await db.buildTracksJson();
       setJsonOutput(json);
-      toast({ title: 'tracks.json built from database' });
+      toast({ title: t('tools.buildJsonDone') });
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
   };
@@ -59,9 +61,9 @@ export function ToolsTab() {
       a.download = 'tracks.zip';
       a.click();
       URL.revokeObjectURL(url);
-      toast({ title: 'Tracks ZIP downloaded' });
+      toast({ title: t('tools.buildZipDone') });
     } catch (e: unknown) {
-      toast({ title: 'Error building ZIP', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('tools.buildZipError'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
   };
@@ -71,9 +73,9 @@ export function ToolsTab() {
     try {
       const json = await db.buildDrawingsJson();
       setDrawingsOutput(json);
-      toast({ title: 'Course drawings exported' });
+      toast({ title: t('tools.exportDrawingsDone') });
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
   };
@@ -94,9 +96,9 @@ export function ToolsTab() {
     try {
       await db.importFromTracksJson(importJson);
       setImportJson('');
-      toast({ title: 'Database rebuilt from JSON' });
+      toast({ title: t('tools.importDone') });
     } catch (e: unknown) {
-      toast({ title: 'Import error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('tools.importError'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
   };
@@ -107,9 +109,9 @@ export function ToolsTab() {
     try {
       await db.importDrawingsJson(importDrawingsJson);
       setImportDrawingsJson('');
-      toast({ title: 'Course drawings imported. Overrides cleared for imported courses.' });
+      toast({ title: t('tools.importDrawingsDone') });
     } catch (e: unknown) {
-      toast({ title: 'Import error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('tools.importError'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
   };
@@ -117,15 +119,15 @@ export function ToolsTab() {
   return (
     <div className="space-y-6 mt-4">
       <div className="racing-card p-4 space-y-3">
-        <h3 className="font-semibold text-foreground">Build tracks.json from Database</h3>
-        <p className="text-sm text-muted-foreground">Generates tracks.json with longName, shortName, defaultCourse, and lengthFt per course (from layout drawings or overrides).</p>
+        <h3 className="font-semibold text-foreground">{t('tools.buildJsonTitle')}</h3>
+        <p className="text-sm text-muted-foreground">{t('tools.buildJsonDesc')}</p>
         <div className="flex gap-2">
           <Button onClick={handleBuildJson} disabled={loading}>
-            <FileJson className="w-4 h-4 mr-2" /> Build JSON
+            <FileJson className="w-4 h-4 mr-2" /> {t('tools.buildJson')}
           </Button>
           {jsonOutput && (
             <Button variant="outline" onClick={handleDownloadJson}>
-              <Download className="w-4 h-4 mr-2" /> Download
+              <Download className="w-4 h-4 mr-2" /> {t('tools.download')}
             </Button>
           )}
         </div>
@@ -135,23 +137,23 @@ export function ToolsTab() {
       </div>
 
       <div className="racing-card p-4 space-y-3">
-        <h3 className="font-semibold text-foreground">Build Tracks ZIP</h3>
-        <p className="text-sm text-muted-foreground">Downloads individual track JSON files (with longName, shortName, defaultCourse, lengthFt) in a TRACKS/ folder.</p>
+        <h3 className="font-semibold text-foreground">{t('tools.buildZipTitle')}</h3>
+        <p className="text-sm text-muted-foreground">{t('tools.buildZipDesc')}</p>
         <Button onClick={handleBuildZip} disabled={loading}>
-          <Archive className="w-4 h-4 mr-2" /> Build & Download ZIP
+          <Archive className="w-4 h-4 mr-2" /> {t('tools.buildZip')}
         </Button>
       </div>
 
       <div className="racing-card p-4 space-y-3">
-        <h3 className="font-semibold text-foreground">Export Course Drawings</h3>
-        <p className="text-sm text-muted-foreground">Export all course layout drawings as JSON (keyed by shortName/courseName). Courses with manual length overrides are skipped.</p>
+        <h3 className="font-semibold text-foreground">{t('tools.exportDrawingsTitle')}</h3>
+        <p className="text-sm text-muted-foreground">{t('tools.exportDrawingsDesc')}</p>
         <div className="flex gap-2">
           <Button onClick={handleBuildDrawings} disabled={loading}>
-            <Pencil className="w-4 h-4 mr-2" /> Export Drawings
+            <Pencil className="w-4 h-4 mr-2" /> {t('tools.exportDrawings')}
           </Button>
           {drawingsOutput && (
             <Button variant="outline" onClick={handleDownloadDrawings}>
-              <Download className="w-4 h-4 mr-2" /> Download
+              <Download className="w-4 h-4 mr-2" /> {t('tools.download')}
             </Button>
           )}
         </div>
@@ -161,30 +163,30 @@ export function ToolsTab() {
       </div>
 
       <div className="racing-card p-4 space-y-3">
-        <h3 className="font-semibold text-foreground">Import Course Drawings</h3>
-        <p className="text-sm text-muted-foreground">Paste course drawings JSON. For each imported drawing, the length override is cleared (drawing becomes source of truth). Courses without a drawing are left alone.</p>
+        <h3 className="font-semibold text-foreground">{t('tools.importDrawingsTitle')}</h3>
+        <p className="text-sm text-muted-foreground">{t('tools.importDrawingsDesc')}</p>
         <Textarea
           value={importDrawingsJson}
           onChange={e => setImportDrawingsJson(e.target.value)}
-          placeholder='Paste course drawings JSON here... (e.g. {"OKC/Normal": [{lat, lon}, ...]})'
+          placeholder={t('tools.importDrawingsPlaceholder')}
           className="font-mono text-xs h-32"
         />
         <Button onClick={handleImportDrawings} disabled={loading || !importDrawingsJson.trim()}>
-          <Upload className="w-4 h-4 mr-2" /> Import Drawings
+          <Upload className="w-4 h-4 mr-2" /> {t('tools.importDrawings')}
         </Button>
       </div>
 
       <div className="racing-card p-4 space-y-3">
-        <h3 className="font-semibold text-foreground">Import tracks.json into Database</h3>
-        <p className="text-sm text-muted-foreground">Paste a tracks.json file to rebuild the database. Course lengthFt values are imported as length overrides.</p>
+        <h3 className="font-semibold text-foreground">{t('tools.importJsonTitle')}</h3>
+        <p className="text-sm text-muted-foreground">{t('tools.importJsonDesc')}</p>
         <Textarea
           value={importJson}
           onChange={e => setImportJson(e.target.value)}
-          placeholder="Paste tracks.json content here..."
+          placeholder={t('tools.importJsonPlaceholder')}
           className="font-mono text-xs h-32"
         />
         <Button onClick={handleImport} disabled={loading || !importJson.trim()}>
-          <Upload className="w-4 h-4 mr-2" /> Import
+          <Upload className="w-4 h-4 mr-2" /> {t('tools.import')}
         </Button>
       </div>
     </div>

--- a/src/components/admin/TracksTab.tsx
+++ b/src/components/admin/TracksTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -9,6 +10,7 @@ import type { DbTrack } from '@/lib/db/types';
 import { Plus, Trash2, Edit2, Check, X } from 'lucide-react';
 
 export function TracksTab() {
+  const { t } = useTranslation('admin');
   const [tracks, setTracks] = useState<DbTrack[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -25,26 +27,26 @@ export function TracksTab() {
     try {
       setTracks(await db.getTracks());
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
     setLoading(false);
-  }, [db]);
+  }, [db, t]);
 
   useEffect(() => { load(); }, [load]);
 
   const handleAdd = async () => {
     if (!newName.trim() || !newShortName.trim()) return;
     if (newShortName.trim().length > 8) {
-      toast({ title: 'Short name must be 8 characters or less', variant: 'destructive' });
+      toast({ title: t('tracks.shortNameTooLong'), variant: 'destructive' });
       return;
     }
     try {
       await db.createTrack({ name: newName.trim(), short_name: newShortName.trim() });
       setNewName(''); setNewShortName(''); setShowAdd(false);
-      toast({ title: 'Track created' });
+      toast({ title: t('tracks.created') });
       load();
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
   };
 
@@ -53,10 +55,10 @@ export function TracksTab() {
     try {
       await db.updateTrack(id, { name: editName.trim(), short_name: editShortName.trim() });
       setEditingId(null);
-      toast({ title: 'Track updated' });
+      toast({ title: t('tracks.updated') });
       load();
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
   };
 
@@ -65,50 +67,50 @@ export function TracksTab() {
       await db.updateTrack(id, { enabled });
       load();
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
   };
 
   const handleDelete = async (id: string) => {
     try {
       await db.deleteTrack(id);
-      toast({ title: 'Track deleted' });
+      toast({ title: t('tracks.deleted') });
       load();
     } catch (e: unknown) {
-      toast({ title: 'Error', description: (e as Error).message, variant: 'destructive' });
+      toast({ title: t('common.error'), description: (e as Error).message, variant: 'destructive' });
     }
   };
 
   return (
     <div className="space-y-4 mt-4">
       <div className="flex justify-between items-center">
-        <h3 className="font-semibold text-foreground">Tracks</h3>
-        <Button size="sm" onClick={() => setShowAdd(!showAdd)}><Plus className="w-4 h-4 mr-1" /> Add Track</Button>
+        <h3 className="font-semibold text-foreground">{t('tracks.title')}</h3>
+        <Button size="sm" onClick={() => setShowAdd(!showAdd)}><Plus className="w-4 h-4 mr-1" /> {t('tracks.addTrack')}</Button>
       </div>
 
       {showAdd && (
         <div className="racing-card p-4 space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <Label>Track Name</Label>
+              <Label>{t('tracks.trackName')}</Label>
               <Input value={newName} onChange={e => setNewName(e.target.value)} placeholder="Orlando Kart Center" />
             </div>
             <div>
-              <Label>Short Name (max 8)</Label>
+              <Label>{t('tracks.shortName')}</Label>
               <Input value={newShortName} onChange={e => setNewShortName(e.target.value.slice(0, 8))} placeholder="OKC" maxLength={8} />
             </div>
           </div>
           <div className="flex gap-2">
-            <Button size="sm" onClick={handleAdd}><Check className="w-4 h-4 mr-1" /> Create</Button>
+            <Button size="sm" onClick={handleAdd}><Check className="w-4 h-4 mr-1" /> {t('tracks.create')}</Button>
             <Button size="sm" variant="outline" onClick={() => setShowAdd(false)}><X className="w-4 h-4" /></Button>
           </div>
         </div>
       )}
 
       {loading ? (
-        <p className="text-muted-foreground">Loading...</p>
+        <p className="text-muted-foreground">{t('common.loading')}</p>
       ) : tracks.length === 0 ? (
-        <p className="text-muted-foreground">No tracks in database.</p>
+        <p className="text-muted-foreground">{t('tracks.none')}</p>
       ) : (
         <div className="space-y-2">
           {tracks.map(track => (

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -35,7 +35,7 @@ export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
  * migrated (see docs/plans/i18n-translation-system.md). `common` is always
  * loaded; the rest load on demand for their surface.
  */
-export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth"] as const;
+export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin"] as const;
 export type Namespace = (typeof NAMESPACES)[number];
 
 export const DEFAULT_NAMESPACE: Namespace = "common";

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -33,6 +33,7 @@ import enWeather from "@/locales/en/weather.json";
 import enTracks from "@/locales/en/tracks.json";
 import enPlugins from "@/locales/en/plugins.json";
 import enAuth from "@/locales/en/auth.json";
+import enAdmin from "@/locales/en/admin.json";
 
 const SETTINGS_KEY = "dove-dataviewer-settings";
 
@@ -61,6 +62,7 @@ const bundledEnglish = {
   tracks: enTracks,
   plugins: enPlugins,
   auth: enAuth,
+  admin: enAdmin,
 } as const;
 
 const importBackend: BackendModule = {

--- a/src/locales/de/admin.json
+++ b/src/locales/de/admin.json
@@ -1,0 +1,98 @@
+{
+  "_machine": true,
+  "loading": "Wird geladen...",
+  "panelTitle": "Admin-Bereich",
+  "home": "Startseite",
+  "logout": "Abmelden",
+  "tabs": {
+    "messages": "Nachrichten",
+    "submissions": "Einsendungen",
+    "tracks": "Strecken",
+    "courses": "Kurse",
+    "tools": "Werkzeuge",
+    "banned": "Gesperrte IPs"
+  },
+  "common": {
+    "error": "Fehler",
+    "loading": "Wird geladen...",
+    "delete": "Löschen"
+  },
+  "bannedIps": {
+    "title": "Gesperrte IPs",
+    "banIp": "IP sperren",
+    "ipAddress": "IP-Adresse",
+    "reasonOptional": "Grund (optional)",
+    "reasonPlaceholder": "Spam-Einsendungen",
+    "expiresAfter": "Läuft ab nach",
+    "duration": {
+      "oneDay": "1 Tag",
+      "sevenDays": "7 Tage",
+      "thirtyDays": "30 Tage",
+      "ninetyDays": "90 Tage",
+      "oneYear": "1 Jahr",
+      "permanent": "Dauerhaft"
+    },
+    "ban": "Sperren",
+    "none": "Keine gesperrten IPs.",
+    "expires": "läuft ab: {{date}}",
+    "banned": "IP gesperrt",
+    "unbanned": "IP entsperrt"
+  },
+  "messages": {
+    "filterAll": "Alle",
+    "filterUnread": "Ungelesen",
+    "filterRead": "Gelesen",
+    "refresh": "Aktualisieren",
+    "none": "Keine Nachrichten",
+    "loading": "Nachrichten werden geladen…",
+    "loadError": "Fehler beim Laden der Nachrichten",
+    "categories": {
+      "comment": "Kommentar",
+      "featureRequest": "Funktionswunsch",
+      "complaint": "Beschwerde",
+      "bugReport": "Fehlerbericht"
+    },
+    "emailLine": "E-Mail: {{email}}",
+    "ipLine": "IP: {{ip}}",
+    "unknownIp": "unbekannt"
+  },
+  "tracks": {
+    "title": "Strecken",
+    "addTrack": "Strecke hinzufügen",
+    "trackName": "Streckenname",
+    "shortName": "Kurzname (max. 8)",
+    "create": "Erstellen",
+    "none": "Keine Strecken in der Datenbank.",
+    "shortNameTooLong": "Der Kurzname darf höchstens 8 Zeichen lang sein",
+    "created": "Strecke erstellt",
+    "updated": "Strecke aktualisiert",
+    "deleted": "Strecke gelöscht"
+  },
+  "tools": {
+    "buildJsonTitle": "tracks.json aus der Datenbank erzeugen",
+    "buildJsonDesc": "Erzeugt tracks.json mit longName, shortName, defaultCourse und lengthFt pro Kurs (aus Streckenzeichnungen oder Überschreibungen).",
+    "buildJson": "JSON erzeugen",
+    "download": "Herunterladen",
+    "buildJsonDone": "tracks.json aus der Datenbank erzeugt",
+    "buildZipTitle": "Strecken-ZIP erzeugen",
+    "buildZipDesc": "Lädt einzelne Strecken-JSON-Dateien (mit longName, shortName, defaultCourse, lengthFt) in einem TRACKS/-Ordner herunter.",
+    "buildZip": "ZIP erzeugen & herunterladen",
+    "buildZipDone": "Strecken-ZIP heruntergeladen",
+    "buildZipError": "Fehler beim Erzeugen des ZIP",
+    "exportDrawingsTitle": "Kurszeichnungen exportieren",
+    "exportDrawingsDesc": "Exportiert alle Kurs-Streckenzeichnungen als JSON (indiziert nach shortName/courseName). Kurse mit manueller Längenüberschreibung werden übersprungen.",
+    "exportDrawings": "Zeichnungen exportieren",
+    "exportDrawingsDone": "Kurszeichnungen exportiert",
+    "importDrawingsTitle": "Kurszeichnungen importieren",
+    "importDrawingsDesc": "Füge das JSON der Kurszeichnungen ein. Für jede importierte Zeichnung wird die Längenüberschreibung gelöscht (die Zeichnung wird zur maßgeblichen Quelle). Kurse ohne Zeichnung bleiben unverändert.",
+    "importDrawingsPlaceholder": "Kurszeichnungs-JSON hier einfügen... (z. B. {\"OKC/Normal\": [{lat, lon}, ...]})",
+    "importDrawings": "Zeichnungen importieren",
+    "importDrawingsDone": "Kurszeichnungen importiert. Überschreibungen für importierte Kurse gelöscht.",
+    "importJsonTitle": "tracks.json in die Datenbank importieren",
+    "importJsonDesc": "Füge eine tracks.json-Datei ein, um die Datenbank neu aufzubauen. Die lengthFt-Werte der Kurse werden als Längenüberschreibungen importiert.",
+    "importJsonPlaceholder": "tracks.json-Inhalt hier einfügen...",
+    "import": "Importieren",
+    "importDone": "Datenbank aus JSON neu aufgebaut",
+    "importError": "Importfehler"
+  }
+}

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -1,0 +1,97 @@
+{
+  "loading": "Loading...",
+  "panelTitle": "Admin Panel",
+  "home": "Home",
+  "logout": "Logout",
+  "tabs": {
+    "messages": "Messages",
+    "submissions": "Submissions",
+    "tracks": "Tracks",
+    "courses": "Courses",
+    "tools": "Tools",
+    "banned": "Banned IPs"
+  },
+  "common": {
+    "error": "Error",
+    "loading": "Loading...",
+    "delete": "Delete"
+  },
+  "bannedIps": {
+    "title": "Banned IPs",
+    "banIp": "Ban IP",
+    "ipAddress": "IP Address",
+    "reasonOptional": "Reason (optional)",
+    "reasonPlaceholder": "Spam submissions",
+    "expiresAfter": "Expires after",
+    "duration": {
+      "oneDay": "1 day",
+      "sevenDays": "7 days",
+      "thirtyDays": "30 days",
+      "ninetyDays": "90 days",
+      "oneYear": "1 year",
+      "permanent": "Permanent"
+    },
+    "ban": "Ban",
+    "none": "No banned IPs.",
+    "expires": "expires: {{date}}",
+    "banned": "IP banned",
+    "unbanned": "IP unbanned"
+  },
+  "messages": {
+    "filterAll": "All",
+    "filterUnread": "Unread",
+    "filterRead": "Read",
+    "refresh": "Refresh",
+    "none": "No messages",
+    "loading": "Loading messages…",
+    "loadError": "Error loading messages",
+    "categories": {
+      "comment": "Comment",
+      "featureRequest": "Feature Request",
+      "complaint": "Complaint",
+      "bugReport": "Bug Report"
+    },
+    "emailLine": "Email: {{email}}",
+    "ipLine": "IP: {{ip}}",
+    "unknownIp": "unknown"
+  },
+  "tracks": {
+    "title": "Tracks",
+    "addTrack": "Add Track",
+    "trackName": "Track Name",
+    "shortName": "Short Name (max 8)",
+    "create": "Create",
+    "none": "No tracks in database.",
+    "shortNameTooLong": "Short name must be 8 characters or less",
+    "created": "Track created",
+    "updated": "Track updated",
+    "deleted": "Track deleted"
+  },
+  "tools": {
+    "buildJsonTitle": "Build tracks.json from Database",
+    "buildJsonDesc": "Generates tracks.json with longName, shortName, defaultCourse, and lengthFt per course (from layout drawings or overrides).",
+    "buildJson": "Build JSON",
+    "download": "Download",
+    "buildJsonDone": "tracks.json built from database",
+    "buildZipTitle": "Build Tracks ZIP",
+    "buildZipDesc": "Downloads individual track JSON files (with longName, shortName, defaultCourse, lengthFt) in a TRACKS/ folder.",
+    "buildZip": "Build & Download ZIP",
+    "buildZipDone": "Tracks ZIP downloaded",
+    "buildZipError": "Error building ZIP",
+    "exportDrawingsTitle": "Export Course Drawings",
+    "exportDrawingsDesc": "Export all course layout drawings as JSON (keyed by shortName/courseName). Courses with manual length overrides are skipped.",
+    "exportDrawings": "Export Drawings",
+    "exportDrawingsDone": "Course drawings exported",
+    "importDrawingsTitle": "Import Course Drawings",
+    "importDrawingsDesc": "Paste course drawings JSON. For each imported drawing, the length override is cleared (drawing becomes source of truth). Courses without a drawing are left alone.",
+    "importDrawingsPlaceholder": "Paste course drawings JSON here... (e.g. {\"OKC/Normal\": [{lat, lon}, ...]})",
+    "importDrawings": "Import Drawings",
+    "importDrawingsDone": "Course drawings imported. Overrides cleared for imported courses.",
+    "importJsonTitle": "Import tracks.json into Database",
+    "importJsonDesc": "Paste a tracks.json file to rebuild the database. Course lengthFt values are imported as length overrides.",
+    "importJsonPlaceholder": "Paste tracks.json content here...",
+    "import": "Import",
+    "importDone": "Database rebuilt from JSON",
+    "importError": "Import error"
+  }
+}

--- a/src/locales/es/admin.json
+++ b/src/locales/es/admin.json
@@ -1,0 +1,98 @@
+{
+  "_machine": true,
+  "loading": "Cargando...",
+  "panelTitle": "Panel de administración",
+  "home": "Inicio",
+  "logout": "Cerrar sesión",
+  "tabs": {
+    "messages": "Mensajes",
+    "submissions": "Envíos",
+    "tracks": "Pistas",
+    "courses": "Circuitos",
+    "tools": "Herramientas",
+    "banned": "IP bloqueadas"
+  },
+  "common": {
+    "error": "Error",
+    "loading": "Cargando...",
+    "delete": "Eliminar"
+  },
+  "bannedIps": {
+    "title": "IP bloqueadas",
+    "banIp": "Bloquear IP",
+    "ipAddress": "Dirección IP",
+    "reasonOptional": "Motivo (opcional)",
+    "reasonPlaceholder": "Envíos de spam",
+    "expiresAfter": "Caduca después de",
+    "duration": {
+      "oneDay": "1 día",
+      "sevenDays": "7 días",
+      "thirtyDays": "30 días",
+      "ninetyDays": "90 días",
+      "oneYear": "1 año",
+      "permanent": "Permanente"
+    },
+    "ban": "Bloquear",
+    "none": "No hay IP bloqueadas.",
+    "expires": "caduca: {{date}}",
+    "banned": "IP bloqueada",
+    "unbanned": "IP desbloqueada"
+  },
+  "messages": {
+    "filterAll": "Todos",
+    "filterUnread": "No leídos",
+    "filterRead": "Leídos",
+    "refresh": "Actualizar",
+    "none": "No hay mensajes",
+    "loading": "Cargando mensajes…",
+    "loadError": "Error al cargar los mensajes",
+    "categories": {
+      "comment": "Comentario",
+      "featureRequest": "Solicitud de función",
+      "complaint": "Queja",
+      "bugReport": "Informe de error"
+    },
+    "emailLine": "Correo: {{email}}",
+    "ipLine": "IP: {{ip}}",
+    "unknownIp": "desconocida"
+  },
+  "tracks": {
+    "title": "Pistas",
+    "addTrack": "Añadir pista",
+    "trackName": "Nombre de la pista",
+    "shortName": "Nombre corto (máx. 8)",
+    "create": "Crear",
+    "none": "No hay pistas en la base de datos.",
+    "shortNameTooLong": "El nombre corto debe tener 8 caracteres o menos",
+    "created": "Pista creada",
+    "updated": "Pista actualizada",
+    "deleted": "Pista eliminada"
+  },
+  "tools": {
+    "buildJsonTitle": "Generar tracks.json desde la base de datos",
+    "buildJsonDesc": "Genera tracks.json con longName, shortName, defaultCourse y lengthFt por circuito (a partir de los trazados o las anulaciones).",
+    "buildJson": "Generar JSON",
+    "download": "Descargar",
+    "buildJsonDone": "tracks.json generado desde la base de datos",
+    "buildZipTitle": "Generar ZIP de pistas",
+    "buildZipDesc": "Descarga archivos JSON de pista individuales (con longName, shortName, defaultCourse, lengthFt) en una carpeta TRACKS/.",
+    "buildZip": "Generar y descargar ZIP",
+    "buildZipDone": "ZIP de pistas descargado",
+    "buildZipError": "Error al generar el ZIP",
+    "exportDrawingsTitle": "Exportar trazados de circuitos",
+    "exportDrawingsDesc": "Exporta todos los trazados de circuitos como JSON (indexados por shortName/courseName). Se omiten los circuitos con anulaciones manuales de longitud.",
+    "exportDrawings": "Exportar trazados",
+    "exportDrawingsDone": "Trazados de circuitos exportados",
+    "importDrawingsTitle": "Importar trazados de circuitos",
+    "importDrawingsDesc": "Pega el JSON de trazados de circuitos. Para cada trazado importado se borra la anulación de longitud (el trazado pasa a ser la fuente de verdad). Los circuitos sin trazado no se modifican.",
+    "importDrawingsPlaceholder": "Pega aquí el JSON de trazados de circuitos... (p. ej. {\"OKC/Normal\": [{lat, lon}, ...]})",
+    "importDrawings": "Importar trazados",
+    "importDrawingsDone": "Trazados de circuitos importados. Anulaciones borradas para los circuitos importados.",
+    "importJsonTitle": "Importar tracks.json a la base de datos",
+    "importJsonDesc": "Pega un archivo tracks.json para reconstruir la base de datos. Los valores de lengthFt de los circuitos se importan como anulaciones de longitud.",
+    "importJsonPlaceholder": "Pega aquí el contenido de tracks.json...",
+    "import": "Importar",
+    "importDone": "Base de datos reconstruida desde el JSON",
+    "importError": "Error de importación"
+  }
+}

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -1,0 +1,98 @@
+{
+  "_machine": true,
+  "loading": "Chargement...",
+  "panelTitle": "Panneau d'administration",
+  "home": "Accueil",
+  "logout": "Déconnexion",
+  "tabs": {
+    "messages": "Messages",
+    "submissions": "Soumissions",
+    "tracks": "Circuits",
+    "courses": "Parcours",
+    "tools": "Outils",
+    "banned": "IP bannies"
+  },
+  "common": {
+    "error": "Erreur",
+    "loading": "Chargement...",
+    "delete": "Supprimer"
+  },
+  "bannedIps": {
+    "title": "IP bannies",
+    "banIp": "Bannir une IP",
+    "ipAddress": "Adresse IP",
+    "reasonOptional": "Motif (facultatif)",
+    "reasonPlaceholder": "Soumissions de spam",
+    "expiresAfter": "Expire après",
+    "duration": {
+      "oneDay": "1 jour",
+      "sevenDays": "7 jours",
+      "thirtyDays": "30 jours",
+      "ninetyDays": "90 jours",
+      "oneYear": "1 an",
+      "permanent": "Permanent"
+    },
+    "ban": "Bannir",
+    "none": "Aucune IP bannie.",
+    "expires": "expire : {{date}}",
+    "banned": "IP bannie",
+    "unbanned": "IP débannie"
+  },
+  "messages": {
+    "filterAll": "Tous",
+    "filterUnread": "Non lus",
+    "filterRead": "Lus",
+    "refresh": "Actualiser",
+    "none": "Aucun message",
+    "loading": "Chargement des messages…",
+    "loadError": "Erreur lors du chargement des messages",
+    "categories": {
+      "comment": "Commentaire",
+      "featureRequest": "Demande de fonctionnalité",
+      "complaint": "Réclamation",
+      "bugReport": "Rapport de bug"
+    },
+    "emailLine": "E-mail : {{email}}",
+    "ipLine": "IP : {{ip}}",
+    "unknownIp": "inconnue"
+  },
+  "tracks": {
+    "title": "Circuits",
+    "addTrack": "Ajouter un circuit",
+    "trackName": "Nom du circuit",
+    "shortName": "Nom court (max 8)",
+    "create": "Créer",
+    "none": "Aucun circuit dans la base de données.",
+    "shortNameTooLong": "Le nom court doit comporter 8 caractères ou moins",
+    "created": "Circuit créé",
+    "updated": "Circuit mis à jour",
+    "deleted": "Circuit supprimé"
+  },
+  "tools": {
+    "buildJsonTitle": "Générer tracks.json depuis la base de données",
+    "buildJsonDesc": "Génère tracks.json avec longName, shortName, defaultCourse et lengthFt par parcours (à partir des tracés ou des remplacements).",
+    "buildJson": "Générer le JSON",
+    "download": "Télécharger",
+    "buildJsonDone": "tracks.json généré depuis la base de données",
+    "buildZipTitle": "Générer le ZIP des circuits",
+    "buildZipDesc": "Télécharge des fichiers JSON de circuit individuels (avec longName, shortName, defaultCourse, lengthFt) dans un dossier TRACKS/.",
+    "buildZip": "Générer et télécharger le ZIP",
+    "buildZipDone": "ZIP des circuits téléchargé",
+    "buildZipError": "Erreur lors de la génération du ZIP",
+    "exportDrawingsTitle": "Exporter les tracés de parcours",
+    "exportDrawingsDesc": "Exporte tous les tracés de parcours en JSON (indexés par shortName/courseName). Les parcours avec un remplacement manuel de longueur sont ignorés.",
+    "exportDrawings": "Exporter les tracés",
+    "exportDrawingsDone": "Tracés de parcours exportés",
+    "importDrawingsTitle": "Importer les tracés de parcours",
+    "importDrawingsDesc": "Collez le JSON des tracés de parcours. Pour chaque tracé importé, le remplacement de longueur est effacé (le tracé devient la source de vérité). Les parcours sans tracé ne sont pas modifiés.",
+    "importDrawingsPlaceholder": "Collez ici le JSON des tracés de parcours... (p. ex. {\"OKC/Normal\": [{lat, lon}, ...]})",
+    "importDrawings": "Importer les tracés",
+    "importDrawingsDone": "Tracés de parcours importés. Remplacements effacés pour les parcours importés.",
+    "importJsonTitle": "Importer tracks.json dans la base de données",
+    "importJsonDesc": "Collez un fichier tracks.json pour reconstruire la base de données. Les valeurs lengthFt des parcours sont importées comme remplacements de longueur.",
+    "importJsonPlaceholder": "Collez ici le contenu de tracks.json...",
+    "import": "Importer",
+    "importDone": "Base de données reconstruite depuis le JSON",
+    "importError": "Erreur d'importation"
+  }
+}

--- a/src/locales/it/admin.json
+++ b/src/locales/it/admin.json
@@ -1,0 +1,98 @@
+{
+  "_machine": true,
+  "loading": "Caricamento...",
+  "panelTitle": "Pannello di amministrazione",
+  "home": "Home",
+  "logout": "Esci",
+  "tabs": {
+    "messages": "Messaggi",
+    "submissions": "Invii",
+    "tracks": "Piste",
+    "courses": "Circuiti",
+    "tools": "Strumenti",
+    "banned": "IP bloccati"
+  },
+  "common": {
+    "error": "Errore",
+    "loading": "Caricamento...",
+    "delete": "Elimina"
+  },
+  "bannedIps": {
+    "title": "IP bloccati",
+    "banIp": "Blocca IP",
+    "ipAddress": "Indirizzo IP",
+    "reasonOptional": "Motivo (facoltativo)",
+    "reasonPlaceholder": "Invii di spam",
+    "expiresAfter": "Scade dopo",
+    "duration": {
+      "oneDay": "1 giorno",
+      "sevenDays": "7 giorni",
+      "thirtyDays": "30 giorni",
+      "ninetyDays": "90 giorni",
+      "oneYear": "1 anno",
+      "permanent": "Permanente"
+    },
+    "ban": "Blocca",
+    "none": "Nessun IP bloccato.",
+    "expires": "scade: {{date}}",
+    "banned": "IP bloccato",
+    "unbanned": "IP sbloccato"
+  },
+  "messages": {
+    "filterAll": "Tutti",
+    "filterUnread": "Non letti",
+    "filterRead": "Letti",
+    "refresh": "Aggiorna",
+    "none": "Nessun messaggio",
+    "loading": "Caricamento messaggi…",
+    "loadError": "Errore nel caricamento dei messaggi",
+    "categories": {
+      "comment": "Commento",
+      "featureRequest": "Richiesta di funzionalità",
+      "complaint": "Reclamo",
+      "bugReport": "Segnalazione di bug"
+    },
+    "emailLine": "Email: {{email}}",
+    "ipLine": "IP: {{ip}}",
+    "unknownIp": "sconosciuto"
+  },
+  "tracks": {
+    "title": "Piste",
+    "addTrack": "Aggiungi pista",
+    "trackName": "Nome della pista",
+    "shortName": "Nome breve (max 8)",
+    "create": "Crea",
+    "none": "Nessuna pista nel database.",
+    "shortNameTooLong": "Il nome breve deve avere 8 caratteri o meno",
+    "created": "Pista creata",
+    "updated": "Pista aggiornata",
+    "deleted": "Pista eliminata"
+  },
+  "tools": {
+    "buildJsonTitle": "Genera tracks.json dal database",
+    "buildJsonDesc": "Genera tracks.json con longName, shortName, defaultCourse e lengthFt per circuito (dai tracciati o dalle sostituzioni).",
+    "buildJson": "Genera JSON",
+    "download": "Scarica",
+    "buildJsonDone": "tracks.json generato dal database",
+    "buildZipTitle": "Genera ZIP delle piste",
+    "buildZipDesc": "Scarica singoli file JSON di pista (con longName, shortName, defaultCourse, lengthFt) in una cartella TRACKS/.",
+    "buildZip": "Genera e scarica ZIP",
+    "buildZipDone": "ZIP delle piste scaricato",
+    "buildZipError": "Errore durante la generazione dello ZIP",
+    "exportDrawingsTitle": "Esporta tracciati dei circuiti",
+    "exportDrawingsDesc": "Esporta tutti i tracciati dei circuiti come JSON (indicizzati per shortName/courseName). I circuiti con sostituzioni manuali della lunghezza vengono saltati.",
+    "exportDrawings": "Esporta tracciati",
+    "exportDrawingsDone": "Tracciati dei circuiti esportati",
+    "importDrawingsTitle": "Importa tracciati dei circuiti",
+    "importDrawingsDesc": "Incolla il JSON dei tracciati dei circuiti. Per ogni tracciato importato la sostituzione della lunghezza viene cancellata (il tracciato diventa la fonte di verità). I circuiti senza tracciato non vengono modificati.",
+    "importDrawingsPlaceholder": "Incolla qui il JSON dei tracciati dei circuiti... (es. {\"OKC/Normal\": [{lat, lon}, ...]})",
+    "importDrawings": "Importa tracciati",
+    "importDrawingsDone": "Tracciati dei circuiti importati. Sostituzioni cancellate per i circuiti importati.",
+    "importJsonTitle": "Importa tracks.json nel database",
+    "importJsonDesc": "Incolla un file tracks.json per ricostruire il database. I valori lengthFt dei circuiti vengono importati come sostituzioni della lunghezza.",
+    "importJsonPlaceholder": "Incolla qui il contenuto di tracks.json...",
+    "import": "Importa",
+    "importDone": "Database ricostruito dal JSON",
+    "importError": "Errore di importazione"
+  }
+}

--- a/src/locales/ja/admin.json
+++ b/src/locales/ja/admin.json
@@ -1,0 +1,98 @@
+{
+  "_machine": true,
+  "loading": "読み込み中...",
+  "panelTitle": "管理パネル",
+  "home": "ホーム",
+  "logout": "ログアウト",
+  "tabs": {
+    "messages": "メッセージ",
+    "submissions": "投稿",
+    "tracks": "トラック",
+    "courses": "コース",
+    "tools": "ツール",
+    "banned": "禁止 IP"
+  },
+  "common": {
+    "error": "エラー",
+    "loading": "読み込み中...",
+    "delete": "削除"
+  },
+  "bannedIps": {
+    "title": "禁止 IP",
+    "banIp": "IP を禁止",
+    "ipAddress": "IP アドレス",
+    "reasonOptional": "理由（任意）",
+    "reasonPlaceholder": "スパム投稿",
+    "expiresAfter": "有効期限",
+    "duration": {
+      "oneDay": "1日",
+      "sevenDays": "7日",
+      "thirtyDays": "30日",
+      "ninetyDays": "90日",
+      "oneYear": "1年",
+      "permanent": "無期限"
+    },
+    "ban": "禁止",
+    "none": "禁止された IP はありません。",
+    "expires": "有効期限: {{date}}",
+    "banned": "IP を禁止しました",
+    "unbanned": "IP の禁止を解除しました"
+  },
+  "messages": {
+    "filterAll": "すべて",
+    "filterUnread": "未読",
+    "filterRead": "既読",
+    "refresh": "更新",
+    "none": "メッセージはありません",
+    "loading": "メッセージを読み込み中…",
+    "loadError": "メッセージの読み込みエラー",
+    "categories": {
+      "comment": "コメント",
+      "featureRequest": "機能リクエスト",
+      "complaint": "苦情",
+      "bugReport": "バグ報告"
+    },
+    "emailLine": "メール: {{email}}",
+    "ipLine": "IP: {{ip}}",
+    "unknownIp": "不明"
+  },
+  "tracks": {
+    "title": "トラック",
+    "addTrack": "トラックを追加",
+    "trackName": "トラック名",
+    "shortName": "短縮名（最大8）",
+    "create": "作成",
+    "none": "データベースにトラックがありません。",
+    "shortNameTooLong": "短縮名は8文字以内にしてください",
+    "created": "トラックを作成しました",
+    "updated": "トラックを更新しました",
+    "deleted": "トラックを削除しました"
+  },
+  "tools": {
+    "buildJsonTitle": "データベースから tracks.json を生成",
+    "buildJsonDesc": "コースごとに longName、shortName、defaultCourse、lengthFt を含む tracks.json を生成します（レイアウト図またはオーバーライドから）。",
+    "buildJson": "JSON を生成",
+    "download": "ダウンロード",
+    "buildJsonDone": "データベースから tracks.json を生成しました",
+    "buildZipTitle": "トラック ZIP を生成",
+    "buildZipDesc": "個別のトラック JSON ファイル（longName、shortName、defaultCourse、lengthFt を含む）を TRACKS/ フォルダーでダウンロードします。",
+    "buildZip": "ZIP を生成してダウンロード",
+    "buildZipDone": "トラック ZIP をダウンロードしました",
+    "buildZipError": "ZIP 生成エラー",
+    "exportDrawingsTitle": "コース図をエクスポート",
+    "exportDrawingsDesc": "すべてのコースレイアウト図を JSON としてエクスポートします（shortName/courseName をキーとして）。手動の長さオーバーライドがあるコースはスキップされます。",
+    "exportDrawings": "図をエクスポート",
+    "exportDrawingsDone": "コース図をエクスポートしました",
+    "importDrawingsTitle": "コース図をインポート",
+    "importDrawingsDesc": "コース図の JSON を貼り付けます。インポートされた各図について、長さオーバーライドは解除されます（図が信頼できる情報源になります）。図のないコースはそのままです。",
+    "importDrawingsPlaceholder": "ここにコース図の JSON を貼り付け...（例: {\"OKC/Normal\": [{lat, lon}, ...]}）",
+    "importDrawings": "図をインポート",
+    "importDrawingsDone": "コース図をインポートしました。インポートされたコースのオーバーライドを解除しました。",
+    "importJsonTitle": "tracks.json をデータベースにインポート",
+    "importJsonDesc": "tracks.json ファイルを貼り付けてデータベースを再構築します。コースの lengthFt 値は長さオーバーライドとしてインポートされます。",
+    "importJsonPlaceholder": "ここに tracks.json の内容を貼り付け...",
+    "import": "インポート",
+    "importDone": "JSON からデータベースを再構築しました",
+    "importError": "インポートエラー"
+  }
+}

--- a/src/locales/pt-BR/admin.json
+++ b/src/locales/pt-BR/admin.json
@@ -1,0 +1,98 @@
+{
+  "_machine": true,
+  "loading": "Carregando...",
+  "panelTitle": "Painel de administração",
+  "home": "Início",
+  "logout": "Sair",
+  "tabs": {
+    "messages": "Mensagens",
+    "submissions": "Envios",
+    "tracks": "Pistas",
+    "courses": "Circuitos",
+    "tools": "Ferramentas",
+    "banned": "IPs banidos"
+  },
+  "common": {
+    "error": "Erro",
+    "loading": "Carregando...",
+    "delete": "Excluir"
+  },
+  "bannedIps": {
+    "title": "IPs banidos",
+    "banIp": "Banir IP",
+    "ipAddress": "Endereço IP",
+    "reasonOptional": "Motivo (opcional)",
+    "reasonPlaceholder": "Envios de spam",
+    "expiresAfter": "Expira após",
+    "duration": {
+      "oneDay": "1 dia",
+      "sevenDays": "7 dias",
+      "thirtyDays": "30 dias",
+      "ninetyDays": "90 dias",
+      "oneYear": "1 ano",
+      "permanent": "Permanente"
+    },
+    "ban": "Banir",
+    "none": "Nenhum IP banido.",
+    "expires": "expira: {{date}}",
+    "banned": "IP banido",
+    "unbanned": "IP desbanido"
+  },
+  "messages": {
+    "filterAll": "Todas",
+    "filterUnread": "Não lidas",
+    "filterRead": "Lidas",
+    "refresh": "Atualizar",
+    "none": "Nenhuma mensagem",
+    "loading": "Carregando mensagens…",
+    "loadError": "Erro ao carregar as mensagens",
+    "categories": {
+      "comment": "Comentário",
+      "featureRequest": "Solicitação de recurso",
+      "complaint": "Reclamação",
+      "bugReport": "Relatório de bug"
+    },
+    "emailLine": "E-mail: {{email}}",
+    "ipLine": "IP: {{ip}}",
+    "unknownIp": "desconhecido"
+  },
+  "tracks": {
+    "title": "Pistas",
+    "addTrack": "Adicionar pista",
+    "trackName": "Nome da pista",
+    "shortName": "Nome curto (máx. 8)",
+    "create": "Criar",
+    "none": "Nenhuma pista no banco de dados.",
+    "shortNameTooLong": "O nome curto deve ter 8 caracteres ou menos",
+    "created": "Pista criada",
+    "updated": "Pista atualizada",
+    "deleted": "Pista excluída"
+  },
+  "tools": {
+    "buildJsonTitle": "Gerar tracks.json a partir do banco de dados",
+    "buildJsonDesc": "Gera tracks.json com longName, shortName, defaultCourse e lengthFt por circuito (a partir dos traçados ou substituições).",
+    "buildJson": "Gerar JSON",
+    "download": "Baixar",
+    "buildJsonDone": "tracks.json gerado a partir do banco de dados",
+    "buildZipTitle": "Gerar ZIP das pistas",
+    "buildZipDesc": "Baixa arquivos JSON de pista individuais (com longName, shortName, defaultCourse, lengthFt) em uma pasta TRACKS/.",
+    "buildZip": "Gerar e baixar ZIP",
+    "buildZipDone": "ZIP das pistas baixado",
+    "buildZipError": "Erro ao gerar o ZIP",
+    "exportDrawingsTitle": "Exportar traçados de circuitos",
+    "exportDrawingsDesc": "Exporta todos os traçados de circuitos como JSON (indexados por shortName/courseName). Circuitos com substituições manuais de comprimento são ignorados.",
+    "exportDrawings": "Exportar traçados",
+    "exportDrawingsDone": "Traçados de circuitos exportados",
+    "importDrawingsTitle": "Importar traçados de circuitos",
+    "importDrawingsDesc": "Cole o JSON dos traçados de circuitos. Para cada traçado importado, a substituição de comprimento é apagada (o traçado passa a ser a fonte de verdade). Circuitos sem traçado não são alterados.",
+    "importDrawingsPlaceholder": "Cole aqui o JSON dos traçados de circuitos... (ex.: {\"OKC/Normal\": [{lat, lon}, ...]})",
+    "importDrawings": "Importar traçados",
+    "importDrawingsDone": "Traçados de circuitos importados. Substituições apagadas para os circuitos importados.",
+    "importJsonTitle": "Importar tracks.json para o banco de dados",
+    "importJsonDesc": "Cole um arquivo tracks.json para reconstruir o banco de dados. Os valores lengthFt dos circuitos são importados como substituições de comprimento.",
+    "importJsonPlaceholder": "Cole aqui o conteúdo de tracks.json...",
+    "import": "Importar",
+    "importDone": "Banco de dados reconstruído a partir do JSON",
+    "importError": "Erro de importação"
+  }
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/contexts/AuthContext';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
@@ -12,6 +13,7 @@ import { BannedIpsTab } from '@/components/admin/BannedIpsTab';
 import { MessagesTab } from '@/components/admin/MessagesTab';
 
 export default function Admin() {
+  const { t } = useTranslation('admin');
   const { user, isAdmin, loading, logout } = useAuth();
   const navigate = useNavigate();
   const [unreadCount, setUnreadCount] = useState(0);
@@ -25,7 +27,7 @@ export default function Admin() {
   }, [user, isAdmin, loading, navigate]);
 
   if (loading) {
-    return <div className="min-h-screen bg-background flex items-center justify-center text-muted-foreground">Loading...</div>;
+    return <div className="min-h-screen bg-background flex items-center justify-center text-muted-foreground">{t('loading')}</div>;
   }
 
   if (!user || !isAdmin) return null;
@@ -37,16 +39,16 @@ export default function Admin() {
           <div className="flex items-center gap-3">
             <Gauge className="w-8 h-8 text-primary" />
             <div>
-              <h1 className="text-xl font-semibold text-foreground">Admin Panel</h1>
+              <h1 className="text-xl font-semibold text-foreground">{t('panelTitle')}</h1>
               <p className="text-sm text-muted-foreground">{user.email}</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
             <Button variant="ghost" size="sm" onClick={() => navigate('/')}>
-              <ArrowLeft className="w-4 h-4 mr-2" /> Home
+              <ArrowLeft className="w-4 h-4 mr-2" /> {t('home')}
             </Button>
             <Button variant="outline" size="sm" onClick={logout}>
-              <LogOut className="w-4 h-4 mr-2" /> Logout
+              <LogOut className="w-4 h-4 mr-2" /> {t('logout')}
             </Button>
           </div>
         </div>
@@ -56,18 +58,18 @@ export default function Admin() {
         <Tabs defaultValue="messages" className="w-full">
           <TabsList className="grid w-full grid-cols-6">
             <TabsTrigger value="messages" className="relative">
-              Messages
+              {t('tabs.messages')}
               {unreadCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground text-[10px] font-bold rounded-full w-5 h-5 flex items-center justify-center">
                   {unreadCount > 99 ? "99+" : unreadCount}
                 </span>
               )}
             </TabsTrigger>
-            <TabsTrigger value="submissions">Submissions</TabsTrigger>
-            <TabsTrigger value="tracks">Tracks</TabsTrigger>
-            <TabsTrigger value="courses">Courses</TabsTrigger>
-            <TabsTrigger value="tools">Tools</TabsTrigger>
-            <TabsTrigger value="banned">Banned IPs</TabsTrigger>
+            <TabsTrigger value="submissions">{t('tabs.submissions')}</TabsTrigger>
+            <TabsTrigger value="tracks">{t('tabs.tracks')}</TabsTrigger>
+            <TabsTrigger value="courses">{t('tabs.courses')}</TabsTrigger>
+            <TabsTrigger value="tools">{t('tabs.tools')}</TabsTrigger>
+            <TabsTrigger value="banned">{t('tabs.banned')}</TabsTrigger>
           </TabsList>
           <TabsContent value="messages"><MessagesTab onUnreadCount={setUnreadCount} /></TabsContent>
           <TabsContent value="submissions"><SubmissionsTab /></TabsContent>

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -16,6 +16,7 @@ import type weather from "@/locales/en/weather.json";
 import type tracks from "@/locales/en/tracks.json";
 import type plugins from "@/locales/en/plugins.json";
 import type auth from "@/locales/en/auth.json";
+import type admin from "@/locales/en/admin.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -31,6 +32,7 @@ declare module "i18next" {
       tracks: typeof tracks;
       plugins: typeof plugins;
       auth: typeof auth;
+      admin: typeof admin;
     };
   }
 }


### PR DESCRIPTION
## Admin panel — part 1 of 2

First slice of the admin panel (the last surface). New host **`admin`** namespace.

**Translated here:**
- **Shell** (`Admin.tsx`) — loading state, header (title, Home, Logout), and the tab bar labels.
- **Messages tab** — filters, refresh, empty/loading states, expanded email/IP lines, delete, load error. The category badge is translated via an English-value→key map so the value **stored/queried in the DB stays English**.
- **Tracks tab** — add/edit form, labels, toasts.
- **Tools tab** — all section headings/descriptions, buttons, textarea placeholders, and toasts.
- **Banned IPs tab** — form, the duration `<select>` options, list, toasts.

Technical tokens stay literal (`tracks.json`, `ZIP`, `TRACKS/`, `longName/shortName/defaultCourse/lengthFt`, `IP`, IP/JSON example placeholders).

**Wire-up:** `admin` added to `config.ts` NAMESPACES, bundled English in `i18n/index.ts`, typed resources in `types/i18next.d.ts`. es/fr/de/it/pt-BR/ja machine-seeded.

### Gates
`typecheck`, `lint`, `build`, full `test:run` (**1740**) pass; i18n parity test (now **140**) green.

### Remaining (Phase 8b, separate PR)
The admin **Submissions** and **Courses** tabs (the two largest). After that, i18n is complete.

> ⚠️ Per your note: **don't merge yet** — you wanted to review first. The registration **pricing section** (PricingCards/PlanCheckout) is being done on a separate branch so the two don't stomp on each other.

https://claude.ai/code/session_01U9pEPejKDiJEWpto8ihNbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9pEPejKDiJEWpto8ihNbh)_