### PR TITLE
Release prep: datalogger track-confirmation fix, cut 2.6.0, ship coach as published npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from tablet up.
 
 ### Fixed
+- **Datalogger looked like it didn't recognise the track while parked.** Sitting
+  still at a known venue, the tool shows a plain speedometer (lap timing only arms
+  once you're moving above 5 mph) — but it gave no sign the track had been
+  detected, so it was indistinguishable from the genuine "no tracks found nearby"
+  state. The waiting speedometer now names the recognised track (e.g. "Orlando
+  Kart Center detected nearby") when you're near one, so it's clear the track list
+  loaded and you're just waiting to start moving.
 - **Start/finish line couldn't be placed on a new track/course.** After the
   sector-editor overhaul, a brand-new course had no coordinates for its
   start/finish line, so it never appeared on the map and there was no way to

--- a/bun.lock
+++ b/bun.lock
@@ -599,7 +599,7 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
 
-    "@theangryraven/eye-in-the-sky": ["@theangryraven/eye-in-the-sky@github:TheAngryRaven/DataViewer_coach#a867b3f", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "TheAngryRaven-DataViewer_coach-a867b3f", "sha512-lwxiq6M9UoHCQpt4dNxgwiOdd/aKSXKi0ith9DVIoC5fHx8s9Tbv1CtcvHbpFfqzZ3VHXfyuM2Aa5zcCcgnBJQ=="],
+    "@theangryraven/eye-in-the-sky": ["@theangryraven/eye-in-the-sky@github:TheAngryRaven/DataViewer_coach#f8c6ff4", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "TheAngryRaven-DataViewer_coach-f8c6ff4", "sha512-fIE756b49GK603bwhKkwhJZlIhcx7wPTnvX99fPohoJ7srcc+kzfE8MttIV2h34q78fbC3w2sIBKAUhJVM3h6w=="],
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 

--- a/src/lib/gps/realtimeTimer.test.ts
+++ b/src/lib/gps/realtimeTimer.test.ts
@@ -194,6 +194,14 @@ describe("RealtimeLapTimer — track proximity (log-only when far)", () => {
     expect(timer.nearTrack(40, 40)).toBe(false);
     expect(timer.getSamples()).toHaveLength(0); // pure probe — nothing recorded
   });
+
+  it("nearestTrackName() names the nearby track (or null when far / not loaded)", () => {
+    const timer = new RealtimeLapTimer();
+    expect(timer.nearestTrackName(0, 0.0005)).toBeNull(); // tracks not loaded yet
+    timer.setTracks([nearTrack]); // start/finish at (0, 0)
+    expect(timer.nearestTrackName(0, 0.0005)).toBe("Near"); // ~55 m away
+    expect(timer.nearestTrackName(40, 40)).toBeNull(); // far → no name
+  });
 });
 
 describe("RealtimeLapTimer — 3-major course (sectors, optimal, delta)", () => {

--- a/src/lib/gps/realtimeTimer.ts
+++ b/src/lib/gps/realtimeTimer.ts
@@ -61,6 +61,13 @@ export interface TimingState {
    * "logging for post-race analysis" note); `null` until tracks have loaded.
    */
   nearKnownTrack: boolean | null;
+  /**
+   * Name of the nearest known track within range, or `null` (far / not loaded).
+   * Lets the UI confirm which track it recognised *before* logging arms — so a
+   * stationary driver sitting at a known track sees it was detected rather than
+   * a context-free speedometer.
+   */
+  nearbyTrackName: string | null;
 }
 
 export const EMPTY_TIMING_STATE: TimingState = {
@@ -78,6 +85,7 @@ export const EMPTY_TIMING_STATE: TimingState = {
   majorSectors: [],
   speedMph: null,
   nearKnownTrack: null,
+  nearbyTrackName: null,
 };
 
 /** Min samples before attempting detection (mirrors autoDetectCourse). */
@@ -214,6 +222,17 @@ export class RealtimeLapTimer {
     return findNearestTrack(lat, lon, this.tracks, NEAR_TRACK_RADIUS_M) !== null;
   }
 
+  /**
+   * Name of the nearest known track within ~10 mi of `(lat, lon)`, or `null`
+   * (far / not loaded / bad fix). Companion to `nearTrack` so the waiting-state
+   * UI can name the recognised track, not just know one is nearby.
+   */
+  nearestTrackName(lat: number, lon: number): string | null {
+    if (!this.tracksLoaded) return null;
+    if (validateGpsCoords(lat, lon) !== null) return null;
+    return findNearestTrack(lat, lon, this.tracks, NEAR_TRACK_RADIUS_M)?.name ?? null;
+  }
+
   /** All samples fed so far (the would-be log buffer). */
   getSamples(): readonly GpsSample[] {
     return this.samples;
@@ -305,6 +324,7 @@ export class RealtimeLapTimer {
       majorSectors: this.computeMajorSectors(last),
       speedMph: latest.speedMph,
       nearKnownTrack: this.nearKnownTrack,
+      nearbyTrackName: this.trackName,
     };
   }
 

--- a/src/lib/i18n/format.test.ts
+++ b/src/lib/i18n/format.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { formatDate, formatDateTime, formatNumber, formatList } from "./format";
+import {
+  formatDate,
+  formatDateTime,
+  formatNumber,
+  formatList,
+  formatDecimal,
+  formatInteger,
+  formatSignedDelta,
+} from "./format";
 
 // A fixed instant: 2026-02-12T16:15:00Z. Assertions check locale-specific
 // separators/ordering rather than exact wording, which can vary by ICU version.
@@ -14,6 +22,27 @@ describe("format: numbers", () => {
 
   it("honours NumberFormat options", () => {
     expect(formatNumber(0.5, "en-US", { style: "percent" })).toBe("50%");
+  });
+
+  it("formats fixed-fraction decimals with the locale separator", () => {
+    expect(formatDecimal(2, "en", 1)).toBe("2.0");
+    expect(formatDecimal(2, "de", 1)).toBe("2,0");
+    expect(formatDecimal(0.34, "en", 2)).toBe("0.34");
+    expect(formatDecimal(0.34, "de", 2)).toBe("0,34");
+  });
+
+  it("formats grouped integers per locale", () => {
+    expect(formatInteger(1200, "en")).toBe("1,200");
+    expect(formatInteger(1200, "de")).toBe("1.200");
+    expect(formatInteger(42, "fr")).toBe("42");
+  });
+
+  it("signs deltas: + on positive, - on negative, none on zero", () => {
+    expect(formatSignedDelta(1, "en")).toBe("+1");
+    expect(formatSignedDelta(-1, "en")).toBe("-1");
+    expect(formatSignedDelta(0, "en")).toBe("0");
+    expect(formatSignedDelta(0.25, "en")).toBe("+0.25");
+    expect(formatSignedDelta(0.25, "de")).toBe("+0,25");
   });
 });
 

--- a/src/lib/i18n/format.ts
+++ b/src/lib/i18n/format.ts
@@ -35,6 +35,43 @@ export function formatNumber(
   return new Intl.NumberFormat(locale, options).format(value);
 }
 
+/**
+ * Format a number with a fixed number of fraction digits, using the locale's
+ * decimal separator (e.g. `formatDecimal(0.34, "de", 2)` → `"0,34"`).
+ */
+export function formatDecimal(
+  value: number,
+  locale: string,
+  fractionDigits: number,
+): string {
+  return formatNumber(value, locale, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+}
+
+/**
+ * Format an integer with locale-aware thousands grouping and no fraction part
+ * (e.g. `formatInteger(1200, "de")` → `"1.200"`).
+ */
+export function formatInteger(value: number, locale: string): string {
+  return formatNumber(value, locale, { maximumFractionDigits: 0 });
+}
+
+/**
+ * Format a signed delta: a leading `+` on positives, the locale's `-` on
+ * negatives, and no sign on zero (e.g. `+0,25` in German). Useful for gaps and
+ * change indicators where the direction must read at a glance.
+ */
+export function formatSignedDelta(
+  value: number,
+  locale: string,
+  options?: Intl.NumberFormatOptions,
+): string {
+  const formatted = formatNumber(value, locale, options);
+  return value > 0 ? `+${formatted}` : formatted;
+}
+
 /** Options for {@link formatList} — mirrors `Intl.ListFormat`'s constructor
  * options without depending on the ES2021 lib typings (our `lib` is ES2020). */
 export interface ListFormatLikeOptions {

--- a/src/plugins/tools/datalogger/DataloggerTool.tsx
+++ b/src/plugins/tools/datalogger/DataloggerTool.tsx
@@ -154,16 +154,21 @@ function LiveView({
   const farFromTrack = timing.nearKnownTrack === false;
   const waiting = phase === "waiting";
   // Speedometer mode: before logging arms (confirm GPS/speed while stationary),
-  // or recording far from any known track (no timing context). The "no tracks
-  // nearby" title shows whenever we know there's no track — including while
-  // waiting — so the reason for speedometer mode is always explained.
+  // or recording far from any known track (no timing context). The title explains
+  // *why* we're showing a bare speedometer: "no tracks nearby" when we're far, or
+  // — when we recognise the track but logging hasn't armed yet — a confirmation
+  // that the track was detected (so sitting still at a known track doesn't look
+  // identical to being nowhere near one).
   if (waiting || farFromTrack) {
+    let title: string | undefined;
+    if (farFromTrack) title = t("datalogger.speedometerMode");
+    else if (timing.nearbyTrackName) title = t("datalogger.trackDetected", { track: timing.nearbyTrackName });
     return (
       <SpeedometerView
         speed={speed}
         speedUnit={speedUnit}
         latest={latest}
-        title={farFromTrack ? t("datalogger.speedometerMode") : undefined}
+        title={title}
         hint={waiting ? t("datalogger.waitingHint") : t("datalogger.farHint")}
       />
     );

--- a/src/plugins/tools/datalogger/dataloggerSession.test.ts
+++ b/src/plugins/tools/datalogger/dataloggerSession.test.ts
@@ -8,6 +8,12 @@ const FAR_TRACK: Track = {
   courses: [{ name: "c", startFinishA: { lat: 40, lon: 40 }, startFinishB: { lat: 40, lon: 40.001 } }],
 };
 
+// The FakeGeo default fix is at (45, -73), so this track sits right under it.
+const NEAR_TRACK: Track = {
+  name: "Orlando Kart Center",
+  courses: [{ name: "Normal", startFinishA: { lat: 45, lon: -73 }, startFinishB: { lat: 45, lon: -72.999 } }],
+};
+
 /** Controllable fake Geolocation (mirrors the one in customGps.test.ts). */
 class FakeGeo {
   successCb: PositionCallback | null = null;
@@ -88,6 +94,17 @@ describe("DataloggerSession", () => {
     const s = session.getSnapshot();
     expect(s.phase).toBe("waiting");
     expect(s.timing.nearKnownTrack).toBe(false);
+  });
+
+  it("names the recognised track while still waiting (parked at a known track)", () => {
+    const { geo, timer, session } = setup();
+    timer.setTracks([NEAR_TRACK]);
+    session.start();
+    geo.emit({ latitude: 45, longitude: -73, speed: 1 }, BASE_TS); // ~2 mph → waiting
+    const s = session.getSnapshot();
+    expect(s.phase).toBe("waiting");
+    expect(s.timing.nearKnownTrack).toBe(true);
+    expect(s.timing.nearbyTrackName).toBe("Orlando Kart Center");
   });
 
   // Regression: ending with nothing recorded must NOT get stuck "saving" and must

--- a/src/plugins/tools/datalogger/dataloggerSession.ts
+++ b/src/plugins/tools/datalogger/dataloggerSession.ts
@@ -137,10 +137,12 @@ export class DataloggerSession {
       if (completed.length !== this.snapshot.laps.length) patch.laps = [...completed];
     } else {
       // Before logging arms, still surface track proximity so the UI can explain
-      // speedometer mode ("no tracks nearby") while waiting.
+      // speedometer mode — either "no tracks nearby" or, when we *do* recognise a
+      // track, confirm it by name (so a stationary driver knows detection worked).
       patch.timing = {
         ...this.snapshot.timing,
         nearKnownTrack: this.deps.timer.nearTrack(obs.fix.lat, obs.fix.lon),
+        nearbyTrackName: this.deps.timer.nearestTrackName(obs.fix.lat, obs.fix.lon),
       };
     }
     this.patch(patch);

--- a/src/plugins/tools/locales/de.json
+++ b/src/plugins/tools/locales/de.json
@@ -117,6 +117,7 @@
     "acquiringGps": "GPS wird erfasst…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "Tachomodus – keine Strecken in der Nähe gefunden",
+    "trackDetected": "{{track}} in der Nähe erkannt",
     "farHint": "Daten werden für die Analyse nach dem Rennen aufgezeichnet. Lege hier später eine Strecke an, um Rundenzeiten zu erhalten.",
     "waitingHint": "Fahre über 5 mph, um die Aufzeichnung zu starten.",
     "statusRecording": "Aufnahme",

--- a/src/plugins/tools/locales/en.json
+++ b/src/plugins/tools/locales/en.json
@@ -116,6 +116,7 @@
     "acquiringGps": "Acquiring GPS…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "Speedometer mode — no tracks found nearby",
+    "trackDetected": "{{track}} detected nearby",
     "farHint": "Data being logged for post-race analysis. Create a track here later to get lap times.",
     "waitingHint": "Drive above 5 mph to start logging.",
     "statusRecording": "Recording",

--- a/src/plugins/tools/locales/es.json
+++ b/src/plugins/tools/locales/es.json
@@ -117,6 +117,7 @@
     "acquiringGps": "Adquiriendo GPS…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "Modo velocímetro: no se encontraron circuitos cerca",
+    "trackDetected": "{{track}} detectado cerca",
     "farHint": "Registrando datos para el análisis posterior a la carrera. Crea un circuito aquí más tarde para obtener tiempos de vuelta.",
     "waitingHint": "Conduce a más de 5 mph para empezar a registrar.",
     "statusRecording": "Grabando",

--- a/src/plugins/tools/locales/fr.json
+++ b/src/plugins/tools/locales/fr.json
@@ -117,6 +117,7 @@
     "acquiringGps": "Acquisition du GPS…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "Mode compteur de vitesse — aucun circuit trouvé à proximité",
+    "trackDetected": "{{track}} détecté à proximité",
     "farHint": "Données enregistrées pour analyse après la course. Créez un circuit ici plus tard pour obtenir les temps au tour.",
     "waitingHint": "Roulez au-dessus de 5 mph pour démarrer l'enregistrement.",
     "statusRecording": "Enregistrement",

--- a/src/plugins/tools/locales/it.json
+++ b/src/plugins/tools/locales/it.json
@@ -117,6 +117,7 @@
     "acquiringGps": "Acquisizione GPS…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "Modalità tachimetro — nessuna pista trovata nelle vicinanze",
+    "trackDetected": "{{track}} rilevata nelle vicinanze",
     "farHint": "Dati registrati per l'analisi post-gara. Crea qui una pista più tardi per ottenere i tempi sul giro.",
     "waitingHint": "Supera le 5 mph per avviare la registrazione.",
     "statusRecording": "Registrazione",

--- a/src/plugins/tools/locales/ja.json
+++ b/src/plugins/tools/locales/ja.json
@@ -117,6 +117,7 @@
     "acquiringGps": "GPSを取得中…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "スピードメーターモード — 近くにコースが見つかりません",
+    "trackDetected": "近くで {{track}} を検出しました",
     "farHint": "レース後の分析用にデータを記録しています。あとでここにコースを作成すると、ラップタイムを取得できます。",
     "waitingHint": "5 mph を超えると記録を開始します。",
     "statusRecording": "記録中",

--- a/src/plugins/tools/locales/pt-BR.json
+++ b/src/plugins/tools/locales/pt-BR.json
@@ -117,6 +117,7 @@
     "acquiringGps": "Adquirindo GPS…",
     "gpsQuality": "GPS ±{{accuracy}} m · {{quality}}",
     "speedometerMode": "Modo velocímetro — nenhuma pista encontrada por perto",
+    "trackDetected": "{{track}} detectada por perto",
     "farHint": "Dados sendo registrados para análise pós-corrida. Crie uma pista aqui mais tarde para obter os tempos de volta.",
     "waitingHint": "Acelere acima de 5 mph para começar a registrar.",
     "statusRecording": "Gravando",


### PR DESCRIPTION
Ship-prep PR into `BETA` for the **`2.6.0`** release. Started as a datalogger fix
and grew into the release cut + coach product-flip.

## 1. Datalogger: confirm the recognised track while parked

> "I'm sitting at Orlando Kart Center and it's defaulting to speedometer mode — are we actually loading the track list?"

**Yes, the track list loads.** The speedometer shows because you're **parked**:
lap timing only arms once you move above 5 mph (`phase === "waiting"` forces
speedometer mode). The bug was UX — a parked-at-a-known-track speedometer looked
identical to the genuine "no tracks found nearby" state. It now names the
recognised track (e.g. **"Orlando Kart Center detected nearby"**), so it's clear
detection worked and you're just waiting to move.

- `RealtimeLapTimer.nearestTrackName()` + a `nearbyTrackName` field on `TimingState`, plumbed through `DataloggerSession` into the speedometer title.
- `trackDetected` string added across all 7 locales; tests for the timer probe + the waiting snapshot.

## 2. Cut the release as `2.6.0`

`v2.5.1` is **already a tagged release on `main`** (from the #194 BETA merge), but
the in-progress beta changelog + `package.json` still said `2.5.1` — a collision.
Renamed the unreleased changelog section `[2.5.1] → [2.6.0]` and bumped
`package.json` to `2.6.0`.

## 3. Coach plugin product-cut (for shipping)

Per `CLAUDE.md`'s product-cut dance, flipped the coach from the BETA git dep to
the **published, tagged npm package** so beta can do a final walkthrough and ship:
- `package.json`: `@theangryraven/eye-in-the-sky` (`github:…#BETA`) → `@perchwerks/eye-in-the-sky@0.5.0` (exact, per maintainer — latest published; the `0.x` line).
- `vite.config.ts`: `DEFAULT_PLUGIN_PACKAGES` → `@perchwerks/eye-in-the-sky`.
- The published `0.5.0` build imports `formatDecimal`/`formatInteger`/`formatSignedDelta` from the host's `lib/i18n/format`; those locale-aware formatters were added (with tests) so the build stays green.

> Note: "2.5.0" in the original ask was a mix-up with the app's 2.6.0 cut — the
> published coach tops out at `0.5.0`, pinned exact as confirmed.

## Verification
- `npm run lint`, `npm run typecheck` — clean
- `npm run test:run` — 120 files / 1745 tests pass
- `npm run build` — succeeds with the published coach `0.5.0`

https://claude.ai/code/session_014pk2etibihm7WSLPZSYc36