### PR TITLE
Video: pick which recording to load from a messy multi-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Fully client-side and offline, no stitching tool needed. Saved playlists
   reload automatically next session. On mobile, where the file picker can't be
   filtered, selecting *everything* still works: sidecar files (`.LRV`/`.THM`),
-  photos, and unrelated clips are silently ignored and only the first
-  recording's chapters are loaded.
+  photos, and other junk are silently ignored. If the selection happens to span
+  more than one recording, you're asked which one to load — and only that one is
+  kept in memory; otherwise the single recording loads straight away.
 - **Video export across GoPro chapters.** Exporting a full session (or a single
   lap) with overlays now stitches across all chapters into one MP4 — the frame
   encoder seeks through the whole virtual timeline and the audio from each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-select any set of files manually), the next chapter is preloaded so the
   boundary is near-seamless, and a small chapter indicator shows where you are.
   Fully client-side and offline, no stitching tool needed. Saved playlists
-  reload automatically next session.
+  reload automatically next session. On mobile, where the file picker can't be
+  filtered, selecting *everything* still works: sidecar files (`.LRV`/`.THM`),
+  photos, and unrelated clips are silently ignored and only the first
+  recording's chapters are loaded.
 - **Video export across GoPro chapters.** Exporting a full session (or a single
   lap) with overlays now stitches across all chapters into one MP4 — the frame
   encoder seeks through the whole virtual timeline and the audio from each

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -225,6 +225,46 @@ function OverlayRenderer({ instance, ctx, fontSize }: { instance: OverlayInstanc
   }
 }
 
