### PR TITLE
Post-session tire pressure & weight on the Notes tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.0] - unreleased
 
 ### Added
+- **Post-session tire pressure & weight on the Notes tab.** A new collapsible
+  **Post-Session** panel sits under the session-setup selector on the Notes page,
+  letting you record the tire pressures you measured after a run (single / halves
+  / quarters — same picker as the setup editor, defaulting to quarters) and a
+  single post-session weight. The values save with the session and cloud-sync like
+  your notes, ready for later processing.
 - **Device Name setting for the logger.** The Device → Settings screen now
   supports a **Device Name** field (a free-text name, up to 32 characters) for
   loggers whose firmware exposes it. When you're signed in, a **Use profile name**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ File Import (drag-drop / BLE download / file manager)
 | `Track` | `name`, `shortName?` (max 8 chars), `courses[]` |
 | `CourseDetectionResult` | `track`, `course`, `direction?`, `laps[]`, `isWaypointMode`, `waypointNotice?` |
 | `FieldMapping` | `index`, `name` (canonical ChannelId or `custom:` slug), `label?`, `unit?`, `enabled` |
-| `FileMetadata` | `fileName`, `trackName`, `courseName`, `weatherStation*?`, `sessionKartId?`, `sessionSetupId?`, `sessionSetupRev?` (frozen hash), `sessionEngine?`, `sessionStartTime?`, `fastestLapMs?`, `fastestLapNumber?`, `displayName?` (browser-name override — the bundled sample), `isSample?` (marks the sample so the browser can hide it). Partial updates go through `updateFileMetadata(fileName, patch)` (read-merge-write — never clobbers untouched tags). |
+| `FileMetadata` | `fileName`, `trackName`, `courseName`, `weatherStation*?`, `sessionKartId?`, `sessionSetupId?`, `sessionSetupRev?` (frozen hash), `sessionEngine?`, `sessionStartTime?`, `fastestLapMs?`, `fastestLapNumber?`, `displayName?` (browser-name override — the bundled sample), `isSample?` (marks the sample so the browser can hide it), `postSession?` (`PostSessionData`: post-session tire pressures — single/halves/quarters — + a single weight, entered on the Notes tab; cloud-synced via metadata, held for later processing). Partial updates go through `updateFileMetadata(fileName, patch)` (read-merge-write — never clobbers untouched tags). |
 
 ---
 

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { X, Gauge, Cpu, User, Bluetooth, BluetoothOff, Loader2, Settings, MapPin, Battery, BatteryLow, BatteryMedium, BatteryFull, BatteryWarning } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { FileEntry, FileMetadata } from "@/lib/fileStorage";
+import { FileEntry, FileMetadata, PostSessionData } from "@/lib/fileStorage";
 import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
 import { VehicleType, SetupTemplate, TemplateSection } from "@/lib/templateStorage";
