### PR TITLE
Cache per-session historical weather in local IndexedDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cloud rows and in the Profile → Cloud logs list.
 
 ### Changed
+- **Weather is cached per session.** Once a session's weather has been looked up,
+  it's saved on your device — a session's date never changes, so its weather is
+  fixed. Reopening that session shows the saved conditions instantly and no longer
+  re-queries the weather station / service every time. The cache stays on your
+  device (it isn't cloud-synced — there's no point re-uploading data the next
+  device can look up for free), and the home-screen **Local Weather** check still
+  fetches live, current conditions as before.
 - **Landing page UX overhaul** — the home screen is simpler and friendlier. The
   cluster of small buttons that used to live inside the file dropzone is gone;
   importing a file is now a single large drag-and-drop / click-to-browse zone,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ src/
 │   ├── db/                # Admin DB layer: ITrackDatabase + supabaseAdapter + getDatabase()
 │   ├── billing*.ts        # Subscription logic + Supabase billing I/O (→ docs/backend.md)
 │   ├── weatherService.ts  # Historical weather (online-only): NWS/IEM METAR → Open-Meteo fallback
+│   ├── weatherCacheStorage.ts # Per-session historical-weather cache (IndexedDB, local-only/never cloud-synced): a session's date is fixed so its weather is immutable — cache it once, stop re-pinging the station/API on reopen
 │   ├── buildInfo.ts       # Build version/hash/branch stamp + isPreviewBuild()
 │   ├── debugConsole.ts    # ★ On-screen debug console (`?dbg=true`) — mobile/PWA has no dev tools
 │   ├── units.ts           # ★ Pure unit conversions for the 3 imperial/metric toggles
@@ -200,7 +201,7 @@ Web Worker) and the binary **iRacing `.ibt`**. Details, plus the **.dovex/.dovep
 
 ## IndexedDB Storage (`src/lib/dbUtils.ts`)
 
-Single shared database: `"dove-file-manager"`, **version 12**.
+Single shared database: `"dove-file-manager"`, **version 13**.
 
 | Store | Key | Module |
 |-------|-----|--------|
@@ -214,6 +215,7 @@ Single shared database: `"dove-file-manager"`, **version 12**.
 | `engines` | `id` | `engineStorage.ts` |
 | `lap-snapshots` | `id` (indexed by `courseKey`, `engineKey`) | `lapSnapshotStorage.ts` |
 | `setup-revisions` | `id` = content hash (indexed by `setupId`) | `setupRevisionStorage.ts` |
+| `weather-cache` | `fileName` | `weatherCacheStorage.ts` (local-only, **not** cloud-synced) |
 
 To add a store: increment `DB_VERSION`, add to `STORE_NAMES`, add creation logic in
 `openDB()`, create a storage module using `withReadTransaction`/`withWriteTransaction`.

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -62,6 +62,7 @@ interface RaceLineViewProps {
   refAvgMinSpeed?: number | null;
   sessionGpsPoint?: { lat: number; lon: number };
   sessionStartDate?: Date;
+  sessionFileName?: string | null;
   cachedWeatherStation?: WeatherStation | null;
   onWeatherStationResolved?: (station: WeatherStation) => void;
   isAllLaps?: boolean;
@@ -110,7 +111,7 @@ function createSpeedEventIcon(event: SpeedEvent, useKph: boolean): L.DivIcon {
   });
 }
 
