### PR TITLE
Export video across GoPro chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-select any set of files manually), the next chapter is preloaded so the
   boundary is near-seamless, and a small chapter indicator shows where you are.
   Fully client-side and offline, no stitching tool needed. Saved playlists
-  reload automatically next session. (Exporting a stitched overlay video across
-  chapters is a follow-up.)
+  reload automatically next session.
+- **Video export across GoPro chapters.** Exporting a full session (or a single
+  lap) with overlays now stitches across all chapters into one MP4 — the frame
+  encoder seeks through the whole virtual timeline and the audio from each
+  chapter is concatenated in sync. Multi-chapter export requires a browser with
+  WebCodecs (Chrome/Edge); single-file export is unchanged everywhere.
 - **Post-session tire pressure & weight on the Notes tab.** A new collapsible
   **Post-Session** panel sits under the session-setup selector on the Notes page,
   letting you record the tire pressures you measured after a run (single / halves

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ src/
 │   ├── gps/               # ★ Phone-as-datalogger layer: gpsFix, customGps, sessionGate, realtimeTimer, dovepWriter
 │   ├── speedHeatmap.ts / mapMarker.ts / brakingZones / gforceCalculation / …  # racing math
 │   ├── chartUtils / canvas2d / chartAxis / chartColors / videoExport / overlayCanvasRenderer  # charts/video
-│   ├── videoPlaylist.ts   # ★ Pure GoPro chunked-video model: parse/order GH/GX/GP/GOPR chunk names, build a virtual timeline (cumulative offsets) + virtual↔local time mapping. useVideoSync swaps the <video> src per chunk; a single file is a 1-chunk playlist
+│   ├── videoPlaylist.ts   # ★ Pure GoPro chunked-video model: parse/order GH/GX/GP/GOPR chunk names, build a virtual timeline (cumulative offsets) + virtual↔local time mapping + planAudioSegments (export audio stitch). useVideoSync swaps the <video> src per chunk; a single file is a 1-chunk playlist
 │   ├── satelliteImagery.ts # ★ Esri Wayback parsing (online-only satellite imagery-date picker)
 │   ├── ble/               # Web Bluetooth DovesLapTimer protocol + firmware OTA (→ docs/ble.md)
 │   ├── db/                # Admin DB layer: ITrackDatabase + supabaseAdapter + getDatabase()

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -25,7 +25,7 @@ import { MapOverlay } from "@/components/video-overlays/MapOverlay";
 import { PaceOverlay } from "@/components/video-overlays/PaceOverlay";
 import { SectorOverlay } from "@/components/video-overlays/SectorOverlay";
 import { LapTimeOverlay } from "@/components/video-overlays/LapTimeOverlay";
-import { startVideoExport, downloadBlob, ExportContext } from "@/lib/videoExport";
+import { startVideoExport, downloadBlob, ExportContext, ExportSource } from "@/lib/videoExport";
 import { computeBrakingGSeriesSG, gToBrakePercent } from "@/lib/brakingZones";
 import { saveSessionVideo, loadSessionVideo, deleteSessionVideo } from "@/lib/videoFileStorage";
 import { courseHasSectors } from "@/types/racing";
@@ -397,12 +397,12 @@ export const VideoPlayer = memo(function VideoPlayer({
     : 0;
 
   // Build export context that resolves overlay data from video time
-  const buildExportRenderCtx = useCallback((_videoTime: number): OverlayRenderContext | null => {
-    // During export, the video element's currentTime is the source of truth.
-    // We map that to the telemetry timeline using the sync offset.
-    const video = actions.videoRef.current;
-    if (!video) return null;
-    const videoMs = video.currentTime * 1000;
+  const buildExportRenderCtx = useCallback((videoTime: number): OverlayRenderContext | null => {
+    // `videoTime` is the virtual (whole-recording) time of the frame being
+    // exported; map it to the telemetry timeline using the sync offset. (Reading
+    // the live element's currentTime would be wrong for multi-chunk exports,
+    // which seek a separate offscreen element.)
+    const videoMs = videoTime * 1000;
     const telemetryMs = videoMs + state.syncOffsetMs;
     const all = allSamplesRef.current;
     const vis = samplesRef.current;
@@ -430,7 +430,7 @@ export const VideoPlayer = memo(function VideoPlayer({
       containerWidth: 0,
       containerHeight: 0,
     };
-  }, [actions.videoRef, state.syncOffsetMs, dataSources, fieldMappings, laps, selectedLapNumber, course, referenceSamples, useKph]);
+  }, [state.syncOffsetMs, dataSources, fieldMappings, laps, selectedLapNumber, course, referenceSamples, useKph]);
 
   // Export
   const handleExport = useCallback((options: ExportOptions) => {
@@ -439,7 +439,11 @@ export const VideoPlayer = memo(function VideoPlayer({
     setIsExporting(true);
     setExportProgress(0);
 
-    // Compute time range for lap export
+    // Whole-recording (virtual) duration; falls back to the element's own
+    // duration when no playlist is present.
+    const totalDuration = state.videoDuration || video.duration;
+
+    // Compute time range for lap export (in virtual time across all chunks)
     let startTime: number | undefined;
     let endTime: number | undefined;
     if (options.range === "lap" && selectedLapNumber !== null) {
@@ -447,7 +451,7 @@ export const VideoPlayer = memo(function VideoPlayer({
       if (lap) {
         // Convert telemetry time to video time using sync offset
         startTime = Math.max(0, (lap.startTime - state.syncOffsetMs) / 1000);
-        endTime = Math.min(video.duration, (lap.endTime - state.syncOffsetMs) / 1000);
+        endTime = Math.min(totalDuration, (lap.endTime - state.syncOffsetMs) / 1000);
       }
     }
 
@@ -464,7 +468,13 @@ export const VideoPlayer = memo(function VideoPlayer({
 
     const destination = options.destination;
 
-    startVideoExport(video, exportContext, exportOptions, {
+    // Single file → 1-chunk playlist so the exporter has one code path.
+    const chunks = state.exportChunks.length > 0
+      ? state.exportChunks
+      : [{ url: video.currentSrc || video.src, startOffsetSec: 0, durationSec: totalDuration }];
+    const exportSource: ExportSource = { liveVideo: video, chunks, totalDuration };
+
+    startVideoExport(exportSource, exportContext, exportOptions, {
       onProgress: (p) => setExportProgress(p),
       onComplete: (blob) => {
         setIsExporting(false);
@@ -498,7 +508,7 @@ export const VideoPlayer = memo(function VideoPlayer({
     // the whole `actions` object would invalidate handleExport on every parent
     // render, defeating the memoization.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actions.videoRef, state.videoFileName, state.syncOffsetMs, overlays, buildExportRenderCtx, sessionFileName, selectedLapNumber, laps]);
+  }, [actions.videoRef, state.videoFileName, state.syncOffsetMs, state.videoDuration, state.exportChunks, overlays, buildExportRenderCtx, sessionFileName, selectedLapNumber, laps]);
 
   // Download existing stored video
   const handleSaveExisting = useCallback(async () => {

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -32,6 +32,8 @@ export interface VideoSyncState {
   chunkCount: number;
   /** Index of the currently-playing chunk. */
   currentChunkIndex: number;
+  /** Chunk descriptors (url + virtual offsets) for video export across chunks. */
+  exportChunks: { url: string; startOffsetSec: number; durationSec: number }[];
   isOutOfRange: boolean;
   overlaySettings: OverlaySettings;
   hasStoredVideo: boolean;
@@ -107,6 +109,7 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const [videoCurrentTime, setVideoCurrentTime] = useState(0);
   const [chunkCount, setChunkCount] = useState(1);
   const [currentChunkIndex, setCurrentChunkIndex] = useState(0);
+  const [exportChunks, setExportChunks] = useState<{ url: string; startOffsetSec: number; durationSec: number }[]>([]);
   const [isOutOfRange, setIsOutOfRange] = useState(false);
   const [fileHandle, setFileHandle] = useState<FileSystemFileHandle | null>(null);
   const [overlaySettings, setOverlaySettings] = useState<OverlaySettings>(DEFAULT_OVERLAY_SETTINGS);
@@ -164,6 +167,11 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     pendingActionRef.current = null;
     setChunkCount(entries.length);
     setCurrentChunkIndex(0);
+    setExportChunks(entries.map((e, i) => ({
+      url: e.url,
+      startOffsetSec: playlist.chunks[i].startOffsetSec,
+      durationSec: playlist.chunks[i].durationSec,
+    })));
     setVideoDuration(playlist.totalDuration);
     setVideoCurrentTime(0);
     setVideoUrl(entries[0].url);
@@ -586,6 +594,7 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     if (!fileHandle) {
       revokeAllUrls();
       setVideoFileName(null);
+      setExportChunks([]);
       playlistRef.current = null;
       chunkHandlesRef.current = [];
       chunkNamesRef.current = [];
@@ -623,12 +632,12 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   // playback rate.
   const state: VideoSyncState = useMemo(() => ({
     videoUrl, preloadUrl, videoFileName, isLocked, isPlaying, syncOffsetMs, fps,
-    videoDuration, videoCurrentTime, chunkCount, currentChunkIndex, isOutOfRange, overlaySettings,
+    videoDuration, videoCurrentTime, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, overlaySettings,
     hasStoredVideo: storedVideoAvailable,
     storedVideoMeta,
   }), [
     videoUrl, preloadUrl, videoFileName, isLocked, isPlaying, syncOffsetMs, fps,
-    videoDuration, videoCurrentTime, chunkCount, currentChunkIndex, isOutOfRange, overlaySettings,
+    videoDuration, videoCurrentTime, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, overlaySettings,
     storedVideoAvailable, storedVideoMeta,
   ]);
 

--- a/src/lib/videoExport.ts
+++ b/src/lib/videoExport.ts
@@ -22,6 +22,7 @@ import type { ExportOptions } from "@/components/video-overlays/VideoExportDialo
 import type { OverlayInstance, OverlayRenderContext } from "@/components/video-overlays/types";
 import { renderOverlaysToCanvas } from "@/lib/overlayCanvasRenderer";
 import { shouldStreamExport, writeStreamChunk, type StreamedPart } from "@/lib/videoExportTarget";
+import { virtualToLocal, planAudioSegments, type Playlist } from "@/lib/videoPlaylist";
 
 /** A muxer over either export target (in-memory buffer or chunked stream). */
 type ExportMuxer = Muxer<ArrayBufferTarget | StreamTarget>;
@@ -56,12 +57,31 @@ export interface ExportContext {
   buildRenderCtx: (videoCurrentTime: number) => OverlayRenderContext | null;
 }
 
+/** One chunk of the source recording on the virtual timeline. */
+export interface ExportChunk {
+  url: string;
+  startOffsetSec: number;
+  durationSec: number;
+}
+
+/**
+ * What the exporter reads from. `chunks` describes the whole recording on the
+ * virtual timeline (a single file is a 1-chunk list); `liveVideo` is the
+ * player's element, reused for dimensions and the single-chunk MediaRecorder
+ * fallback.
+ */
+export interface ExportSource {
+  liveVideo: HTMLVideoElement;
+  chunks: ExportChunk[];
+  totalDuration: number;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Public entry point                                                 */
 /* ------------------------------------------------------------------ */
 
 export function startVideoExport(
-  videoElement: HTMLVideoElement,
+  source: ExportSource,
   exportCtx: ExportContext | null,
   options: ExportOptions,
   callbacks: ExportCallbacks,
@@ -73,12 +93,81 @@ export function startVideoExport(
   };
 
   if (supportsWebCodecs()) {
-    runWebCodecsExport(videoElement, exportCtx, options, callbacks, () => cancelled);
+    runWebCodecsExport(source, exportCtx, options, callbacks, () => cancelled);
+  } else if (source.chunks.length > 1) {
+    // The MediaRecorder fallback plays a single element through; it can't span
+    // chunk boundaries. Multi-chapter recordings need WebCodecs.
+    callbacks.onError("Exporting a multi-chapter (GoPro) recording requires a browser with WebCodecs support.");
   } else {
-    runFallbackExport(videoElement, exportCtx, options, callbacks, () => cancelled);
+    runFallbackExport(source.liveVideo, exportCtx, options, callbacks, () => cancelled);
   }
 
   return controller;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Frame source: a dedicated offscreen <video> that seeks across chunks */
+/* ------------------------------------------------------------------ */
+
+interface FrameSource {
+  element: HTMLVideoElement;
+  /** Seek to a virtual (whole-recording) time, switching chunks as needed. */
+  seek: (virtualSec: number) => Promise<void>;
+  dispose: () => void;
+}
+
+/**
+ * Build an offscreen <video> that the frame loop seeks through in virtual time.
+ * Keeping it separate from the player element means the export never disturbs
+ * on-screen playback and the single-chunk case is just a 1-element playlist.
+ */
+async function createFrameSource(chunks: ExportChunk[]): Promise<FrameSource> {
+  const playlist: Playlist = {
+    chunks: chunks.map((c) => ({ name: "", durationSec: c.durationSec, startOffsetSec: c.startOffsetSec })),
+    totalDuration: chunks.reduce((sum, c) => sum + c.durationSec, 0),
+  };
+
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.preload = "auto";
+  // Kept on-screen (but invisible & offscreen) so browsers don't throttle
+  // media loading/seeking the way they can for a fully-detached element.
+  video.style.cssText = "position:fixed;left:-10000px;top:0;width:1px;height:1px;opacity:0;pointer-events:none;";
+  document.body.appendChild(video);
+
+  let currentIndex = -1;
+
+  const loadChunk = (index: number) => new Promise<void>((resolve, reject) => {
+    currentIndex = index;
+    const cleanup = () => {
+      video.removeEventListener("loadeddata", onReady);
+      video.removeEventListener("error", onErr);
+    };
+    const onReady = () => { cleanup(); resolve(); };
+    const onErr = () => { cleanup(); reject(new Error("Failed to load video chunk")); };
+    video.addEventListener("loadeddata", onReady);
+    video.addEventListener("error", onErr);
+    video.src = chunks[index].url;
+    video.load();
+  });
+
+  await loadChunk(0);
+
+  return {
+    element: video,
+    async seek(virtualSec: number) {
+      const { index, localSec } = virtualToLocal(playlist, virtualSec);
+      if (index !== currentIndex) await loadChunk(index);
+      video.currentTime = Math.max(0, localSec);
+      await waitForFrameReady(video);
+    },
+    dispose() {
+      video.removeAttribute("src");
+      video.load();
+      video.remove();
+    },
+  };
 }
 
 /* ------------------------------------------------------------------ */
@@ -93,52 +182,63 @@ function supportsWebCodecs(): boolean {
 /*  Audio extraction + encoding                                        */
 /* ------------------------------------------------------------------ */
 
+/** Decode a single chunk's full audio track, or null if it has none. */
+async function decodeChunkAudio(url: string): Promise<AudioBuffer | null> {
+  try {
+    const response = await fetch(url);
+    const arrayBuffer = await response.arrayBuffer();
+    const audioCtx = new OfflineAudioContext(2, 1, 44100); // temp context for decoding
+    return await audioCtx.decodeAudioData(arrayBuffer);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Extract the audio from a video element's source as an AudioBuffer.
- * Returns null if the video has no audio or decoding fails.
+ * Extract and concatenate audio across the chunks overlapping [startTime, endTime)
+ * into one AudioBuffer aligned to the export range. Chunks are decoded and copied
+ * one at a time so a long multi-chunk recording never holds every track in memory
+ * at once. Returns null if no chunk in range has audio.
  */
-async function extractAudioBuffer(
-  video: HTMLVideoElement,
+async function extractPlaylistAudio(
+  chunks: ExportChunk[],
   startTime: number,
   endTime: number,
 ): Promise<AudioBuffer | null> {
-  try {
-    // Fetch the raw video data from the blob URL
-    const response = await fetch(video.src);
-    const arrayBuffer = await response.arrayBuffer();
+  const overlapping = chunks.filter(
+    (c) => c.startOffsetSec < endTime && c.startOffsetSec + c.durationSec > startTime,
+  );
+  if (overlapping.length === 0) return null;
 
-    // Decode audio from the video file
-    const audioCtx = new OfflineAudioContext(2, 1, 44100); // temp context for decoding
-    let fullBuffer: AudioBuffer;
-    try {
-      fullBuffer = await audioCtx.decodeAudioData(arrayBuffer);
-    } catch {
-      console.log("Video has no audio track or audio decode failed");
-      return null;
+  let out: AudioBuffer | null = null;
+  let sampleRate = 0;
+  let channels = 0;
+
+  for (const chunk of overlapping) {
+    const buf = await decodeChunkAudio(chunk.url);
+    if (!buf) continue;
+
+    // The first decoded chunk fixes the output format + length.
+    if (!out) {
+      sampleRate = buf.sampleRate;
+      channels = buf.numberOfChannels;
+      const totalLen = Math.max(1, Math.round((endTime - startTime) * sampleRate));
+      out = new OfflineAudioContext(channels, totalLen, sampleRate).createBuffer(channels, totalLen, sampleRate);
     }
 
-    // If we need a sub-range, slice the buffer
-    const sampleRate = fullBuffer.sampleRate;
-    const channels = fullBuffer.numberOfChannels;
-    const startSample = Math.floor(startTime * sampleRate);
-    const endSample = Math.min(Math.ceil(endTime * sampleRate), fullBuffer.length);
-    const length = endSample - startSample;
+    const [seg] = planAudioSegments([chunk], startTime, endTime, sampleRate);
+    if (!seg) continue;
 
-    if (length <= 0) return null;
-
-    const sliced = new OfflineAudioContext(channels, length, sampleRate);
-    const slicedBuffer = sliced.createBuffer(channels, length, sampleRate);
     for (let ch = 0; ch < channels; ch++) {
-      const src = fullBuffer.getChannelData(ch);
-      const dst = slicedBuffer.getChannelData(ch);
-      dst.set(src.subarray(startSample, endSample));
+      const src = buf.getChannelData(Math.min(ch, buf.numberOfChannels - 1));
+      const dst = out.getChannelData(ch);
+      const slice = src.subarray(seg.srcStartSample, seg.srcStartSample + seg.lenSamples);
+      const writable = Math.min(slice.length, dst.length - seg.outStartSample);
+      if (writable > 0) dst.set(slice.subarray(0, writable), seg.outStartSample);
     }
-
-    return slicedBuffer;
-  } catch (e) {
-    console.warn("Audio extraction failed:", e);
-    return null;
   }
+
+  return out;
 }
 
 /**
@@ -236,15 +336,20 @@ function buildPlanarBuffer(
 /* ------------------------------------------------------------------ */
 
 async function runWebCodecsExport(
-  video: HTMLVideoElement,
+  source: ExportSource,
   exportCtx: ExportContext | null,
   options: ExportOptions,
   callbacks: ExportCallbacks,
   isCancelled: () => boolean,
 ) {
+  const liveVideo = source.liveVideo;
+  let frameSource: FrameSource | null = null;
+  let restorePlay = false;
   try {
-    const vw = video.videoWidth;
-    const vh = video.videoHeight;
+    // All chunks of one recording share a resolution, so the player element's
+    // dimensions describe every chunk.
+    const vw = liveVideo.videoWidth;
+    const vh = liveVideo.videoHeight;
     if (!vw || !vh) { callbacks.onError("Video has no dimensions"); return; }
 
     // Target resolution
@@ -263,14 +368,11 @@ async function runWebCodecsExport(
 
     const fps = 30;
     const startTime = options.startTime ?? 0;
-    const endTime = options.endTime ?? video.duration;
+    const endTime = options.endTime ?? source.totalDuration;
     const duration = endTime - startTime;
     const totalFrames = Math.ceil(duration * fps);
     const frameInterval = 1 / fps;
     const keyFrameInterval = fps; // keyframe every 1 second
-
-    // Extract audio in parallel with video setup
-    const audioPromise = extractAudioBuffer(video, startTime, endTime);
 
     // Canvas for compositing
     const canvas = document.createElement("canvas");
@@ -279,6 +381,17 @@ async function runWebCodecsExport(
     const ctx = canvas.getContext("2d");
     if (!ctx) { callbacks.onError("Failed to get canvas context"); return; }
 
+    // Don't let the player keep advancing behind the export dialog. The export
+    // reads a separate offscreen element, so the live element is only paused.
+    restorePlay = !liveVideo.paused;
+    liveVideo.pause();
+
+    // Offscreen source seeked in virtual time + audio stitched across chunks,
+    // both kicked off in parallel with encoder setup.
+    const sourcePromise = createFrameSource(source.chunks);
+    const audioPromise = extractPlaylistAudio(source.chunks, startTime, endTime);
+
+    frameSource = await sourcePromise;
     // Wait for audio extraction
     const audioBuffer = await audioPromise;
     if (isCancelled()) return;
@@ -336,12 +449,6 @@ async function runWebCodecsExport(
       framerate: fps,
     });
 
-    // Pause video for seeking
-    const wasMuted = video.muted;
-    const wasPlaying = !video.paused;
-    video.pause();
-    video.muted = true;
-
     const graphHistories = new Map<string, number[]>();
 
     // Frame-stepping loop
@@ -351,14 +458,13 @@ async function runWebCodecsExport(
 
       const t = startTime + i * frameInterval;
 
-      // Seek to frame time and wait for frame to be fully ready
-      video.currentTime = t;
-      await waitForFrameReady(video);
+      // Seek the offscreen source to this virtual time (crossing chunks as needed).
+      await frameSource.seek(t);
 
       if (isCancelled()) break;
 
       // Draw video frame to canvas
-      ctx.drawImage(video, 0, 0, targetW, targetH);
+      ctx.drawImage(frameSource.element, 0, 0, targetW, targetH);
 
       // Draw overlays
       if (options.includeOverlays && exportCtx) {
@@ -385,7 +491,6 @@ async function runWebCodecsExport(
 
     if (isCancelled()) {
       encoder.close();
-      video.muted = wasMuted;
       return;
     }
 
@@ -407,12 +512,14 @@ async function runWebCodecsExport(
       : new Blob([(target as ArrayBufferTarget).buffer], { type: "video/mp4" });
     streamedParts.length = 0;
 
-    video.muted = wasMuted;
-    if (wasPlaying) video.play();
-
     callbacks.onComplete(blob);
   } catch (e) {
     callbacks.onError(e instanceof Error ? e.message : "Export failed");
+  } finally {
+    // Tear down the offscreen source and resume the player on every exit path
+    // (success, cancel, encoder error, or throw).
+    frameSource?.dispose();
+    if (restorePlay) liveVideo.play();
   }
 }
 

--- a/src/lib/videoPlaylist.test.ts
+++ b/src/lib/videoPlaylist.test.ts
@@ -5,6 +5,7 @@ import {
   buildPlaylist,
   virtualToLocal,
   localToVirtual,
+  planAudioSegments,
   type Playlist,
 } from "./videoPlaylist";
 
@@ -131,5 +132,44 @@ describe("virtualToLocal / localToVirtual", () => {
   it("localToVirtual clamps the chunk index", () => {
     expect(localToVirtual(pl, 5, 10)).toBe(580 + 10);
     expect(localToVirtual(pl, -1, 10)).toBe(10);
+  });
+});
+
+describe("planAudioSegments", () => {
+  const chunks = [
+    { startOffsetSec: 0, durationSec: 300 },
+    { startOffsetSec: 300, durationSec: 280 },
+    { startOffsetSec: 580, durationSec: 120 },
+  ];
+  const sr = 48000;
+
+  it("maps a full-range export to one segment per chunk, end-to-end", () => {
+    const segs = planAudioSegments(chunks, 0, 700, sr);
+    expect(segs).toEqual([
+      { index: 0, srcStartSample: 0, lenSamples: 300 * sr, outStartSample: 0 },
+      { index: 1, srcStartSample: 0, lenSamples: 280 * sr, outStartSample: 300 * sr },
+      { index: 2, srcStartSample: 0, lenSamples: 120 * sr, outStartSample: 580 * sr },
+    ]);
+  });
+
+  it("handles a range spanning a single boundary (lap export)", () => {
+    // 250s..400s crosses the 300s boundary between chunk 0 and chunk 1.
+    const segs = planAudioSegments(chunks, 250, 400, sr);
+    expect(segs).toEqual([
+      { index: 0, srcStartSample: 250 * sr, lenSamples: 50 * sr, outStartSample: 0 },
+      { index: 1, srcStartSample: 0, lenSamples: 100 * sr, outStartSample: 50 * sr },
+    ]);
+  });
+
+  it("omits chunks outside the range", () => {
+    const segs = planAudioSegments(chunks, 610, 700, sr);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toEqual({ index: 2, srcStartSample: 30 * sr, lenSamples: 90 * sr, outStartSample: 0 });
+  });
+
+  it("returns nothing for an empty or inverted range", () => {
+    expect(planAudioSegments(chunks, 100, 100, sr)).toEqual([]);
+    expect(planAudioSegments(chunks, 400, 200, sr)).toEqual([]);
+    expect(planAudioSegments(chunks, 0, 700, 0)).toEqual([]);
   });
 });

--- a/src/lib/videoPlaylist.ts
+++ b/src/lib/videoPlaylist.ts
@@ -160,3 +160,47 @@ export function localToVirtual(
   const i = Math.max(0, Math.min(index, chunks.length - 1));
   return chunks[i].startOffsetSec + Math.max(0, localSec);
 }
+
+/** Where one chunk's audio lands when concatenating a [startSec, endSec) export range. */
+export interface AudioSegmentPlan {
+  /** Index into the input chunk list. */
+  index: number;
+  /** First sample to copy from the chunk's own audio. */
+  srcStartSample: number;
+  /** Number of samples to copy. */
+  lenSamples: number;
+  /** Sample position in the output buffer to copy them to. */
+  outStartSample: number;
+}
+
+/**
+ * Plan how each chunk's audio maps into one concatenated output buffer covering
+ * the virtual range [startSec, endSec). Pure sample-domain math so the
+ * audio-stitching in the exporter is unit-testable; chunks that don't overlap
+ * the range are omitted.
+ */
+export function planAudioSegments(
+  chunks: { startOffsetSec: number; durationSec: number }[],
+  startSec: number,
+  endSec: number,
+  sampleRate: number,
+): AudioSegmentPlan[] {
+  const plans: AudioSegmentPlan[] = [];
+  if (endSec <= startSec || sampleRate <= 0) return plans;
+
+  chunks.forEach((c, index) => {
+    const chunkEnd = c.startOffsetSec + c.durationSec;
+    const segStart = Math.max(startSec, c.startOffsetSec);
+    const segEnd = Math.min(endSec, chunkEnd);
+    if (segEnd <= segStart) return;
+
+    plans.push({
+      index,
+      srcStartSample: Math.round((segStart - c.startOffsetSec) * sampleRate),
+      lenSamples: Math.round((segEnd - segStart) * sampleRate),
+      outStartSample: Math.round((segStart - startSec) * sampleRate),
+    });
+  });
+
+  return plans;
+}


### PR DESCRIPTION
## What & why

Follow-up to the GoPro chunked-video work (#236). That PR let multi-chapter GoPro
recordings (`GH010042.MP4`, `GH020042.MP4`, …) **play and sync** as one
continuous video, but **export** still assumed a single file — exporting a
multi-chapter recording would only cover the first chunk.

This makes the video exporter stitch the whole recording (full session **or** a
single lap) into one MP4 with overlays, fully client-side.

## How it works

- **`src/lib/videoExport.ts`** — introduces an `ExportSource` (the live player
  element + an ordered list of chunk descriptors with virtual offsets). The
  WebCodecs path now drives a **dedicated offscreen `<video>`** through a
  `FrameSource` that seeks across chunk boundaries in *virtual* time, so the
  frame loop is unchanged conceptually but spans chapters. Audio is decoded
  per-chunk and concatenated in sync. All teardown is consolidated into a
  `finally` (dispose the offscreen element + resume the player on every exit
  path — success, cancel, encoder error, throw). The export no longer disturbs
  on-screen playback (it only pauses the live element).
  - Multi-chunk export **requires WebCodecs** (Chrome/Edge); the MediaRecorder
    fallback stays single-chunk-only and returns a clear error for multi-chapter
    recordings. Single-file export is unchanged everywhere.
- **`src/lib/videoPlaylist.ts`** — adds pure, unit-tested `planAudioSegments()`
  that maps each chunk's audio into the concatenated export range in the sample
  domain (handles full-range, boundary-spanning lap ranges, and out-of-range
  chunks).
- **`src/hooks/useVideoSync.ts`** — exposes `exportChunks` (url + virtual
  offsets) on the sync state for the exporter.
- **`src/components/VideoPlayer.tsx`** — builds the `ExportSource`, clamps lap
  export to the virtual (whole-recording) duration, and fixes
  `buildExportRenderCtx` to resolve overlays from the **passed virtual time**
  rather than the live element's `currentTime` (which is wrong once the export
  reads a separate offscreen element).

## Notes

- Exports remain a single concatenated output blob, so `saveSessionVideo` and the
  streaming mux target are unchanged. As before, a saved "Save to App" export is
  only auto-loaded when the original source files/handles aren't available
  (source takes priority) — unchanged behavior.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run test:run` (1810 passed, incl. 4
  new `planAudioSegments` tests), and `bun run build` all green.
- Manual: with 2–3 GoPro chapters loaded, export Full Session and a single lap
  (one that spans a chapter boundary) with overlays → output is one MP4 covering
  the whole range with overlays animating and audio in sync across the boundary;
  player resumes afterward; cancel mid-export cleans up. Single non-GoPro file
  exports exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZk7uYn7BN6ArrsBiSv8HQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZk7uYn7BN6ArrsBiSv8HQ)_