### PR TITLE
Attribute track submissions to accounts + basic admin user management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.0] - unreleased
 
 ### Added
+- **Earn free cloud storage by contributing tracks.** When you submit tracks to
+  the community database while signed in, your contribution is now linked to your
+  account — and the submit screen shows a note that signed-in contributions earn
+  free cloud storage. Submitting without an account still works exactly as before.
+- **Admin: user management.** A new **Users** tab in the admin panel lists every
+  account with its email/display name, plan, storage used, and number of track
+  contributions. Click a user to see details and **grant them free months of
+  premium** (or remove the grant). Comped premium expires automatically when the
+  granted months run out.
+- **Admin: see who submitted a track.** The Submissions tab now shows the
+  contributor's account name (or "Anonymous") alongside the existing IP/date.
 - **Tools on the home screen.** A new **Tools** tile on the landing page opens the
   trackside tools (the seat-position visualizer and more) in a full-screen panel —
   no datalog needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   granted months run out.
 - **Admin: see who submitted a track.** The Submissions tab now shows the
   contributor's account name (or "Anonymous") alongside the existing IP/date.
+- **Complimentary plan badge.** If you've been granted free premium, your Profile
+  now shows a "Complimentary" badge and how long it lasts — and hides the Stripe
+  billing buttons (there's no paid subscription to manage).
 - **Tools on the home screen.** A new **Tools** tile on the landing page opens the
   trackside tools (the seat-position visualizer and more) in a full-screen panel —
   no datalog needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 │   └── …                  # Login / Register / Privacy / Terms / NotFound
 ├── components/
 │   ├── ui/                # shadcn/ui primitives
-│   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, BannedIps, Tools, Messages)
+│   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, Users, BannedIps, Tools, Messages)
 │   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Labs, Coach, Tools; Profile is mounted in the drawer)
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Notes, Setups, Device*)
@@ -726,6 +726,19 @@ approved individually (approval is still manual — it flips status; the admin t
 builds/imports `tracks.json` as before). The single-submission body shape stays
 supported for back-compat. `DbSubmission.batch_id` carries the group id client-
 side (the generated Supabase types are untouched — `getSubmissions` casts).
+
+**Submitter attribution + the cloud-storage incentive.** Submitting works signed
+out *and* signed in. When signed in, `submit-track` records
+`submissions.submitted_by_user_id` (migration
+`20260617000000_submissions_user_id_comp_tier.sql`) derived from the caller's
+**verified JWT** (never a client-supplied id — anonymous stays `NULL`). The submit
+screen shows a "signed-in contributions earn free cloud storage" note (only on
+cloud builds — `VITE_ENABLE_CLOUD`; `useAuth()` decides signed-in vs -out copy).
+The admin **Submissions** tab shows the contributor's `profiles.display_name`
+(`db.getProfiles`). The admin **Users** tab (`admin-users` edge function) then
+lists accounts with plan + storage + contribution count and can **comp free months
+of premium** — see `docs/backend.md` → *User management* (incl. the comp-aware
+`user_tier()` so comps auto-expire).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -278,8 +278,9 @@ src/lib/db/
 
 | Function | Purpose |
 |----------|---------|
-| `submit-track` | Public endpoint for track submissions (with IP ban check) |
+| `submit-track` | Public endpoint for track submissions (with IP ban check); attributes the submission to the signed-in user when a valid JWT is present |
 | `admin-build-zip` | Admin-only: generates per-track JSON files |
+| `admin-users` | Admin-only: lists users with plan/storage/contribution count; grants or clears comped premium months |
 | `check-login-rate` | Rate limiting for login attempts |
 | `submit-message` | Public contact-form endpoint (with IP ban + rate limit) |
 | `stripe-prices` | Public: reports whether Stripe is configured + live monthly/annual prices (resolved by lookup_key) for the pricing UI |

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -147,6 +147,16 @@ the set there). Only **Free** + **Plus** are shown at launch. They can still be
 subscription's `metadata.user_id`, or change an existing customer's price); the
 webhook grants whatever tier the price's lookup_key maps to.
 
+**Admin comps (in-app, no Stripe):** the admin **Users** tab grants free months of
+a paid tier via the `admin-users` edge function, which writes a `user_subscriptions`
+row directly (tier `premium`, `status = active`, `current_period_end = now + N
+months`, `cancel_at_period_end = true`, **no `stripe_subscription_id`**). Because
+`user_tier()` is comp-aware, a row with no Stripe id only grants its tier until
+`current_period_end` passes — so comps **auto-expire** with no cron. Stripe-backed
+rows keep status-only semantics (unchanged). The function refuses to touch a user
+who already has a `stripe_subscription_id` (manage those in Stripe). See *User
+management* below.
+
 **Cancellation grace:** a cancelled sub ends at the period boundary (Stripe
 `customer.subscription.deleted`), dropping to free limits immediately (via
 `user_tier`), but `grace_until = period_end + 60 days` keeps the user's logs so
@@ -174,6 +184,26 @@ manually like the rest of the repo, the webhook verifies the Stripe signature):
   subscription to update.
 
 Secrets: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
+
+### User management — `admin-users` edge function
+
+A single admin-only function (`verify_jwt = false`; verifies the caller's JWT then
+checks `user_roles` for `admin`, like `admin-build-zip`) backing the admin **Users**
+tab (`src/components/admin/UsersTab.tsx`). Service-role actions:
+
+- `list` (`{ page?, perPage? }`) → one row per account: email + `created_at` (from
+  `auth.admin.listUsers`), `display_name` (`profiles`), effective tier/status/
+  period-end (`user_subscriptions`, comp-aware), pooled storage used
+  (`total_storage_used(uuid)` RPC per listed user) + limit (tier `total_bytes`), and
+  a **track-contribution count** (`submissions.submitted_by_user_id`). Paginated.
+- `grant_premium` (`{ user_id, months }`, 1–36) → upserts the comp row described
+  above, **extending** an unexpired comp's end date. Refuses a Stripe-managed user.
+- `clear_grant` (`{ user_id }`) → deletes a comp row (refuses Stripe-managed).
+
+Submissions are attributed to a signed-in contributor via
+`submissions.submitted_by_user_id`, which the `submit-track` edge function derives
+from the caller's **verified JWT** (never a client-supplied id; anonymous stays
+`NULL`). The admin Submissions tab resolves it to a `profiles.display_name`.
 
 **Client wiring** (core, not the cloud-sync plugin — billing is account-level and
 PricingCards renders even with cloud disabled): `lib/billing.ts` is the pure,

--- a/src/components/SubmitTrackDialog.tsx
+++ b/src/components/SubmitTrackDialog.tsx
@@ -4,12 +4,15 @@ import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from '@/components/ui/dialog';
 import { toast } from '@/hooks/use-toast';
-import { Send, ShieldCheck, ArrowRight, ArrowLeft, Loader2, CheckCircle2, AlertTriangle, Check } from 'lucide-react';
+import { Send, ShieldCheck, ArrowRight, ArrowLeft, Loader2, CheckCircle2, AlertTriangle, Check, Gift } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
 import { loadTracks, loadDefaultTracks } from '@/lib/trackStorage';
 import { buildSubmissionPlan, type SubmissionPlan, type SubmissionCourse } from '@/lib/trackSubmission';
 import { loadSubmittedRecords, markCoursesSubmitted } from '@/lib/submittedTracksStorage';
 
 const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+// The free-cloud-storage incentive only makes sense when accounts exist.
+const CLOUD_ENABLED = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 
 interface SubmitTrackDialogProps {
   trigger: React.ReactNode;
@@ -40,6 +43,7 @@ const CHANGE_STYLE: Record<SubmissionCourse['change'], string> = {
 
 export function SubmitTrackDialog({ trigger, onSubmitted }: SubmitTrackDialogProps) {
   const { t } = useTranslation('tracks');
+  const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<Step>('confirm');
   const [plan, setPlan] = useState<SubmissionPlan | null>(null);
@@ -274,6 +278,15 @@ export function SubmitTrackDialog({ trigger, onSubmitted }: SubmitTrackDialogPro
                       </div>
                     </div>
                   ))}
+                </div>
+              )}
+
+              {CLOUD_ENABLED && hasAnything && (
+                <div className="flex items-start gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3 text-sm">
+                  <Gift className="w-4 h-4 text-primary shrink-0 mt-0.5" />
+                  <span className="text-muted-foreground">
+                    {user ? t('submit.accountNoticeSignedIn') : t('submit.accountNotice')}
+                  </span>
                 </div>
               )}
 

--- a/src/components/admin/SubmissionsTab.tsx
+++ b/src/components/admin/SubmissionsTab.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { toast } from '@/hooks/use-toast';
 import { getDatabase } from '@/lib/db';
 import type { DbSubmission } from '@/lib/db/types';