-export function RaceLineView({ samples, allSamples, referenceSamples = [], course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, showOverlayLegend = true, onToggleOverlayLegend }: RaceLineViewProps) {
+export function RaceLineView({ samples, allSamples, referenceSamples = [], course, bounds, paceDiff = null, paceDiffLabel = 'best', deltaTopSpeed = null, deltaMinSpeed = null, referenceLapNumber = null, lapToFastestDelta = null, showOverlays = true, lapTimeMs = null, refAvgTopSpeed = null, refAvgMinSpeed = null, sessionGpsPoint, sessionStartDate, sessionFileName, cachedWeatherStation, onWeatherStationResolved, isAllLaps, parserStats, overlayLines = [], rangeStart = 0, onRemoveOverlay, alignOverlays, onToggleAlignOverlays, showOverlayLegend = true, onToggleOverlayLegend }: RaceLineViewProps) {
   const { t } = useTranslation('session');
   const { useKph, brakingZoneSettings } = useSettingsContext();
   const { currentIndex } = usePlaybackContext();
@@ -807,6 +808,7 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], cours
                 lat={sessionGpsPoint?.lat}
                 lon={sessionGpsPoint?.lon}
                 sessionDate={sessionStartDate}
+                sessionFileName={sessionFileName}
                 cachedStation={cachedWeatherStation}
                 onStationResolved={onWeatherStationResolved}
                 onWeatherLoaded={setSessionWeatherData}

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -8,6 +8,7 @@ import {
   WeatherData,
   WeatherStation,
 } from "@/lib/weatherService";
+import { getCachedWeather, saveCachedWeather } from "@/lib/weatherCacheStorage";
 import { useOptionalSettingsContext } from "@/contexts/SettingsContext";
 import {
   formatTemperature,
@@ -26,6 +27,12 @@ interface WeatherPanelProps {
   lon?: number;
   sessionDate?: Date;
   cachedStation?: WeatherStation | null;
+  /**
+   * Session file name. When set, the resolved weather is read from / written to
+   * the local per-session weather cache, so reopening a session never re-pings
+   * the weather station/API (a session's date — and thus its weather — is fixed).
+   */
+  sessionFileName?: string | null;
   onStationResolved?: (station: WeatherStation) => void;
   onWeatherLoaded?: (data: WeatherData) => void;
   /** Show full detailed weather (wind, dew point, pressure alt, tuning note) */
@@ -37,6 +44,7 @@ export function WeatherPanel({
   lon,
   sessionDate,
   cachedStation,
+  sessionFileName,
   onStationResolved,
   onWeatherLoaded,
   detailed = false,
@@ -71,6 +79,20 @@ export function WeatherPanel({
     const doFetch = async () => {
       setLoading(true);
       try {
+        // A session's date never changes, so its weather is immutable: serve a
+        // previously-cached result and skip the network entirely (don't keep
+        // pinging the station/API on every reopen).
+        if (sessionFileName) {
+          const cached = await getCachedWeather(sessionFileName);
+          if (cancelled) return;
+          if (cached) {
+            setWeather(cached);
+            onWeatherLoadedRef.current?.(cached);
+            setError(false);
+            return;
+          }
+        }
+
         // One call: cached/US-ASOS path with an automatic global (Open-Meteo)
         // fallback, so non-US sessions still resolve.
         const data = await fetchSessionWeather(lat, lon, sessionDate, cachedStation);
@@ -81,6 +103,9 @@ export function WeatherPanel({
           // Cache the resolved source (real station or the Open-Meteo marker) so
           // the next open skips re-resolving it.
           if (!cachedStation) onStationResolvedRef.current?.(data.station);
+          // Persist the full result locally so we never hit the network for this
+          // session again (best-effort; the station-cache fallback still works).
+          if (sessionFileName) void saveCachedWeather(sessionFileName, data);
           setError(false);
         } else {
           setError(true);
@@ -101,7 +126,7 @@ export function WeatherPanel({
     return () => {
       cancelled = true;
     };
-  }, [lat, lon, sessionDate, cachedStation]);
+  }, [lat, lon, sessionDate, cachedStation, sessionFileName]);
 
   // Don't render if no valid GPS
   if (

--- a/src/components/tabs/RaceLineTab.tsx
+++ b/src/components/tabs/RaceLineTab.tsx
@@ -34,6 +34,7 @@ export const RaceLineTab = memo(function RaceLineTab({ showOverlays }: RaceLineT
           refAvgMinSpeed={s.refAvgMinSpeed}
           sessionGpsPoint={s.sessionGpsPoint}
           sessionStartDate={s.sessionStartDate}
+          sessionFileName={s.sessionFileName}
           cachedWeatherStation={s.cachedWeatherStation}
           onWeatherStationResolved={s.onWeatherStationResolved}
           isAllLaps={s.isAllLaps}

--- a/src/lib/dbUtils.ts
+++ b/src/lib/dbUtils.ts
@@ -5,7 +5,7 @@
  */
 
 export const DB_NAME = "dove-file-manager";
-export const DB_VERSION = 12;
+export const DB_VERSION = 13;
 
 export const STORE_NAMES = {
   FILES: "files",
@@ -21,6 +21,7 @@ export const STORE_NAMES = {
   ENGINES: "engines",       // reusable engine-type list for vehicle profiles
   LAP_SNAPSHOTS: "lap-snapshots", // frozen "course fastest lap" captures per engine
   SETUP_REVISIONS: "setup-revisions", // immutable, content-addressed frozen setups (session history)
+  WEATHER_CACHE: "weather-cache", // per-session historical weather (local-only, never cloud-synced)
 } as const;
 
 /**
@@ -90,6 +91,14 @@ export function openDB(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains(STORE_NAMES.SETUP_REVISIONS)) {
         const revStore = db.createObjectStore(STORE_NAMES.SETUP_REVISIONS, { keyPath: "id" });
         revStore.createIndex("setupId", "setupId", { unique: false });
+      }
+
+      // v13: Per-session historical weather cache. A session's date never
+      // changes, so its looked-up weather is immutable — cache it locally and
+      // stop re-pinging the weather station/API on every reopen. Keyed by the
+      // file name; deliberately NOT in the cloud-sync store list (local-only).
+      if (!db.objectStoreNames.contains(STORE_NAMES.WEATHER_CACHE)) {
+        db.createObjectStore(STORE_NAMES.WEATHER_CACHE, { keyPath: "fileName" });
       }
 
       // v8 migration: add vehicleId index to setups if upgrading from v7

--- a/src/lib/fileStorage.ts
+++ b/src/lib/fileStorage.ts
@@ -3,6 +3,7 @@
  */
 
 import { openDB, STORE_NAMES } from './dbUtils';
+import { deleteCachedWeather } from './weatherCacheStorage';
 
 export interface FileEntry {
   name: string;
@@ -114,6 +115,9 @@ export async function deleteFile(name: string): Promise<void> {
       tx.onerror = () => reject(tx.error);
     });
     db.close();
+    // Drop the session's locally-cached weather so a future file reusing this
+    // name doesn't inherit stale conditions (best-effort).
+    await deleteCachedWeather(name);
   } catch (e) {
     console.warn("Failed to delete file from IndexedDB:", e);
     throw e;

--- a/src/lib/weatherCacheStorage.idb.test.ts
+++ b/src/lib/weatherCacheStorage.idb.test.ts
@@ -1,0 +1,74 @@
+/**
+ * IndexedDB round-trip tests for weatherCacheStorage: a session's historical
+ * weather is cached locally and keyed by file name, so reopening never re-pings
+ * the weather station/API.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { freshIndexedDB } from "./__test__/idb";
+import {
+  getCachedWeather,
+  saveCachedWeather,
+  deleteCachedWeather,
+} from "./weatherCacheStorage";
+import type { WeatherData } from "./weatherService";
+
+beforeEach(() => freshIndexedDB());
+
+function sampleWeather(overrides: Partial<WeatherData> = {}): WeatherData {
+  return {
+    station: { stationId: "KOKC", name: "Oklahoma City", distanceKm: 4.2, source: "asos" },
+    temperatureF: 75,
+    temperatureC: 23.9,
+    humidity: 55,
+    altimeterInHg: 29.92,
+    densityAltitudeFt: 1500,
+    windSpeedKts: 8,
+    windDirectionDeg: 180,
+    windGustKts: null,
+    observationTime: new Date("2026-03-15T19:30:00Z"),
+    ...overrides,
+  };
+}
+
+describe("weatherCacheStorage round-trip", () => {
+  it("returns null when nothing is cached for the session", async () => {
+    expect(await getCachedWeather("none.dove")).toBeNull();
+  });
+
+  it("saves and loads a session's weather, preserving the observation Date", async () => {
+    const data = sampleWeather();
+    await saveCachedWeather("s.dove", data);
+    const loaded = await getCachedWeather("s.dove");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.temperatureF).toBe(75);
+    expect(loaded!.station.stationId).toBe("KOKC");
+    expect(loaded!.observationTime).toBeInstanceOf(Date);
+    expect(loaded!.observationTime.getTime()).toBe(new Date("2026-03-15T19:30:00Z").getTime());
+  });
+
+  it("is scoped per session file name", async () => {
+    await saveCachedWeather("a.dove", sampleWeather({ temperatureF: 60 }));
+    await saveCachedWeather("b.dove", sampleWeather({ temperatureF: 90 }));
+    expect((await getCachedWeather("a.dove"))!.temperatureF).toBe(60);
+    expect((await getCachedWeather("b.dove"))!.temperatureF).toBe(90);
+  });
+
+  it("upserts in place on re-save", async () => {
+    await saveCachedWeather("s.dove", sampleWeather({ temperatureF: 60 }));
+    await saveCachedWeather("s.dove", sampleWeather({ temperatureF: 72 }));
+    expect((await getCachedWeather("s.dove"))!.temperatureF).toBe(72);
+  });
+
+  it("deletes a session's cached weather", async () => {
+    await saveCachedWeather("s.dove", sampleWeather());
+    await deleteCachedWeather("s.dove");
+    expect(await getCachedWeather("s.dove")).toBeNull();
+  });
+
+  it("ignores empty file names without throwing", async () => {
+    await saveCachedWeather("", sampleWeather());
+    expect(await getCachedWeather("")).toBeNull();
+    await expect(deleteCachedWeather("")).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/weatherCacheStorage.ts
+++ b/src/lib/weatherCacheStorage.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-session historical weather cache (IndexedDB, local-only).
+ *
+ * A session's date/time is fixed, so the weather looked up for it never changes.
+ * Once resolved, the full result is cached here keyed by file name so reopening
+ * a session serves it instantly and we stop re-pinging the weather station / API
+ * (e.g. the IEM ASOS endpoint) on every view.
+ *
+ * This store is intentionally absent from the cloud-sync store list
+ * (`plugins/cloud-sync/syncStores.ts`): it's derived data the next device can
+ * re-fetch for itself, so syncing it would just waste the user's quota.
+ */
+import { STORE_NAMES, withReadTransaction, withWriteTransaction } from "./dbUtils";
+import type { WeatherData } from "./weatherService";
+
+interface WeatherCacheRecord {
+  fileName: string;
+  data: WeatherData;
+  /** When this entry was cached (epoch ms) — for future TTL/eviction if needed. */
+  cachedAt: number;
+}
+
+const STORE = STORE_NAMES.WEATHER_CACHE;
+
+/** Return the cached weather for a session file, or null when not cached. */
+export async function getCachedWeather(fileName: string): Promise<WeatherData | null> {
+  if (!fileName) return null;
+  const record = await withReadTransaction<WeatherCacheRecord | undefined>(
+    STORE,
+    (store) => store.get(fileName),
+  );
+  return record?.data ?? null;
+}
+
+/** Cache the resolved weather for a session file. */
+export async function saveCachedWeather(fileName: string, data: WeatherData): Promise<void> {
+  if (!fileName) return;
+  await withWriteTransaction(STORE, (store) => {
+    store.put({ fileName, data, cachedAt: Date.now() } satisfies WeatherCacheRecord);
+  });
+}
+
+/** Drop a session's cached weather (e.g. when its file is deleted). */
+export async function deleteCachedWeather(fileName: string): Promise<void> {
+  if (!fileName) return;
+  await withWriteTransaction(STORE, (store) => {
+    store.delete(fileName);
+  });
+}


### PR DESCRIPTION
## Why

A session's date/time is fixed, so the weather looked up for it never changes — yet `WeatherPanel` re-fetched it from the NWS / IEM ASOS endpoint (or the Open-Meteo fallback) on **every** reopen, needlessly hammering the upstream station. This caches the result so the station gets pinged at most once per session.

## What

- **New local-only IndexedDB store `weather-cache`** (keyed by file name, DB `v12 → v13`) in `weatherCacheStorage.ts` (`get`/`save`/`delete`).
- **`WeatherPanel`** takes a `sessionFileName` prop: on a cache hit it serves the stored conditions and **skips the network entirely**; on a miss it fetches once and persists the full `WeatherData`. Threaded through `RaceLineTab → RaceLineView → WeatherPanel` from the existing `SessionContext.sessionFileName`.
- **Not cloud-synced.** The store is deliberately excluded from cloud-sync's `DOC_STORES` — it's derived data the next device can re-fetch for free, so syncing it would just waste the user's storage quota.
- **Home-screen Local Weather is untouched** — `LocalWeatherDialog` still fetches live, current conditions (it passes no `sessionFileName` and queries `new Date()`).
- **Cache invalidation:** dropped in `deleteFile()` so a future file reusing the name can't inherit stale conditions.

## Tests / checks

- New `weatherCacheStorage.idb.test.ts` round-trip coverage (save/load/delete, per-file scoping, upsert, Date preservation, empty-name guard).
- `bun run lint`, `bun run typecheck`, `bun run build` clean; full suite **1751 tests pass**.
- `CHANGELOG.md` (2.6.0) + `CLAUDE.md` (store table + version + architecture map) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmXnxstpEwcC4gvjMC7mvz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmXnxstpEwcC4gvjMC7mvz)_