### PR TITLE
Add setup revision history panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.0] - unreleased
 
 ### Added
+- **Setup history.** Each setup in the Garage now has a **history** (book) icon
+  that opens a full-panel timeline of every saved revision. It starts with the
+  original setup shown in full, then lists each later revision as a **diff** —
+  only the values that changed, coloured **green when a number went up** and
+  **red when it went down** vs the previous revision (with a per-revision toggle
+  to show the full setup instead). Every revision shows the **fastest lap** run
+  on it, the revision holding the overall fastest lap is **highlighted**, and the
+  history is **filterable by kart and course** — when unfiltered, each revision
+  shows a bubble for the kart/course where its fastest lap was set.
 - **Tools on the home screen.** A new **Tools** tile on the landing page opens the
   trackside tools (the seat-position visualizer and more) in a full-screen panel —
   no datalog needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ src/
 │   ├── lapSnapshotStorage.ts # ★ IndexedDB CRUD for lap snapshots (emits garageEvents)
 │   ├── setupRevision.ts  # ★ Pure content-addressed setup history: hash + freeze (immutable revisions)
 │   ├── setupRevisionStorage.ts # ★ IndexedDB CRUD for setup revisions (freezeSetupRevision; emits garageEvents)
+│   ├── setupHistory.ts   # ★ Pure setup-history view-model: flatten revision→fields, diff vs previous (numeric up/down), aggregate sessions (fastest lap, karts/courses) + kart/course filter — renders in drawer/SetupHistoryPanel
 │   ├── trackSubmission.ts # ★ Pure community-DB upload plan: diff local tracks vs built-ins → new/edited, geometry hash + dedupe
 │   ├── submittedTracksStorage.ts # localStorage record of already-submitted course hashes (dedupe)
 │   ├── dbUtils.ts         # ★ Shared IndexedDB: DB_NAME, DB_VERSION, openDB(), tx helpers
@@ -577,6 +578,17 @@ exactly as it was the day it ran, even after the live setup is later edited.
 - **Display.** `shortRevHash()` surfaces the leading 6 hex chars (git-style). The
   **SetupsTab** list shows each setup's current would-be hash; **NotesTab** shows
   the frozen `#hash` of the session's setup revision.
+- **History panel.** Each **SetupsTab** row has a history (book) icon opening
+  `drawer/SetupHistoryPanel.tsx` — a full-panel chronological timeline built by the
+  pure `lib/setupHistory.ts` (`buildSetupHistory`). It joins this setup's revisions
+  with the `FileMetadata` that reference them (`sessionSetupRev`) to show: the
+  **original** revision in full, each later one as a **diff vs the previous** (only
+  changed fields; numbers coloured green=up / red=down via `diffRevisionFields`,
+  with a per-row full/diff toggle), each revision's **fastest lap** (the overall
+  fastest highlighted), kart/course **bubbles** for the fastest usage, and a
+  **kart + course filter** (drops non-matching revisions). Field flattening
+  (`flattenRevisionFields`) reads each revision's *frozen* template so old history
+  renders with the labels it had that day.
 - **Orphan prune (GC).** A revision is an orphan once no `FileMetadata.sessionSetupRev`
   points at it. `pruneSetupRevisions()` deletes orphans (pure split:
   `findOrphanRevisionIds`); `maybePruneSetupRevisions()` throttles it to ~once every

