### PR TITLE
Track coach BETA branch again post-2.6.0 release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@perchwerks/eye-in-the-sky": "0.5.0",
+        "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA",
       },
     },
   },
@@ -383,8 +383,6 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
-    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.5.0", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-fwIfgSLf9llZMOUsyVYC74xADiKV8IXBgGiDUIDzoMqQjDKDa2VchZtNCNN4TNrhcntgGjKLVDcxM35cjwBz2w=="],
-
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
@@ -600,6 +598,8 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
+
+    "@theangryraven/eye-in-the-sky": ["@theangryraven/eye-in-the-sky@github:TheAngryRaven/DataViewer_coach#25ebf08", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "TheAngryRaven-DataViewer_coach-25ebf08", "sha512-siK7iocn6ukWdqLVe96ZYCFKMemnc8uuoNAFasfEHy8zsNzqpPSfvKhrH46uTgsJft7GOZjaNR5w8oBMxNmQsg=="],
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@perchwerks/eye-in-the-sky": "0.5.0"
+    "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,7 @@ export default defineConfig(({ mode }) => {
   const branch = gitBranch();
   const commitDate = gitCommitDate();
 
-  const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
+  const DEFAULT_PLUGIN_PACKAGES = "@theangryraven/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)
     .split(",")
     .map((s) => s.trim())


### PR DESCRIPTION
## Why

Step 2 of the `CLAUDE.md` coach product-cut dance. `2.6.0` has shipped to `main`
with the published, tagged coach (`@perchwerks/eye-in-the-sky@0.5.0`). Now flip
BETA **back** to the coach git dependency so beta builds keep tracking the latest
coach BETA without a per-iteration npm publish.

## What changed (reverses #220's coach flip)

- `package.json`: `@perchwerks/eye-in-the-sky@0.5.0` → `@theangryraven/eye-in-the-sky` (`github:TheAngryRaven/DataViewer_coach#BETA`).
- `vite.config.ts`: `DEFAULT_PLUGIN_PACKAGES` → `@theangryraven/eye-in-the-sky`.
- `bun.lock`: re-resolved to the coach BETA HEAD (`25ebf08`).

The `2.6.0` version cut stays — only the coach dependency is reverted.

> Reminder: a git dep records the resolved commit SHA, so future coach BETA
> pushes need `bun update @theangryraven/eye-in-the-sky` to pull them in.

## Verification
- `bun install` resolves the coach BETA git dep
- `npm run typecheck`, `npm run test:run` (1745 tests), `npm run build` — all pass

https://claude.ai/code/session_014pk2etibihm7WSLPZSYc36

---
_Generated by [Claude Code](https://claude.ai/code/session_014pk2etibihm7WSLPZSYc36)_