+/**
+ * Prompt shown when a single file selection spans several distinct recordings
+ * (e.g. a mobile "select all" of a whole GoPro card). The user picks the one
+ * recording to load; every other selected file is dropped from memory.
+ */
+function RecordingPicker({ state, actions }: { state: VideoSyncState; actions: VideoSyncActions }) {
+  const { t } = useTranslation("video");
+  const pending = state.pendingRecordings;
+  return (
+    <Dialog open={!!pending && pending.length > 0} onOpenChange={(open) => { if (!open) actions.cancelRecordingChoice(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Video className="w-5 h-5" />
+            {t("player.pickRecordingTitle")}
+          </DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">{t("player.pickRecordingDesc")}</p>
+        <div className="flex flex-col gap-2 mt-1">
+          {pending?.map((r) => (
+            <Button
+              key={r.key}
+              variant="outline"
+              className="justify-between h-auto py-2.5"
+              onClick={() => actions.chooseRecording(r.key)}
+            >
+              <span className="font-mono text-sm truncate">{r.label}</span>
+              {r.count > 1 && (
+                <span className="text-xs text-muted-foreground ml-2 shrink-0">
+                  {t("player.pickRecordingCount", { count: r.count })}
+                </span>
+              )}
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export const VideoPlayer = memo(function VideoPlayer({
   state, actions, onLoadedMetadata,
   samples = [], allSamples = [],
@@ -540,6 +580,7 @@ export const VideoPlayer = memo(function VideoPlayer({
           <Video className="w-4 h-4" /> {t("player.loadVideo")}
         </Button>
         <p className="text-xs text-muted-foreground/70">{t("player.goproHint")}</p>
+        <RecordingPicker state={state} actions={actions} />
       </div>
     );
   }
@@ -640,6 +681,9 @@ export const VideoPlayer = memo(function VideoPlayer({
         onSaveExisting={handleSaveExisting}
         onDeleteStored={handleDeleteStored}
       />
+
+      {/* Recording picker (multi-recording selection) */}
+      <RecordingPicker state={state} actions={actions} />
 
       {/* Unified bottom toolbar + progress bar */}
       <div

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -5,7 +5,7 @@ import { loadSessionVideo, hasSessionVideo, deleteSessionVideo, getSessionVideoM
 import type { OverlaySettings } from "@/components/video-overlays/types";
 import { DEFAULT_OVERLAY_SETTINGS } from "@/components/video-overlays/types";
 import { findNearestIndex } from "@/components/video-overlays/overlayUtils";
-import { buildPlaylist, selectRecordingChunks, virtualToLocal, localToVirtual, type Playlist } from "@/lib/videoPlaylist";
+import { buildPlaylist, groupVideoRecordings, virtualToLocal, localToVirtual, type Playlist, type VideoRecording } from "@/lib/videoPlaylist";
 
 interface UseVideoSyncOptions {
   samples: GpsSample[];
@@ -38,10 +38,20 @@ export interface VideoSyncState {
   overlaySettings: OverlaySettings;
   hasStoredVideo: boolean;
   storedVideoMeta: StoredVideoMeta | null;
+  /**
+   * When a selection holds several distinct recordings, the choices to prompt
+   * the user with (null = no prompt pending). Each is one recording's display
+   * label + chapter count; only the chosen one is ever loaded into memory.
+   */
+  pendingRecordings: { key: string; label: string; count: number }[] | null;
 }
 
 export interface VideoSyncActions {
   loadVideo: () => void;
+  /** Load one of the prompted recordings; the others are dropped from memory. */
+  chooseRecording: (key: string) => void;
+  /** Dismiss the recording prompt without loading anything. */
+  cancelRecordingChoice: () => void;
   toggleLock: () => void;
   togglePlay: () => void;
   stepFrame: (direction: 1 | -1) => void;
@@ -53,6 +63,13 @@ export interface VideoSyncActions {
     videoRef: React.RefObject<HTMLVideoElement>;
     preloadVideoRef: React.RefObject<HTMLVideoElement>;
   }
+
+/** A picked video file held in memory while a recording prompt is pending. */
+interface SelectedVideoFile {
+  name: string;
+  file: File;
+  handle?: FileSystemFileHandle;
+}
 
 /** Entry describing one chunk before it's turned into a playlist. */
 interface ChunkEntry {
@@ -115,6 +132,12 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const [overlaySettings, setOverlaySettings] = useState<OverlaySettings>(DEFAULT_OVERLAY_SETTINGS);
   const [storedVideoAvailable, setStoredVideoAvailable] = useState(false);
   const [storedVideoMeta, setStoredVideoMeta] = useState<StoredVideoMeta | null>(null);
+  // Recording-picker state: when a selection holds >1 recording we hold the
+  // grouped File objects in a ref (heavy) and mirror just the labels to state
+  // (for rendering). Choosing one drops the ref so the rest are GC'd.
+  const pendingGroupsRef = useRef<VideoRecording<SelectedVideoFile>[] | null>(null);
+  const [pendingRecordings, setPendingRecordings] =
+    useState<{ key: string; label: string; count: number }[] | null>(null);
 
   // Playlist model + per-chunk resources (refs so the sync loops read them
   // without re-subscribing every render).
@@ -288,7 +311,50 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     saveVideoSync(record);
   }, [sessionFileName, videoFileName, fileHandle, isLocked, overlaySettings]);
 
-  // Load video file(s) — supports selecting multiple GoPro chunks at once.
+  // Build the playlist from one chosen recording's files (creates the object
+  // URLs only for these — the other recordings in a selection never get one).
+  const loadRecording = useCallback(async (recording: VideoRecording<SelectedVideoFile>) => {
+    revokeAllUrls();
+    await applyPlaylist(recording.files.map((e) => ({
+      name: e.name,
+      url: URL.createObjectURL(e.file),
+      handle: e.handle,
+    })));
+    persistSync(syncOffsetMsRef.current);
+  }, [revokeAllUrls, applyPlaylist, persistSync]);
+
+  // Group a fresh selection into recordings: load straight away when there's
+  // exactly one, otherwise stash them and prompt the user to pick.
+  const handleSelectedFiles = useCallback(async (selected: SelectedVideoFile[]) => {
+    const groups = groupVideoRecordings(selected);
+    if (groups.length === 0) return;
+    if (groups.length === 1) {
+      pendingGroupsRef.current = null;
+      setPendingRecordings(null);
+      await loadRecording(groups[0]);
+      return;
+    }
+    pendingGroupsRef.current = groups;
+    setPendingRecordings(groups.map((g) => ({ key: g.key, label: g.label, count: g.files.length })));
+  }, [loadRecording]);
+
+  // Load the picked recording; clearing the ref drops every other recording's
+  // File objects so they're freed from memory.
+  const chooseRecording = useCallback((key: string) => {
+    const group = pendingGroupsRef.current?.find((g) => g.key === key);
+    pendingGroupsRef.current = null;
+    setPendingRecordings(null);
+    if (group) void loadRecording(group);
+  }, [loadRecording]);
+
+  // Dismiss the prompt and drop all the held selections from memory.
+  const cancelRecordingChoice = useCallback(() => {
+    pendingGroupsRef.current = null;
+    setPendingRecordings(null);
+  }, []);
+
+  // Load video file(s) — supports selecting multiple GoPro chunks at once. A
+  // selection spanning several recordings prompts the user to choose one.
   const loadVideo = useCallback(async () => {
     if ("showOpenFilePicker" in window) {
       try {
@@ -307,13 +373,7 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
           }],
         });
         const files = await Promise.all(handles.map((h) => h.getFile()));
-        // Keep only the first video's GoPro recording — a mobile "select all"
-        // can drag in sidecars and unrelated clips; we silently ignore them.
-        const ordered = selectRecordingChunks(files.map((f, i) => ({ name: f.name, file: f, handle: handles[i] })));
-        if (ordered.length === 0) return;
-        revokeAllUrls();
-        await applyPlaylist(ordered.map((e) => ({ name: e.name, url: URL.createObjectURL(e.file), handle: e.handle })));
-        persistSync(syncOffsetMsRef.current);
+        await handleSelectedFiles(files.map((f, i) => ({ name: f.name, file: f, handle: handles[i] })));
         return;
       } catch (e) {
         // User cancelled the file picker — DOMException("AbortError"). Swallow.
@@ -332,16 +392,12 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     const input = fileInputRef.current;
     input.onchange = async () => {
       const files = input.files ? Array.from(input.files) : [];
-      if (files.length === 0) return;
-      const ordered = selectRecordingChunks(files.map((f) => ({ name: f.name, file: f })));
-      if (ordered.length === 0) { input.value = ""; return; }
-      revokeAllUrls();
-      await applyPlaylist(ordered.map((e) => ({ name: e.name, url: URL.createObjectURL(e.file) })));
-      persistSync(syncOffsetMsRef.current);
       input.value = "";
+      if (files.length === 0) return;
+      await handleSelectedFiles(files.map((f) => ({ name: f.name, file: f })));
     };
     input.click();
-  }, [revokeAllUrls, applyPlaylist, persistSync]);
+  }, [handleSelectedFiles]);
 
   // After a chunk's metadata loads, apply any pending seek/play and refresh time.
   const handleLoadedMetadata = useCallback(() => {
@@ -639,17 +695,18 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     videoDuration, videoCurrentTime, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, overlaySettings,
     hasStoredVideo: storedVideoAvailable,
     storedVideoMeta,
+    pendingRecordings,
   }), [
     videoUrl, preloadUrl, videoFileName, isLocked, isPlaying, syncOffsetMs, fps,
     videoDuration, videoCurrentTime, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, overlaySettings,
-    storedVideoAvailable, storedVideoMeta,
+    storedVideoAvailable, storedVideoMeta, pendingRecordings,
   ]);
 
   const actions: VideoSyncActions = useMemo(() => ({
-    loadVideo, toggleLock, togglePlay, stepFrame, setSyncPoint,
+    loadVideo, chooseRecording, cancelRecordingChoice, toggleLock, togglePlay, stepFrame, setSyncPoint,
     seekVideo, updateOverlaySettings, deleteStoredVideo: handleDeleteStoredVideo, refreshStoredMeta, videoRef, preloadVideoRef,
   }), [
-    loadVideo, toggleLock, togglePlay, stepFrame, setSyncPoint,
+    loadVideo, chooseRecording, cancelRecordingChoice, toggleLock, togglePlay, stepFrame, setSyncPoint,
     seekVideo, updateOverlaySettings, handleDeleteStoredVideo, refreshStoredMeta,
   ]);
 

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -5,7 +5,7 @@ import { loadSessionVideo, hasSessionVideo, deleteSessionVideo, getSessionVideoM
 import type { OverlaySettings } from "@/components/video-overlays/types";
 import { DEFAULT_OVERLAY_SETTINGS } from "@/components/video-overlays/types";
 import { findNearestIndex } from "@/components/video-overlays/overlayUtils";
-import { buildPlaylist, orderVideoFiles, virtualToLocal, localToVirtual, type Playlist } from "@/lib/videoPlaylist";
+import { buildPlaylist, selectRecordingChunks, virtualToLocal, localToVirtual, type Playlist } from "@/lib/videoPlaylist";
 
 interface UseVideoSyncOptions {
   samples: GpsSample[];
@@ -307,7 +307,10 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
           }],
         });
         const files = await Promise.all(handles.map((h) => h.getFile()));
-        const ordered = orderVideoFiles(files.map((f, i) => ({ name: f.name, file: f, handle: handles[i] })));
+        // Keep only the first video's GoPro recording — a mobile "select all"
+        // can drag in sidecars and unrelated clips; we silently ignore them.
+        const ordered = selectRecordingChunks(files.map((f, i) => ({ name: f.name, file: f, handle: handles[i] })));
+        if (ordered.length === 0) return;
         revokeAllUrls();
         await applyPlaylist(ordered.map((e) => ({ name: e.name, url: URL.createObjectURL(e.file), handle: e.handle })));
         persistSync(syncOffsetMsRef.current);
@@ -330,7 +333,8 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     input.onchange = async () => {
       const files = input.files ? Array.from(input.files) : [];
       if (files.length === 0) return;
-      const ordered = orderVideoFiles(files.map((f) => ({ name: f.name, file: f })));
+      const ordered = selectRecordingChunks(files.map((f) => ({ name: f.name, file: f })));
+      if (ordered.length === 0) { input.value = ""; return; }
       revokeAllUrls();
       await applyPlaylist(ordered.map((e) => ({ name: e.name, url: URL.createObjectURL(e.file) })));
       persistSync(syncOffsetMsRef.current);

--- a/src/lib/videoPlaylist.test.ts
+++ b/src/lib/videoPlaylist.test.ts
@@ -3,7 +3,7 @@ import {
   parseGoProName,
   orderVideoFiles,
   isVideoFile,
-  selectRecordingChunks,
+  groupVideoRecordings,
   buildPlaylist,
   virtualToLocal,
   localToVirtual,
@@ -83,46 +83,63 @@ describe("isVideoFile", () => {
   });
 });
 
-describe("selectRecordingChunks", () => {
+describe("groupVideoRecordings", () => {
   const f = (name: string) => ({ name });
+  const shape = (groups: ReturnType<typeof groupVideoRecordings>) =>
+    groups.map((g) => ({ label: g.label, files: g.files.map((x) => x.name) }));
 
-  it("keeps only the first recording's chapters, dropping a second recording", () => {
-    const picked = selectRecordingChunks([
-      f("GH010042.MP4"), f("GH020042.MP4"), f("GH010099.MP4"), f("GH020099.MP4"),
+  it("collapses one recording's chapters into a single group", () => {
+    const groups = groupVideoRecordings([f("GH030042.MP4"), f("GH010042.MP4"), f("GH020042.MP4")]);
+    expect(shape(groups)).toEqual([
+      { label: "GH010042.MP4", files: ["GH010042.MP4", "GH020042.MP4", "GH030042.MP4"] },
     ]);
-    expect(picked.map((x) => x.name)).toEqual(["GH010042.MP4", "GH020042.MP4"]);
   });
 
-  it("orders the kept recording's chapters regardless of selection order", () => {
-    const picked = selectRecordingChunks([f("GH030042.MP4"), f("GH010042.MP4"), f("GH020042.MP4")]);
-    expect(picked.map((x) => x.name)).toEqual(["GH010042.MP4", "GH020042.MP4", "GH030042.MP4"]);
+  it("separates distinct recordings, each ordered by chapter", () => {
+    const groups = groupVideoRecordings([
+      f("GH020099.MP4"), f("GH010042.MP4"), f("GH010099.MP4"), f("GH020042.MP4"),
+    ]);
+    expect(shape(groups)).toEqual([
+      { label: "GH010042.MP4", files: ["GH010042.MP4", "GH020042.MP4"] },
+      { label: "GH010099.MP4", files: ["GH010099.MP4", "GH020099.MP4"] },
+    ]);
   });
 
   it("unites the legacy GOPR first file with its GP continuations", () => {
-    const picked = selectRecordingChunks([f("GP020042.MP4"), f("GOPR0042.MP4"), f("GP010042.MP4")]);
-    expect(picked.map((x) => x.name)).toEqual(["GOPR0042.MP4", "GP010042.MP4", "GP020042.MP4"]);
+    const groups = groupVideoRecordings([f("GP020042.MP4"), f("GOPR0042.MP4"), f("GP010042.MP4")]);
+    expect(shape(groups)).toEqual([
+      { label: "GOPR0042.MP4", files: ["GOPR0042.MP4", "GP010042.MP4", "GP020042.MP4"] },
+    ]);
   });
 
-  it("ignores non-video sidecars from a blind mobile 'select all'", () => {
-    const picked = selectRecordingChunks([
+  it("drops non-video sidecars from a blind mobile 'select all'", () => {
+    const groups = groupVideoRecordings([
       f("GX010042.LRV"), f("GX010042.THM"), f("GX010042.MP4"),
       f("GX020042.LRV"), f("GX020042.MP4"), f("IMG_0001.JPG"),
     ]);
-    expect(picked.map((x) => x.name)).toEqual(["GX010042.MP4", "GX020042.MP4"]);
+    expect(shape(groups)).toEqual([
+      { label: "GX010042.MP4", files: ["GX010042.MP4", "GX020042.MP4"] },
+    ]);
   });
 
-  it("loads a single non-GoPro video and ignores other unrelated clips", () => {
-    const picked = selectRecordingChunks([f("my-race.mp4"), f("another.mov")]);
-    expect(picked.map((x) => x.name)).toEqual(["my-race.mp4"]);
+  it("treats each standalone clip as its own recording", () => {
+    const groups = groupVideoRecordings([f("my-race.mp4"), f("another.mov")]);
+    expect(shape(groups)).toEqual([
+      { label: "my-race.mp4", files: ["my-race.mp4"] },
+      { label: "another.mov", files: ["another.mov"] },
+    ]);
   });
 
-  it("prefers a GoPro recording over a standalone clip in the selection", () => {
-    const picked = selectRecordingChunks([f("random.mp4"), f("GH010042.MP4"), f("GH020042.MP4")]);
-    expect(picked.map((x) => x.name)).toEqual(["GH010042.MP4", "GH020042.MP4"]);
+  it("lists GoPro recordings before standalone clips", () => {
+    const groups = groupVideoRecordings([f("random.mp4"), f("GH010042.MP4"), f("GH020042.MP4")]);
+    expect(shape(groups)).toEqual([
+      { label: "GH010042.MP4", files: ["GH010042.MP4", "GH020042.MP4"] },
+      { label: "random.mp4", files: ["random.mp4"] },
+    ]);
   });
 
   it("returns nothing when the selection has no playable video", () => {
-    expect(selectRecordingChunks([f("a.txt"), f("b.lrv"), f("c.jpg")])).toEqual([]);
+    expect(groupVideoRecordings([f("a.txt"), f("b.lrv"), f("c.jpg")])).toEqual([]);
   });
 });
 

--- a/src/lib/videoPlaylist.test.ts
+++ b/src/lib/videoPlaylist.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   parseGoProName,
   orderVideoFiles,
+  isVideoFile,
+  selectRecordingChunks,
   buildPlaylist,
   virtualToLocal,
   localToVirtual,
@@ -64,6 +66,63 @@ describe("orderVideoFiles", () => {
 
   it("leaves a single non-GoPro file untouched", () => {
     expect(orderVideoFiles([f("race.mp4")]).map((x) => x.name)).toEqual(["race.mp4"]);
+  });
+});
+
+describe("isVideoFile", () => {
+  it("accepts playable video extensions, case-insensitively", () => {
+    for (const name of ["a.mp4", "b.M4V", "c.mov", "d.webm", "e.mkv", "f.AVI"]) {
+      expect(isVideoFile(name)).toBe(true);
+    }
+  });
+
+  it("rejects GoPro sidecars and photos", () => {
+    for (const name of ["GX010042.LRV", "GX010042.THM", "GOPR0042.JPG", "notes.txt", "GX010042.GPR"]) {
+      expect(isVideoFile(name)).toBe(false);
+    }
+  });
+});
+
+describe("selectRecordingChunks", () => {
+  const f = (name: string) => ({ name });
+
+  it("keeps only the first recording's chapters, dropping a second recording", () => {
+    const picked = selectRecordingChunks([
+      f("GH010042.MP4"), f("GH020042.MP4"), f("GH010099.MP4"), f("GH020099.MP4"),
+    ]);
+    expect(picked.map((x) => x.name)).toEqual(["GH010042.MP4", "GH020042.MP4"]);
+  });
+
+  it("orders the kept recording's chapters regardless of selection order", () => {
+    const picked = selectRecordingChunks([f("GH030042.MP4"), f("GH010042.MP4"), f("GH020042.MP4")]);
+    expect(picked.map((x) => x.name)).toEqual(["GH010042.MP4", "GH020042.MP4", "GH030042.MP4"]);
+  });
+
+  it("unites the legacy GOPR first file with its GP continuations", () => {
+    const picked = selectRecordingChunks([f("GP020042.MP4"), f("GOPR0042.MP4"), f("GP010042.MP4")]);
+    expect(picked.map((x) => x.name)).toEqual(["GOPR0042.MP4", "GP010042.MP4", "GP020042.MP4"]);
+  });
+
+  it("ignores non-video sidecars from a blind mobile 'select all'", () => {
+    const picked = selectRecordingChunks([
+      f("GX010042.LRV"), f("GX010042.THM"), f("GX010042.MP4"),
+      f("GX020042.LRV"), f("GX020042.MP4"), f("IMG_0001.JPG"),
+    ]);
+    expect(picked.map((x) => x.name)).toEqual(["GX010042.MP4", "GX020042.MP4"]);
+  });
+
+  it("loads a single non-GoPro video and ignores other unrelated clips", () => {
+    const picked = selectRecordingChunks([f("my-race.mp4"), f("another.mov")]);
+    expect(picked.map((x) => x.name)).toEqual(["my-race.mp4"]);
+  });
+
+  it("prefers a GoPro recording over a standalone clip in the selection", () => {
+    const picked = selectRecordingChunks([f("random.mp4"), f("GH010042.MP4"), f("GH020042.MP4")]);
+    expect(picked.map((x) => x.name)).toEqual(["GH010042.MP4", "GH020042.MP4"]);
+  });
+
+  it("returns nothing when the selection has no playable video", () => {
+    expect(selectRecordingChunks([f("a.txt"), f("b.lrv"), f("c.jpg")])).toEqual([]);
   });
 });
 

--- a/src/lib/videoPlaylist.ts
+++ b/src/lib/videoPlaylist.ts
@@ -105,6 +105,53 @@ export function orderVideoFiles<T extends { name: string }>(files: T[]): T[] {
   return [...gopro.map((g) => g.file), ...other.map((o) => o.file)];
 }
 
+/** Video container extensions the player can actually open. */
+const VIDEO_EXTENSIONS = [".mp4", ".m4v", ".mov", ".webm", ".mkv", ".avi"];
+
+/** True when a filename ends in a playable video extension (case-insensitive). */
+export function isVideoFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  return VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/**
+ * Stable key uniting one GoPro recording's chapters. A recording's chapters
+ * share the encoding family and recording number; the legacy first file (GOPR)
+ * and its GP continuations belong to the same recording, so both fold into one
+ * `legacy-<number>` key.
+ */
+function recordingKey(parts: GoProNameParts): string {
+  if (parts.encoding === "GOPR" || parts.encoding === "GP") return `legacy-${parts.fileNumber}`;
+  return `${parts.encoding}-${parts.fileNumber}`;
+}
+
+/**
+ * Pick the single recording to load from a (possibly messy) multi-selection.
+ *
+ * On mobile there's no way to filter a file picker, so a user is likely to just
+ * "select all" — pulling in GoPro `.LRV`/`.THM` sidecars, photos, and unrelated
+ * recordings alongside the chapters they want. Rather than alerting them or
+ * stitching everything into one nonsensical timeline, we quietly: drop anything
+ * that isn't a playable video, take the first video, and keep only *its* GoPro
+ * recording (all chapters, in order). A non-GoPro first video loads on its own.
+ * Everything else in the selection is silently ignored.
+ */
+export function selectRecordingChunks<T extends { name: string }>(files: T[]): T[] {
+  const videos = files.filter((f) => isVideoFile(f.name));
+  if (videos.length === 0) return [];
+
+  const ordered = orderVideoFiles(videos);
+  const firstParts = parseGoProName(ordered[0].name);
+  // Not a GoPro chunk → a plain single video; load just that one, ignore the rest.
+  if (!firstParts) return [ordered[0]];
+
+  const key = recordingKey(firstParts);
+  return ordered.filter((f) => {
+    const parts = parseGoProName(f.name);
+    return parts != null && recordingKey(parts) === key;
+  });
+}
+
 /** Build a playlist with cumulative start offsets from ordered chunks. */
 export function buildPlaylist(
   chunks: { name: string; durationSec: number }[],

--- a/src/lib/videoPlaylist.ts
+++ b/src/lib/videoPlaylist.ts
@@ -125,31 +125,51 @@ function recordingKey(parts: GoProNameParts): string {
   return `${parts.encoding}-${parts.fileNumber}`;
 }
 
+/** Strip any directory prefix, keeping the original case + extension for display. */
+function displayName(name: string): string {
+  return name.split(/[\\/]/).pop() ?? name;
+}
+
+/** One distinct recording from a selection: its ordered file(s) + a display label. */
+export interface VideoRecording<T> {
+  /** Stable identity for this recording within the selection. */
+  key: string;
+  /** Human label — the first file's name (e.g. "GH010042.MP4"). */
+  label: string;
+  /** The recording's files in playback order (chapters for a GoPro recording). */
+  files: T[];
+}
+
 /**
- * Pick the single recording to load from a (possibly messy) multi-selection.
+ * Group a (possibly messy) multi-selection into distinct recordings.
  *
  * On mobile there's no way to filter a file picker, so a user is likely to just
- * "select all" — pulling in GoPro `.LRV`/`.THM` sidecars, photos, and unrelated
- * recordings alongside the chapters they want. Rather than alerting them or
- * stitching everything into one nonsensical timeline, we quietly: drop anything
- * that isn't a playable video, take the first video, and keep only *its* GoPro
- * recording (all chapters, in order). A non-GoPro first video loads on its own.
- * Everything else in the selection is silently ignored.
+ * "select all" — pulling in GoPro `.LRV`/`.THM` sidecars, photos, and *several*
+ * unrelated recordings alongside the chapters they want. We can't ask the camera
+ * which clips belong together, so instead we: drop anything that isn't a playable
+ * video, fold each GoPro recording's chapters into one ordered group, and treat
+ * every standalone (non-GoPro) clip as its own group. The caller loads the group
+ * directly when there's only one, or prompts the user to pick when there are
+ * several — and discards the rest.
  */
-export function selectRecordingChunks<T extends { name: string }>(files: T[]): T[] {
-  const videos = files.filter((f) => isVideoFile(f.name));
-  if (videos.length === 0) return [];
+export function groupVideoRecordings<T extends { name: string }>(files: T[]): VideoRecording<T>[] {
+  const videos = orderVideoFiles(files.filter((f) => isVideoFile(f.name)));
 
-  const ordered = orderVideoFiles(videos);
-  const firstParts = parseGoProName(ordered[0].name);
-  // Not a GoPro chunk → a plain single video; load just that one, ignore the rest.
-  if (!firstParts) return [ordered[0]];
+  const groups = new Map<string, VideoRecording<T>>();
+  let standaloneCount = 0;
+  for (const file of videos) {
+    const parts = parseGoProName(file.name);
+    // Each standalone clip is its own recording (a unique key per file); GoPro
+    // chapters collapse onto their shared recording key.
+    const key = parts ? recordingKey(parts) : `single-${standaloneCount++}`;
+    const existing = groups.get(key);
+    if (existing) existing.files.push(file);
+    else groups.set(key, { key, label: displayName(file.name), files: [file] });
+  }
 
-  const key = recordingKey(firstParts);
-  return ordered.filter((f) => {
-    const parts = parseGoProName(f.name);
-    return parts != null && recordingKey(parts) === key;
-  });
+  // Map preserves insertion order, which follows `orderVideoFiles` (GoPro
+  // recordings first by number, standalone clips after in selection order).
+  return [...groups.values()];
 }
 
 /** Build a playlist with cumulative start offsets from ordered chunks. */

--- a/src/locales/de/video.json
+++ b/src/locales/de/video.json
@@ -21,7 +21,10 @@
     "unlockOverlays": "Overlays entsperren",
     "overlaySettings": "Overlay-Einstellungen",
     "exportVideo": "Video exportieren",
-    "replaceVideo": "Video ersetzen"
+    "replaceVideo": "Video ersetzen",
+    "pickRecordingTitle": "Welches Video?",
+    "pickRecordingDesc": "Du hast mehr als eine Aufnahme ausgewählt. Wähle die zu ladende aus – die anderen werden verworfen.",
+    "pickRecordingCount": "{{count}} Kapitel"
   },
   "export": {
     "title": "Video exportieren",

--- a/src/locales/en/video.json
+++ b/src/locales/en/video.json
@@ -20,7 +20,10 @@
     "unlockOverlays": "Unlock overlays",
     "overlaySettings": "Overlay settings",
     "exportVideo": "Export video",
-    "replaceVideo": "Replace video"
+    "replaceVideo": "Replace video",
+    "pickRecordingTitle": "Which video?",
+    "pickRecordingDesc": "You selected more than one recording. Pick the one to load — the rest are discarded.",
+    "pickRecordingCount": "{{count}} chapters"
   },
   "export": {
     "title": "Export Video",

--- a/src/locales/es/video.json
+++ b/src/locales/es/video.json
@@ -21,7 +21,10 @@
     "unlockOverlays": "Desbloquear superposiciones",
     "overlaySettings": "Ajustes de superposición",
     "exportVideo": "Exportar vídeo",
-    "replaceVideo": "Reemplazar vídeo"
+    "replaceVideo": "Reemplazar vídeo",
+    "pickRecordingTitle": "¿Qué vídeo?",
+    "pickRecordingDesc": "Has seleccionado más de una grabación. Elige la que quieres cargar; las demás se descartan.",
+    "pickRecordingCount": "{{count}} capítulos"
   },
   "export": {
     "title": "Exportar vídeo",

--- a/src/locales/fr/video.json
+++ b/src/locales/fr/video.json
@@ -21,7 +21,10 @@
     "unlockOverlays": "Déverrouiller les superpositions",
     "overlaySettings": "Réglages des superpositions",
     "exportVideo": "Exporter la vidéo",
-    "replaceVideo": "Remplacer la vidéo"
+    "replaceVideo": "Remplacer la vidéo",
+    "pickRecordingTitle": "Quelle vidéo ?",
+    "pickRecordingDesc": "Vous avez sélectionné plusieurs enregistrements. Choisissez celui à charger — les autres sont ignorés.",
+    "pickRecordingCount": "{{count}} chapitres"
   },
   "export": {
     "title": "Exporter la vidéo",

--- a/src/locales/it/video.json
+++ b/src/locales/it/video.json
@@ -21,7 +21,10 @@
     "unlockOverlays": "Sblocca sovrapposizioni",
     "overlaySettings": "Impostazioni sovrapposizioni",
     "exportVideo": "Esporta video",
-    "replaceVideo": "Sostituisci video"
+    "replaceVideo": "Sostituisci video",
+    "pickRecordingTitle": "Quale video?",
+    "pickRecordingDesc": "Hai selezionato più di una registrazione. Scegli quella da caricare: le altre vengono scartate.",
+    "pickRecordingCount": "{{count}} capitoli"
   },
   "export": {
     "title": "Esporta video",

--- a/src/locales/ja/video.json
+++ b/src/locales/ja/video.json
@@ -21,7 +21,10 @@
     "unlockOverlays": "オーバーレイのロックを解除",
     "overlaySettings": "オーバーレイ設定",
     "exportVideo": "動画を書き出す",
-    "replaceVideo": "動画を差し替える"
+    "replaceVideo": "動画を差し替える",
+    "pickRecordingTitle": "どの動画ですか？",
+    "pickRecordingDesc": "複数の録画が選択されました。読み込むものを選んでください（ほかは破棄されます）。",
+    "pickRecordingCount": "{{count}} チャプター"
   },
   "export": {
     "title": "動画を書き出す",

--- a/src/locales/pt-BR/video.json
+++ b/src/locales/pt-BR/video.json
@@ -21,7 +21,10 @@
     "unlockOverlays": "Desbloquear sobreposições",
     "overlaySettings": "Configurações de sobreposição",
     "exportVideo": "Exportar vídeo",
-    "replaceVideo": "Substituir vídeo"
+    "replaceVideo": "Substituir vídeo",
+    "pickRecordingTitle": "Qual vídeo?",
+    "pickRecordingDesc": "Você selecionou mais de uma gravação. Escolha qual carregar — as outras são descartadas.",
+    "pickRecordingCount": "{{count}} capítulos"
   },
   "export": {
     "title": "Exportar vídeo",


### PR DESCRIPTION
## What & why

A user on mobile has no way to filter the video file picker. Faced with a GoPro SD card they'll just **"select all"** — which drags in `.LRV`/`.THM` sidecars, photos, and (crucially) *several distinct recordings* alongside the chapters they actually want. Today `orderVideoFiles` stitches **every** selected file into one nonsensical timeline, and all of it sits in memory.

This makes that case Just Work:
- non-video junk (`.LRV`/`.THM`/photos) is **silently dropped** — no alert;
- if the selection is **one** recording, it loads straight away (no prompt);
- if it spans **several** recordings, the user is **prompted to pick one** — and only that one is kept in memory; the rest are released.

## How

- **`lib/videoPlaylist.ts`** — new pure `groupVideoRecordings()` (replaces the earlier `selectRecordingChunks`): filters to playable videos, folds each GoPro recording's chapters into one ordered group (legacy `GOPR` + `GP` continuations unite via a shared `recordingKey`), and treats each standalone clip as its own group. Also exports `isVideoFile()`.
- **`hooks/useVideoSync.ts`** — `loadVideo` now groups the selection: 1 group → load immediately; >1 → stash the grouped `File` objects in a ref and mirror just the labels/counts to `state.pendingRecordings`. New actions `chooseRecording(key)` (creates object URLs for only the chosen group, clears the ref so the others are GC'd) and `cancelRecordingChoice()`.
- **`components/VideoPlayer.tsx`** — a `RecordingPicker` dialog rendered in both the empty and active states; lists each recording's label + chapter count.
- **i18n** — 3 new `video.player.*` keys added across all 7 locales (parity test passes).

## Memory
Object URLs are created **only** for the recording the user picks; choosing clears the stash holding the other recordings' `File` objects, so they're freed. Nothing unrelated stays resident.

## Tests & gates
- Rewrote the pure-logic unit tests around `groupVideoRecordings` (distinct-recording split, chapter ordering, legacy GOPR/GP grouping, sidecar/photo filtering, standalone clips, GoPro-before-standalone ordering, empty selection) + `isVideoFile`.
- `bun run lint`, `bun run typecheck`, `bun run test:run` (1819 passing, incl. i18n parity), and `bun run build` all green.

## Changelog
Folded into the unreleased **2.6.0** GoPro entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)