### PR TITLE
Release prep: cut 2.6.0 and switch coach to published npm (re-land)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [2.5.1] - unreleased
+## [2.6.0] - unreleased
 
 ### Added
 - **Tools on the home screen.** A new **Tools** tile on the landing page opens the

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA",
+        "@perchwerks/eye-in-the-sky": "0.5.0",
       },
     },
   },
@@ -383,6 +383,8 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
+    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.5.0", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-fwIfgSLf9llZMOUsyVYC74xADiKV8IXBgGiDUIDzoMqQjDKDa2VchZtNCNN4TNrhcntgGjKLVDcxM35cjwBz2w=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
@@ -598,8 +600,6 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
-
-    "@theangryraven/eye-in-the-sky": ["@theangryraven/eye-in-the-sky@github:TheAngryRaven/DataViewer_coach#f8c6ff4", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "TheAngryRaven-DataViewer_coach-f8c6ff4", "sha512-fIE756b49GK603bwhKkwhJZlIhcx7wPTnvX99fPohoJ7srcc+kzfE8MttIV2h34q78fbC3w2sIBKAUhJVM3h6w=="],
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",
@@ -90,6 +90,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"
+    "@perchwerks/eye-in-the-sky": "0.5.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,7 @@ export default defineConfig(({ mode }) => {
   const branch = gitBranch();
   const commitDate = gitCommitDate();
 
-  const DEFAULT_PLUGIN_PACKAGES = "@theangryraven/eye-in-the-sky";
+  const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)
     .split(",")
     .map((s) => s.trim())


### PR DESCRIPTION
## Why this exists

This re-lands the release-prep commit that got **orphaned** off #219: that PR was
merged into BETA at `302e6c0`, but the third commit (`55ea809`, the 2.6.0 cut +
coach flip) landed on the branch *after* the merge cut, so it never reached BETA.
BETA currently still says `2.5.1` and still uses the `@theangryraven` git coach
dep. This brings the change onto BETA via a fresh branch off the current tip.

## What's in it (cherry-picked `55ea809`)

**1. Cut the release as `2.6.0`.** `v2.5.1` is already a tagged release on `main`
(from the #194 merge), so the in-progress beta collided with a shipped version.
Renamed the unreleased changelog section `[2.5.1] → [2.6.0]` and bumped
`package.json` to `2.6.0`.

**2. Coach plugin product-cut for shipping** (per `CLAUDE.md`):
- `package.json`: `@theangryraven/eye-in-the-sky` (`github:…#BETA`) → `@perchwerks/eye-in-the-sky@0.5.0` (exact pin — latest published; the coach's `0.x` line).
- `vite.config.ts`: `DEFAULT_PLUGIN_PACKAGES` → `@perchwerks/eye-in-the-sky`.
- `bun.lock`: re-resolved to the published `0.5.0` (`@theangryraven` fully removed).

> After BETA → main (#206) ships, flip BETA back to `github:…#BETA` per the
> CLAUDE.md product-cut dance.

## Verification
- `bun install` resolves `@perchwerks/eye-in-the-sky@0.5.0`
- `npm run typecheck`, `npm run test:run` (1745 tests), `npm run build` — all pass

https://claude.ai/code/session_014pk2etibihm7WSLPZSYc36

---
_Generated by [Claude Code](https://claude.ai/code/session_014pk2etibihm7WSLPZSYc36)_