### PR TITLE
Device settings: add Device Name field with "use profile name" shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.0] - unreleased
 
 ### Added
+- **Device Name setting for the logger.** The Device → Settings screen now
+  supports a **Device Name** field (a free-text name, up to 32 characters) for
+  loggers whose firmware exposes it. When you're signed in, a **Use profile name**
+  shortcut fills the field with your account name in one tap.
 - **Feature roadmap on the home screen.** The landing page now shows a short
   "Remaining feature roadmap" panel under the action tiles, listing what's still
   coming (cheaper DIY logger, leaderboards & public profiles, 3rd-party logger

--- a/src/components/drawer/DeviceSettingsTab.tsx
+++ b/src/components/drawer/DeviceSettingsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Save, AlertCircle, RefreshCw, RotateCcw } from "lucide-react";
+import { Loader2, Save, AlertCircle, RefreshCw, RotateCcw, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
@@ -11,7 +11,11 @@ import {
   getSettingDef,
   validateSettingValue,
 } from "@/lib/deviceSettingsSchema";
+import { useAuth } from "@/contexts/AuthContext";
 import { FirmwareUpdateSection } from "./FirmwareUpdateSection";
+
+/** The setting whose field offers a "use profile name" shortcut. */
+const DEVICE_NAME_KEY = "device_name";
 
 interface DeviceSettingsTabProps {
   connection: BleConnection;
@@ -28,11 +32,40 @@ interface SettingRow {
 
 export function DeviceSettingsTab({ connection, onResetComplete }: DeviceSettingsTabProps) {
   const { t } = useTranslation("drawer");
+  const { user } = useAuth();
   const [rows, setRows] = useState<SettingRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [resetting, setResetting] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
+  // The signed-in user's account name, used by the "use profile name" shortcut
+  // on the Device Name field. Loaded lazily so the Supabase client never lands
+  // on the offline-first eager graph; null when signed out or unavailable.
+  const [profileName, setProfileName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setProfileName(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { supabase } = await import("@/integrations/supabase/client");
+        const { data } = await supabase
+          .from("profiles")
+          .select("display_name")
+          .eq("user_id", user.id)
+          .maybeSingle();
+        if (!cancelled) setProfileName(data?.display_name?.trim() || null);
+      } catch {
+        if (!cancelled) setProfileName(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
 
   const fetchSettings = useCallback(async () => {
     setLoading(true);
@@ -171,6 +204,17 @@ export function DeviceSettingsTab({ connection, onResetComplete }: DeviceSetting
                 )}
               </Button>
             </div>
+            {row.key === DEVICE_NAME_KEY && profileName && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+                onClick={() => handleChange(i, profileName.slice(0, def?.maxLength ?? profileName.length))}
+              >
+                <UserRound className="w-3.5 h-3.5" />
+                {t("device.useProfileName")}
+              </Button>
+            )}
             {row.error && (
               <p className="text-xs text-destructive">{row.error}</p>
             )}

--- a/src/lib/deviceSettingsSchema.test.ts
+++ b/src/lib/deviceSettingsSchema.test.ts
@@ -22,10 +22,24 @@ describe("DEVICE_SETTINGS_SCHEMA", () => {
 
   it("includes the known device keys", () => {
     const keys = DEVICE_SETTINGS_SCHEMA.map((d) => d.key);
+    expect(keys).toContain("device_name");
     expect(keys).toContain("bluetooth_name");
     expect(keys).toContain("bluetooth_pin");
     expect(keys).toContain("lap_detection_distance");
     expect(keys).toContain("use_legacy_csv");
+  });
+
+  it("defines device_name as a 32-character string field", () => {
+    const def = getSettingDef("device_name");
+    expect(def?.type).toBe("string");
+    expect(def?.maxLength).toBe(32);
+  });
+
+  it("rejects a device_name over 32 characters", () => {
+    expect(validateSettingValue("device_name", "x".repeat(32))).toBeNull();
+    expect(validateSettingValue("device_name", "x".repeat(33))).toBe(
+      "Maximum 32 characters"
+    );
   });
 });
 

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -14,6 +14,13 @@ export interface DeviceSettingDef {
 
 export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
   {
+    key: 'device_name',
+    label: 'Device Name',
+    type: 'string',
+    maxLength: 32,
+    description: 'A custom name for this logger',
+  },
+  {
     key: 'bluetooth_name',
     label: 'Bluetooth Name',
     type: 'string',

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -1,9 +1,21 @@
 {
   "_machine": true,
   "shell": {
-    "tabs": { "garage": "Garage", "profile": "Profil", "device": "Gerät" },
-    "garageTabs": { "files": "Dateien", "vehicles": "Fahrzeuge", "setups": "Setups", "notes": "Notizen" },
-    "deviceTabs": { "settings": "Einstellungen", "tracks": "Strecken" },
+    "tabs": {
+      "garage": "Garage",
+      "profile": "Profil",
+      "device": "Gerät"
+    },
+    "garageTabs": {
+      "files": "Dateien",
+      "vehicles": "Fahrzeuge",
+      "setups": "Setups",
+      "notes": "Notizen"
+    },
+    "deviceTabs": {
+      "settings": "Einstellungen",
+      "tracks": "Strecken"
+    },
     "disconnect": "Trennen",
     "batteryTitle": "{{voltage}} V — zum Aktualisieren klicken",
     "btNotAvailable": "Bluetooth nicht verfügbar",
@@ -207,6 +219,7 @@
     "readingSettings": "Einstellungen werden gelesen…",
     "retry": "Erneut versuchen",
     "noSettings": "Keine Einstellungen auf dem Gerät gefunden.",
+    "useProfileName": "Profilnamen verwenden",
     "reset": "Einstellungen auf Standard zurücksetzen",
     "resetConfirm": "Zurücksetzen bestätigen — Gerät startet neu",
     "cancel": "Abbrechen",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -218,6 +218,7 @@
     "readingSettings": "Reading settings…",
     "retry": "Retry",
     "noSettings": "No settings found on device.",
+    "useProfileName": "Use profile name",
     "reset": "Reset Settings to Default",
     "resetConfirm": "Confirm Reset — Device Will Reboot",
     "cancel": "Cancel",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -1,9 +1,21 @@
 {
   "_machine": true,
   "shell": {
-    "tabs": { "garage": "Garaje", "profile": "Perfil", "device": "Dispositivo" },
-    "garageTabs": { "files": "Archivos", "vehicles": "Vehículos", "setups": "Reglajes", "notes": "Notas" },
-    "deviceTabs": { "settings": "Ajustes", "tracks": "Circuitos" },
+    "tabs": {
+      "garage": "Garaje",
+      "profile": "Perfil",
+      "device": "Dispositivo"
+    },
+    "garageTabs": {
+      "files": "Archivos",
+      "vehicles": "Vehículos",
+      "setups": "Reglajes",
+      "notes": "Notas"
+    },
+    "deviceTabs": {
+      "settings": "Ajustes",
+      "tracks": "Circuitos"
+    },
     "disconnect": "Desconectar",
     "batteryTitle": "{{voltage}} V — haz clic para actualizar",
     "btNotAvailable": "Bluetooth no disponible",
@@ -207,6 +219,7 @@
     "readingSettings": "Leyendo ajustes…",
     "retry": "Reintentar",
     "noSettings": "No se encontraron ajustes en el dispositivo.",
+    "useProfileName": "Usar nombre de perfil",
     "reset": "Restablecer ajustes predeterminados",
     "resetConfirm": "Confirmar restablecimiento: el dispositivo se reiniciará",
     "cancel": "Cancelar",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -1,9 +1,21 @@
 {
   "_machine": true,
   "shell": {
-    "tabs": { "garage": "Garage", "profile": "Profil", "device": "Appareil" },
-    "garageTabs": { "files": "Fichiers", "vehicles": "Véhicules", "setups": "Réglages", "notes": "Notes" },
-    "deviceTabs": { "settings": "Réglages", "tracks": "Circuits" },
+    "tabs": {
+      "garage": "Garage",
+      "profile": "Profil",
+      "device": "Appareil"
+    },
+    "garageTabs": {
+      "files": "Fichiers",
+      "vehicles": "Véhicules",
+      "setups": "Réglages",
+      "notes": "Notes"
+    },
+    "deviceTabs": {
+      "settings": "Réglages",
+      "tracks": "Circuits"
+    },
     "disconnect": "Déconnecter",
     "batteryTitle": "{{voltage}} V — cliquez pour actualiser",
     "btNotAvailable": "Bluetooth non disponible",
@@ -207,6 +219,7 @@
     "readingSettings": "Lecture des réglages…",
     "retry": "Réessayer",
     "noSettings": "Aucun réglage trouvé sur l'appareil.",
+    "useProfileName": "Utiliser le nom du profil",
     "reset": "Réinitialiser les réglages par défaut",
     "resetConfirm": "Confirmer la réinitialisation — l'appareil va redémarrer",
     "cancel": "Annuler",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -1,9 +1,21 @@
 {
   "_machine": true,
   "shell": {
-    "tabs": { "garage": "Garage", "profile": "Profilo", "device": "Dispositivo" },
-    "garageTabs": { "files": "File", "vehicles": "Veicoli", "setups": "Assetti", "notes": "Note" },
-    "deviceTabs": { "settings": "Impostazioni", "tracks": "Piste" },
+    "tabs": {
+      "garage": "Garage",
+      "profile": "Profilo",
+      "device": "Dispositivo"
+    },
+    "garageTabs": {
+      "files": "File",
+      "vehicles": "Veicoli",
+      "setups": "Assetti",
+      "notes": "Note"
+    },
+    "deviceTabs": {
+      "settings": "Impostazioni",
+      "tracks": "Piste"
+    },
     "disconnect": "Disconnetti",
     "batteryTitle": "{{voltage}} V — clicca per aggiornare",
     "btNotAvailable": "Bluetooth non disponibile",
@@ -207,6 +219,7 @@
     "readingSettings": "Lettura impostazioni…",
     "retry": "Riprova",
     "noSettings": "Nessuna impostazione trovata sul dispositivo.",
+    "useProfileName": "Usa il nome del profilo",
     "reset": "Ripristina impostazioni predefinite",
     "resetConfirm": "Conferma ripristino — il dispositivo si riavvierà",
     "cancel": "Annulla",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -1,9 +1,21 @@
 {
   "_machine": true,
   "shell": {
-    "tabs": { "garage": "ガレージ", "profile": "プロフィール", "device": "デバイス" },
-    "garageTabs": { "files": "ファイル", "vehicles": "車両", "setups": "セットアップ", "notes": "メモ" },
-    "deviceTabs": { "settings": "設定", "tracks": "コース" },
+    "tabs": {
+      "garage": "ガレージ",
+      "profile": "プロフィール",
+      "device": "デバイス"
+    },
+    "garageTabs": {
+      "files": "ファイル",
+      "vehicles": "車両",
+      "setups": "セットアップ",
+      "notes": "メモ"
+    },
+    "deviceTabs": {
+      "settings": "設定",
+      "tracks": "コース"
+    },
     "disconnect": "切断",
     "batteryTitle": "{{voltage}} V — クリックして更新",
     "btNotAvailable": "Bluetooth を利用できません",
@@ -207,6 +219,7 @@
     "readingSettings": "設定を読み込み中…",
     "retry": "再試行",
     "noSettings": "デバイスに設定が見つかりません。",
+    "useProfileName": "プロフィール名を使う",
     "reset": "設定を既定値に戻す",
     "resetConfirm": "リセットを確定 — デバイスが再起動します",
     "cancel": "キャンセル",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -1,9 +1,21 @@
 {
   "_machine": true,
   "shell": {
-    "tabs": { "garage": "Garagem", "profile": "Perfil", "device": "Dispositivo" },
-    "garageTabs": { "files": "Arquivos", "vehicles": "Veículos", "setups": "Acertos", "notes": "Notas" },
-    "deviceTabs": { "settings": "Configurações", "tracks": "Pistas" },
+    "tabs": {
+      "garage": "Garagem",
+      "profile": "Perfil",
+      "device": "Dispositivo"
+    },
+    "garageTabs": {
+      "files": "Arquivos",
+      "vehicles": "Veículos",
+      "setups": "Acertos",
+      "notes": "Notas"
+    },
+    "deviceTabs": {
+      "settings": "Configurações",
+      "tracks": "Pistas"
+    },
     "disconnect": "Desconectar",
     "batteryTitle": "{{voltage}} V — clique para atualizar",
     "btNotAvailable": "Bluetooth indisponível",
@@ -207,6 +219,7 @@
     "readingSettings": "Lendo configurações…",
     "retry": "Tentar novamente",
     "noSettings": "Nenhuma configuração encontrada no dispositivo.",
+    "useProfileName": "Usar nome do perfil",
     "reset": "Restaurar configurações padrão",
     "resetConfirm": "Confirmar restauração — o dispositivo vai reiniciar",
     "cancel": "Cancelar",


### PR DESCRIPTION
## Summary

Adds a new **Device Name** datalogger setting, ready for firmware to start reporting the `device_name` key.

- **New setting key: `device_name`** — added to `DEVICE_SETTINGS_SCHEMA` as a free-text **string** field, **max 32 characters**, labelled "Device Name". Like every other setting, the row only appears in **Device → Settings** when the connected firmware actually reports the key via `SLIST` — so this is a no-op against current firmware and lights up automatically once the firmware exposes `device_name`.
- **"Use profile name" shortcut** — when the user is signed in, the Device Name field shows a small **Use profile name** button that copies their account display name into the field (truncated to the 32-char cap). The profile name is fetched lazily via a dynamic `import()` of the Supabase client, so `vendor-supabase` stays off the offline-first eager graph (per the bundle-splitting rules). Signed-out users simply don't see the button.

## Firmware note

The protocol is unchanged — it's the existing generic `SSET:device_name=<value>` / `SGET:device_name` / `SVAL:device_name=<value>` key/value flow. Just emit `device_name` from the firmware's `SLIST` and it'll render with the right label, 32-char limit, and the profile-name shortcut.

## i18n

New `drawer:device.useProfileName` key added and translated across all locales (`en, es, fr, de, it, pt-BR, ja`).

## Tests

Added schema coverage for `device_name` (type/maxLength + over-length validation).

## Checks

- ✅ `bun run lint`
- ✅ `bun run typecheck`
- ✅ `bun run test:run` (1785 passed, +2 new)
- ✅ `bun run build`

`CHANGELOG.md` updated under `[2.6.0] - unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AasYtsiQD1zSMyxV17pYxJ)_