-import { Check, X, Layers, Route } from 'lucide-react';
+import { Check, X, Layers, Route, User } from 'lucide-react';
 
 /** Mini SVG preview of a submitted track outline. */
 function DrawingPreview({ points, size = 64 }: { points: Array<{ lat: number; lon: number }>; size?: number }) {
@@ -63,6 +63,8 @@ export function SubmissionsTab() {
   const [filter, setFilter] = useState('pending');
   const [loading, setLoading] = useState(true);
   const [reviewNotes, setReviewNotes] = useState<Record<string, string>>({});
+  // Resolve submitter user ids → display names so the admin sees who contributed.
+  const [namesByUserId, setNamesByUserId] = useState<Record<string, string>>({});
 
   const db = getDatabase();
 
@@ -71,6 +73,13 @@ export function SubmissionsTab() {
     try {
       const data = await db.getSubmissions(filter === 'all' ? undefined : filter);
       setSubmissions(data);
+      const userIds = data.map(s => s.submitted_by_user_id).filter((id): id is string => !!id);
+      if (userIds.length > 0) {
+        try {
+          const profiles = await db.getProfiles(userIds);
+          setNamesByUserId(Object.fromEntries(profiles.map(p => [p.user_id, p.display_name])));
+        } catch { /* names are a nicety; fall back to the raw id */ }
+      }
     } catch (e: unknown) {
       toast({ title: t('submissions.loadError'), description: (e as Error).message, variant: 'destructive' });
     }
@@ -162,9 +171,17 @@ export function SubmissionsTab() {
             </div>
           </div>
         )}
-        <p className="text-xs text-muted-foreground">
-          {t('submissions.ipLine', { ip: sub.submitted_by_ip || t('submissions.unknownIp'), date: new Date(sub.created_at).toLocaleString() })}
-        </p>
+        <div className="flex items-center gap-2 flex-wrap text-xs text-muted-foreground">
+          {sub.submitted_by_user_id ? (
+            <span className="flex items-center gap-1 rounded bg-primary/15 text-primary px-2 py-0.5">
+              <User className="w-3 h-3" />
+              {t('submissions.byUser', { name: namesByUserId[sub.submitted_by_user_id] || `${sub.submitted_by_user_id.slice(0, 8)}…` })}
+            </span>
+          ) : (
+            <span className="rounded bg-muted px-2 py-0.5">{t('submissions.anonymous')}</span>
+          )}
+          <span>{t('submissions.ipLine', { ip: sub.submitted_by_ip || t('submissions.unknownIp'), date: new Date(sub.created_at).toLocaleString() })}</span>
+        </div>
         {sub.status === 'pending' && (
           <div className="flex items-center gap-2 pt-2">
             <Input

--- a/src/components/admin/UsersTab.tsx
+++ b/src/components/admin/UsersTab.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/hooks/use-toast';
+import { Gift, RotateCcw, ChevronDown, ChevronRight, HardDrive, Mail, Route as RouteIcon } from 'lucide-react';
+
+interface AdminUserRow {
+  user_id: string;
+  email: string | null;
+  display_name: string | null;
+  created_at: string;
+  tier: string;
+  tier_label: string;
+  status: string | null;
+  current_period_end: string | null;
+  is_comp: boolean;
+  has_stripe: boolean;
+  used_bytes: number;
+  limit_bytes: number;
+  submission_count: number;
+}
+
+/** Compact byte formatter (no external dep — admin chunk only). */
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes < 1024) return `${bytes || 0} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = bytes / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+/** Invoke the admin-users edge function, surfacing its JSON error body. */
+async function invokeAdmin<T>(body: Record<string, unknown>): Promise<T> {
+  const { data, error } = await supabase.functions.invoke('admin-users', { body });
+  if (error) {
+    let msg = error.message;
+    try {
+      const ctx = (error as { context?: { json?: () => Promise<{ error?: string }> } }).context;
+      const j = await ctx?.json?.();
+      if (j?.error) msg = j.error;
+    } catch { /* keep the generic message */ }
+    throw new Error(msg);
+  }
+  return data as T;
+}
+
+export function UsersTab() {
+  const { t } = useTranslation('admin');
+  const [users, setUsers] = useState<AdminUserRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [grantMonths, setGrantMonths] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async (targetPage: number, append: boolean) => {
+    setLoading(true);
+    try {
+      const res = await invokeAdmin<{ users: AdminUserRow[]; hasMore: boolean }>({ action: 'list', page: targetPage });
+      setUsers(prev => append ? [...prev, ...res.users] : res.users);
+      setHasMore(res.hasMore);
+      setPage(targetPage);
+    } catch (e: unknown) {
+      toast({ title: t('users.loadError'), description: (e as Error).message, variant: 'destructive' });
+    }
+    setLoading(false);
+  }, [t]);
+
+  useEffect(() => { load(1, false); }, [load]);
+
+  const grant = async (u: AdminUserRow) => {
+    const months = Math.floor(Number(grantMonths[u.user_id] ?? '1'));
+    if (!Number.isFinite(months) || months < 1) {
+      toast({ title: t('users.invalidMonths'), variant: 'destructive' });
+      return;
+    }
+    setBusy(u.user_id);
+    try {
+      await invokeAdmin({ action: 'grant_premium', user_id: u.user_id, months });
+      toast({ title: t('users.granted', { count: months }) });
+      await load(1, false);
+    } catch (e: unknown) {
+      toast({ title: t('users.grantFailed'), description: (e as Error).message, variant: 'destructive' });
+    }
+    setBusy(null);
+  };
+
+  const clearGrant = async (u: AdminUserRow) => {
+    setBusy(u.user_id);
+    try {
+      await invokeAdmin({ action: 'clear_grant', user_id: u.user_id });
+      toast({ title: t('users.grantRemoved') });
+      await load(1, false);
+    } catch (e: unknown) {
+      toast({ title: t('users.grantFailed'), description: (e as Error).message, variant: 'destructive' });
+    }
+    setBusy(null);
+  };
+
+  const tierBadgeClass = (u: AdminUserRow) =>
+    u.tier === 'free'
+      ? 'bg-muted text-muted-foreground'
+      : u.is_comp
+        ? 'bg-amber-500/20 text-amber-400'
+        : 'bg-primary/20 text-primary';
+
+  return (
+    <div className="space-y-4 mt-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-foreground">{t('users.title')}</h2>
+        <Button variant="outline" size="sm" onClick={() => load(1, false)}>{t('users.refresh')}</Button>
+      </div>
+
+      {loading && users.length === 0 ? (
+        <p className="text-muted-foreground">{t('common.loading')}</p>
+      ) : users.length === 0 ? (
+        <p className="text-muted-foreground">{t('users.none')}</p>
+      ) : (
+        <div className="space-y-2">
+          {users.map(u => {
+            const isOpen = expanded === u.user_id;
+            const overLimit = u.used_bytes > u.limit_bytes;
+            return (
+              <div key={u.user_id} className="racing-card">
+                <button
+                  type="button"
+                  onClick={() => setExpanded(isOpen ? null : u.user_id)}
+                  className="w-full flex items-center gap-3 p-3 text-left"
+                >
+                  {isOpen ? <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground" />}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-foreground truncate">
+                        {u.display_name || u.email || `${u.user_id.slice(0, 8)}…`}
+                      </span>
+                      <span className={`text-xs px-2 py-0.5 rounded ${tierBadgeClass(u)}`}>
+                        {u.tier_label}{u.is_comp ? ` · ${t('users.comp')}` : ''}
+                      </span>
+                      {u.submission_count > 0 && (
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                          <RouteIcon className="w-3 h-3" /> {t('users.submissions', { count: u.submission_count })}
+                        </span>
+                      )}
+                    </div>
+                    {u.email && <span className="text-xs text-muted-foreground truncate block">{u.email}</span>}
+                  </div>
+                  <div className={`text-xs shrink-0 text-right ${overLimit ? 'text-destructive' : 'text-muted-foreground'}`}>
+                    <div className="flex items-center gap-1 justify-end"><HardDrive className="w-3 h-3" /> {formatBytes(u.used_bytes)}</div>
+                    <div>{t('users.ofLimit', { limit: formatBytes(u.limit_bytes) })}</div>
+                  </div>
+                </button>
+
+                {isOpen && (
+                  <div className="border-t border-border p-3 space-y-3 text-sm">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                      <div className="flex items-center gap-1 text-muted-foreground"><Mail className="w-3 h-3" /> {u.email || t('users.noEmail')}</div>
+                      <div className="text-muted-foreground">{t('users.userId')}: <span className="font-mono">{u.user_id}</span></div>
+                      <div className="text-muted-foreground">{t('users.created')}: {new Date(u.created_at).toLocaleDateString()}</div>
+                      <div className="text-muted-foreground">{t('users.statusLabel')}: {u.status || t('users.statusFree')}</div>
+                      {u.current_period_end && (
+                        <div className="text-muted-foreground">{t('users.renewsOrEnds')}: {new Date(u.current_period_end).toLocaleDateString()}</div>
+                      )}
+                      <div className="text-muted-foreground">{t('users.usage')}: {formatBytes(u.used_bytes)} / {formatBytes(u.limit_bytes)}</div>
+                    </div>
+
+                    {u.has_stripe ? (
+                      <p className="text-xs text-muted-foreground italic">{t('users.stripeManaged')}</p>
+                    ) : (
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-xs text-muted-foreground">{t('users.grantLabel')}</span>
+                        <Input
+                          type="number"
+                          min={1}
+                          max={36}
+                          value={grantMonths[u.user_id] ?? '1'}
+                          onChange={e => setGrantMonths(prev => ({ ...prev, [u.user_id]: e.target.value }))}
+                          className="w-20 h-8 text-sm"
+                        />
+                        <span className="text-xs text-muted-foreground">{t('users.months')}</span>
+                        <Button size="sm" disabled={busy === u.user_id} onClick={() => grant(u)} className="gap-1">
+                          <Gift className="w-3 h-3" /> {t('users.grantPremium')}
+                        </Button>
+                        {u.is_comp && (
+                          <Button size="sm" variant="outline" disabled={busy === u.user_id} onClick={() => clearGrant(u)} className="gap-1">
+                            <RotateCcw className="w-3 h-3" /> {t('users.removeGrant')}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {hasMore && (
+            <Button variant="outline" className="w-full" disabled={loading} onClick={() => load(page + 1, true)}>
+              {t('users.loadMore')}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -3,6 +3,7 @@ import {
   isActiveStatus,
   effectiveTier,
   isPaidTier,
+  isComped,
   pricingCta,
   lookupKey,
   tiersWithPrices,
@@ -56,6 +57,31 @@ describe("isPaidTier", () => {
     expect(isPaidTier("free")).toBe(false);
     expect(isPaidTier("plus")).toBe(true);
     expect(isPaidTier("pro")).toBe(true);
+  });
+});
+
+describe("isComped", () => {
+  const NOW = Date.UTC(2026, 5, 17); // fixed clock for the date-window checks
+  const future = new Date(NOW + 86_400_000).toISOString();
+  const past = new Date(NOW - 86_400_000).toISOString();
+
+  it("is true for an active paid tier with no Stripe id, still in window", () => {
+    expect(isComped({ tier: "premium", status: "active", stripe_subscription_id: null, current_period_end: future }, NOW)).toBe(true);
+  });
+  it("treats a no-end-date comp as open-ended", () => {
+    expect(isComped({ tier: "premium", status: "active", stripe_subscription_id: null, current_period_end: null }, NOW)).toBe(true);
+  });
+  it("is false once the comp window has passed", () => {
+    expect(isComped({ tier: "premium", status: "active", stripe_subscription_id: null, current_period_end: past }, NOW)).toBe(false);
+  });
+  it("is false for a Stripe-managed subscription (not a comp)", () => {
+    expect(isComped({ tier: "premium", status: "active", stripe_subscription_id: "sub_123", current_period_end: future }, NOW)).toBe(false);
+  });
+  it("is false for free, inactive, or missing rows", () => {
+    expect(isComped({ tier: "free", status: "active", stripe_subscription_id: null, current_period_end: future }, NOW)).toBe(false);
+    expect(isComped({ tier: "premium", status: "canceled", stripe_subscription_id: null, current_period_end: future }, NOW)).toBe(false);
+    expect(isComped(null, NOW)).toBe(false);
+    expect(isComped(undefined, NOW)).toBe(false);
   });
 });
 

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -21,6 +21,8 @@ export interface UserSubscriptionRow {
   cancel_at_period_end?: boolean;
   billing_interval?: string | null;
   grace_until?: string | null;
+  /** Set for Stripe-managed subscriptions; NULL for admin comps. */
+  stripe_subscription_id?: string | null;
 }
 
 // Paid plans bill either monthly or annually. The slug encodes both halves of a
@@ -105,6 +107,23 @@ export function effectiveTier(
 
 export function isPaidTier(tier: string): boolean {
   return tier !== "free";
+}
+
+/**
+ * Whether the user is on an admin **comp** (complimentary) rather than a paid
+ * Stripe subscription. Mirrors the server `user_tier()` comp branch: an active
+ * paid tier with no `stripe_subscription_id`, still within its granted window
+ * (an open-ended comp has no `current_period_end`). A comp has no Stripe
+ * customer, so the billing-portal actions must be hidden for it.
+ */
+export function isComped(
+  sub: Pick<UserSubscriptionRow, "tier" | "status" | "stripe_subscription_id" | "current_period_end"> | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!sub || !isActiveStatus(sub.status) || !isPaidTier(sub.tier)) return false;
+  if (sub.stripe_subscription_id) return false; // Stripe-managed — not a comp
+  if (!sub.current_period_end) return true; // open-ended comp
+  return new Date(sub.current_period_end).getTime() > now;
 }
 
 // Tiers that exist but aren't yet self-service purchasable — shown as

--- a/src/lib/billingClient.ts
+++ b/src/lib/billingClient.ts
@@ -30,7 +30,7 @@ export async function fetchTiers(): Promise<SubscriptionTierRow[]> {
 export async function fetchMySubscription(userId: string): Promise<UserSubscriptionRow | null> {
   const { data, error } = await untyped
     .from("user_subscriptions")
-    .select("user_id, tier, status, current_period_end, cancel_at_period_end, billing_interval, grace_until")
+    .select("user_id, tier, status, current_period_end, cancel_at_period_end, billing_interval, grace_until, stripe_subscription_id")
     .eq("user_id", userId)
     .maybeSingle();
   if (error) throw new Error(`Failed to load subscription: ${error.message}`);

--- a/src/lib/db/supabaseAdapter.ts
+++ b/src/lib/db/supabaseAdapter.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
-import type { ITrackDatabase, DbTrack, DbCourse, DbSubmission, DbBannedIp, DbCourseLayout } from './types';
+import type { ITrackDatabase, DbTrack, DbCourse, DbSubmission, DbBannedIp, DbCourseLayout, DbProfile } from './types';
 import { calculatePolylineLength } from '@/lib/trackUtils';
 import { METERS_TO_FEET } from '@/lib/parserUtils';
 
@@ -115,6 +115,16 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
       reviewed_by: user?.id ?? null,
     }).eq('id', id);
     if (error) throw error;
+  }
+
+  // Profiles — resolve user ids to display names (e.g. submission attribution).
+  // profiles is readable by any authenticated user (admins included).
+  async getProfiles(userIds: string[]): Promise<DbProfile[]> {
+    const ids = Array.from(new Set(userIds.filter(Boolean)));
+    if (ids.length === 0) return [];
+    const { data, error } = await supabase.from('profiles').select('user_id, display_name').in('user_id', ids);
+    if (error) throw error;
+    return (data ?? []) as DbProfile[];
   }
 
   // Banned IPs

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -48,6 +48,8 @@ export interface DbSubmission {
   course_data: Record<string, unknown>;
   status: 'pending' | 'approved' | 'denied';
   submitted_by_ip: string | null;
+  /** The signed-in user who submitted, when they were logged in. NULL = anonymous. */
+  submitted_by_user_id: string | null;
   /** True when the submitter included a drawn track outline. */
   has_layout?: boolean;
   /** The drawn outline polyline, when `has_layout`. */
@@ -78,6 +80,11 @@ export interface DbCourseLayout {
   updated_at: string;
 }
 
+export interface DbProfile {
+  user_id: string;
+  display_name: string;
+}
+
 export interface ITrackDatabase {
   // Tracks
   getTracks(): Promise<DbTrack[]>;
@@ -102,6 +109,9 @@ export interface ITrackDatabase {
   // Submissions
   getSubmissions(status?: string): Promise<DbSubmission[]>;
   updateSubmission(id: string, status: string, reviewNotes?: string): Promise<void>;
+
+  // Profiles (display-name lookup, e.g. to show who submitted a track)
+  getProfiles(userIds: string[]): Promise<DbProfile[]>;
 
   // Banned IPs
   getBannedIps(): Promise<DbBannedIp[]>;

--- a/src/locales/de/admin.json
+++ b/src/locales/de/admin.json
@@ -10,7 +10,8 @@
     "tracks": "Strecken",
     "courses": "Kurse",
     "tools": "Werkzeuge",
-    "banned": "Gesperrte IPs"
+    "banned": "Gesperrte IPs",
+    "users": "Benutzer"
   },
   "common": {
     "error": "Fehler",
@@ -134,7 +135,9 @@
     "trackCount_other": "{{count}} Strecken",
     "bulkSummary": "{{courses}} auf {{tracks}} • {{date}}",
     "approveAll": "Alle genehmigen ({{count}})",
-    "denyAll": "Alle ablehnen"
+    "denyAll": "Alle ablehnen",
+    "byUser": "von {{name}}",
+    "anonymous": "Anonym"
   },
   "courses": {
     "created": "Kurs erstellt",
@@ -169,5 +172,33 @@
     "overridePlaceholder": "auto",
     "noLayouts": "Noch keine Layouts gezeichnet. Bearbeite einen Kurs und nutze das Zeichnen-Werkzeug, um den Streckenumriss nachzuzeichnen.",
     "unknownCourse": "Unbekannt"
+  },
+  "users": {
+    "title": "Benutzerverwaltung",
+    "refresh": "Aktualisieren",
+    "none": "Keine Benutzer gefunden.",
+    "loadError": "Benutzer konnten nicht geladen werden",
+    "comp": "gratis",
+    "submissions_one": "{{count}} Einreichung",
+    "submissions_other": "{{count}} Einreichungen",
+    "ofLimit": "von {{limit}}",
+    "noEmail": "Keine E-Mail",
+    "userId": "Benutzer-ID",
+    "created": "Erstellt",
+    "statusLabel": "Status",
+    "statusFree": "kostenlos",
+    "renewsOrEnds": "Premium bis",
+    "usage": "Belegter Speicher",
+    "stripeManaged": "Dieser Benutzer hat ein Stripe-Abo – verwalte es in Stripe.",
+    "grantLabel": "Gratis-Premium gewähren:",
+    "months": "Monate",
+    "grantPremium": "Premium gewähren",
+    "removeGrant": "Gewährung entfernen",
+    "loadMore": "Mehr laden",
+    "invalidMonths": "Gib eine gültige Anzahl von Monaten ein",
+    "granted_one": "{{count}} Monat Premium gewährt",
+    "granted_other": "{{count}} Monate Premium gewährt",
+    "grantFailed": "Aktion fehlgeschlagen",
+    "grantRemoved": "Premium-Gewährung entfernt"
   }
 }

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -37,7 +37,10 @@
     "upgrade": "Upgrade über die Tarif- und Preiskarten.",
     "changePlan": "Tarif ändern",
     "manageSubscription": "Abonnement verwalten",
-    "portalFailed": "Das Abrechnungsportal konnte nicht geöffnet werden."
+    "portalFailed": "Das Abrechnungsportal konnte nicht geöffnet werden.",
+    "compBadge": "Gratis",
+    "comp": "Gratis-Plan — mit freundlicher Empfehlung des Teams.",
+    "compUntil": "Gratis-Plan — kostenlos bis {{date}}."
   },
   "storage": {
     "title": "Speicher",

--- a/src/locales/de/tracks.json
+++ b/src/locales/de/tracks.json
@@ -119,7 +119,9 @@
     "back": "Zurück",
     "submitting": "Wird gesendet…",
     "submitBtn_one": "{{count}} Kurs senden",
-    "submitBtn_other": "{{count}} Kurse senden"
+    "submitBtn_other": "{{count}} Kurse senden",
+    "accountNotice": "Einreichung ohne Konto. Melde dich zuerst an, um kostenlosen Cloud-Speicher für die von dir beigetragenen Strecken zu erhalten.",
+    "accountNoticeSignedIn": "Du bist angemeldet – das Beitragen dieser Strecken bringt dir kostenlosen Cloud-Speicher."
   },
   "trackEditor": {
     "toastCopied": "Kopiert!",

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -9,7 +9,8 @@
     "tracks": "Tracks",
     "courses": "Courses",
     "tools": "Tools",
-    "banned": "Banned IPs"
+    "banned": "Banned IPs",
+    "users": "Users"
   },
   "common": {
     "error": "Error",
@@ -133,7 +134,9 @@
     "trackCount_other": "{{count}} tracks",
     "bulkSummary": "{{courses}} across {{tracks}} • {{date}}",
     "approveAll": "Approve all ({{count}})",
-    "denyAll": "Deny all"
+    "denyAll": "Deny all",
+    "byUser": "by {{name}}",
+    "anonymous": "Anonymous"
   },
   "courses": {
     "created": "Course created",
@@ -168,5 +171,33 @@
     "overridePlaceholder": "auto",
     "noLayouts": "No layouts drawn yet. Edit a course and use the Draw tool to trace the track outline.",
     "unknownCourse": "Unknown"
+  },
+  "users": {
+    "title": "User Management",
+    "refresh": "Refresh",
+    "none": "No users found.",
+    "loadError": "Failed to load users",
+    "comp": "comped",
+    "submissions_one": "{{count}} submission",
+    "submissions_other": "{{count}} submissions",
+    "ofLimit": "of {{limit}}",
+    "noEmail": "No email",
+    "userId": "User ID",
+    "created": "Created",
+    "statusLabel": "Status",
+    "statusFree": "free",
+    "renewsOrEnds": "Premium until",
+    "usage": "Storage used",
+    "stripeManaged": "This user has a Stripe subscription — manage it in Stripe.",
+    "grantLabel": "Grant free premium:",
+    "months": "months",
+    "grantPremium": "Grant premium",
+    "removeGrant": "Remove grant",
+    "loadMore": "Load more",
+    "invalidMonths": "Enter a valid number of months",
+    "granted_one": "Granted {{count}} month of premium",
+    "granted_other": "Granted {{count}} months of premium",
+    "grantFailed": "Action failed",
+    "grantRemoved": "Premium grant removed"
   }
 }

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -36,7 +36,10 @@
     "upgrade": "Upgrade from the Plans & pricing cards.",
     "changePlan": "Change plan",
     "manageSubscription": "Manage subscription",
-    "portalFailed": "Couldn't open the billing portal."
+    "portalFailed": "Couldn't open the billing portal.",
+    "compBadge": "Complimentary",
+    "comp": "Complimentary plan — courtesy of the team.",
+    "compUntil": "Complimentary plan — free until {{date}}."
   },
   "storage": {
     "title": "Storage",

--- a/src/locales/en/tracks.json
+++ b/src/locales/en/tracks.json
@@ -118,7 +118,9 @@
     "back": "Back",
     "submitting": "Submitting…",
     "submitBtn_one": "Submit {{count}} course",
-    "submitBtn_other": "Submit {{count}} courses"
+    "submitBtn_other": "Submit {{count}} courses",
+    "accountNotice": "Submitting without an account. Sign in first to earn free cloud storage for the tracks you contribute.",
+    "accountNoticeSignedIn": "You're signed in — contributing these tracks earns you free cloud storage."
   },
   "trackEditor": {
     "toastCopied": "Copied!",

--- a/src/locales/es/admin.json
+++ b/src/locales/es/admin.json
@@ -10,7 +10,8 @@
     "tracks": "Pistas",
     "courses": "Circuitos",
     "tools": "Herramientas",
-    "banned": "IP bloqueadas"
+    "banned": "IP bloqueadas",
+    "users": "Usuarios"
   },
   "common": {
     "error": "Error",
@@ -134,7 +135,9 @@
     "trackCount_other": "{{count}} pistas",
     "bulkSummary": "{{courses}} en {{tracks}} • {{date}}",
     "approveAll": "Aprobar todo ({{count}})",
-    "denyAll": "Rechazar todo"
+    "denyAll": "Rechazar todo",
+    "byUser": "por {{name}}",
+    "anonymous": "Anónimo"
   },
   "courses": {
     "created": "Circuito creado",
@@ -169,5 +172,33 @@
     "overridePlaceholder": "automático",
     "noLayouts": "Aún no hay trazados dibujados. Edita un circuito y usa la herramienta Dibujar para trazar el contorno de la pista.",
     "unknownCourse": "Desconocido"
+  },
+  "users": {
+    "title": "Gestión de usuarios",
+    "refresh": "Actualizar",
+    "none": "No se encontraron usuarios.",
+    "loadError": "Error al cargar los usuarios",
+    "comp": "cortesía",
+    "submissions_one": "{{count}} envío",
+    "submissions_other": "{{count}} envíos",
+    "ofLimit": "de {{limit}}",
+    "noEmail": "Sin correo",
+    "userId": "ID de usuario",
+    "created": "Creado",
+    "statusLabel": "Estado",
+    "statusFree": "gratis",
+    "renewsOrEnds": "Premium hasta",
+    "usage": "Almacenamiento usado",
+    "stripeManaged": "Este usuario tiene una suscripción de Stripe; gestiónala en Stripe.",
+    "grantLabel": "Conceder premium gratis:",
+    "months": "meses",
+    "grantPremium": "Conceder premium",
+    "removeGrant": "Quitar concesión",
+    "loadMore": "Cargar más",
+    "invalidMonths": "Introduce un número de meses válido",
+    "granted_one": "Se concedió {{count}} mes de premium",
+    "granted_other": "Se concedieron {{count}} meses de premium",
+    "grantFailed": "La acción falló",
+    "grantRemoved": "Concesión de premium eliminada"
   }
 }

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -37,7 +37,10 @@
     "upgrade": "Mejora desde las tarjetas de Planes y precios.",
     "changePlan": "Cambiar de plan",
     "manageSubscription": "Gestionar suscripción",
-    "portalFailed": "No se pudo abrir el portal de facturación."
+    "portalFailed": "No se pudo abrir el portal de facturación.",
+    "compBadge": "Cortesía",
+    "comp": "Plan de cortesía — un obsequio del equipo.",
+    "compUntil": "Plan de cortesía — gratis hasta el {{date}}."
   },
   "storage": {
     "title": "Almacenamiento",

--- a/src/locales/es/tracks.json
+++ b/src/locales/es/tracks.json
@@ -119,7 +119,9 @@
     "back": "Atrás",
     "submitting": "Enviando…",
     "submitBtn_one": "Enviar {{count}} trazado",
-    "submitBtn_other": "Enviar {{count}} trazados"
+    "submitBtn_other": "Enviar {{count}} trazados",
+    "accountNotice": "Enviando sin una cuenta. Inicia sesión primero para obtener almacenamiento en la nube gratis por las pistas que aportes.",
+    "accountNoticeSignedIn": "Has iniciado sesión: aportar estas pistas te da almacenamiento en la nube gratis."
   },
   "trackEditor": {
     "toastCopied": "¡Copiado!",

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -10,7 +10,8 @@
     "tracks": "Circuits",
     "courses": "Parcours",
     "tools": "Outils",
-    "banned": "IP bannies"
+    "banned": "IP bannies",
+    "users": "Utilisateurs"
   },
   "common": {
     "error": "Erreur",
@@ -134,7 +135,9 @@
     "trackCount_other": "{{count}} circuits",
     "bulkSummary": "{{courses}} sur {{tracks}} • {{date}}",
     "approveAll": "Tout approuver ({{count}})",
-    "denyAll": "Tout refuser"
+    "denyAll": "Tout refuser",
+    "byUser": "par {{name}}",
+    "anonymous": "Anonyme"
   },
   "courses": {
     "created": "Parcours créé",
@@ -169,5 +172,33 @@
     "overridePlaceholder": "auto",
     "noLayouts": "Aucun tracé dessiné pour l'instant. Modifiez un parcours et utilisez l'outil Dessiner pour tracer le contour du circuit.",
     "unknownCourse": "Inconnu"
+  },
+  "users": {
+    "title": "Gestion des utilisateurs",
+    "refresh": "Actualiser",
+    "none": "Aucun utilisateur trouvé.",
+    "loadError": "Échec du chargement des utilisateurs",
+    "comp": "offert",
+    "submissions_one": "{{count}} contribution",
+    "submissions_other": "{{count}} contributions",
+    "ofLimit": "sur {{limit}}",
+    "noEmail": "Aucun e-mail",
+    "userId": "ID utilisateur",
+    "created": "Créé",
+    "statusLabel": "Statut",
+    "statusFree": "gratuit",
+    "renewsOrEnds": "Premium jusqu'au",
+    "usage": "Stockage utilisé",
+    "stripeManaged": "Cet utilisateur a un abonnement Stripe — gérez-le dans Stripe.",
+    "grantLabel": "Offrir premium gratuit :",
+    "months": "mois",
+    "grantPremium": "Offrir premium",
+    "removeGrant": "Retirer l'offre",
+    "loadMore": "Charger plus",
+    "invalidMonths": "Saisissez un nombre de mois valide",
+    "granted_one": "{{count}} mois de premium offert",
+    "granted_other": "{{count}} mois de premium offerts",
+    "grantFailed": "L'action a échoué",
+    "grantRemoved": "Offre premium retirée"
   }
 }

--- a/src/locales/fr/plugins.json
+++ b/src/locales/fr/plugins.json
@@ -37,7 +37,10 @@
     "upgrade": "Mettez à niveau depuis les cartes Forfaits et tarifs.",
     "changePlan": "Changer de forfait",
     "manageSubscription": "Gérer l'abonnement",
-    "portalFailed": "Impossible d'ouvrir le portail de facturation."
+    "portalFailed": "Impossible d'ouvrir le portail de facturation.",
+    "compBadge": "Offert",
+    "comp": "Plan offert — gracieusement par l'équipe.",
+    "compUntil": "Plan offert — gratuit jusqu'au {{date}}."
   },
   "storage": {
     "title": "Stockage",

--- a/src/locales/fr/tracks.json
+++ b/src/locales/fr/tracks.json
@@ -119,7 +119,9 @@
     "back": "Retour",
     "submitting": "Envoi…",
     "submitBtn_one": "Envoyer {{count}} tracé",
-    "submitBtn_other": "Envoyer {{count}} tracés"
+    "submitBtn_other": "Envoyer {{count}} tracés",
+    "accountNotice": "Envoi sans compte. Connectez-vous d'abord pour obtenir un stockage cloud gratuit pour les circuits que vous partagez.",
+    "accountNoticeSignedIn": "Vous êtes connecté — partager ces circuits vous offre un stockage cloud gratuit."
   },
   "trackEditor": {
     "toastCopied": "Copié !",

--- a/src/locales/it/admin.json
+++ b/src/locales/it/admin.json
@@ -10,7 +10,8 @@
     "tracks": "Piste",
     "courses": "Circuiti",
     "tools": "Strumenti",
-    "banned": "IP bloccati"
+    "banned": "IP bloccati",
+    "users": "Utenti"
   },
   "common": {
     "error": "Errore",
@@ -134,7 +135,9 @@
     "trackCount_other": "{{count}} piste",
     "bulkSummary": "{{courses}} su {{tracks}} • {{date}}",
     "approveAll": "Approva tutto ({{count}})",
-    "denyAll": "Rifiuta tutto"
+    "denyAll": "Rifiuta tutto",
+    "byUser": "da {{name}}",
+    "anonymous": "Anonimo"
   },
   "courses": {
     "created": "Circuito creato",
@@ -169,5 +172,33 @@
     "overridePlaceholder": "auto",
     "noLayouts": "Nessun tracciato disegnato ancora. Modifica un circuito e usa lo strumento Disegna per tracciare il contorno della pista.",
     "unknownCourse": "Sconosciuto"
+  },
+  "users": {
+    "title": "Gestione utenti",
+    "refresh": "Aggiorna",
+    "none": "Nessun utente trovato.",
+    "loadError": "Impossibile caricare gli utenti",
+    "comp": "omaggio",
+    "submissions_one": "{{count}} invio",
+    "submissions_other": "{{count}} invii",
+    "ofLimit": "di {{limit}}",
+    "noEmail": "Nessuna email",
+    "userId": "ID utente",
+    "created": "Creato",
+    "statusLabel": "Stato",
+    "statusFree": "gratis",
+    "renewsOrEnds": "Premium fino al",
+    "usage": "Spazio utilizzato",
+    "stripeManaged": "Questo utente ha un abbonamento Stripe — gestiscilo in Stripe.",
+    "grantLabel": "Concedi premium gratis:",
+    "months": "mesi",
+    "grantPremium": "Concedi premium",
+    "removeGrant": "Rimuovi concessione",
+    "loadMore": "Carica altro",
+    "invalidMonths": "Inserisci un numero di mesi valido",
+    "granted_one": "Concesso {{count}} mese di premium",
+    "granted_other": "Concessi {{count}} mesi di premium",
+    "grantFailed": "Azione non riuscita",
+    "grantRemoved": "Concessione premium rimossa"
   }
 }

--- a/src/locales/it/plugins.json
+++ b/src/locales/it/plugins.json
@@ -37,7 +37,10 @@
     "upgrade": "Esegui l'upgrade dalle schede Piani e prezzi.",
     "changePlan": "Cambia piano",
     "manageSubscription": "Gestisci abbonamento",
-    "portalFailed": "Impossibile aprire il portale di fatturazione."
+    "portalFailed": "Impossibile aprire il portale di fatturazione.",
+    "compBadge": "Omaggio",
+    "comp": "Piano omaggio — offerto dal team.",
+    "compUntil": "Piano omaggio — gratis fino al {{date}}."
   },
   "storage": {
     "title": "Spazio",

--- a/src/locales/it/tracks.json
+++ b/src/locales/it/tracks.json
@@ -119,7 +119,9 @@
     "back": "Indietro",
     "submitting": "Invio in corso…",
     "submitBtn_one": "Invia {{count}} tracciato",
-    "submitBtn_other": "Invia {{count}} tracciati"
+    "submitBtn_other": "Invia {{count}} tracciati",
+    "accountNotice": "Invio senza un account. Accedi prima per ottenere spazio cloud gratuito per i circuiti che condividi.",
+    "accountNoticeSignedIn": "Hai effettuato l'accesso: contribuire con questi circuiti ti dà spazio cloud gratuito."
   },
   "trackEditor": {
     "toastCopied": "Copiato!",

--- a/src/locales/ja/admin.json
+++ b/src/locales/ja/admin.json
@@ -10,7 +10,8 @@
     "tracks": "トラック",
     "courses": "コース",
     "tools": "ツール",
-    "banned": "禁止 IP"
+    "banned": "禁止 IP",
+    "users": "ユーザー"
   },
   "common": {
     "error": "エラー",
@@ -134,7 +135,9 @@
     "trackCount_other": "{{count}} トラック",
     "bulkSummary": "{{tracks}}の{{courses}} • {{date}}",
     "approveAll": "すべて承認 ({{count}})",
-    "denyAll": "すべて却下"
+    "denyAll": "すべて却下",
+    "byUser": "{{name}} さん",
+    "anonymous": "匿名"
   },
   "courses": {
     "created": "コースを作成しました",
@@ -169,5 +172,33 @@
     "overridePlaceholder": "自動",
     "noLayouts": "まだレイアウトが描画されていません。コースを編集し、描画ツールでトラックの輪郭をなぞってください。",
     "unknownCourse": "不明"
+  },
+  "users": {
+    "title": "ユーザー管理",
+    "refresh": "更新",
+    "none": "ユーザーが見つかりません。",
+    "loadError": "ユーザーの読み込みに失敗しました",
+    "comp": "無償提供",
+    "submissions_one": "{{count}}件の投稿",
+    "submissions_other": "{{count}}件の投稿",
+    "ofLimit": "/ {{limit}}",
+    "noEmail": "メールなし",
+    "userId": "ユーザーID",
+    "created": "作成日",
+    "statusLabel": "ステータス",
+    "statusFree": "無料",
+    "renewsOrEnds": "プレミアム有効期限",
+    "usage": "使用ストレージ",
+    "stripeManaged": "このユーザーには Stripe のサブスクリプションがあります。Stripe で管理してください。",
+    "grantLabel": "無料プレミアムを付与:",
+    "months": "か月",
+    "grantPremium": "プレミアムを付与",
+    "removeGrant": "付与を取り消す",
+    "loadMore": "もっと読み込む",
+    "invalidMonths": "有効な月数を入力してください",
+    "granted_one": "{{count}}か月のプレミアムを付与しました",
+    "granted_other": "{{count}}か月のプレミアムを付与しました",
+    "grantFailed": "操作に失敗しました",
+    "grantRemoved": "プレミアム付与を取り消しました"
   }
 }

--- a/src/locales/ja/plugins.json
+++ b/src/locales/ja/plugins.json
@@ -37,7 +37,10 @@
     "upgrade": "プランと料金のカードからアップグレードしてください。",
     "changePlan": "プランを変更",
     "manageSubscription": "サブスクリプションを管理",
-    "portalFailed": "請求ポータルを開けませんでした。"
+    "portalFailed": "請求ポータルを開けませんでした。",
+    "compBadge": "無償提供",
+    "comp": "無償提供プラン — チームからの提供です。",
+    "compUntil": "無償提供プラン — {{date}} まで無料です。"
   },
   "storage": {
     "title": "ストレージ",

--- a/src/locales/ja/tracks.json
+++ b/src/locales/ja/tracks.json
@@ -119,7 +119,9 @@
     "back": "戻る",
     "submitting": "送信中…",
     "submitBtn_one": "{{count}}件のコースを送信",
-    "submitBtn_other": "{{count}}件のコースを送信"
+    "submitBtn_other": "{{count}}件のコースを送信",
+    "accountNotice": "アカウントなしで送信しています。先にサインインすると、提供したトラックに対して無料のクラウドストレージを獲得できます。",
+    "accountNoticeSignedIn": "サインイン済みです。これらのトラックを提供すると無料のクラウドストレージを獲得できます。"
   },
   "trackEditor": {
     "toastCopied": "コピーしました！",

--- a/src/locales/pt-BR/admin.json
+++ b/src/locales/pt-BR/admin.json
@@ -10,7 +10,8 @@
     "tracks": "Pistas",
     "courses": "Circuitos",
     "tools": "Ferramentas",
-    "banned": "IPs banidos"
+    "banned": "IPs banidos",
+    "users": "Usuários"
   },
   "common": {
     "error": "Erro",
@@ -134,7 +135,9 @@
     "trackCount_other": "{{count}} pistas",
     "bulkSummary": "{{courses}} em {{tracks}} • {{date}}",
     "approveAll": "Aprovar tudo ({{count}})",
-    "denyAll": "Recusar tudo"
+    "denyAll": "Recusar tudo",
+    "byUser": "por {{name}}",
+    "anonymous": "Anônimo"
   },
   "courses": {
     "created": "Circuito criado",
@@ -169,5 +172,33 @@
     "overridePlaceholder": "automático",
     "noLayouts": "Nenhum traçado desenhado ainda. Edite um circuito e use a ferramenta Desenhar para traçar o contorno da pista.",
     "unknownCourse": "Desconhecido"
+  },
+  "users": {
+    "title": "Gerenciamento de usuários",
+    "refresh": "Atualizar",
+    "none": "Nenhum usuário encontrado.",
+    "loadError": "Falha ao carregar usuários",
+    "comp": "cortesia",
+    "submissions_one": "{{count}} envio",
+    "submissions_other": "{{count}} envios",
+    "ofLimit": "de {{limit}}",
+    "noEmail": "Sem e-mail",
+    "userId": "ID do usuário",
+    "created": "Criado",
+    "statusLabel": "Status",
+    "statusFree": "grátis",
+    "renewsOrEnds": "Premium até",
+    "usage": "Armazenamento usado",
+    "stripeManaged": "Este usuário tem uma assinatura Stripe — gerencie no Stripe.",
+    "grantLabel": "Conceder premium grátis:",
+    "months": "meses",
+    "grantPremium": "Conceder premium",
+    "removeGrant": "Remover concessão",
+    "loadMore": "Carregar mais",
+    "invalidMonths": "Insira um número de meses válido",
+    "granted_one": "{{count}} mês de premium concedido",
+    "granted_other": "{{count}} meses de premium concedidos",
+    "grantFailed": "A ação falhou",
+    "grantRemoved": "Concessão premium removida"
   }
 }

--- a/src/locales/pt-BR/plugins.json
+++ b/src/locales/pt-BR/plugins.json
@@ -37,7 +37,10 @@
     "upgrade": "Faça upgrade pelos cartões de Planos e preços.",
     "changePlan": "Mudar de plano",
     "manageSubscription": "Gerenciar assinatura",
-    "portalFailed": "Não foi possível abrir o portal de cobrança."
+    "portalFailed": "Não foi possível abrir o portal de cobrança.",
+    "compBadge": "Cortesia",
+    "comp": "Plano cortesia — um presente da equipe.",
+    "compUntil": "Plano cortesia — grátis até {{date}}."
   },
   "storage": {
     "title": "Armazenamento",

--- a/src/locales/pt-BR/tracks.json
+++ b/src/locales/pt-BR/tracks.json
@@ -119,7 +119,9 @@
     "back": "Voltar",
     "submitting": "Enviando…",
     "submitBtn_one": "Enviar {{count}} traçado",
-    "submitBtn_other": "Enviar {{count}} traçados"
+    "submitBtn_other": "Enviar {{count}} traçados",
+    "accountNotice": "Enviando sem uma conta. Entre primeiro para ganhar armazenamento na nuvem grátis pelas pistas que você contribuir.",
+    "accountNoticeSignedIn": "Você está conectado — contribuir com essas pistas garante armazenamento na nuvem grátis."
   },
   "trackEditor": {
     "toastCopied": "Copiado!",

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -11,6 +11,7 @@ import { CoursesTab } from '@/components/admin/CoursesTab';
 import { ToolsTab } from '@/components/admin/ToolsTab';
 import { BannedIpsTab } from '@/components/admin/BannedIpsTab';
 import { MessagesTab } from '@/components/admin/MessagesTab';
+import { UsersTab } from '@/components/admin/UsersTab';
 
 export default function Admin() {
   const { t } = useTranslation('admin');
@@ -56,7 +57,7 @@ export default function Admin() {
 
       <main className="flex-1 p-6 max-w-6xl mx-auto w-full">
         <Tabs defaultValue="messages" className="w-full">
-          <TabsList className="grid w-full grid-cols-6">
+          <TabsList className="grid w-full grid-cols-7">
             <TabsTrigger value="messages" className="relative">
               {t('tabs.messages')}
               {unreadCount > 0 && (
@@ -66,6 +67,7 @@ export default function Admin() {
               )}
             </TabsTrigger>
             <TabsTrigger value="submissions">{t('tabs.submissions')}</TabsTrigger>
+            <TabsTrigger value="users">{t('tabs.users')}</TabsTrigger>
             <TabsTrigger value="tracks">{t('tabs.tracks')}</TabsTrigger>
             <TabsTrigger value="courses">{t('tabs.courses')}</TabsTrigger>
             <TabsTrigger value="tools">{t('tabs.tools')}</TabsTrigger>
@@ -73,6 +75,7 @@ export default function Admin() {
           </TabsList>
           <TabsContent value="messages"><MessagesTab onUnreadCount={setUnreadCount} /></TabsContent>
           <TabsContent value="submissions"><SubmissionsTab /></TabsContent>
+          <TabsContent value="users"><UsersTab /></TabsContent>
           <TabsContent value="tracks"><TracksTab /></TabsContent>
           <TabsContent value="courses"><CoursesTab /></TabsContent>
           <TabsContent value="tools"><ToolsTab /></TabsContent>

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { useSubscription } from "@/hooks/useSubscription";
-import { isPaidTier } from "@/lib/billing";
+import { isPaidTier, isComped } from "@/lib/billing";
 import { createPortal } from "@/lib/billingClient";
 import { onGarageChange } from "@/lib/garageEvents";
 import { getStorageUsage } from "./syncEngine";
@@ -257,6 +257,10 @@ function PlanSection() {
   const label = tiers.find((t) => t.tier === currentTier)?.label
     ?? currentTier.charAt(0).toUpperCase() + currentTier.slice(1);
   const subscribed = isPaidTier(currentTier);
+  // An admin comp (complimentary plan) — a paid tier with no Stripe subscription
+  // behind it. It has no billing portal to manage, so the comp note replaces the
+  // renews/cancel line and the Stripe buttons are hidden.
+  const comped = isComped(subscription);
   const renews = subscription?.current_period_end
     ? new Date(subscription.current_period_end).toLocaleDateString()
     : null;
@@ -267,7 +271,8 @@ function PlanSection() {
     ? new Date(subscription.grace_until).toLocaleDateString()
     : null;
   const inGrace = !subscribed && !!graceUntil;
-  const canManage = !!subscription?.current_period_end || subscribed || inGrace;
+  // Comps have no Stripe customer, so the portal can't open for them.
+  const canManage = !comped && (!!subscription?.current_period_end || subscribed || inGrace);
 
   // Open the Stripe portal — generic (cancel / payment methods) or, with
   // flow "update", deep-linked into the change-plan screen.
@@ -287,13 +292,24 @@ function PlanSection() {
       <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t("plan.title")}</p>
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-sm font-medium text-foreground">{loading ? "…" : label}</p>
-          {subscribed && renews && (
+          <p className="text-sm font-medium text-foreground">
+            {loading ? "…" : label}
+            {comped && (
+              <span className="ml-2 rounded bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary align-middle">
+                {t("plan.compBadge")}
+              </span>
+            )}
+          </p>
+          {comped ? (
+            <p className="text-[11px] text-primary">
+              {renews ? t("plan.compUntil", { date: renews }) : t("plan.comp")}
+            </p>
+          ) : subscribed && renews && (
             <p className="text-[11px] text-muted-foreground">
               {cancelsAtPeriodEnd ? t("plan.cancels", { date: renews }) : t("plan.renews", { date: renews })}
             </p>
           )}
-          {inGrace && (
+          {!comped && inGrace && (
             <p className="text-[11px] text-amber-600 dark:text-amber-500">
               {t("plan.grace", { date: graceUntil })}
             </p>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,6 +6,9 @@ verify_jwt = false
 [functions.admin-build-zip]
 verify_jwt = false
 
+[functions.admin-users]
+verify_jwt = false
+
 [functions.check-login-rate]
 verify_jwt = false
 

--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -1,0 +1,191 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+// Comp grants are bounded so a fat-fingered admin can't hand out a decade.
+const MAX_GRANT_MONTHS = 36;
+const COMP_TIER = 'premium';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+/** Add whole calendar months to a date (clamps to month end, like Stripe). */
+function addMonths(from: Date, months: number): Date {
+  const d = new Date(from);
+  d.setMonth(d.getMonth() + months);
+  return d;
+}
+
+interface SubRow {
+  user_id: string;
+  tier: string;
+  status: string;
+  current_period_end: string | null;
+  cancel_at_period_end?: boolean | null;
+  stripe_subscription_id: string | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    // ── Verify the caller is an admin ──────────────────────────────────────
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) return json({ error: 'Unauthorized' }, 401);
+
+    const supabaseAuth = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const { data: claims, error: claimsErr } =
+      await supabaseAuth.auth.getClaims(authHeader.replace('Bearer ', ''));
+    if (claimsErr || !claims?.claims?.sub) return json({ error: 'Unauthorized' }, 401);
+
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const { data: roleRow } = await admin
+      .from('user_roles')
+      .select('id')
+      .eq('user_id', claims.claims.sub)
+      .eq('role', 'admin')
+      .maybeSingle();
+    if (!roleRow) return json({ error: 'Admin access required' }, 403);
+
+    const body = req.method === 'POST' ? await req.json().catch(() => ({})) : {};
+    const action: string = body.action ?? 'list';
+
+    // ── List users with subscription + storage usage ───────────────────────
+    if (action === 'list') {
+      const page = Math.max(1, Number(body.page) || 1);
+      const perPage = Math.min(100, Math.max(1, Number(body.perPage) || 50));
+
+      const { data: listed, error: listErr } = await admin.auth.admin.listUsers({ page, perPage });
+      if (listErr) throw listErr;
+      const users = listed.users;
+      const ids = users.map((u) => u.id);
+
+      // Resolve display names, subscriptions, and a contribution count in bulk.
+      const [{ data: profiles }, { data: subs }, { data: tiers }, { data: subRows }] = await Promise.all([
+        admin.from('profiles').select('user_id, display_name').in('user_id', ids),
+        admin.from('user_subscriptions').select('*').in('user_id', ids),
+        admin.from('subscription_tiers').select('tier, label, total_bytes'),
+        admin.from('submissions').select('submitted_by_user_id').in('submitted_by_user_id', ids),
+      ]);
+
+      const nameById = new Map((profiles ?? []).map((p) => [p.user_id, p.display_name as string]));
+      const subById = new Map((subs ?? []).map((s) => [s.user_id, s as SubRow]));
+      const tierByName = new Map((tiers ?? []).map((t) => [t.tier, t]));
+      const freeBytes = Number(tierByName.get('free')?.total_bytes ?? 52428800);
+      const submissionCount = new Map<string, number>();
+      for (const row of subRows ?? []) {
+        const id = (row as { submitted_by_user_id: string | null }).submitted_by_user_id;
+        if (id) submissionCount.set(id, (submissionCount.get(id) ?? 0) + 1);
+      }
+
+      // Usage is a per-user SECURITY DEFINER sum; do the page's worth in parallel.
+      const usage = await Promise.all(
+        ids.map((id) => admin.rpc('total_storage_used', { p_user: id }).then((r) => Number(r.data ?? 0))),
+      );
+      const usedById = new Map(ids.map((id, i) => [id, usage[i]]));
+
+      const now = Date.now();
+      const rows = users.map((u) => {
+        const sub = subById.get(u.id);
+        // Mirror user_tier(): a comp (no Stripe id) only counts until it expires.
+        const active = sub
+          && ['active', 'trialing', 'past_due'].includes(sub.status)
+          && (sub.stripe_subscription_id
+            || !sub.current_period_end
+            || new Date(sub.current_period_end).getTime() > now);
+        const effectiveTier = active ? sub!.tier : 'free';
+        const isComp = !!sub && !sub.stripe_subscription_id && effectiveTier !== 'free';
+        return {
+          user_id: u.id,
+          email: u.email ?? null,
+          display_name: nameById.get(u.id) ?? null,
+          created_at: u.created_at,
+          tier: effectiveTier,
+          tier_label: tierByName.get(effectiveTier)?.label ?? effectiveTier,
+          status: sub?.status ?? null,
+          current_period_end: sub?.current_period_end ?? null,
+          is_comp: isComp,
+          has_stripe: !!sub?.stripe_subscription_id,
+          used_bytes: usedById.get(u.id) ?? 0,
+          limit_bytes: Number(tierByName.get(effectiveTier)?.total_bytes ?? freeBytes),
+          submission_count: submissionCount.get(u.id) ?? 0,
+        };
+      });
+
+      return json({ users: rows, page, perPage, hasMore: users.length === perPage });
+    }
+
+    // ── Grant N free months of the comp tier ───────────────────────────────
+    if (action === 'grant_premium') {
+      const userId: string = body.user_id;
+      const months = Math.floor(Number(body.months));
+      if (!userId) return json({ error: 'user_id required' }, 400);
+      if (!Number.isFinite(months) || months < 1 || months > MAX_GRANT_MONTHS) {
+        return json({ error: `months must be between 1 and ${MAX_GRANT_MONTHS}` }, 400);
+      }
+
+      const { data: existing } = await admin
+        .from('user_subscriptions').select('*').eq('user_id', userId).maybeSingle();
+      const cur = existing as SubRow | null;
+      if (cur?.stripe_subscription_id) {
+        return json({ error: 'User has a Stripe subscription — manage it in Stripe.' }, 409);
+      }
+
+      // Extend an unexpired comp; otherwise start from now.
+      const now = new Date();
+      const base = cur?.current_period_end && new Date(cur.current_period_end) > now
+        ? new Date(cur.current_period_end) : now;
+      const end = addMonths(base, months);
+
+      const { error: upErr } = await admin.from('user_subscriptions').upsert({
+        user_id: userId,
+        tier: COMP_TIER,
+        status: 'active',
+        current_period_end: end.toISOString(),
+        cancel_at_period_end: true,
+        updated_at: now.toISOString(),
+      }, { onConflict: 'user_id' });
+      if (upErr) throw upErr;
+
+      return json({ ok: true, tier: COMP_TIER, current_period_end: end.toISOString() });
+    }
+
+    // ── Remove a comp grant (never touches a Stripe subscription) ───────────
+    if (action === 'clear_grant') {
+      const userId: string = body.user_id;
+      if (!userId) return json({ error: 'user_id required' }, 400);
+
+      const { data: existing } = await admin
+        .from('user_subscriptions').select('stripe_subscription_id').eq('user_id', userId).maybeSingle();
+      if (!existing) return json({ ok: true });
+      if ((existing as { stripe_subscription_id: string | null }).stripe_subscription_id) {
+        return json({ error: 'User has a Stripe subscription — manage it in Stripe.' }, 409);
+      }
+      const { error: delErr } = await admin
+        .from('user_subscriptions').delete().eq('user_id', userId);
+      if (delErr) throw delErr;
+      return json({ ok: true });
+    }
+
+    return json({ error: 'Unknown action' }, 400);
+  } catch (e) {
+    console.error('admin-users error:', e);
+    return json({ error: 'An error occurred. Please try again later.' }, 500);
+  }
+});

--- a/supabase/functions/submit-track/index.ts
+++ b/supabase/functions/submit-track/index.ts
@@ -149,6 +149,26 @@ Deno.serve(async (req) => {
     const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
                req.headers.get('cf-connecting-ip') || 'unknown';
 
+    // Attribute the submission to a signed-in user when the request carries a
+    // real user JWT. supabase-js attaches the session token (or, when signed
+    // out, the anon key) as the Authorization bearer — only a genuine user
+    // token resolves to a user here, so we never trust a client-supplied id.
+    let submittedByUserId: string | null = null;
+    const authHeader = req.headers.get('Authorization');
+    const token = authHeader?.replace(/^Bearer\s+/i, '');
+    if (token) {
+      try {
+        const authClient = createClient(
+          Deno.env.get('SUPABASE_URL')!,
+          Deno.env.get('SUPABASE_ANON_KEY')!,
+        );
+        const { data: userData } = await authClient.auth.getUser(token);
+        submittedByUserId = userData.user?.id ?? null;
+      } catch {
+        // Anonymous (anon key or expired token) — leave attribution null.
+      }
+    }
+
     // Verify Turnstile token (once for the whole batch)
     if (Deno.env.get('TURNSTILE_SECRET_KEY')) {
       if (!turnstile_token || typeof turnstile_token !== 'string') {
@@ -207,6 +227,7 @@ Deno.serve(async (req) => {
         course_data: s.course_data,
         status: 'pending',
         submitted_by_ip: ip,
+        submitted_by_user_id: submittedByUserId,
         batch_id: batchId,
         has_layout: hasLayout,
         layout_data: hasLayout ? s.layout_data : null,

--- a/supabase/migrations/20260617000000_submissions_user_id_comp_tier.sql
+++ b/supabase/migrations/20260617000000_submissions_user_id_comp_tier.sql
@@ -1,0 +1,51 @@
+-- Track submissions: attribute to a signed-in user, + admin-comped tiers.
+--
+-- Two related changes:
+--
+--   1. submissions.submitted_by_user_id — when a logged-in user contributes
+--      tracks, the submit-track edge function records who they are (derived from
+--      their verified JWT, never a client-supplied id). Anonymous submissions
+--      stay supported (the column is NULL). This lets an admin see who sent a
+--      contribution and reward contributors with comped storage.
+--
+--   2. user_tier() becomes comp-expiry aware. Admins can grant a user free
+--      months of a paid tier by writing a user_subscriptions row directly (no
+--      Stripe). Those comp rows have no stripe_subscription_id, so — unlike a
+--      Stripe-managed sub whose status is the source of truth — they must expire
+--      at current_period_end. Stripe-backed rows are untouched (status-only, as
+--      before), so paying users see no behavioural change.
+
+-- ── 1. Submitter attribution ────────────────────────────────────────────────
+alter table public.submissions
+  add column if not exists submitted_by_user_id uuid references auth.users(id) on delete set null;
+
+create index if not exists submissions_submitted_by_user_id_idx
+  on public.submissions (submitted_by_user_id);
+
+comment on column public.submissions.submitted_by_user_id is
+  'The signed-in user who submitted this contribution (derived from their JWT by the submit-track edge function). NULL for anonymous submissions.';
+
+-- ── 2. Comp-aware tier resolution ───────────────────────────────────────────
+-- Effective tier: a row grants its tier while status allows access AND, for
+-- comp rows (no Stripe subscription), only until current_period_end passes.
+-- Stripe-managed rows (stripe_subscription_id set) keep status-only semantics.
+create or replace function public.user_tier(p_user uuid)
+returns text language sql stable security definer set search_path = public as $$
+  select coalesce(
+    (select tier from public.user_subscriptions
+      where user_id = p_user
+        and status in ('active','trialing','past_due')
+        and (
+          stripe_subscription_id is not null   -- Stripe-managed: status is source of truth
+          or current_period_end is null        -- open-ended comp
+          or current_period_end > now()        -- comp still within its granted window
+        )
+     order by current_period_end desc nulls first
+     limit 1),
+    'free');
+$$;
+
+grant execute on function public.user_tier(uuid) to authenticated;
+
+-- Surface the new column + function to PostgREST immediately.
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## What & why

Anonymous track submissions stay exactly as they are — but we now **encourage signed-in contributions** (linking them to an account so contributors can be rewarded with cloud storage), and give admins a **basic user-management** surface.

### Primary — submitter attribution + the incentive
- **`submit-track` edge fn** now derives the contributor from their **verified JWT** and stores `submissions.submitted_by_user_id`. It never trusts a client-supplied id, and anonymous submissions stay `NULL` and work unchanged.
- **`SubmitTrackDialog`** shows a 🎁 note by the submit button — *"signed-in contributions earn free cloud storage."* Shown only on cloud builds (`VITE_ENABLE_CLOUD`); copy adapts to signed-in vs signed-out via `useAuth()`.
- **Admin → Submissions** resolves the submitter to a `profiles.display_name` and shows it (or "Anonymous") beside the existing IP/date.

### Secondary — admin user management
- New **Users** tab + **`admin-users`** edge fn (admin-gated, same JWT→`user_roles` check as `admin-build-zip`). Actions:
  - `list` — accounts with email/display name, effective plan, **pooled storage used vs limit**, and **track-contribution count**. Paginated.
  - `grant_premium` (`months` 1–36) — comp free premium; **extends** an unexpired comp.
  - `clear_grant` — remove a comp.
  - Refuses to touch a **Stripe-managed** user (manage those in Stripe).
- Comps are written straight to `user_subscriptions` with **no `stripe_subscription_id`**, and `user_tier()` is now **comp-aware** so they **auto-expire** at `current_period_end` with no cron. Stripe-backed rows keep status-only semantics — paying users see no behavioural change.

## Migration
`20260617000000_submissions_user_id_comp_tier.sql`: adds `submissions.submitted_by_user_id` (+ index, FK `on delete set null`) and the comp-aware `user_tier()`. Ends with `notify pgrst, 'reload schema'`.

## Checks
- `lint`, `typecheck`, `test:run` (1745 tests, incl. i18n parity), `test:coverage`, and `build` all green.
- i18n keys added across **all 7 languages** (parity test enforces this).
- Docs updated: `CLAUDE.md`, `docs/backend.md`, README edge-fn table, `CHANGELOG.md` (under the existing `[2.6.0] - unreleased`).

## Notes / follow-ups
- The new logic lives in Deno edge functions (outside the Vitest scope) and React/admin view code (excluded from coverage), so there's no natural pure-unit to add here — flagging rather than padding tests.
- "Free cloud storage for contributors" is currently a **manual** reward (admin comps premium from the Users tab). Auto-granting storage on approved submissions could be a future step if you want it automated.
- Based on `BETA`, targeting `BETA`. After a migration, Lovable regenerates `integrations/supabase/types.ts`; the client reads the new column through the existing cast in `getSubmissions`, so no type regen is required to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VeJLAJzx3zK2YkeSJhTThw)_