--- a/src/components/drawer/SetupHistoryPanel.tsx
+++ b/src/components/drawer/SetupHistoryPanel.tsx
@@ -1,0 +1,314 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import { ArrowLeft, ArrowDown, ArrowUp, Trophy, Car, MapPin, ChevronDown, ChevronUp, History } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Vehicle } from "@/lib/vehicleStorage";
+import { VehicleSetup } from "@/lib/setupStorage";
+import { FileMetadata, listAllMetadata } from "@/lib/fileStorage";
+import { SetupRevision, shortRevHash } from "@/lib/setupRevision";
+import { listSetupRevisions } from "@/lib/setupRevisionStorage";
+import { formatLapTime } from "@/lib/lapCalculation";
+import {
+  buildSetupHistory,
+  type SetupField,
+  type SetupFieldDiff,
+  type SetupHistoryEntry,
+} from "@/lib/setupHistory";
+
+interface SetupHistoryPanelProps {
+  setup: VehicleSetup;
+  vehicles: Vehicle[];
+  onBack: () => void;
+}
+
+/** Full-panel chronological history of a setup's frozen revisions. */
+export function SetupHistoryPanel({ setup, vehicles, onBack }: SetupHistoryPanelProps) {
+  const { t } = useTranslation("drawer");
+  const [revisions, setRevisions] = useState<SetupRevision[]>([]);
+  const [metas, setMetas] = useState<FileMetadata[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [kartFilter, setKartFilter] = useState<string>("");
+  const [courseFilter, setCourseFilter] = useState<string>("");
+  // Per-revision override: show the full setup instead of the default diff view.
+  const [fullOpen, setFullOpen] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [revs, m] = await Promise.all([listSetupRevisions(), listAllMetadata()]);
+      if (!cancelled) {
+        setRevisions(revs);
+        setMetas(m);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const history = useMemo(
+    () =>
+      buildSetupHistory({
+        setupId: setup.id,
+        setupName: setup.name,
+        revisions,
+        metas,
+        vehicles,
+        filter: { kartId: kartFilter || null, courseKey: courseFilter || null },
+      }),
+    [setup.id, setup.name, revisions, metas, vehicles, kartFilter, courseFilter],
+  );
+
+  const labelFor = (f: { label?: string; labelKey?: string }): string =>
+    f.label ?? (f.labelKey ? t(f.labelKey as never) : "");
+
+  const hasFilters = history.kartOptions.length > 0 || history.courseOptions.length > 0;
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-border">
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onBack}>
+          <ArrowLeft className="w-4 h-4" />
+        </Button>
+        <div className="flex items-center gap-1.5 flex-1 min-w-0">
+          <History className="w-4 h-4 text-muted-foreground shrink-0" />
+          <h3 className="text-sm font-semibold text-foreground truncate">{t("setupHistory.title")}</h3>
+        </div>
+        <span className="text-xs text-muted-foreground truncate max-w-[40%]">{setup.name}</span>
+      </div>
+
+      {/* Filters */}
+      {hasFilters && (
+        <div className="shrink-0 flex gap-2 px-3 py-2 border-b border-border">
+          {history.kartOptions.length > 0 && (
+            <Select value={kartFilter || "__all__"} onValueChange={(v) => setKartFilter(v === "__all__" ? "" : v)}>
+              <SelectTrigger className="h-8 text-xs flex-1">
+                <SelectValue placeholder={t("setupHistory.allKarts")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">{t("setupHistory.allKarts")}</SelectItem>
+                {history.kartOptions.map((k) => (
+                  <SelectItem key={k.id} value={k.id}>{k.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {history.courseOptions.length > 0 && (
+            <Select value={courseFilter || "__all__"} onValueChange={(v) => setCourseFilter(v === "__all__" ? "" : v)}>
+              <SelectTrigger className="h-8 text-xs flex-1">
+                <SelectValue placeholder={t("setupHistory.allCourses")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">{t("setupHistory.allCourses")}</SelectItem>
+                {history.courseOptions.map((c) => (
+                  <SelectItem key={c.key} value={c.key}>{c.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
+        {loading ? (
+          <p className="text-center text-xs text-muted-foreground py-8">{t("setupHistory.loading")}</p>
+        ) : history.entries.length === 0 ? (
+          <div className="flex flex-col items-center justify-center text-muted-foreground gap-3 py-16">
+            <History className="w-12 h-12 opacity-30" />
+            <p className="text-sm font-medium">{t("setupHistory.empty")}</p>
+            <p className="text-xs text-center">{t("setupHistory.emptyHint")}</p>
+          </div>
+        ) : (
+          history.entries.map((entry, i) => (
+            <RevisionCard
+              key={entry.revision.id}
+              entry={entry}
+              isOriginal={i === 0}
+              showFull={i === 0 || !!fullOpen[entry.revision.id]}
+              onToggleFull={() =>
+                setFullOpen((prev) => ({ ...prev, [entry.revision.id]: !prev[entry.revision.id] }))
+              }
+              hideKartBubble={!!kartFilter}
+              hideCourseBubble={!!courseFilter}
+              labelFor={labelFor}
+              t={t}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface RevisionCardProps {
+  entry: SetupHistoryEntry;
+  isOriginal: boolean;
+  showFull: boolean;
+  onToggleFull: () => void;
+  hideKartBubble: boolean;
+  hideCourseBubble: boolean;
+  labelFor: (f: { label?: string; labelKey?: string }) => string;
+  t: TFunction<"drawer">;
+}
+
+function RevisionCard({
+  entry, isOriginal, showFull, onToggleFull, hideKartBubble, hideCourseBubble, labelFor, t,
+}: RevisionCardProps) {
+  const { revision, fastestLapMs, fastestUsage, isFastestOverall, diff, usages } = entry;
+  const date = new Date(revision.createdAt).toLocaleDateString();
+
+  return (
+    <div
+      className={`rounded-lg border p-3 space-y-2.5 ${
+        isFastestOverall ? "border-success/60 bg-success/5" : "border-border"
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span
+              className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+                isOriginal ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {isOriginal ? t("setupHistory.original") : t("setupHistory.revision")}
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground">#{shortRevHash(revision.id)}</span>
+            <span className="text-[10px] text-muted-foreground">{date}</span>
+            {isFastestOverall && (
+              <span className="flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-success/15 text-success">
+                <Trophy className="w-3 h-3" /> {t("setupHistory.fastestTag")}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          {fastestLapMs !== null ? (
+            <span className="font-mono text-sm font-semibold text-foreground">{formatLapTime(fastestLapMs)}</span>
+          ) : (
+            <span className="text-xs text-muted-foreground">{t("setupHistory.noLap")}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Bubbles for the fastest usage's kart/course (the dimensions not filtered) */}
+      {(((!hideKartBubble && fastestUsage?.kartName) || (!hideCourseBubble && fastestUsage?.courseLabel))) && (
+        <div className="flex flex-wrap gap-1">
+          {!hideKartBubble && fastestUsage?.kartName && (
+            <span className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+              <Car className="w-3 h-3" /> {fastestUsage.kartName}
+            </span>
+          )}
+          {!hideCourseBubble && fastestUsage?.courseLabel && (
+            <span className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+              <MapPin className="w-3 h-3" /> {fastestUsage.courseLabel}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Setup content: full table, or diff-only for later revisions */}
+      {showFull ? (
+        <FullSetup fields={entry.fields} labelFor={labelFor} t={t} />
+      ) : diff && diff.length > 0 ? (
+        <DiffList diff={diff} labelFor={labelFor} />
+      ) : (
+        <p className="text-xs text-muted-foreground italic">{t("setupHistory.noChanges")}</p>
+      )}
+
+      {/* Full/diff toggle (original is always full) */}
+      {!isOriginal && (
+        <button
+          type="button"
+          onClick={onToggleFull}
+          className="flex items-center gap-1 text-[11px] text-primary hover:underline"
+        >
+          {showFull ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          {showFull ? t("setupHistory.showChanges") : t("setupHistory.showFull")}
+        </button>
+      )}
+
+      {/* Fastest laps completed with this revision */}
+      {usages.length > 0 && (
+        <div className="pt-1.5 border-t border-border/60 space-y-0.5">
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
+            {t("setupHistory.lapsHeader")}
+          </p>
+          {usages.slice(0, 6).map((u) => (
+            <div key={u.fileName} className="flex items-center justify-between gap-2 text-[11px]">
+              <span className="text-muted-foreground truncate">
+                {[u.courseLabel, u.kartName].filter(Boolean).join(" · ") || u.fileName}
+              </span>
+              <span className="font-mono text-foreground shrink-0">
+                {u.fastestLapMs !== undefined ? formatLapTime(u.fastestLapMs) : t("setupHistory.noLap")}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FullSetup({
+  fields, labelFor, t,
+}: {
+  fields: SetupField[];
+  labelFor: (f: { label?: string; labelKey?: string }) => string;
+  t: TFunction<"drawer">;
+}) {
+  if (fields.length === 0) {
+    return <p className="text-xs text-muted-foreground">{t("setupHistory.noSetupData")}</p>;
+  }
+  return (
+    <div className="space-y-0.5">
+      {fields.map((f) => (
+        <div key={f.key} className="flex justify-between gap-2 text-xs">
+          <span className="text-muted-foreground truncate">{labelFor(f)}</span>
+          <span className="font-mono text-foreground shrink-0">
+            {f.display}{f.unit ? ` ${f.unit}` : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DiffList({
+  diff, labelFor,
+}: {
+  diff: SetupFieldDiff[];
+  labelFor: (f: { label?: string; labelKey?: string }) => string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      {diff.map((d) => {
+        const color =
+          d.direction === "up" ? "text-success" : d.direction === "down" ? "text-destructive" : "text-foreground";
+        const Arrow = d.direction === "up" ? ArrowUp : d.direction === "down" ? ArrowDown : null;
+        return (
+          <div key={d.key} className="flex justify-between gap-2 text-xs items-center">
+            <span className="text-muted-foreground truncate">{labelFor(d)}</span>
+            <span className="flex items-center gap-1 font-mono shrink-0">
+              {d.prevDisplay !== null && (
+                <span className="text-muted-foreground/70 line-through decoration-muted-foreground/40">
+                  {d.prevDisplay}
+                </span>
+              )}
+              <span className={`flex items-center gap-0.5 ${color}`}>
+                {Arrow && <Arrow className="w-3 h-3" />}
+                {d.nextDisplay !== null ? `${d.nextDisplay}${d.unit ? ` ${d.unit}` : ""}` : "—"}
+              </span>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Wrench, Plus, ArrowLeft, Pencil, Trash2, Info, Car } from "lucide-react";
+import { Wrench, Plus, ArrowLeft, Pencil, Trash2, Info, Car, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
@@ -12,6 +12,7 @@ import { VehicleSetup } from "@/lib/setupStorage";
 import { VehicleType, SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
 import { TemplateCreator } from "@/components/drawer/TemplateCreator";
 import { computeSetupHash, shortRevHash } from "@/lib/setupRevision";
+import { SetupHistoryPanel } from "@/components/drawer/SetupHistoryPanel";
 import { useAuth } from "@/contexts/AuthContext";
 
 interface SetupsTabProps {
@@ -27,7 +28,7 @@ interface SetupsTabProps {
   onRemoveVehicleType: (vehicleTypeId: string, templateId: string) => Promise<void>;
 }
 
-type FormMode = "list" | "new" | "edit" | "new-type";
+type FormMode = "list" | "new" | "edit" | "new-type" | "history";
 
 const emptyForm = (): Omit<VehicleSetup, "id" | "createdAt" | "updatedAt"> => ({
   vehicleId: "",
@@ -66,6 +67,7 @@ export function SetupsTab({
   const [preloaded, setPreloaded] = useState(false);
   const preloadSnapshot = useRef<Record<string, unknown> | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [historySetup, setHistorySetup] = useState<VehicleSetup | null>(null);
   const { user } = useAuth();
 
   // The content hash each setup would freeze to right now (git-style short id).
@@ -265,6 +267,17 @@ export function SetupsTab({
 
   const canSave = form.vehicleId && form.name.trim();
 
+  // ── Setup History ──
+  if (mode === "history" && historySetup) {
+    return (
+      <SetupHistoryPanel
+        setup={historySetup}
+        vehicles={vehicles}
+        onBack={() => { setHistorySetup(null); setMode("list"); }}
+      />
+    );
+  }
+
   // ── Template Creator ──
   if (mode === "new-type") {
     return (
@@ -316,6 +329,9 @@ export function SetupsTab({
                           {vehicle?.name ?? t("setups.unknownVehicle")}{vt ? ` (${vt.name})` : ""} · {new Date(setup.updatedAt).toLocaleDateString()}
                         </p>
                       </div>
+                      <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" title={t("setupHistory.openTitle")} onClick={() => { setHistorySetup(setup); setMode("history"); }}>
+                        <History className="w-3.5 h-3.5" />
+                      </Button>
                       <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={() => openEdit(setup)}>
                         <Pencil className="w-3.5 h-3.5" />
                       </Button>

--- a/src/lib/setupHistory.test.ts
+++ b/src/lib/setupHistory.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import type { VehicleSetup } from "./setupStorage";
+import type { SetupRevision, FrozenTemplate } from "./setupRevision";
+import type { FileMetadata } from "./fileStorage";
+import type { Vehicle } from "./vehicleStorage";
+import {
+  buildSetupHistory,
+  diffRevisionFields,
+  flattenRevisionFields,
+} from "./setupHistory";
+
+const TEMPLATE: FrozenTemplate = {
+  id: "tpl-1",
+  name: "Kart",
+  wheelCount: 4,
+  includeTires: true,
+  sections: [
+    {
+      id: "sec",
+      name: "Alignment",
+      fields: [
+        { id: "f-toe", name: "Toe", type: "number" },
+        { id: "f-camber", name: "Camber", type: "number" },
+        { id: "f-front-sprocket", name: "Front Sprocket", type: "number" },
+        { id: "f-rear-sprocket", name: "Rear Sprocket", type: "number" },
+        { id: "f-front-width", name: "Front Width", type: "number", unit: "mm" },
+      ],
+    },
+  ],
+};
+
+function makeSetup(overrides: Partial<VehicleSetup> = {}): VehicleSetup {
+  return {
+    id: "setup-1",
+    vehicleId: "veh-1",
+    templateId: "tpl-1",
+    name: "Race Day Dry",
+    unitSystem: "mm",
+    tireBrand: "MG",
+    psiMode: "single",
+    psiFrontLeft: 12,
+    psiFrontRight: 12,
+    psiRearLeft: 12,
+    psiRearRight: 12,
+    tireWidthMode: "halves",
+    tireWidthFrontLeft: null,
+    tireWidthFrontRight: null,
+    tireWidthRearLeft: null,
+    tireWidthRearRight: null,
+    tireDiameterMode: "halves",
+    tireDiameterFrontLeft: null,
+    tireDiameterFrontRight: null,
+    tireDiameterRearLeft: null,
+    tireDiameterRearRight: null,
+    customFields: { "f-toe": 1, "f-camber": -2, "f-front-sprocket": 11, "f-rear-sprocket": 82, "f-front-width": 1380 },
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeRevision(id: string, createdAt: number, setup: VehicleSetup): SetupRevision {
+  return {
+    id,
+    setupId: "setup-1",
+    vehicleId: "veh-1",
+    name: setup.name,
+    setup,
+    template: TEMPLATE,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function makeMeta(overrides: Partial<FileMetadata> & { fileName: string }): FileMetadata {
+  return {
+    trackName: "",
+    courseName: "",
+    ...overrides,
+  };
+}
+
+const VEHICLES: Vehicle[] = [
+  { id: "veh-1", name: "Kart #7", vehicleTypeId: "vt", engine: "X30", number: 7, weight: 80, weightUnit: "kg" },
+  { id: "veh-2", name: "Kart #9", vehicleTypeId: "vt", engine: "KA100", number: 9, weight: 82, weightUnit: "kg" },
+];
+
+describe("flattenRevisionFields", () => {
+  it("flattens template fields, derived ratio, and tire data", () => {
+    const fields = flattenRevisionFields(makeRevision("a", 1, makeSetup()));
+    const byKey = Object.fromEntries(fields.map((f) => [f.key, f]));
+    expect(byKey["tpl:f-toe"].value).toBe(1);
+    expect(byKey["tpl:f-camber"].value).toBe(-2);
+    expect(byKey["tpl:f-front-width"].unit).toBe("mm");
+    // 82/11 = 7.454...
+    expect(byKey["ratio"].display).toBe("7.455");
+    expect(byKey["tireBrand"].value).toBe("MG");
+    // single PSI collapses to one "all" field
+    expect(byKey["psiAll"].display).toBe("12.00");
+    expect(byKey["psiFront"]).toBeUndefined();
+  });
+
+  it("skips empty/zero template values", () => {
+    const fields = flattenRevisionFields(
+      makeRevision("a", 1, makeSetup({ customFields: { "f-toe": 1 } })),
+    );
+    expect(fields.find((f) => f.key === "tpl:f-camber")).toBeUndefined();
+    expect(fields.find((f) => f.key === "ratio")).toBeUndefined();
+  });
+
+  it("splits PSI into front/rear when halves differ", () => {
+    const fields = flattenRevisionFields(
+      makeRevision("a", 1, makeSetup({ psiFrontLeft: 11, psiFrontRight: 11, psiRearLeft: 13, psiRearRight: 13 })),
+    );
+    const keys = fields.map((f) => f.key);
+    expect(keys).toContain("psiFront");
+    expect(keys).toContain("psiRear");
+    expect(keys).not.toContain("psiAll");
+  });
+});
+
+describe("diffRevisionFields", () => {
+  it("reports numeric direction and added/removed fields", () => {
+    const prev = flattenRevisionFields(makeRevision("a", 1, makeSetup({ customFields: { "f-toe": 1, "f-camber": -2 } })));
+    const next = flattenRevisionFields(
+      makeRevision("b", 2, makeSetup({ customFields: { "f-toe": 3, "f-rear-sprocket": 80, "f-front-sprocket": 11 } })),
+    );
+    const diff = diffRevisionFields(prev, next);
+    const byKey = Object.fromEntries(diff.map((d) => [d.key, d]));
+    // toe 1 → 3 increased
+    expect(byKey["tpl:f-toe"].direction).toBe("up");
+    // camber present before, gone now → removed
+    expect(byKey["tpl:f-camber"].nextDisplay).toBeNull();
+    // ratio added (sprockets now present)
+    expect(byKey["ratio"].prevDisplay).toBeNull();
+  });
+
+  it("omits unchanged fields", () => {
+    const fields = flattenRevisionFields(makeRevision("a", 1, makeSetup()));
+    expect(diffRevisionFields(fields, fields)).toEqual([]);
+  });
+
+  it("flags a decrease as down", () => {
+    const prev = flattenRevisionFields(makeRevision("a", 1, makeSetup()));
+    const next = flattenRevisionFields(makeRevision("b", 2, makeSetup({ psiFrontLeft: 10, psiFrontRight: 10, psiRearLeft: 10, psiRearRight: 10 })));
+    const diff = diffRevisionFields(prev, next);
+    expect(diff.find((d) => d.key === "psiAll")?.direction).toBe("down");
+  });
+});
+
+describe("buildSetupHistory", () => {
+  const revA = makeRevision("rev-a", 1000, makeSetup({ customFields: { "f-toe": 1 } }));
+  const revB = makeRevision("rev-b", 2000, makeSetup({ customFields: { "f-toe": 2 } }));
+  const revs = [revB, revA]; // intentionally unsorted
+
+  const metas = [
+    makeMeta({ fileName: "s1", sessionSetupRev: "rev-a", sessionKartId: "veh-1", trackName: "Track A", courseName: "CW", fastestLapMs: 65000, sessionStartTime: 100 }),
+    makeMeta({ fileName: "s2", sessionSetupRev: "rev-a", sessionKartId: "veh-2", trackName: "Track B", courseName: "CCW", fastestLapMs: 63000, sessionStartTime: 200 }),
+    makeMeta({ fileName: "s3", sessionSetupRev: "rev-b", sessionKartId: "veh-1", trackName: "Track A", courseName: "CW", fastestLapMs: 61000, sessionStartTime: 300 }),
+  ];
+
+  it("orders entries chronologically with the first as the original (no diff)", () => {
+    const h = buildSetupHistory({ setupId: "setup-1", setupName: "Race Day Dry", revisions: revs, metas, vehicles: VEHICLES });
+    expect(h.entries.map((e) => e.revision.id)).toEqual(["rev-a", "rev-b"]);
+    expect(h.entries[0].diff).toBeNull();
+    expect(h.entries[1].diff).not.toBeNull();
+  });
+
+  it("computes fastest lap per revision and flags the overall fastest", () => {
+    const h = buildSetupHistory({ setupId: "setup-1", setupName: "x", revisions: revs, metas, vehicles: VEHICLES });
+    expect(h.entries[0].fastestLapMs).toBe(63000);
+    expect(h.entries[1].fastestLapMs).toBe(61000);
+    expect(h.overallFastestLapMs).toBe(61000);
+    expect(h.entries[1].isFastestOverall).toBe(true);
+    expect(h.entries[0].isFastestOverall).toBe(false);
+  });
+
+  it("exposes kart and course filter options used across the setup", () => {
+    const h = buildSetupHistory({ setupId: "setup-1", setupName: "x", revisions: revs, metas, vehicles: VEHICLES });
+    expect(h.kartOptions.map((k) => k.name)).toEqual(["Kart #7", "Kart #9"]);
+    expect(h.courseOptions.map((c) => c.label)).toContain("Track A — CW");
+    expect(h.courseOptions.map((c) => c.label)).toContain("Track B — CCW");
+  });
+
+  it("filters by kart, dropping revisions with no matching session", () => {
+    const h = buildSetupHistory({
+      setupId: "setup-1",
+      setupName: "x",
+      revisions: revs,
+      metas,
+      vehicles: VEHICLES,
+      filter: { kartId: "veh-2" },
+    });
+    // only rev-a was run on veh-2
+    expect(h.entries.map((e) => e.revision.id)).toEqual(["rev-a"]);
+    expect(h.entries[0].fastestLapMs).toBe(63000);
+  });
+
+  it("filters by course", () => {
+    const courseKey = h(metas[0]);
+    const built = buildSetupHistory({
+      setupId: "setup-1",
+      setupName: "x",
+      revisions: revs,
+      metas,
+      vehicles: VEHICLES,
+      filter: { courseKey },
+    });
+    expect(built.entries.map((e) => e.revision.id)).toEqual(["rev-a", "rev-b"]);
+    // CW on Track A: rev-a 65000, rev-b 61000
+    expect(built.entries[0].fastestLapMs).toBe(65000);
+    expect(built.entries[1].fastestLapMs).toBe(61000);
+  });
+
+  it("ignores revisions for other setups", () => {
+    const other = makeRevision("rev-x", 5000, makeSetup());
+    other.setupId = "setup-2";
+    const built = buildSetupHistory({ setupId: "setup-1", setupName: "x", revisions: [...revs, other], metas, vehicles: VEHICLES });
+    expect(built.entries.find((e) => e.revision.id === "rev-x")).toBeUndefined();
+  });
+});
+
+// Helper to derive the composite course key the module builds internally.
+function h(meta: FileMetadata): string {
+  return `${meta.trackName ?? ""}\x1f${meta.courseName}`;
+}

--- a/src/lib/setupHistory.ts
+++ b/src/lib/setupHistory.ts
@@ -1,0 +1,408 @@
+// Pure view-model for the setup-revision history panel.
+//
+// A live `VehicleSetup` accumulates immutable, content-addressed `SetupRevision`s
+// over time (see setupRevision.ts). This module turns that flat list — plus the
+// session metadata that references each revision — into a chronological history
+// the UI can render: the original revision in full, every later revision as a
+// diff against the one before it, the sessions (karts/courses) each was run on,
+// and the fastest lap achieved on each.
+//
+// Kept pure (no IndexedDB / React) so the aggregation + diff logic is unit-tested.
+
+import type { SetupRevision, FrozenTemplate } from "./setupRevision";
+import type { FileMetadata } from "./fileStorage";
+import type { Vehicle } from "./vehicleStorage";
+
+/** Separator for the composite course key (never appears in track/course names). */
+const COURSE_KEY_SEP = "\x1f";
+
+/** A single flattened setup value, ready to render or diff. */
+export interface SetupField {
+  /** Stable identity used to line fields up across revisions. */
+  key: string;
+  /** Raw label for data-driven (template) fields — already human text, not i18n. */
+  label?: string;
+  /** i18n key (drawer namespace) for built-in tire/PSI/ratio fields. */
+  labelKey?: string;
+  /** Display unit (mm/in resolved to the setup's unit system). */
+  unit?: string;
+  /** Canonical value — number for numeric fields, string otherwise, null when unset. */
+  value: number | string | null;
+  /** Pre-formatted display string (without unit). */
+  display: string;
+  isNumeric: boolean;
+}
+
+/** One changed field between two revisions. */
+export interface SetupFieldDiff {
+  key: string;
+  label?: string;
+  labelKey?: string;
+  unit?: string;
+  /** Previous display value; null when the field was added in this revision. */
+  prevDisplay: string | null;
+  /** New display value; null when the field was removed in this revision. */
+  nextDisplay: string | null;
+  /** Numeric direction vs the previous revision: up = increased, down = decreased. */
+  direction: "up" | "down" | "neutral";
+  isNumeric: boolean;
+}
+
+/** One session this revision was run on. */
+export interface SetupUsage {
+  fileName: string;
+  kartId?: string;
+  kartName?: string;
+  engine?: string;
+  trackName?: string;
+  courseName?: string;
+  /** Composite track+course key, present only when a course is tagged. */
+  courseKey?: string;
+  /** Human course label ("Track — Course" or the course name). */
+  courseLabel?: string;
+  fastestLapMs?: number;
+  sessionStartTime?: number;
+}
+
+export interface SetupHistoryEntry {
+  revision: SetupRevision;
+  /** Fully flattened fields, in template order then tires. */
+  fields: SetupField[];
+  /** Diff vs the previous displayed entry; null for the first (show full). */
+  diff: SetupFieldDiff[] | null;
+  /** Filtered sessions, fastest lap first. */
+  usages: SetupUsage[];
+  fastestLapMs: number | null;
+  fastestUsage: SetupUsage | null;
+  /** Distinct kart names across the (filtered) usages. */
+  karts: string[];
+  /** Distinct course labels across the (filtered) usages. */
+  courses: string[];
+  /** True when this revision holds the fastest lap in the current view. */
+  isFastestOverall: boolean;
+}
+
+export interface SetupHistory {
+  setupId: string;
+  setupName: string;
+  /** Chronological, oldest first. Filtered-out (no matching usage) entries removed. */
+  entries: SetupHistoryEntry[];
+  /** Every kart this setup has been run on (for the filter). */
+  kartOptions: { id: string; name: string }[];
+  /** Every course this setup has been run on (for the filter). */
+  courseOptions: { key: string; label: string }[];
+  overallFastestLapMs: number | null;
+}
+
+export interface SetupHistoryFilter {
+  kartId?: string | null;
+  courseKey?: string | null;
+}
+
+export interface BuildSetupHistoryInput {
+  setupId: string;
+  setupName: string;
+  /** All revisions in the store; filtered to this setup internally. */
+  revisions: SetupRevision[];
+  /** All session metadata; only those referencing a revision are used. */
+  metas: FileMetadata[];
+  vehicles: Vehicle[];
+  filter?: SetupHistoryFilter;
+}
+
+/** Format a numeric setup value to a stable display string. */
+function formatNumber(value: number, decimals: number): string {
+  return value.toFixed(decimals);
+}
+
+/** Collapse a four-corner tire group (FL/FR/RL/RR) the way the InfoBox does. */
+function cornerFields(
+  fl: number | null,
+  fr: number | null,
+  rl: number | null,
+  rr: number | null,
+  keys: { all: string; front: string; rear: string; fl: string; fr: string; rl: string; rr: string },
+  labelKeys: { all: string; front: string; rear: string; fl: string; fr: string; rl: string; rr: string },
+  unit: string | undefined,
+  decimals: number,
+): SetupField[] {
+  if (fl === null) return [];
+  const field = (key: string, labelKey: string, v: number): SetupField => ({
+    key,
+    labelKey,
+    unit,
+    value: v,
+    display: formatNumber(v, decimals),
+    isNumeric: true,
+  });
+  if (fl === fr && rl === rr && fl === rl) {
+    return [field(keys.all, labelKeys.all, fl)];
+  }
+  if (fl === fr && rl === rr) {
+    return [field(keys.front, labelKeys.front, fl), field(keys.rear, labelKeys.rear, rl ?? fl)];
+  }
+  const out: SetupField[] = [field(keys.fl, labelKeys.fl, fl)];
+  if (fr !== null) out.push(field(keys.fr, labelKeys.fr, fr));
+  if (rl !== null) out.push(field(keys.rl, labelKeys.rl, rl));
+  if (rr !== null) out.push(field(keys.rr, labelKeys.rr, rr));
+  return out;
+}
+
+/**
+ * Flatten one revision's frozen setup + template into an ordered field list.
+ * Uses the revision's own frozen template so old history renders with the labels
+ * it had the day it ran.
+ */
+export function flattenRevisionFields(revision: SetupRevision): SetupField[] {
+  const setup = revision.setup;
+  const template: FrozenTemplate | null = revision.template;
+  const fields: SetupField[] = [];
+
+  if (template) {
+    for (const section of template.sections) {
+      for (const field of section.fields) {
+        const raw = setup.customFields[field.id];
+        if (raw === null || raw === undefined || raw === "") continue;
+        const displayUnit =
+          field.unit === "mm" || field.unit === "in" ? setup.unitSystem || "mm" : field.unit;
+        const isNumeric = field.type === "number";
+        fields.push({
+          key: `tpl:${field.id}`,
+          label: field.name,
+          unit: displayUnit,
+          value: isNumeric ? Number(raw) : String(raw),
+          display: String(raw),
+          isNumeric,
+        });
+      }
+    }
+    const front = setup.customFields["f-front-sprocket"];
+    const rear = setup.customFields["f-rear-sprocket"];
+    if (typeof front === "number" && typeof rear === "number" && front > 0) {
+      const ratio = rear / front;
+      fields.push({
+        key: "ratio",
+        labelKey: "setupDetails.ratio",
+        value: Number(ratio.toFixed(3)),
+        display: ratio.toFixed(3),
+        isNumeric: true,
+      });
+    }
+  }
+
+  if (setup.tireBrand) {
+    fields.push({
+      key: "tireBrand",
+      labelKey: "setupDetails.tireBrand",
+      value: setup.tireBrand,
+      display: setup.tireBrand,
+      isNumeric: false,
+    });
+  }
+
+  const unit = setup.unitSystem || "mm";
+  fields.push(
+    ...cornerFields(
+      setup.psiFrontLeft,
+      setup.psiFrontRight,
+      setup.psiRearLeft,
+      setup.psiRearRight,
+      { all: "psiAll", front: "psiFront", rear: "psiRear", fl: "psiFL", fr: "psiFR", rl: "psiRL", rr: "psiRR" },
+      {
+        all: "setupDetails.psiAll", front: "setupDetails.psiFront", rear: "setupDetails.psiRear",
+        fl: "setupDetails.psiFL", fr: "setupDetails.psiFR", rl: "setupDetails.psiRL", rr: "setupDetails.psiRR",
+      },
+      undefined,
+      2,
+    ),
+  );
+  fields.push(
+    ...cornerFields(
+      setup.tireWidthFrontLeft,
+      setup.tireWidthFrontRight,
+      setup.tireWidthRearLeft,
+      setup.tireWidthRearRight,
+      { all: "widthAll", front: "widthFront", rear: "widthRear", fl: "widthFL", fr: "widthFR", rl: "widthRL", rr: "widthRR" },
+      {
+        all: "setupDetails.tireWidthFront", front: "setupDetails.tireWidthFront", rear: "setupDetails.tireWidthRear",
+        fl: "setupDetails.tireWidthFL", fr: "setupDetails.tireWidthFR", rl: "setupDetails.tireWidthRL", rr: "setupDetails.tireWidthRR",
+      },
+      unit,
+      2,
+    ),
+  );
+  fields.push(
+    ...cornerFields(
+      setup.tireDiameterFrontLeft,
+      setup.tireDiameterFrontRight,
+      setup.tireDiameterRearLeft,
+      setup.tireDiameterRearRight,
+      { all: "diamAll", front: "diamFront", rear: "diamRear", fl: "diamFL", fr: "diamFR", rl: "diamRL", rr: "diamRR" },
+      {
+        all: "setupDetails.tireDiameterFront", front: "setupDetails.tireDiameterFront", rear: "setupDetails.tireDiameterRear",
+        fl: "setupDetails.tireDiameterFL", fr: "setupDetails.tireDiameterFR", rl: "setupDetails.tireDiameterRL", rr: "setupDetails.tireDiameterRR",
+      },
+      unit,
+      2,
+    ),
+  );
+
+  return fields;
+}
+
+/** Diff `next` against `prev` — only changed/added/removed fields, in `next` order. */
+export function diffRevisionFields(prev: SetupField[], next: SetupField[]): SetupFieldDiff[] {
+  const prevMap = new Map(prev.map((f) => [f.key, f]));
+  const nextMap = new Map(next.map((f) => [f.key, f]));
+  const diffs: SetupFieldDiff[] = [];
+
+  for (const n of next) {
+    const p = prevMap.get(n.key);
+    if (p && p.display === n.display) continue;
+    let direction: SetupFieldDiff["direction"] = "neutral";
+    if (p && p.isNumeric && n.isNumeric && typeof p.value === "number" && typeof n.value === "number") {
+      direction = n.value > p.value ? "up" : n.value < p.value ? "down" : "neutral";
+    }
+    diffs.push({
+      key: n.key,
+      label: n.label,
+      labelKey: n.labelKey,
+      unit: n.unit,
+      prevDisplay: p ? p.display : null,
+      nextDisplay: n.display,
+      direction,
+      isNumeric: n.isNumeric,
+    });
+  }
+  // Fields present before but gone now (removed).
+  for (const p of prev) {
+    if (nextMap.has(p.key)) continue;
+    diffs.push({
+      key: p.key,
+      label: p.label,
+      labelKey: p.labelKey,
+      unit: p.unit,
+      prevDisplay: p.display,
+      nextDisplay: null,
+      direction: "neutral",
+      isNumeric: p.isNumeric,
+    });
+  }
+  return diffs;
+}
+
+function buildUsage(meta: FileMetadata, vehicles: Vehicle[]): SetupUsage {
+  const vehicle = meta.sessionKartId ? vehicles.find((v) => v.id === meta.sessionKartId) : undefined;
+  const trackName = meta.trackName || undefined;
+  const courseName = meta.courseName || undefined;
+  const courseKey = courseName ? `${trackName ?? ""}${COURSE_KEY_SEP}${courseName}` : undefined;
+  const courseLabel = courseName
+    ? trackName
+      ? `${trackName} — ${courseName}`
+      : courseName
+    : undefined;
+  return {
+    fileName: meta.fileName,
+    kartId: meta.sessionKartId,
+    kartName: vehicle?.name,
+    engine: meta.sessionEngine || vehicle?.engine || undefined,
+    trackName,
+    courseName,
+    courseKey,
+    courseLabel,
+    fastestLapMs: meta.fastestLapMs,
+    sessionStartTime: meta.sessionStartTime,
+  };
+}
+
+/** Sort usages fastest lap first; sessions without a lap time sink to the bottom. */
+function byFastestLap(a: SetupUsage, b: SetupUsage): number {
+  const av = a.fastestLapMs ?? Infinity;
+  const bv = b.fastestLapMs ?? Infinity;
+  if (av !== bv) return av - bv;
+  return (a.sessionStartTime ?? 0) - (b.sessionStartTime ?? 0);
+}
+
+function distinct<T>(values: (T | undefined)[]): T[] {
+  return Array.from(new Set(values.filter((v): v is T => v !== undefined && v !== "")));
+}
+
+/** Build the full chronological history view-model for one setup. */
+export function buildSetupHistory(input: BuildSetupHistoryInput): SetupHistory {
+  const { setupId, setupName, revisions, metas, vehicles, filter } = input;
+
+  const revs = revisions
+    .filter((r) => r.setupId === setupId)
+    .sort((a, b) => a.createdAt - b.createdAt);
+
+  // Group every session by the revision it referenced.
+  const usagesByRev = new Map<string, SetupUsage[]>();
+  for (const meta of metas) {
+    const revId = meta.sessionSetupRev;
+    if (!revId) continue;
+    if (!revs.some((r) => r.id === revId)) continue;
+    const list = usagesByRev.get(revId) ?? [];
+    list.push(buildUsage(meta, vehicles));
+    usagesByRev.set(revId, list);
+  }
+
+  // Filter options span every (unfiltered) usage of this setup.
+  const allUsages = Array.from(usagesByRev.values()).flat();
+  const kartMap = new Map<string, string>();
+  for (const u of allUsages) {
+    if (u.kartId) kartMap.set(u.kartId, u.kartName ?? u.kartId);
+  }
+  const kartOptions = Array.from(kartMap, ([id, name]) => ({ id, name })).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  const courseMap = new Map<string, string>();
+  for (const u of allUsages) {
+    if (u.courseKey) courseMap.set(u.courseKey, u.courseLabel ?? u.courseKey);
+  }
+  const courseOptions = Array.from(courseMap, ([key, label]) => ({ key, label })).sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+
+  const matchesFilter = (u: SetupUsage): boolean => {
+    if (filter?.kartId && u.kartId !== filter.kartId) return false;
+    if (filter?.courseKey && u.courseKey !== filter.courseKey) return false;
+    return true;
+  };
+  const filtering = !!(filter?.kartId || filter?.courseKey);
+
+  // First pass: per-revision aggregation (still in chronological order).
+  const built = revs
+    .map((revision) => {
+      const usages = (usagesByRev.get(revision.id) ?? [])
+        .filter(matchesFilter)
+        .sort(byFastestLap);
+      const laps = usages.map((u) => u.fastestLapMs).filter((v): v is number => v !== undefined);
+      const fastestLapMs = laps.length ? Math.min(...laps) : null;
+      const fastestUsage = usages.find((u) => u.fastestLapMs !== undefined) ?? null;
+      return {
+        revision,
+        fields: flattenRevisionFields(revision),
+        usages,
+        fastestLapMs,
+        fastestUsage,
+        karts: distinct(usages.map((u) => u.kartName)),
+        courses: distinct(usages.map((u) => u.courseLabel)),
+      };
+    })
+    // When filtering, only show revisions actually run under that filter.
+    .filter((e) => !filtering || e.usages.length > 0);
+
+  const overallFastestLapMs = built.reduce<number | null>((min, e) => {
+    if (e.fastestLapMs === null) return min;
+    return min === null ? e.fastestLapMs : Math.min(min, e.fastestLapMs);
+  }, null);
+
+  // Second pass: diff each displayed entry against the previous displayed one.
+  const entries: SetupHistoryEntry[] = built.map((e, i) => ({
+    ...e,
+    diff: i === 0 ? null : diffRevisionFields(built[i - 1].fields, e.fields),
+    isFastestOverall: overallFastestLapMs !== null && e.fastestLapMs === overallFastestLapMs,
+  }));
+
+  return { setupId, setupName, entries, kartOptions, courseOptions, overallFastestLapMs };
+}

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -110,6 +110,24 @@
     "update": "Aktualisieren",
     "save": "Speichern"
   },
+  "setupHistory": {
+    "title": "Setup-Verlauf",
+    "openTitle": "Setup-Verlauf anzeigen",
+    "loading": "Verlauf wird geladen…",
+    "empty": "Noch kein Verlauf",
+    "emptyHint": "Weise dieses Setup einer Sitzung zu, um den Verlauf aufzubauen.",
+    "allKarts": "Alle Karts",
+    "allCourses": "Alle Strecken",
+    "original": "Original",
+    "revision": "Revision",
+    "fastestTag": "Schnellste Runde",
+    "noLap": "—",
+    "noChanges": "Keine Änderungen gegenüber der vorherigen Revision",
+    "noSetupData": "Keine Setup-Daten",
+    "showFull": "Vollständiges Setup anzeigen",
+    "showChanges": "Nur Änderungen anzeigen",
+    "lapsHeader": "Schnellste Runden"
+  },
   "notes": {
     "loadSession": "Lade eine Session, um Notizen hinzuzufügen",
     "sessionSetup": "Session-Setup",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -121,6 +121,24 @@
     "update": "Update",
     "save": "Save"
   },
+  "setupHistory": {
+    "title": "Setup History",
+    "openTitle": "View setup history",
+    "loading": "Loading history…",
+    "empty": "No history yet",
+    "emptyHint": "Assign this setup to a session to start building its history.",
+    "allKarts": "All karts",
+    "allCourses": "All courses",
+    "original": "Original",
+    "revision": "Revision",
+    "fastestTag": "Fastest lap",
+    "noLap": "—",
+    "noChanges": "No changes from previous revision",
+    "noSetupData": "No setup data",
+    "showFull": "Show full setup",
+    "showChanges": "Show changes only",
+    "lapsHeader": "Fastest laps"
+  },
   "notes": {
     "loadSession": "Load a session to add notes",
     "sessionSetup": "Session Setup",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -110,6 +110,24 @@
     "update": "Actualizar",
     "save": "Guardar"
   },
+  "setupHistory": {
+    "title": "Historial de configuración",
+    "openTitle": "Ver historial de configuración",
+    "loading": "Cargando historial…",
+    "empty": "Aún no hay historial",
+    "emptyHint": "Asigna esta configuración a una sesión para empezar a crear su historial.",
+    "allKarts": "Todos los karts",
+    "allCourses": "Todos los circuitos",
+    "original": "Original",
+    "revision": "Revisión",
+    "fastestTag": "Vuelta más rápida",
+    "noLap": "—",
+    "noChanges": "Sin cambios respecto a la revisión anterior",
+    "noSetupData": "Sin datos de configuración",
+    "showFull": "Mostrar configuración completa",
+    "showChanges": "Mostrar solo cambios",
+    "lapsHeader": "Vueltas más rápidas"
+  },
   "notes": {
     "loadSession": "Carga una sesión para añadir notas",
     "sessionSetup": "Reglaje de la sesión",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -110,6 +110,24 @@
     "update": "Mettre à jour",
     "save": "Enregistrer"
   },
+  "setupHistory": {
+    "title": "Historique des réglages",
+    "openTitle": "Voir l'historique des réglages",
+    "loading": "Chargement de l'historique…",
+    "empty": "Pas encore d'historique",
+    "emptyHint": "Associez ce réglage à une session pour commencer à construire son historique.",
+    "allKarts": "Tous les karts",
+    "allCourses": "Tous les circuits",
+    "original": "Original",
+    "revision": "Révision",
+    "fastestTag": "Meilleur tour",
+    "noLap": "—",
+    "noChanges": "Aucun changement par rapport à la révision précédente",
+    "noSetupData": "Aucune donnée de réglage",
+    "showFull": "Afficher le réglage complet",
+    "showChanges": "Afficher uniquement les changements",
+    "lapsHeader": "Meilleurs tours"
+  },
   "notes": {
     "loadSession": "Chargez une session pour ajouter des notes",
     "sessionSetup": "Réglage de la session",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -110,6 +110,24 @@
     "update": "Aggiorna",
     "save": "Salva"
   },
+  "setupHistory": {
+    "title": "Cronologia assetto",
+    "openTitle": "Visualizza cronologia assetto",
+    "loading": "Caricamento cronologia…",
+    "empty": "Nessuna cronologia",
+    "emptyHint": "Assegna questo assetto a una sessione per iniziare a creare la sua cronologia.",
+    "allKarts": "Tutti i kart",
+    "allCourses": "Tutti i circuiti",
+    "original": "Originale",
+    "revision": "Revisione",
+    "fastestTag": "Giro più veloce",
+    "noLap": "—",
+    "noChanges": "Nessuna modifica rispetto alla revisione precedente",
+    "noSetupData": "Nessun dato dell'assetto",
+    "showFull": "Mostra assetto completo",
+    "showChanges": "Mostra solo le modifiche",
+    "lapsHeader": "Giri più veloci"
+  },
   "notes": {
     "loadSession": "Carica una sessione per aggiungere note",
     "sessionSetup": "Assetto della sessione",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -110,6 +110,24 @@
     "update": "更新",
     "save": "保存"
   },
+  "setupHistory": {
+    "title": "セットアップ履歴",
+    "openTitle": "セットアップ履歴を表示",
+    "loading": "履歴を読み込み中…",
+    "empty": "まだ履歴がありません",
+    "emptyHint": "このセットアップをセッションに割り当てると履歴の作成が始まります。",
+    "allKarts": "すべてのカート",
+    "allCourses": "すべてのコース",
+    "original": "オリジナル",
+    "revision": "リビジョン",
+    "fastestTag": "最速ラップ",
+    "noLap": "—",
+    "noChanges": "前のリビジョンから変更なし",
+    "noSetupData": "セットアップデータなし",
+    "showFull": "セットアップ全体を表示",
+    "showChanges": "変更のみ表示",
+    "lapsHeader": "最速ラップ"
+  },
   "notes": {
     "loadSession": "メモを追加するにはセッションを読み込んでください",
     "sessionSetup": "セッションのセットアップ",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -110,6 +110,24 @@
     "update": "Atualizar",
     "save": "Salvar"
   },
+  "setupHistory": {
+    "title": "Histórico de configuração",
+    "openTitle": "Ver histórico de configuração",
+    "loading": "Carregando histórico…",
+    "empty": "Ainda não há histórico",
+    "emptyHint": "Atribua esta configuração a uma sessão para começar a criar o histórico.",
+    "allKarts": "Todos os karts",
+    "allCourses": "Todas as pistas",
+    "original": "Original",
+    "revision": "Revisão",
+    "fastestTag": "Volta mais rápida",
+    "noLap": "—",
+    "noChanges": "Sem alterações em relação à revisão anterior",
+    "noSetupData": "Sem dados de configuração",
+    "showFull": "Mostrar configuração completa",
+    "showChanges": "Mostrar apenas alterações",
+    "lapsHeader": "Voltas mais rápidas"
+  },
   "notes": {
     "loadSession": "Carregue uma sessão para adicionar notas",
     "sessionSetup": "Acerto da sessão",


### PR DESCRIPTION
## Setup revision history

Adds a full-panel chronological **history** for each saved setup, opened from a new history (book) icon on every row of the Garage → Setups list.

### What it does
- **Starts with the original setup, in full** — the oldest frozen revision is shown with every value.
- **Later revisions show a diff** against the previous revision — only the values that changed, with **green for increases / red for decreases** (numeric). Each later revision has a toggle to **show the full setup** instead of the diff.
- **Fastest lap per revision**, with the revision holding the **overall fastest lap highlighted** (trophy tag + accent border).
- **Filterable by kart and course** — the panel lists every kart/course this setup has run on. When *unfiltered*, each revision shows a **bubble** for the kart and course where its fastest lap was set; filtering by one dimension hides that bubble.
- Each revision also lists the **fastest laps** completed on it (course · kart → lap time).

### Implementation
- **`src/lib/setupHistory.ts`** (pure, unit-tested) — the view-model:
  - `flattenRevisionFields` reads each revision's *frozen* template so old history renders with the labels it had that day.
  - `diffRevisionFields` computes changed/added/removed fields and numeric direction.
  - `buildSetupHistory` joins this setup's revisions with the `FileMetadata` referencing them (`sessionSetupRev`) → fastest laps, karts, courses, filter options.
- **`src/components/drawer/SetupHistoryPanel.tsx`** — the UI, rendered as a mode inside `SetupsTab` (rides the lazy `FileManagerDrawer` chunk; off the initial bundle).
- Reuses existing immutable, content-addressed setup revisions — no schema/storage changes, fully offline.
- i18n keys added to the `drawer` namespace and seeded across all 7 languages.
- `CHANGELOG.md` + `CLAUDE.md` updated.

### Checks
`bun run lint`, `bun run typecheck`, `bun run test:run` (1757 passing, incl. 12 new), and `bun run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUDxuzo5ELhG2HDRaUbAjM)_