@@ -62,6 +62,9 @@ interface FileManagerDrawerProps {
   sessionSetupId: string | null;
   sessionSetupRev: string | null;
   onSaveSessionSetup: (kartId: string | null, setupId: string | null) => Promise<void>;
+  // Post-session measurements (tire pressure, weight)
+  postSession: PostSessionData | null;
+  onSavePostSession: (data: PostSessionData) => Promise<void>;
   // Setup props
   setups: VehicleSetup[];
   onAddSetup: (setup: Omit<VehicleSetup, "id" | "createdAt" | "updatedAt">) => Promise<void>;
@@ -83,6 +86,7 @@ export function FileManagerDrawer({
   currentTrackName, currentCourseName,
   currentFileName, notes, onAddNote, onUpdateNote, onRemoveNote,
   sessionKartId, sessionSetupId, sessionSetupRev, onSaveSessionSetup,
+  postSession, onSavePostSession,
   setups, onAddSetup, onUpdateSetup, onRemoveSetup, onGetLatestSetupForVehicle,
   onAddVehicleType, onRemoveVehicleType,
 }: FileManagerDrawerProps) {
@@ -231,6 +235,8 @@ export function FileManagerDrawer({
                 sessionSetupId={sessionSetupId}
                 sessionSetupRev={sessionSetupRev}
                 onSaveSessionSetup={onSaveSessionSetup}
+                postSession={postSession}
+                onSavePostSession={onSavePostSession}
               />
             )}
           </>

--- a/src/components/drawer/ModeToggle.tsx
+++ b/src/components/drawer/ModeToggle.tsx
@@ -1,0 +1,30 @@
+/**
+ * Segmented single/halves/quarters (or any string-set) toggle, shared by the
+ * setup editor and the post-session panel so the "pick a granularity" control
+ * looks and behaves identically everywhere it's used.
+ */
+export function ModeToggle<T extends string>({
+  options, labels, value, onChange,
+}: {
+  options: readonly T[];
+  labels: string[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex gap-1 bg-muted/50 rounded-md p-0.5">
+      {options.map((opt, i) => (
+        <button
+          key={opt}
+          type="button"
+          onClick={() => onChange(opt)}
+          className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+            value === opt ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {labels[i]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/drawer/NotesTab.tsx
+++ b/src/components/drawer/NotesTab.tsx
@@ -7,7 +7,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Note, MAX_NOTE_BYTES } from "@/lib/noteStorage";
 import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
+import { PostSessionData } from "@/lib/fileStorage";
 import { shortRevHash } from "@/lib/setupRevision";
+import { PostSessionPanel } from "@/components/drawer/PostSessionPanel";
 
 interface NotesTabProps {
   fileName: string | null;
@@ -22,11 +24,15 @@ interface NotesTabProps {
   /** Content hash of the frozen setup revision this session ran (immutable id). */
   sessionSetupRev: string | null;
   onSaveSessionSetup: (kartId: string | null, setupId: string | null) => Promise<void>;
+  /** Post-session measurements (tire pressure, weight) for this session. */
+  postSession: PostSessionData | null;
+  onSavePostSession: (data: PostSessionData) => Promise<void>;
 }
 
 export function NotesTab({
   fileName, notes, onAdd, onUpdate, onRemove,
   vehicles, setups, sessionKartId, sessionSetupId, sessionSetupRev, onSaveSessionSetup,
+  postSession, onSavePostSession,
 }: NotesTabProps) {
   const { t } = useTranslation("drawer");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -138,6 +144,9 @@ export function NotesTab({
           </p>
         )}
       </div>
+
+      {/* Post-session measurements (tire pressure + weight) */}
+      <PostSessionPanel postSession={postSession} onSave={onSavePostSession} />
 
       {/* Delete Confirmation */}
       {confirmDelete && (

--- a/src/components/drawer/PostSessionPanel.tsx
+++ b/src/components/drawer/PostSessionPanel.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, Gauge, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ModeToggle } from "@/components/drawer/ModeToggle";
+import { PostSessionData, TirePsiMode } from "@/lib/fileStorage";
+
+interface PostSessionPanelProps {
+  /** The session's saved post-session data (null until first save). */
+  postSession: PostSessionData | null;
+  onSave: (data: PostSessionData) => Promise<void>;
+}
+
+const PSI_OPTIONS = ["single", "halves", "quarters"] as const;
+
+/** Detect the editor mode from stored corner pressures (defaults to quarters). */
+function detectMode(d: PostSessionData | null): TirePsiMode {
+  if (d?.tirePsiMode) return d.tirePsiMode;
+  return "quarters";
+}
+
+const numOrNull = (v: string): number | null => (v === "" ? null : parseFloat(v));
+
+/**
+ * Collapsible post-session capture under the Notes session-setup panel: tire
+ * pressures (single / halves / quarters, default quarters) + a single weight.
+ * Saved to FileMetadata so it cloud-syncs with the session. Held for later
+ * processing — nothing consumes it yet.
+ */
+export function PostSessionPanel({ postSession, onSave }: PostSessionPanelProps) {
+  const { t } = useTranslation("drawer");
+  const [open, setOpen] = useState(false);
+
+  const [mode, setMode] = useState<TirePsiMode>("quarters");
+  const [psiSingle, setPsiSingle] = useState<number | null>(null);
+  const [psiFront, setPsiFront] = useState<number | null>(null);
+  const [psiRear, setPsiRear] = useState<number | null>(null);
+  const [fl, setFl] = useState<number | null>(null);
+  const [fr, setFr] = useState<number | null>(null);
+  const [rl, setRl] = useState<number | null>(null);
+  const [rr, setRr] = useState<number | null>(null);
+  const [weight, setWeight] = useState<number | null>(null);
+
+  // Reload local state whenever a different session's data arrives.
+  useEffect(() => {
+    const m = detectMode(postSession);
+    setMode(m);
+    setFl(postSession?.tirePsiFrontLeft ?? null);
+    setFr(postSession?.tirePsiFrontRight ?? null);
+    setRl(postSession?.tirePsiRearLeft ?? null);
+    setRr(postSession?.tirePsiRearRight ?? null);
+    setPsiSingle(m === "single" ? postSession?.tirePsiFrontLeft ?? null : null);
+    setPsiFront(m === "halves" ? postSession?.tirePsiFrontLeft ?? null : null);
+    setPsiRear(m === "halves" ? postSession?.tirePsiRearLeft ?? null : null);
+    setWeight(postSession?.weight ?? null);
+  }, [postSession]);
+
+  // Project the current editor state into the canonical 4-corner + weight shape.
+  const draft = useMemo<PostSessionData>(() => {
+    let corners: Pick<PostSessionData, "tirePsiFrontLeft" | "tirePsiFrontRight" | "tirePsiRearLeft" | "tirePsiRearRight">;
+    if (mode === "single") {
+      corners = { tirePsiFrontLeft: psiSingle, tirePsiFrontRight: psiSingle, tirePsiRearLeft: psiSingle, tirePsiRearRight: psiSingle };
+    } else if (mode === "halves") {
+      corners = { tirePsiFrontLeft: psiFront, tirePsiFrontRight: psiFront, tirePsiRearLeft: psiRear, tirePsiRearRight: psiRear };
+    } else {
+      corners = { tirePsiFrontLeft: fl, tirePsiFrontRight: fr, tirePsiRearLeft: rl, tirePsiRearRight: rr };
+    }
+    return { tirePsiMode: mode, ...corners, weight };
+  }, [mode, psiSingle, psiFront, psiRear, fl, fr, rl, rr, weight]);
+
+  const saved = useMemo<PostSessionData>(() => ({
+    tirePsiMode: detectMode(postSession),
+    tirePsiFrontLeft: postSession?.tirePsiFrontLeft ?? null,
+    tirePsiFrontRight: postSession?.tirePsiFrontRight ?? null,
+    tirePsiRearLeft: postSession?.tirePsiRearLeft ?? null,
+    tirePsiRearRight: postSession?.tirePsiRearRight ?? null,
+    weight: postSession?.weight ?? null,
+  }), [postSession]);
+
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(saved);
+  const hasData = postSession != null;
+
+  const handleSave = useCallback(async () => {
+    await onSave(draft);
+  }, [onSave, draft]);
+
+  return (
+    <div className="border-b border-border shrink-0">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 hover:bg-muted/40 transition-colors">
+          <Gauge className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide flex-1 text-left">
+            {t("postSession.title")}
+          </span>
+          {hasData && <Check className="w-3 h-3 text-primary shrink-0" />}
+          <ChevronDown className={`w-4 h-4 text-muted-foreground shrink-0 transition-transform ${open ? "rotate-180" : ""}`} />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="px-3 pb-3 space-y-3">
+            {/* Tire Pressure */}
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">{t("postSession.tirePressure")}</Label>
+              <ModeToggle
+                options={PSI_OPTIONS}
+                labels={[t("setups.single"), t("setups.halves"), t("setups.quarters")]}
+                value={mode}
+                onChange={setMode}
+              />
+              {mode === "single" && (
+                <Field label={t("setups.allTires")}>
+                  <NumberInput step="0.01" className="h-9" value={psiSingle ?? ""} onChange={e => setPsiSingle(numOrNull(e.target.value))} />
+                </Field>
+              )}
+              {mode === "halves" && (
+                <div className="grid grid-cols-2 gap-2">
+                  <Field label={t("setups.front")}><NumberInput step="0.01" className="h-9" value={psiFront ?? ""} onChange={e => setPsiFront(numOrNull(e.target.value))} /></Field>
+                  <Field label={t("setups.rear")}><NumberInput step="0.01" className="h-9" value={psiRear ?? ""} onChange={e => setPsiRear(numOrNull(e.target.value))} /></Field>
+                </div>
+              )}
+              {mode === "quarters" && (
+                <div className="grid grid-cols-2 gap-2">
+                  <Field label={t("setups.fl")}><NumberInput step="0.01" className="h-9" value={fl ?? ""} onChange={e => setFl(numOrNull(e.target.value))} /></Field>
+                  <Field label={t("setups.fr")}><NumberInput step="0.01" className="h-9" value={fr ?? ""} onChange={e => setFr(numOrNull(e.target.value))} /></Field>
+                  <Field label={t("setups.rl")}><NumberInput step="0.01" className="h-9" value={rl ?? ""} onChange={e => setRl(numOrNull(e.target.value))} /></Field>
+                  <Field label={t("setups.rr")}><NumberInput step="0.01" className="h-9" value={rr ?? ""} onChange={e => setRr(numOrNull(e.target.value))} /></Field>
+                </div>
+              )}
+            </div>
+
+            {/* Weight */}
+            <Field label={t("postSession.weight")}>
+              <NumberInput step="0.01" className="h-9" value={weight ?? ""} onChange={e => setWeight(numOrNull(e.target.value))} placeholder={t("postSession.weightPlaceholder")} />
+            </Field>
+
+            <Button className="w-full" size="sm" onClick={handleSave} disabled={!isDirty}>
+              {hasData ? t("postSession.update") : t("postSession.save")}
+            </Button>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs">{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -11,6 +11,7 @@ import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
 import { VehicleType, SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
 import { TemplateCreator } from "@/components/drawer/TemplateCreator";
+import { ModeToggle } from "@/components/drawer/ModeToggle";
 import { computeSetupHash, shortRevHash } from "@/lib/setupRevision";
 import { SetupHistoryPanel } from "@/components/drawer/SetupHistoryPanel";
 import { useAuth } from "@/contexts/AuthContext";
@@ -618,28 +619,3 @@ function Field({ label, changed, children }: { label: string; changed?: boolean;
   );
 }
 
-function ModeToggle<T extends string>({
-  options, labels, value, onChange,
-}: {
-  options: readonly T[];
-  labels: string[];
-  value: T;
-  onChange: (v: T) => void;
-}) {
-  return (
-    <div className="flex gap-1 bg-muted/50 rounded-md p-0.5">
-      {options.map((opt, i) => (
-        <button
-          key={opt}
-          type="button"
-          onClick={() => onChange(opt)}
-          className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-            value === opt ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          {labels[i]}
-        </button>
-      ))}
-    </div>
-  );
-}

--- a/src/hooks/useSessionMetadata.ts
+++ b/src/hooks/useSessionMetadata.ts
@@ -1,7 +1,9 @@
 import { useState, useCallback } from "react";
 import { WeatherStation } from "@/lib/weatherService";
-import { updateFileMetadata, FileMetadata } from "@/lib/fileStorage";
+import { updateFileMetadata, FileMetadata, PostSessionData } from "@/lib/fileStorage";
 import { freezeSetupRevision } from "@/lib/setupRevisionStorage";
+import { emitGarageChange } from "@/lib/garageEvents";
+import { STORE_NAMES } from "@/lib/dbUtils";
 
 /**
  * Manages session-level metadata: cached weather station, kart/setup
@@ -12,6 +14,7 @@ export function useSessionMetadata(currentFileName: string | null) {
   const [sessionKartId, setSessionKartId] = useState<string | null>(null);
   const [sessionSetupId, setSessionSetupId] = useState<string | null>(null);
   const [sessionSetupRev, setSessionSetupRev] = useState<string | null>(null);
+  const [postSession, setPostSession] = useState<PostSessionData | null>(null);
 
   const restoreFromMetadata = useCallback((meta: FileMetadata | null) => {
     if (meta) {
@@ -28,11 +31,13 @@ export function useSessionMetadata(currentFileName: string | null) {
       setSessionKartId(meta.sessionKartId ?? null);
       setSessionSetupId(meta.sessionSetupId ?? null);
       setSessionSetupRev(meta.sessionSetupRev ?? null);
+      setPostSession(meta.postSession ?? null);
     } else {
       setCachedWeatherStation(null);
       setSessionKartId(null);
       setSessionSetupId(null);
       setSessionSetupRev(null);
+      setPostSession(null);
     }
   }, []);
 
@@ -73,13 +78,29 @@ export function useSessionMetadata(currentFileName: string | null) {
     [currentFileName]
   );
 
+  const handleSavePostSession = useCallback(
+    async (data: PostSessionData) => {
+      if (!currentFileName) return;
+      // updateFileMetadata merges, so this never clobbers track/setup/weather tags.
+      await updateFileMetadata(currentFileName, { postSession: data });
+      setPostSession(data);
+      // Push to the cloud immediately like a note save. Metadata writes don't
+      // emit garage events on their own (they'd flood sync on every fastest-lap
+      // write), so we emit explicitly here for this deliberate, user-driven save.
+      emitGarageChange({ store: STORE_NAMES.METADATA, key: currentFileName, type: "put" });
+    },
+    [currentFileName]
+  );
+
   return {
     cachedWeatherStation,
     sessionKartId,
     sessionSetupId,
     sessionSetupRev,
+    postSession,
     restoreFromMetadata,
     handleWeatherStationResolved,
     handleSaveSessionSetup,
+    handleSavePostSession,
   };
 }

--- a/src/lib/fileStorage.ts
+++ b/src/lib/fileStorage.ts
@@ -11,6 +11,26 @@ export interface FileEntry {
   savedAt: number;
 }
 
+/** Granularity for the post-session tire-pressure entry (mirrors the setup PSI modes). */
+export type TirePsiMode = "single" | "halves" | "quarters";
+
+/**
+ * Post-session measurements captured on the Notes tab after a session is run
+ * (tire pressures, total weight). Stored on FileMetadata so they ride the same
+ * cloud-sync path as the rest of the session's metadata. Held for later
+ * processing — nothing consumes these yet.
+ */
+export interface PostSessionData {
+  /** UI granularity of the pressures below (defaults to quarters). */
+  tirePsiMode?: TirePsiMode;
+  tirePsiFrontLeft?: number | null;
+  tirePsiFrontRight?: number | null;
+  tirePsiRearLeft?: number | null;
+  tirePsiRearRight?: number | null;
+  /** Single post-session weight (unit-agnostic — lbs or kg, user's choice). */
+  weight?: number | null;
+}
+
 export interface FileMetadata {
   fileName: string;
   trackName: string;
@@ -42,6 +62,8 @@ export interface FileMetadata {
   // Marks the bundled sample log so the browser can hide it behind the
   // "show sample files" setting. Sample files are otherwise ordinary logs.
   isSample?: boolean;
+  // Post-session measurements entered on the Notes tab (tire pressures, weight).
+  postSession?: PostSessionData;
 }
 
 interface StoredFile {

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -165,6 +165,14 @@
     "updateNote": "Notiz aktualisieren",
     "addNote": "Notiz hinzufügen"
   },
+  "postSession": {
+    "title": "Nach der Session",
+    "tirePressure": "Reifendruck",
+    "weight": "Gewicht",
+    "weightPlaceholder": "z. B. 380",
+    "save": "Speichern",
+    "update": "Aktualisieren"
+  },
   "templateCreator": {
     "title": "Neuer Fahrzeugtyp",
     "vehicleTypeName": "Name des Fahrzeugtyps",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -164,6 +164,14 @@
     "updateNote": "Update Note",
     "addNote": "Add Note"
   },
+  "postSession": {
+    "title": "Post-Session",
+    "tirePressure": "Tire Pressure",
+    "weight": "Weight",
+    "weightPlaceholder": "e.g. 380",
+    "save": "Save",
+    "update": "Update"
+  },
   "templateCreator": {
     "title": "New Vehicle Type",
     "vehicleTypeName": "Vehicle Type Name",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -165,6 +165,14 @@
     "updateNote": "Actualizar nota",
     "addNote": "Añadir nota"
   },
+  "postSession": {
+    "title": "Post-sesión",
+    "tirePressure": "Presión de neumáticos",
+    "weight": "Peso",
+    "weightPlaceholder": "p. ej. 380",
+    "save": "Guardar",
+    "update": "Actualizar"
+  },
   "templateCreator": {
     "title": "Nuevo tipo de vehículo",
     "vehicleTypeName": "Nombre del tipo de vehículo",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -165,6 +165,14 @@
     "updateNote": "Mettre à jour la note",
     "addNote": "Ajouter une note"
   },
+  "postSession": {
+    "title": "Après-session",
+    "tirePressure": "Pression des pneus",
+    "weight": "Poids",
+    "weightPlaceholder": "p. ex. 380",
+    "save": "Enregistrer",
+    "update": "Mettre à jour"
+  },
   "templateCreator": {
     "title": "Nouveau type de véhicule",
     "vehicleTypeName": "Nom du type de véhicule",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -165,6 +165,14 @@
     "updateNote": "Aggiorna nota",
     "addNote": "Aggiungi nota"
   },
+  "postSession": {
+    "title": "Post-sessione",
+    "tirePressure": "Pressione pneumatici",
+    "weight": "Peso",
+    "weightPlaceholder": "es. 380",
+    "save": "Salva",
+    "update": "Aggiorna"
+  },
   "templateCreator": {
     "title": "Nuovo tipo di veicolo",
     "vehicleTypeName": "Nome del tipo di veicolo",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -165,6 +165,14 @@
     "updateNote": "メモを更新",
     "addNote": "メモを追加"
   },
+  "postSession": {
+    "title": "走行後",
+    "tirePressure": "タイヤ空気圧",
+    "weight": "重量",
+    "weightPlaceholder": "例: 380",
+    "save": "保存",
+    "update": "更新"
+  },
   "templateCreator": {
     "title": "新しい車両の種類",
     "vehicleTypeName": "車両の種類の名前",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -165,6 +165,14 @@
     "updateNote": "Atualizar nota",
     "addNote": "Adicionar nota"
   },
+  "postSession": {
+    "title": "Pós-sessão",
+    "tirePressure": "Pressão dos pneus",
+    "weight": "Peso",
+    "weightPlaceholder": "ex. 380",
+    "save": "Salvar",
+    "update": "Atualizar"
+  },
   "templateCreator": {
     "title": "Novo tipo de veículo",
     "vehicleTypeName": "Nome do tipo de veículo",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -137,7 +137,7 @@ export default function Index() {
 
   // Session metadata
   const sessionMeta = useSessionMetadata(currentFileName);
-  const { cachedWeatherStation, sessionKartId, sessionSetupId, sessionSetupRev } = sessionMeta;
+  const { cachedWeatherStation, sessionKartId, sessionSetupId, sessionSetupRev, postSession } = sessionMeta;
 
   // Playback
   const { isPlaying, toggle: togglePlayback, averageFrameRate } = usePlayback({
@@ -515,6 +515,8 @@ export default function Index() {
     sessionSetupId,
     sessionSetupRev,
     onSaveSessionSetup: handleSaveSessionSetupWithSnapshot,
+    postSession,
+    onSavePostSession: sessionMeta.handleSavePostSession,
   }), [
     fileManager.isOpen, fileManager.files, fileManager.fileMetadataMap, fileManager.storageUsed, fileManager.storageQuota,
     fileManager.close, fileManager.loadFile, fileManager.removeFile, fileManager.exportFile, fileManager.saveFile,
@@ -526,6 +528,7 @@ export default function Index() {
     noteManager.notes, noteManager.addNote, noteManager.updateNote, noteManager.removeNote,
     setupManager.setups, setupManager.addSetup, setupManager.updateSetup, setupManager.removeSetup, setupManager.getLatestForVehicle,
     lapMgmt.selection, sessionKartId, sessionSetupId, sessionSetupRev, handleSaveSessionSetupWithSnapshot,
+    postSession, sessionMeta.handleSavePostSession,
   ]);
 
   // No data loaded - show import UI


### PR DESCRIPTION
## What

Adds a collapsible **Post-Session** panel under the session-setup selector on the **Notes** page so you can record measurements taken *after* a run:

- **Tire pressure** — the same single / halves / quarters picker used in the setup editor, **defaulting to quarters**.
- **Weight** — a single post-session weight (not per-corner).

Both values save locally and **cloud-sync like notes**. They're held for later processing — nothing consumes them yet.

## How

- **Storage** — the data lives on `FileMetadata` as a new `postSession?: PostSessionData` field (`src/lib/fileStorage.ts`), so it's per-session and rides the existing `metadata` cloud-sync store. Saved through `updateFileMetadata` (read-merge-write), so it never clobbers track/course/setup/weather tags.
- **Immediate sync** — metadata writes don't emit garage events on their own (that would flood sync on every fastest-lap write), so the post-session save path in `useSessionMetadata` emits one `emitGarageChange` explicitly for this deliberate, user-driven save — giving the same instant push notes get.
- **UI** — new `PostSessionPanel.tsx` (collapsible, default closed) wired through `Index.tsx` → `FileManagerDrawer` → `NotesTab`. The single/halves/quarters `ModeToggle` is extracted out of `SetupsTab` into a shared `ModeToggle.tsx` so both surfaces use the identical control.
- **i18n** — new `drawer.postSession.*` keys added to all 7 locales (parity test green).

## Checks

- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run test:run` ✅ (1785 tests, incl. i18n parity)
- `bun run build` ✅
- `bun run test:coverage` ✅ (thresholds hold)

Changelog (`2.6.0` unreleased), `CLAUDE.md` (FileMetadata) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtBgwCFuCh26B3oT9kCKoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtBgwCFuCh26B3oT9kCKoQ)_