### PR TITLE
Setups + Notes: responsive split panel and a pile of garage UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   come from. On the landing page (no session loaded) the Setups tab is hosted
   inside the Garage so vehicles, setups and types stay reachable before you open a
   log.
+- **Setups guide you to a vehicle first.** With no vehicles yet, the **Add setup**
+  button is disabled and a **First create a vehicle** button takes you to the
+  Vehicles tab — no more dead-end where a setup has nothing to attach to.
+- **Copy setup from another vehicle.** When a same-type vehicle already has a
+  setup, the new-setup form shows a **Copy setup from…** button: pick a vehicle
+  (filtered to the current type) and one of its setups, and the form is pre-filled
+  so you can tweak and save — a big time-saver across similar karts/cars.
 - **Tighter lap selector.** The lap dropdown in the session header now sizes to
   its label instead of a fixed width, freeing up room so the toolbar controls
   (snapshots, overlays) don't get squeezed off-screen on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,17 +135,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   once). The setup-status nag jumps straight to the right place. On **tablets and
   desktop** the two share one **Setups & Notes** tab shown as a 50/50 split, so
   the extra width isn't wasted; phones keep them as separate full-width tabs.
-- **Fewer taps for single-vehicle garages.** The new-setup form now pre-fills the
-  vehicle type when you only have one, and the vehicle when only one fits — both
-  pickers stay visible, they're just filled in for you. The session-setup selector
-  on Notes likewise pre-fills your only vehicle (and its only setup). Nothing is
-  auto-saved — you still tap Save. And if you linked the wrong setup to a session,
-  a **Clear session data** button (with an "are you sure" confirm) unlinks it so
-  you can re-assign; your notes and measurements are kept.
+- **Fewer taps for single-vehicle garages.** The new-setup form now pre-fills
+  (and locks) the vehicle type when you only have one, and the vehicle when only
+  one fits — the pickers stay visible, just filled in for you. The session-setup
+  selector on Notes likewise pre-fills your only vehicle (and its only setup).
+  Nothing is auto-saved — you still tap Save. And if you linked the wrong setup to
+  a session, a **Clear session data** button (with an "are you sure" confirm)
+  unlinks it so you can re-assign; your notes and measurements are kept.
 - **Easier vehicle types.** Adding a vehicle now locks the type when there's only
   one (nothing to choose), and a **New type** button on the Vehicles tab jumps you
   straight to the vehicle-type creator on the Setups tab so it's clear where types
-  come from.
+  come from. On the landing page (no session loaded) the Setups tab is hosted
+  inside the Garage so vehicles, setups and types stay reachable before you open a
+  log.
 - **Tighter lap selector.** The lap dropdown in the session header now sizes to
   its label instead of a fixed width, freeing up room so the toolbar controls
   (snapshots, overlays) don't get squeezed off-screen on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   once). The setup-status nag jumps straight to the right place. On **tablets and
   desktop** the two share one **Setups & Notes** tab shown as a 50/50 split, so
   the extra width isn't wasted; phones keep them as separate full-width tabs.
+- **Fewer taps for single-vehicle setups.** When you only have one vehicle, the
+  new-setup form hides the redundant vehicle picker and selects it for you, and
+  the session-setup selector on Notes pre-fills your only vehicle (and its only
+  setup) — you still tap Save, nothing is auto-saved. And if you linked the wrong
+  setup to a session, a **Clear session data** button (with an "are you sure"
+  confirm) unlinks it so you can re-assign; your notes and measurements are kept.
 - **Tighter lap selector.** The lap dropdown in the session header now sizes to
   its label instead of a fixed width, freeing up room so the toolbar controls
   (snapshots, overlays) don't get squeezed off-screen on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their own tabs in the main view bar — **Setups** then **Notes**, to the right of
   Tools — instead of living inside the Garage drawer. They update often, so this
   keeps them a single tap away. **Vehicles** stay in the Garage (you set those up
-  once). The setup-status nag jumps straight to the right place.
+  once). The setup-status nag jumps straight to the right place. On **tablets and
+  desktop** the two share one **Setups & Notes** tab shown as a 50/50 split, so
+  the extra width isn't wasted; phones keep them as separate full-width tabs.
 - **Tighter lap selector.** The lap dropdown in the session header now sizes to
   its label instead of a fixed width, freeing up room so the toolbar controls
   (snapshots, overlays) don't get squeezed off-screen on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,12 +135,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   once). The setup-status nag jumps straight to the right place. On **tablets and
   desktop** the two share one **Setups & Notes** tab shown as a 50/50 split, so
   the extra width isn't wasted; phones keep them as separate full-width tabs.
-- **Fewer taps for single-vehicle setups.** When you only have one vehicle, the
-  new-setup form hides the redundant vehicle picker and selects it for you, and
-  the session-setup selector on Notes pre-fills your only vehicle (and its only
-  setup) — you still tap Save, nothing is auto-saved. And if you linked the wrong
-  setup to a session, a **Clear session data** button (with an "are you sure"
-  confirm) unlinks it so you can re-assign; your notes and measurements are kept.
+- **Fewer taps for single-vehicle garages.** The new-setup form now pre-fills the
+  vehicle type when you only have one, and the vehicle when only one fits — both
+  pickers stay visible, they're just filled in for you. The session-setup selector
+  on Notes likewise pre-fills your only vehicle (and its only setup). Nothing is
+  auto-saved — you still tap Save. And if you linked the wrong setup to a session,
+  a **Clear session data** button (with an "are you sure" confirm) unlinks it so
+  you can re-assign; your notes and measurements are kept.
+- **Easier vehicle types.** Adding a vehicle now locks the type when there's only
+  one (nothing to choose), and a **New type** button on the Vehicles tab jumps you
+  straight to the vehicle-type creator on the Setups tab so it's clear where types
+  come from.
 - **Tighter lap selector.** The lap dropdown in the session header now sizes to
   its label instead of a fixed width, freeing up room so the toolbar controls
   (snapshots, overlays) don't get squeezed off-screen on mobile.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ src/
 ├── components/
 │   ├── ui/                # shadcn/ui primitives
 │   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, Users, BannedIps, Tools, Messages)
-│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Coach, Tools; Setups + Notes live in drawer/ but are main-view tabs)
+│   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Coach, Tools; SetupsNotesPanel = Setups+Notes 50/50 split on md+, separate tabs on phones — bodies live in drawer/)
 │   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Device*); SetupsTab + NotesTab also here but mounted as main-view tabs
 │   ├── track-editor/      # Track editor: VisualEditor, SectorListEditor, CourseSectorEditor, Add*Dialog

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { X, Gauge, Cpu, User, Bluetooth, BluetoothOff, Loader2, Settings, MapPin, Battery, BatteryLow, BatteryMedium, BatteryFull, BatteryWarning } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ import { useDeviceContext } from "@/contexts/DeviceContext";
 import { isBleSupported, requestBatteryLevel, type BatteryInfo } from "@/lib/bleDatalogger";
 
 type TopTab = "garage" | "profile" | "device";
-type GarageTab = "files" | "vehicles";
+type GarageTab = "files" | "vehicles" | "setups";
 type DeviceTab = "settings" | "tracks";
 
 interface FileManagerDrawerProps {
@@ -46,6 +46,11 @@ interface FileManagerDrawerProps {
   // Jump to the vehicle-type creator (closes the drawer, opens the Setups tab).
   // Omitted off-session, where the Setups tab isn't reachable.
   onCreateVehicleType?: () => void;
+  // Off-session fallback: Setups normally lives in the main toolbar, but that
+  // tab only exists once a session is loaded. When provided (landing page only),
+  // host it as a garage sub-tab so setups/vehicle-types stay reachable. Passed as
+  // a ready-made node so the drawer needn't know about setup props.
+  setupsTab?: ReactNode;
   // Current session context (the browser opens at this track/course)
   currentTrackName: string | null;
   currentCourseName: string | null;
@@ -59,6 +64,7 @@ export function FileManagerDrawer({
   showProfile,
   vehicles, vehicleTypes,
   onAddVehicle, onUpdateVehicle, onRemoveVehicle, onCreateVehicleType,
+  setupsTab,
   currentTrackName, currentCourseName,
 }: FileManagerDrawerProps) {
   const { t } = useTranslation("drawer");
@@ -69,6 +75,7 @@ export function FileManagerDrawer({
   const garageTabs: { key: GarageTab; label: string }[] = [
     { key: "files", label: t("shell.garageTabs.files") },
     { key: "vehicles", label: t("shell.garageTabs.vehicles") },
+    ...(setupsTab ? [{ key: "setups" as const, label: t("shell.garageTabs.setups") }] : []),
   ];
 
   const deviceTabs: { key: DeviceTab; label: string; icon: React.ReactNode }[] = [
@@ -177,6 +184,7 @@ export function FileManagerDrawer({
             {garageTab === "vehicles" && (
               <VehiclesTab vehicles={vehicles} vehicleTypes={vehicleTypes} onAdd={onAddVehicle} onUpdate={onUpdateVehicle} onRemove={onRemoveVehicle} onCreateVehicleType={onCreateVehicleType} />
             )}
+            {garageTab === "setups" && setupsTab}
           </>
         )}
 

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -43,6 +43,9 @@ interface FileManagerDrawerProps {
   onAddVehicle: (vehicle: Omit<Vehicle, "id">) => Promise<void>;
   onUpdateVehicle: (vehicle: Vehicle) => Promise<void>;
   onRemoveVehicle: (id: string) => Promise<void>;
+  // Jump to the vehicle-type creator (closes the drawer, opens the Setups tab).
+  // Omitted off-session, where the Setups tab isn't reachable.
+  onCreateVehicleType?: () => void;
   // Current session context (the browser opens at this track/course)
   currentTrackName: string | null;
   currentCourseName: string | null;
@@ -55,7 +58,7 @@ export function FileManagerDrawer({
   initialGarageTab = "files",
   showProfile,
   vehicles, vehicleTypes,
-  onAddVehicle, onUpdateVehicle, onRemoveVehicle,
+  onAddVehicle, onUpdateVehicle, onRemoveVehicle, onCreateVehicleType,
   currentTrackName, currentCourseName,
 }: FileManagerDrawerProps) {
   const { t } = useTranslation("drawer");
@@ -172,7 +175,7 @@ export function FileManagerDrawer({
               <FilesTab files={files} fileMetadataMap={fileMetadataMap} vehicles={vehicles} currentTrackName={currentTrackName} currentCourseName={currentCourseName} isOpen={isOpen} storageUsed={storageUsed} storageQuota={storageQuota} onLoadFile={onLoadFile} onDeleteFile={onDeleteFile} onExportFile={onExportFile} onSaveFile={onSaveFile} onDataLoaded={onDataLoaded} onClose={onClose} autoSave={autoSave} showSampleFiles={showSampleFiles} />
             )}
             {garageTab === "vehicles" && (
-              <VehiclesTab vehicles={vehicles} vehicleTypes={vehicleTypes} onAdd={onAddVehicle} onUpdate={onUpdateVehicle} onRemove={onRemoveVehicle} />
+              <VehiclesTab vehicles={vehicles} vehicleTypes={vehicleTypes} onAdd={onAddVehicle} onUpdate={onUpdateVehicle} onRemove={onRemoveVehicle} onCreateVehicleType={onCreateVehicleType} />
             )}
           </>
         )}

--- a/src/components/drawer/NotesTab.tsx
+++ b/src/components/drawer/NotesTab.tsx
@@ -38,19 +38,35 @@ export function NotesTab({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [text, setText] = useState("");
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [confirmClearSession, setConfirmClearSession] = useState(false);
   const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(null);
   const [selectedSetupId, setSelectedSetupId] = useState<string | null>(null);
 
+  // The setup to default to for a vehicle: its only one, or none when ambiguous.
+  const defaultSetupFor = useCallback((vehicleId: string): string | null => {
+    const forVehicle = setups.filter(s => s.vehicleId === vehicleId);
+    return forVehicle.length === 1 ? forVehicle[0].id : null;
+  }, [setups]);
+
   useEffect(() => {
-    setSelectedVehicleId(sessionKartId);
-    setSelectedSetupId(sessionSetupId);
-  }, [sessionKartId, sessionSetupId]);
+    if (sessionKartId) {
+      // Session already linked — restore exactly what was saved.
+      setSelectedVehicleId(sessionKartId);
+      setSelectedSetupId(sessionSetupId);
+      return;
+    }
+    // Unlinked session: pre-fill the obvious choices (the only vehicle, and its
+    // only setup) so the user just has to hit Save — we never auto-save for them.
+    const onlyVehicle = vehicles.length === 1 ? vehicles[0].id : null;
+    setSelectedVehicleId(onlyVehicle);
+    setSelectedSetupId(onlyVehicle ? defaultSetupFor(onlyVehicle) : null);
+  }, [sessionKartId, sessionSetupId, vehicles, defaultSetupFor]);
 
   const handleVehicleChange = useCallback((value: string) => {
     const id = value === "none" ? null : value;
     setSelectedVehicleId(id);
-    setSelectedSetupId(null);
-  }, []);
+    setSelectedSetupId(id ? defaultSetupFor(id) : null);
+  }, [defaultSetupFor]);
 
   const handleSetupChange = useCallback((value: string) => {
     setSelectedSetupId(value === "none" ? null : value);
@@ -67,6 +83,13 @@ export function NotesTab({
   const handleSaveSetup = useCallback(async () => {
     await onSaveSessionSetup(selectedVehicleId, selectedSetupId);
   }, [selectedVehicleId, selectedSetupId, onSaveSessionSetup]);
+
+  // Escape hatch for a setup saved to the session by mistake: unlink it so the
+  // user can re-assign the correct one. Notes/measurements are left untouched.
+  const handleClearSession = useCallback(async () => {
+    await onSaveSessionSetup(null, null);
+    setConfirmClearSession(false);
+  }, [onSaveSessionSetup]);
 
   const resetForm = () => { setEditingId(null); setText(""); };
 
@@ -142,6 +165,22 @@ export function NotesTab({
             </span>{" "}
             {t("notes.setupFrozen")}
           </p>
+        )}
+        {/* Recover from a wrong setup saved to the session: clear and re-assign. */}
+        {(sessionKartId || sessionSetupId) && (
+          confirmClearSession ? (
+            <div className="p-3 rounded-md border border-border bg-muted/60 space-y-2">
+              <p className="text-sm text-foreground">{t("notes.clearConfirm")}</p>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={() => setConfirmClearSession(false)}>{t("notes.cancel")}</Button>
+                <Button variant="destructive" size="sm" onClick={handleClearSession}>{t("notes.clearConfirmAction")}</Button>
+              </div>
+            </div>
+          ) : (
+            <Button variant="ghost" size="sm" className="w-full text-destructive hover:text-destructive hover:bg-destructive/10" onClick={() => setConfirmClearSession(true)}>
+              {t("notes.clearSession")}
+            </Button>
+          )
         )}
       </div>
 

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -1,12 +1,13 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Wrench, Plus, ArrowLeft, Pencil, Trash2, Info, Car, History } from "lucide-react";
+import { Wrench, Plus, ArrowLeft, Pencil, Trash2, Info, Car, History, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
 import { VehicleType, SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
@@ -31,6 +32,8 @@ interface SetupsTabProps {
    *  the Vehicles tab's "New type" shortcut). Cleared via onRequestNewTypeHandled. */
   requestNewType?: boolean;
   onRequestNewTypeHandled?: () => void;
+  /** Open the garage to the Vehicles tab (setups require a vehicle to attach to). */
+  onCreateVehicle?: () => void;
 }
 
 type FormMode = "list" | "new" | "edit" | "new-type" | "history";
@@ -64,12 +67,17 @@ export function SetupsTab({
   onAdd, onUpdate, onRemove, onGetLatestForVehicle,
   onAddVehicleType, onRemoveVehicleType,
   requestNewType, onRequestNewTypeHandled,
+  onCreateVehicle,
 }: SetupsTabProps) {
   const { t } = useTranslation("drawer");
   const [mode, setMode] = useState<FormMode>("list");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState(emptyForm());
   const [selectedTypeId, setSelectedTypeId] = useState<string>("");
+  // "Copy setup from…" dialog state (copy another same-type vehicle's setup).
+  const [copyOpen, setCopyOpen] = useState(false);
+  const [copyVehicleId, setCopyVehicleId] = useState("");
+  const [copySetupId, setCopySetupId] = useState("");
   const [preloaded, setPreloaded] = useState(false);
   const preloadSnapshot = useRef<Record<string, unknown> | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
@@ -177,63 +185,66 @@ export function SetupsTab({
     setMode("edit");
   }, [vehicles]);
 
+  // Copy a source setup's values into the current form, keeping the form's own
+  // target vehicle and name. Shared by the per-vehicle preload and the explicit
+  // "Copy setup from…" dialog. Also seeds the change-highlight snapshot.
+  const applySourceSetup = useCallback((source: VehicleSetup) => {
+    const psiMode = detectPsiMode(source);
+    const widthMode = detectWidthMode(source);
+    const diamMode = detectDiameterMode(source);
+    setForm(prev => ({
+      ...prev,
+      templateId: source.templateId,
+      unitSystem: source.unitSystem || "mm",
+      tireBrand: source.tireBrand,
+      psiMode,
+      psiFrontLeft: source.psiFrontLeft,
+      psiFrontRight: source.psiFrontRight,
+      psiRearLeft: source.psiRearLeft,
+      psiRearRight: source.psiRearRight,
+      tireWidthMode: widthMode,
+      tireWidthFrontLeft: source.tireWidthFrontLeft,
+      tireWidthFrontRight: source.tireWidthFrontRight,
+      tireWidthRearLeft: source.tireWidthRearLeft,
+      tireWidthRearRight: source.tireWidthRearRight,
+      tireDiameterMode: diamMode,
+      tireDiameterFrontLeft: source.tireDiameterFrontLeft,
+      tireDiameterFrontRight: source.tireDiameterFrontRight,
+      tireDiameterRearLeft: source.tireDiameterRearLeft,
+      tireDiameterRearRight: source.tireDiameterRearRight,
+      customFields: { ...source.customFields },
+    }));
+    if (psiMode === "single") setPsiSingle(source.psiFrontLeft);
+    if (psiMode === "halves") { setPsiFront(source.psiFrontLeft); setPsiRear(source.psiRearLeft); }
+    if (widthMode === "halves") { setWidthFront(source.tireWidthFrontLeft); setWidthRear(source.tireWidthRearLeft); }
+    if (diamMode === "halves") { setDiamFront(source.tireDiameterFrontLeft); setDiamRear(source.tireDiameterRearLeft); }
+    // Snapshot for change highlighting
+    preloadSnapshot.current = {
+      ...source.customFields,
+      tireBrand: source.tireBrand,
+      psiSingle: psiMode === "single" ? source.psiFrontLeft : null,
+      psiFront: psiMode === "halves" ? source.psiFrontLeft : null,
+      psiRear: psiMode === "halves" ? source.psiRearLeft : null,
+      psiFrontLeft: source.psiFrontLeft, psiFrontRight: source.psiFrontRight,
+      psiRearLeft: source.psiRearLeft, psiRearRight: source.psiRearRight,
+      widthFront: widthMode === "halves" ? source.tireWidthFrontLeft : null,
+      widthRear: widthMode === "halves" ? source.tireWidthRearLeft : null,
+      tireWidthFrontLeft: source.tireWidthFrontLeft, tireWidthFrontRight: source.tireWidthFrontRight,
+      tireWidthRearLeft: source.tireWidthRearLeft, tireWidthRearRight: source.tireWidthRearRight,
+      diamFront: diamMode === "halves" ? source.tireDiameterFrontLeft : null,
+      diamRear: diamMode === "halves" ? source.tireDiameterRearLeft : null,
+      tireDiameterFrontLeft: source.tireDiameterFrontLeft, tireDiameterFrontRight: source.tireDiameterFrontRight,
+      tireDiameterRearLeft: source.tireDiameterRearLeft, tireDiameterRearRight: source.tireDiameterRearRight,
+    };
+    setPreloaded(true);
+  }, []);
+
   const handleVehicleChange = useCallback(async (vehicleId: string) => {
     setForm(prev => ({ ...prev, vehicleId }));
     if (mode !== "new") return;
     const latest = await onGetLatestForVehicle(vehicleId);
-    if (latest) {
-      const psiMode = detectPsiMode(latest);
-      const widthMode = detectWidthMode(latest);
-      const diamMode = detectDiameterMode(latest);
-      setForm(prev => ({
-        ...prev,
-        vehicleId,
-        name: prev.name,
-        templateId: latest.templateId,
-        unitSystem: latest.unitSystem || "mm",
-        tireBrand: latest.tireBrand,
-        psiMode,
-        psiFrontLeft: latest.psiFrontLeft,
-        psiFrontRight: latest.psiFrontRight,
-        psiRearLeft: latest.psiRearLeft,
-        psiRearRight: latest.psiRearRight,
-        tireWidthMode: widthMode,
-        tireWidthFrontLeft: latest.tireWidthFrontLeft,
-        tireWidthFrontRight: latest.tireWidthFrontRight,
-        tireWidthRearLeft: latest.tireWidthRearLeft,
-        tireWidthRearRight: latest.tireWidthRearRight,
-        tireDiameterMode: diamMode,
-        tireDiameterFrontLeft: latest.tireDiameterFrontLeft,
-        tireDiameterFrontRight: latest.tireDiameterFrontRight,
-        tireDiameterRearLeft: latest.tireDiameterRearLeft,
-        tireDiameterRearRight: latest.tireDiameterRearRight,
-        customFields: { ...latest.customFields },
-      }));
-      if (psiMode === "single") setPsiSingle(latest.psiFrontLeft);
-      if (psiMode === "halves") { setPsiFront(latest.psiFrontLeft); setPsiRear(latest.psiRearLeft); }
-      if (widthMode === "halves") { setWidthFront(latest.tireWidthFrontLeft); setWidthRear(latest.tireWidthRearLeft); }
-      if (diamMode === "halves") { setDiamFront(latest.tireDiameterFrontLeft); setDiamRear(latest.tireDiameterRearLeft); }
-      // Snapshot for change highlighting
-      preloadSnapshot.current = {
-        ...latest.customFields,
-        tireBrand: latest.tireBrand,
-        psiSingle: psiMode === "single" ? latest.psiFrontLeft : null,
-        psiFront: psiMode === "halves" ? latest.psiFrontLeft : null,
-        psiRear: psiMode === "halves" ? latest.psiRearLeft : null,
-        psiFrontLeft: latest.psiFrontLeft, psiFrontRight: latest.psiFrontRight,
-        psiRearLeft: latest.psiRearLeft, psiRearRight: latest.psiRearRight,
-        widthFront: widthMode === "halves" ? latest.tireWidthFrontLeft : null,
-        widthRear: widthMode === "halves" ? latest.tireWidthRearLeft : null,
-        tireWidthFrontLeft: latest.tireWidthFrontLeft, tireWidthFrontRight: latest.tireWidthFrontRight,
-        tireWidthRearLeft: latest.tireWidthRearLeft, tireWidthRearRight: latest.tireWidthRearRight,
-        diamFront: diamMode === "halves" ? latest.tireDiameterFrontLeft : null,
-        diamRear: diamMode === "halves" ? latest.tireDiameterRearLeft : null,
-        tireDiameterFrontLeft: latest.tireDiameterFrontLeft, tireDiameterFrontRight: latest.tireDiameterFrontRight,
-        tireDiameterRearLeft: latest.tireDiameterRearLeft, tireDiameterRearRight: latest.tireDiameterRearRight,
-      };
-      setPreloaded(true);
-    }
-  }, [mode, onGetLatestForVehicle]);
+    if (latest) applySourceSetup(latest);
+  }, [mode, onGetLatestForVehicle, applySourceSetup]);
 
   const handleTypeChange = useCallback((typeId: string) => {
     setSelectedTypeId(typeId);
@@ -266,6 +277,34 @@ export function SetupsTab({
     setMode("new-type");
     onRequestNewTypeHandled?.();
   }, [requestNewType, onRequestNewTypeHandled]);
+
+  // "Copy setup from…": same-type vehicles that already have a setup to copy.
+  const copyableVehicles = useMemo(
+    () => filteredVehicles.filter(v => setups.some(s => s.vehicleId === v.id)),
+    [filteredVehicles, setups],
+  );
+  const copyVehicleSetups = useMemo(
+    () => setups.filter(s => s.vehicleId === copyVehicleId),
+    [setups, copyVehicleId],
+  );
+
+  const openCopy = useCallback(() => {
+    const firstVehicle = copyableVehicles[0]?.id ?? "";
+    setCopyVehicleId(firstVehicle);
+    setCopySetupId(setups.find(s => s.vehicleId === firstVehicle)?.id ?? "");
+    setCopyOpen(true);
+  }, [copyableVehicles, setups]);
+
+  const handleCopyVehicleChange = useCallback((vehicleId: string) => {
+    setCopyVehicleId(vehicleId);
+    setCopySetupId(setups.find(s => s.vehicleId === vehicleId)?.id ?? "");
+  }, [setups]);
+
+  const handleCopyConfirm = useCallback(() => {
+    const source = setups.find(s => s.id === copySetupId);
+    if (source) applySourceSetup(source);
+    setCopyOpen(false);
+  }, [copySetupId, setups, applySourceSetup]);
 
   const handleSave = useCallback(async () => {
     let finalForm = { ...form };
@@ -387,9 +426,16 @@ export function SetupsTab({
           <Button variant="secondary" className="w-full gap-2" onClick={() => setMode("new-type")}>
             <Car className="w-4 h-4" /> {t("setups.newVehicleType")}
           </Button>
-          <Button className="w-full gap-2" onClick={openNew}>
+          {/* A setup must attach to a vehicle — block new setups until one exists
+              and point the user at the Vehicles tab. */}
+          <Button className="w-full gap-2" onClick={openNew} disabled={vehicles.length === 0}>
             <Plus className="w-4 h-4" /> {t("setups.addNewSetup")}
           </Button>
+          {vehicles.length === 0 && onCreateVehicle && (
+            <Button className="w-full gap-2" onClick={onCreateVehicle}>
+              <Car className="w-4 h-4" /> {t("setups.firstCreateVehicle")}
+            </Button>
+          )}
         </div>
       </div>
     );
@@ -434,6 +480,12 @@ export function SetupsTab({
                 </SelectContent>
               </Select>
             </Field>
+          )}
+          {/* Bootstrap a new setup from a same-type vehicle that already has one. */}
+          {mode === "new" && selectedTypeId && copyableVehicles.length > 0 && (
+            <Button variant="outline" size="sm" className="w-full gap-2" onClick={openCopy}>
+              <Copy className="w-4 h-4" /> {t("setups.copyFrom")}
+            </Button>
           )}
           <Field label={t("setups.vehicle")}>
             <Select value={form.vehicleId} onValueChange={handleVehicleChange} disabled={filteredVehicles.length <= 1}>
@@ -599,6 +651,39 @@ export function SetupsTab({
           {mode === "edit" ? t("setups.update") : t("setups.save")}
         </Button>
       </div>
+
+      {/* Copy-setup-from dialog */}
+      <Dialog open={copyOpen} onOpenChange={setCopyOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t("setups.copyFrom")}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label className="text-xs">{t("setups.vehicle")}</Label>
+              <Select value={copyVehicleId} onValueChange={handleCopyVehicleChange}>
+                <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectVehicle")} /></SelectTrigger>
+                <SelectContent>
+                  {copyableVehicles.map(v => <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">{t("setups.setup")}</Label>
+              <Select value={copySetupId} onValueChange={setCopySetupId} disabled={copyVehicleSetups.length === 0}>
+                <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectSetup")} /></SelectTrigger>
+                <SelectContent>
+                  {copyVehicleSetups.map(s => <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCopyOpen(false)}>{t("setups.cancel")}</Button>
+            <Button onClick={handleCopyConfirm} disabled={!copySetupId}>{t("setups.copy")}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -239,6 +239,17 @@ export function SetupsTab({
     }
   }, [vehicleTypes, templates]);
 
+  // When the chosen type leaves exactly one candidate vehicle there's nothing to
+  // pick — auto-select it (which also preloads its latest setup) so the redundant
+  // vehicle dropdown can be hidden.
+  useEffect(() => {
+    if (mode !== "new" || !selectedTypeId) return;
+    if (filteredVehicles.length !== 1) return;
+    const only = filteredVehicles[0];
+    if (form.vehicleId === only.id) return;
+    handleVehicleChange(only.id);
+  }, [mode, selectedTypeId, filteredVehicles, form.vehicleId, handleVehicleChange]);
+
   const handleSave = useCallback(async () => {
     let finalForm = { ...form };
     if (form.psiMode === "single" && psiSingle !== null) {
@@ -405,16 +416,20 @@ export function SetupsTab({
               </Select>
             </Field>
           )}
-          <Field label={t("setups.vehicle")}>
-            <Select value={form.vehicleId} onValueChange={handleVehicleChange}>
-              <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectVehicle")} /></SelectTrigger>
-              <SelectContent>
-                {filteredVehicles.map(v => (
-                  <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
+          {/* One candidate vehicle is auto-selected (see effect above), so only
+              surface the picker when there's an actual choice to make. */}
+          {filteredVehicles.length !== 1 && (
+            <Field label={t("setups.vehicle")}>
+              <Select value={form.vehicleId} onValueChange={handleVehicleChange}>
+                <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectVehicle")} /></SelectTrigger>
+                <SelectContent>
+                  {filteredVehicles.map(v => (
+                    <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          )}
           <Field label={t("setups.setupName")}>
             <Input value={form.name} onChange={e => setForm(p => ({ ...p, name: e.target.value }))} placeholder={t("setups.setupNamePlaceholder")} className="h-9" />
           </Field>

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -421,9 +421,11 @@ export function SetupsTab({
       <div className="flex-1 overflow-y-auto px-3 py-3 space-y-4">
         {/* Vehicle Type & Vehicle Selection */}
         <Section>
+          {/* A single option leaves nothing to choose — populate (via the effect
+              above) and lock the picker. */}
           {mode === "new" && (
             <Field label={t("setups.vehicleType")}>
-              <Select value={selectedTypeId} onValueChange={handleTypeChange}>
+              <Select value={selectedTypeId} onValueChange={handleTypeChange} disabled={vehicleTypes.length <= 1}>
                 <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectType")} /></SelectTrigger>
                 <SelectContent>
                   {vehicleTypes.map(vt => (
@@ -434,7 +436,7 @@ export function SetupsTab({
             </Field>
           )}
           <Field label={t("setups.vehicle")}>
-            <Select value={form.vehicleId} onValueChange={handleVehicleChange}>
+            <Select value={form.vehicleId} onValueChange={handleVehicleChange} disabled={filteredVehicles.length <= 1}>
               <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectVehicle")} /></SelectTrigger>
               <SelectContent>
                 {filteredVehicles.map(v => (

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -27,6 +27,10 @@ interface SetupsTabProps {
   onGetLatestForVehicle: (vehicleId: string) => Promise<VehicleSetup | null>;
   onAddVehicleType: (name: string, wheelCount: 2 | 4, includeTires: boolean, sections: TemplateSection[]) => Promise<unknown>;
   onRemoveVehicleType: (vehicleTypeId: string, templateId: string) => Promise<void>;
+  /** When toggled true, jump straight into the vehicle-type creator (e.g. from
+   *  the Vehicles tab's "New type" shortcut). Cleared via onRequestNewTypeHandled. */
+  requestNewType?: boolean;
+  onRequestNewTypeHandled?: () => void;
 }
 
 type FormMode = "list" | "new" | "edit" | "new-type" | "history";
@@ -59,6 +63,7 @@ export function SetupsTab({
   vehicles, setups, vehicleTypes, templates,
   onAdd, onUpdate, onRemove, onGetLatestForVehicle,
   onAddVehicleType, onRemoveVehicleType,
+  requestNewType, onRequestNewTypeHandled,
 }: SetupsTabProps) {
   const { t } = useTranslation("drawer");
   const [mode, setMode] = useState<FormMode>("list");
@@ -239,16 +244,28 @@ export function SetupsTab({
     }
   }, [vehicleTypes, templates]);
 
-  // When the chosen type leaves exactly one candidate vehicle there's nothing to
-  // pick — auto-select it (which also preloads its latest setup) so the redundant
-  // vehicle dropdown can be hidden.
+  // New-setup defaults: with a single vehicle type, pre-select it; with a single
+  // candidate vehicle, pre-select that too (which also preloads its latest
+  // setup). Both pickers stay visible — these are convenience defaults, not locks.
   useEffect(() => {
-    if (mode !== "new" || !selectedTypeId) return;
-    if (filteredVehicles.length !== 1) return;
-    const only = filteredVehicles[0];
-    if (form.vehicleId === only.id) return;
-    handleVehicleChange(only.id);
-  }, [mode, selectedTypeId, filteredVehicles, form.vehicleId, handleVehicleChange]);
+    if (mode !== "new") return;
+    if (!selectedTypeId && vehicleTypes.length === 1) {
+      handleTypeChange(vehicleTypes[0].id);
+      return;
+    }
+    if (selectedTypeId && filteredVehicles.length === 1 && form.vehicleId !== filteredVehicles[0].id) {
+      handleVehicleChange(filteredVehicles[0].id);
+    }
+  }, [mode, selectedTypeId, vehicleTypes, filteredVehicles, form.vehicleId, handleTypeChange, handleVehicleChange]);
+
+  // External shortcut (the Vehicles tab's "New type" button) drops the user
+  // straight into the vehicle-type creator. The parent clears the request once
+  // handled so it fires once per click.
+  useEffect(() => {
+    if (!requestNewType) return;
+    setMode("new-type");
+    onRequestNewTypeHandled?.();
+  }, [requestNewType, onRequestNewTypeHandled]);
 
   const handleSave = useCallback(async () => {
     let finalForm = { ...form };
@@ -416,20 +433,16 @@ export function SetupsTab({
               </Select>
             </Field>
           )}
-          {/* One candidate vehicle is auto-selected (see effect above), so only
-              surface the picker when there's an actual choice to make. */}
-          {filteredVehicles.length !== 1 && (
-            <Field label={t("setups.vehicle")}>
-              <Select value={form.vehicleId} onValueChange={handleVehicleChange}>
-                <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectVehicle")} /></SelectTrigger>
-                <SelectContent>
-                  {filteredVehicles.map(v => (
-                    <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-          )}
+          <Field label={t("setups.vehicle")}>
+            <Select value={form.vehicleId} onValueChange={handleVehicleChange}>
+              <SelectTrigger className="h-9"><SelectValue placeholder={t("setups.selectVehicle")} /></SelectTrigger>
+              <SelectContent>
+                {filteredVehicles.map(v => (
+                  <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
           <Field label={t("setups.setupName")}>
             <Input value={form.name} onChange={e => setForm(p => ({ ...p, name: e.target.value }))} placeholder={t("setups.setupNamePlaceholder")} className="h-9" />
           </Field>

--- a/src/components/drawer/VehiclesTab.tsx
+++ b/src/components/drawer/VehiclesTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Pencil, Trash2, Car } from "lucide-react";
+import { Pencil, Trash2, Car, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -17,6 +17,8 @@ interface VehiclesTabProps {
   onAdd: (vehicle: Omit<Vehicle, "id">) => Promise<void>;
   onUpdate: (vehicle: Vehicle) => Promise<void>;
   onRemove: (id: string) => Promise<void>;
+  /** Jump to the vehicle-type creator (closes the garage, opens the Setups tab). */
+  onCreateVehicleType?: () => void;
 }
 
 const emptyForm = (defaultTypeId: string): Omit<Vehicle, "id"> => ({
@@ -28,7 +30,7 @@ const emptyForm = (defaultTypeId: string): Omit<Vehicle, "id"> => ({
   weightUnit: "lb",
 });
 
-export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove }: VehiclesTabProps) {
+export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove, onCreateVehicleType }: VehiclesTabProps) {
   const { t } = useTranslation("drawer");
   const defaultTypeId = vehicleTypes[0]?.id ?? "";
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -136,8 +138,16 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
 
       <div className="border-t border-border p-4 space-y-3 shrink-0">
         <div className="space-y-1">
-          <Label className="text-xs">{t("vehicles.vehicleType")}</Label>
-          <Select value={form.vehicleTypeId} onValueChange={v => setForm(f => ({ ...f, vehicleTypeId: v }))}>
+          <div className="flex items-center justify-between">
+            <Label className="text-xs">{t("vehicles.vehicleType")}</Label>
+            {onCreateVehicleType && (
+              <Button variant="ghost" size="sm" className="h-6 px-2 text-xs gap-1" onClick={onCreateVehicleType}>
+                <Plus className="w-3 h-3" /> {t("vehicles.newType")}
+              </Button>
+            )}
+          </div>
+          {/* A single type leaves nothing to choose — populate and lock it. */}
+          <Select value={form.vehicleTypeId} onValueChange={v => setForm(f => ({ ...f, vehicleTypeId: v }))} disabled={vehicleTypes.length <= 1}>
             <SelectTrigger className="h-8 text-sm"><SelectValue placeholder={t("vehicles.selectType")} /></SelectTrigger>
             <SelectContent>
               {vehicleTypes.map(vt => (

--- a/src/components/tabs/SetupsNotesPanel.tsx
+++ b/src/components/tabs/SetupsNotesPanel.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/** Which of the two panels the small-screen tab bar has selected. */
+export type SetupsNotesTab = "setups" | "notes";
+
+interface SetupsNotesPanelProps {
+  /**
+   * The panel the user picked from the toolbar. Only affects the small-screen
+   * (single-panel) layout — at `md` and up both panels are always visible.
+   */
+  active: SetupsNotesTab;
+  /** The Setups panel content (rendered on the left half at `md`+). */
+  setups: ReactNode;
+  /** The Notes panel content (rendered on the right half at `md`+). */
+  notes: ReactNode;
+}
+
+/**
+ * Responsive container that hosts the Setups and Notes panels together.
+ *
+ * - **Below `md`** (phones): only the `active` panel is shown, full width. The
+ *   toolbar exposes Setups and Notes as two separate tabs there.
+ * - **`md` and up** (tablets/desktop): both panels sit side by side in a 50/50
+ *   split, reclaiming the horizontal space a single centred panel wastes. The
+ *   toolbar collapses to one combined "Setups & Notes" tab.
+ *
+ * Both panels stay mounted at every breakpoint and visibility is pure CSS, so
+ * crossing the breakpoint (or switching the small-screen tab) never remounts a
+ * panel or drops its in-progress form state.
+ */
+export function SetupsNotesPanel({ active, setups, notes }: SetupsNotesPanelProps) {
+  return (
+    <div className="h-full flex">
+      <SplitHalf show={active === "setups"} className="md:border-r md:border-border">
+        {setups}
+      </SplitHalf>
+      <SplitHalf show={active === "notes"}>{notes}</SplitHalf>
+    </div>
+  );
+}
+
+/**
+ * One half of the split. Hidden on small screens unless it's the active panel;
+ * always an equal-width column at `md`+ (the responsive utilities override the
+ * small-screen `hidden`/`w-full` via their media query).
+ */
+function SplitHalf({
+  show,
+  className,
+  children,
+}: {
+  show: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 min-h-0 flex-col overflow-hidden md:flex md:w-1/2",
+        show ? "flex w-full" : "hidden",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -121,7 +121,12 @@
     "halves": "Hälften",
     "quarters": "Viertel",
     "update": "Aktualisieren",
-    "save": "Speichern"
+    "save": "Speichern",
+    "copyFrom": "Setup kopieren von…",
+    "setup": "Setup",
+    "selectSetup": "Setup auswählen…",
+    "copy": "Kopieren",
+    "firstCreateVehicle": "Zuerst ein Fahrzeug erstellen"
   },
   "setupHistory": {
     "title": "Setup-Verlauf",

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -163,7 +163,10 @@
     "edit": "Bearbeiten",
     "writeNote": "Notiz schreiben…",
     "updateNote": "Notiz aktualisieren",
-    "addNote": "Notiz hinzufügen"
+    "addNote": "Notiz hinzufügen",
+    "clearSession": "Sitzungsdaten löschen",
+    "clearConfirm": "Dies löscht das für diese Sitzung gespeicherte Fahrzeug und Setup. Dies kann nicht rückgängig gemacht werden.",
+    "clearConfirmAction": "Löschen"
   },
   "postSession": {
     "title": "Nach der Session",

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -63,6 +63,7 @@
     "unknownType": "Unbekannter Typ",
     "edit": "Bearbeiten",
     "vehicleType": "Fahrzeugtyp",
+    "newType": "Neuer Typ",
     "selectType": "Typ auswählen…",
     "name": "Name",
     "namePlaceholder": "Fahrzeugname",

--- a/src/locales/de/session.json
+++ b/src/locales/de/session.json
@@ -7,7 +7,8 @@
     "coach": "Coach",
     "tools": "Werkzeuge",
     "setups": "Setups",
-    "notes": "Notizen"
+    "notes": "Notizen",
+    "setupsNotes": "Setups & Notizen"
   },
   "header": {
     "play": "Abspielen",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -162,7 +162,10 @@
     "edit": "Edit",
     "writeNote": "Write a note…",
     "updateNote": "Update Note",
-    "addNote": "Add Note"
+    "addNote": "Add Note",
+    "clearSession": "Clear session data",
+    "clearConfirm": "This clears the vehicle and setup saved to this session. This cannot be undone.",
+    "clearConfirmAction": "Clear"
   },
   "postSession": {
     "title": "Post-Session",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -120,7 +120,12 @@
     "halves": "Halves",
     "quarters": "Quarters",
     "update": "Update",
-    "save": "Save"
+    "save": "Save",
+    "copyFrom": "Copy setup from…",
+    "setup": "Setup",
+    "selectSetup": "Select setup…",
+    "copy": "Copy",
+    "firstCreateVehicle": "First create a vehicle"
   },
   "setupHistory": {
     "title": "Setup History",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -62,6 +62,7 @@
     "unknownType": "Unknown type",
     "edit": "Edit",
     "vehicleType": "Vehicle Type",
+    "newType": "New type",
     "selectType": "Select type…",
     "name": "Name",
     "namePlaceholder": "Vehicle name",

--- a/src/locales/en/session.json
+++ b/src/locales/en/session.json
@@ -6,7 +6,8 @@
     "coach": "Coach",
     "tools": "Tools",
     "setups": "Setups",
-    "notes": "Notes"
+    "notes": "Notes",
+    "setupsNotes": "Setups & Notes"
   },
   "header": {
     "play": "Play",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -121,7 +121,12 @@
     "halves": "Mitades",
     "quarters": "Cuartos",
     "update": "Actualizar",
-    "save": "Guardar"
+    "save": "Guardar",
+    "copyFrom": "Copiar reglaje de…",
+    "setup": "Reglaje",
+    "selectSetup": "Seleccionar reglaje…",
+    "copy": "Copiar",
+    "firstCreateVehicle": "Primero crea un vehículo"
   },
   "setupHistory": {
     "title": "Historial de configuración",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -163,7 +163,10 @@
     "edit": "Editar",
     "writeNote": "Escribe una nota…",
     "updateNote": "Actualizar nota",
-    "addNote": "Añadir nota"
+    "addNote": "Añadir nota",
+    "clearSession": "Borrar datos de sesión",
+    "clearConfirm": "Esto borra el vehículo y el reglaje guardados en esta sesión. No se puede deshacer.",
+    "clearConfirmAction": "Borrar"
   },
   "postSession": {
     "title": "Post-sesión",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -63,6 +63,7 @@
     "unknownType": "Tipo desconocido",
     "edit": "Editar",
     "vehicleType": "Tipo de vehículo",
+    "newType": "Nuevo tipo",
     "selectType": "Seleccionar tipo…",
     "name": "Nombre",
     "namePlaceholder": "Nombre del vehículo",

--- a/src/locales/es/session.json
+++ b/src/locales/es/session.json
@@ -7,7 +7,8 @@
     "coach": "Coach",
     "tools": "Herramientas",
     "setups": "Reglajes",
-    "notes": "Notas"
+    "notes": "Notas",
+    "setupsNotes": "Reglajes y notas"
   },
   "header": {
     "play": "Reproducir",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -121,7 +121,12 @@
     "halves": "Moitiés",
     "quarters": "Quarts",
     "update": "Mettre à jour",
-    "save": "Enregistrer"
+    "save": "Enregistrer",
+    "copyFrom": "Copier le réglage de…",
+    "setup": "Réglage",
+    "selectSetup": "Sélectionner un réglage…",
+    "copy": "Copier",
+    "firstCreateVehicle": "Créez d'abord un véhicule"
   },
   "setupHistory": {
     "title": "Historique des réglages",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -163,7 +163,10 @@
     "edit": "Modifier",
     "writeNote": "Écrire une note…",
     "updateNote": "Mettre à jour la note",
-    "addNote": "Ajouter une note"
+    "addNote": "Ajouter une note",
+    "clearSession": "Effacer les données de session",
+    "clearConfirm": "Ceci efface le véhicule et le réglage enregistrés pour cette session. Cette action est irréversible.",
+    "clearConfirmAction": "Effacer"
   },
   "postSession": {
     "title": "Après-session",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -63,6 +63,7 @@
     "unknownType": "Type inconnu",
     "edit": "Modifier",
     "vehicleType": "Type de véhicule",
+    "newType": "Nouveau type",
     "selectType": "Sélectionner un type…",
     "name": "Nom",
     "namePlaceholder": "Nom du véhicule",

--- a/src/locales/fr/session.json
+++ b/src/locales/fr/session.json
@@ -7,7 +7,8 @@
     "coach": "Coach",
     "tools": "Outils",
     "setups": "Réglages",
-    "notes": "Notes"
+    "notes": "Notes",
+    "setupsNotes": "Réglages et notes"
   },
   "header": {
     "play": "Lecture",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -121,7 +121,12 @@
     "halves": "Metà",
     "quarters": "Quarti",
     "update": "Aggiorna",
-    "save": "Salva"
+    "save": "Salva",
+    "copyFrom": "Copia assetto da…",
+    "setup": "Assetto",
+    "selectSetup": "Seleziona assetto…",
+    "copy": "Copia",
+    "firstCreateVehicle": "Crea prima un veicolo"
   },
   "setupHistory": {
     "title": "Cronologia assetto",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -163,7 +163,10 @@
     "edit": "Modifica",
     "writeNote": "Scrivi una nota…",
     "updateNote": "Aggiorna nota",
-    "addNote": "Aggiungi nota"
+    "addNote": "Aggiungi nota",
+    "clearSession": "Cancella dati sessione",
+    "clearConfirm": "Questo cancella il veicolo e l'assetto salvati per questa sessione. Operazione irreversibile.",
+    "clearConfirmAction": "Cancella"
   },
   "postSession": {
     "title": "Post-sessione",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -63,6 +63,7 @@
     "unknownType": "Tipo sconosciuto",
     "edit": "Modifica",
     "vehicleType": "Tipo di veicolo",
+    "newType": "Nuovo tipo",
     "selectType": "Seleziona tipo…",
     "name": "Nome",
     "namePlaceholder": "Nome del veicolo",

--- a/src/locales/it/session.json
+++ b/src/locales/it/session.json
@@ -7,7 +7,8 @@
     "coach": "Coach",
     "tools": "Strumenti",
     "setups": "Assetti",
-    "notes": "Note"
+    "notes": "Note",
+    "setupsNotes": "Assetti e note"
   },
   "header": {
     "play": "Riproduci",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -163,7 +163,10 @@
     "edit": "編集",
     "writeNote": "メモを入力…",
     "updateNote": "メモを更新",
-    "addNote": "メモを追加"
+    "addNote": "メモを追加",
+    "clearSession": "セッションデータを消去",
+    "clearConfirm": "このセッションに保存された車両とセットアップを消去します。この操作は元に戻せません。",
+    "clearConfirmAction": "消去"
   },
   "postSession": {
     "title": "走行後",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -121,7 +121,12 @@
     "halves": "前後",
     "quarters": "4輪別",
     "update": "更新",
-    "save": "保存"
+    "save": "保存",
+    "copyFrom": "セットアップをコピー…",
+    "setup": "セットアップ",
+    "selectSetup": "セットアップを選択…",
+    "copy": "コピー",
+    "firstCreateVehicle": "まず車両を作成"
   },
   "setupHistory": {
     "title": "セットアップ履歴",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -63,6 +63,7 @@
     "unknownType": "不明な種類",
     "edit": "編集",
     "vehicleType": "車両の種類",
+    "newType": "新しいタイプ",
     "selectType": "種類を選択…",
     "name": "名前",
     "namePlaceholder": "車両名",

--- a/src/locales/ja/session.json
+++ b/src/locales/ja/session.json
@@ -7,7 +7,8 @@
     "coach": "コーチ",
     "tools": "ツール",
     "setups": "セットアップ",
-    "notes": "メモ"
+    "notes": "メモ",
+    "setupsNotes": "セットアップとメモ"
   },
   "header": {
     "play": "再生",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -163,7 +163,10 @@
     "edit": "Editar",
     "writeNote": "Escreva uma nota…",
     "updateNote": "Atualizar nota",
-    "addNote": "Adicionar nota"
+    "addNote": "Adicionar nota",
+    "clearSession": "Limpar dados da sessão",
+    "clearConfirm": "Isso limpa o veículo e o acerto salvos nesta sessão. Não pode ser desfeito.",
+    "clearConfirmAction": "Limpar"
   },
   "postSession": {
     "title": "Pós-sessão",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -121,7 +121,12 @@
     "halves": "Metades",
     "quarters": "Quartos",
     "update": "Atualizar",
-    "save": "Salvar"
+    "save": "Salvar",
+    "copyFrom": "Copiar acerto de…",
+    "setup": "Acerto",
+    "selectSetup": "Selecionar acerto…",
+    "copy": "Copiar",
+    "firstCreateVehicle": "Crie um veículo primeiro"
   },
   "setupHistory": {
     "title": "Histórico de configuração",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -63,6 +63,7 @@
     "unknownType": "Tipo desconhecido",
     "edit": "Editar",
     "vehicleType": "Tipo de veículo",
+    "newType": "Novo tipo",
     "selectType": "Selecionar tipo…",
     "name": "Nome",
     "namePlaceholder": "Nome do veículo",

--- a/src/locales/pt-BR/session.json
+++ b/src/locales/pt-BR/session.json
@@ -7,7 +7,8 @@
     "coach": "Coach",
     "tools": "Ferramentas",
     "setups": "Acertos",
-    "notes": "Notas"
+    "notes": "Notas",
+    "setupsNotes": "Acertos e notas"
   },
   "header": {
     "play": "Reproduzir",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -186,6 +186,8 @@ export default function Index() {
     if (target === "setups" || target === "notes") setTopPanelView(target);
     else fileManager.open(target);
   }, [fileManager]);
+  // Open the garage on the Vehicles tab — setups need a vehicle to attach to.
+  const openVehiclesGarage = useCallback(() => fileManager.open("vehicles"), [fileManager]);
 
   // "New type" shortcut on the Vehicles tab: close the garage, jump to the Setups
   // tab, and ask it to open the vehicle-type creator (one-shot, cleared once the
@@ -546,10 +548,11 @@ export default function Index() {
     onGetLatestForVehicle: setupManager.getLatestForVehicle,
     onAddVehicleType: templateManager.addVehicleType,
     onRemoveVehicleType: templateManager.removeVehicleType,
+    onCreateVehicle: openVehiclesGarage,
   }), [
     vehicleManager.vehicles, setupManager.setups, templateManager.vehicleTypes, templateManager.templates,
     setupManager.addSetup, setupManager.updateSetup, setupManager.removeSetup, setupManager.getLatestForVehicle,
-    templateManager.addVehicleType, templateManager.removeVehicleType,
+    templateManager.addVehicleType, templateManager.removeVehicleType, openVehiclesGarage,
   ]);
 
   // No data loaded - show import UI

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -533,6 +533,25 @@ export default function Index() {
     lapMgmt.selection,
   ]);
 
+  // Shared SetupsTab wiring — used by the main-view Setups tab and (off-session)
+  // by the Setups garage sub-tab on the landing page.
+  const setupsTabProps = useMemo(() => ({
+    vehicles: vehicleManager.vehicles,
+    setups: setupManager.setups,
+    vehicleTypes: templateManager.vehicleTypes,
+    templates: templateManager.templates,
+    onAdd: setupManager.addSetup,
+    onUpdate: setupManager.updateSetup,
+    onRemove: setupManager.removeSetup,
+    onGetLatestForVehicle: setupManager.getLatestForVehicle,
+    onAddVehicleType: templateManager.addVehicleType,
+    onRemoveVehicleType: templateManager.removeVehicleType,
+  }), [
+    vehicleManager.vehicles, setupManager.setups, templateManager.vehicleTypes, templateManager.templates,
+    setupManager.addSetup, setupManager.updateSetup, setupManager.removeSetup, setupManager.getLatestForVehicle,
+    templateManager.addVehicleType, templateManager.removeVehicleType,
+  ]);
+
   // No data loaded - show import UI
   if (!data) {
     return (
@@ -551,7 +570,10 @@ export default function Index() {
             enableCloud={enableCloud}
           />
           <Suspense fallback={null}>
-            <FileManagerDrawer {...fileManagerProps} />
+            {/* Off-session stopgap: Setups normally lives in the main toolbar
+                (session-only), so host it inside the garage here on the landing
+                page. A planned UI overhaul will revisit this relocation. */}
+            <FileManagerDrawer {...fileManagerProps} setupsTab={<SetupsTab {...setupsTabProps} />} />
           </Suspense>
         </>
       </DeviceProvider>
@@ -660,16 +682,7 @@ export default function Index() {
                   // out the (eager) Notes half rendered beside it in the split.
                   <Suspense fallback={null}>
                     <SetupsTab
-                      vehicles={vehicleManager.vehicles}
-                      setups={setupManager.setups}
-                      vehicleTypes={templateManager.vehicleTypes}
-                      templates={templateManager.templates}
-                      onAdd={setupManager.addSetup}
-                      onUpdate={setupManager.updateSetup}
-                      onRemove={setupManager.removeSetup}
-                      onGetLatestForVehicle={setupManager.getLatestForVehicle}
-                      onAddVehicleType={templateManager.addVehicleType}
-                      onRemoveVehicleType={templateManager.removeVehicleType}
+                      {...setupsTabProps}
                       requestNewType={requestNewVehicleType}
                       onRequestNewTypeHandled={handleNewVehicleTypeHandled}
                     />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -187,6 +187,17 @@ export default function Index() {
     else fileManager.open(target);
   }, [fileManager]);
 
+  // "New type" shortcut on the Vehicles tab: close the garage, jump to the Setups
+  // tab, and ask it to open the vehicle-type creator (one-shot, cleared once the
+  // tab consumes it — see SetupsTab's requestNewType).
+  const [requestNewVehicleType, setRequestNewVehicleType] = useState(false);
+  const handleCreateVehicleType = useCallback(() => {
+    fileManager.close();
+    setTopPanelView("setups");
+    setRequestNewVehicleType(true);
+  }, [fileManager]);
+  const handleNewVehicleTypeHandled = useCallback(() => setRequestNewVehicleType(false), []);
+
   // Video sync for the video player
   const videoSync = useVideoSync({
     samples: visibleSamples,
@@ -506,6 +517,9 @@ export default function Index() {
     onAddVehicle: vehicleManager.addVehicle,
     onUpdateVehicle: vehicleManager.updateVehicle,
     onRemoveVehicle: vehicleManager.removeVehicle,
+    // The "New type" shortcut targets the Setups tab, which only exists once a
+    // session is loaded — omit it (hiding the button) on the landing page.
+    onCreateVehicleType: data ? handleCreateVehicleType : undefined,
     currentTrackName: lapMgmt.selection?.trackName ?? null,
     currentCourseName: lapMgmt.selection?.courseName ?? null,
   }), [
@@ -514,6 +528,7 @@ export default function Index() {
     fileManager.initialGarageTab,
     handleDataLoaded, settings.autoSaveFiles, effectiveShowSampleFiles, showProfile,
     vehicleManager.vehicles, vehicleManager.addVehicle, vehicleManager.updateVehicle, vehicleManager.removeVehicle,
+    data, handleCreateVehicleType,
     templateManager.vehicleTypes,
     lapMgmt.selection,
   ]);
@@ -655,6 +670,8 @@ export default function Index() {
                       onGetLatestForVehicle={setupManager.getLatestForVehicle}
                       onAddVehicleType={templateManager.addVehicleType}
                       onRemoveVehicleType={templateManager.removeVehicleType}
+                      requestNewType={requestNewVehicleType}
+                      onRequestNewTypeHandled={handleNewVehicleTypeHandled}
                     />
                   </Suspense>
                 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { LapTimesTab } from "@/components/tabs/LapTimesTab";
 import { NotesTab } from "@/components/drawer/NotesTab";
+import { SetupsNotesPanel } from "@/components/tabs/SetupsNotesPanel";
 // Heavy tabs lazy-loaded so the initial bundle doesn't carry their deps.
 // RaceLine pulls in Leaflet (vendor-leaflet, ~150 kB) + the telemetry chart —
 // lazy keeps the whole mapping stack off the landing page; it loads the moment
@@ -42,6 +43,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { ParsedData } from "@/types/racing";
 import { calculateDistanceArray } from "@/lib/referenceUtils";
 import { formatAxisDistance } from "@/lib/chartAxis";
+import { cn } from "@/lib/utils";
 import { usePanelsForSlot, PanelSlot } from "@/plugins/panels";
 import { TrackPromptDialog } from "@/components/TrackPromptDialog";
 import { useSettings } from "@/hooks/useSettings";
@@ -628,45 +630,52 @@ export default function Index() {
 
         <div className="flex-1 min-h-0 overflow-hidden">
           {topPanelView === "laptable" && <LapTimesTab />}
-          {topPanelView === "notes" && (
-            <div className="h-full flex flex-col max-w-2xl mx-auto w-full">
-              <NotesTab
-                fileName={currentFileName}
-                notes={noteManager.notes}
-                onAdd={noteManager.addNote}
-                onUpdate={noteManager.updateNote}
-                onRemove={noteManager.removeNote}
-                vehicles={vehicleManager.vehicles}
-                setups={setupManager.setups}
-                sessionKartId={sessionKartId}
-                sessionSetupId={sessionSetupId}
-                sessionSetupRev={sessionSetupRev}
-                onSaveSessionSetup={handleSaveSessionSetupWithSnapshot}
-                postSession={postSession}
-                onSavePostSession={sessionMeta.handleSavePostSession}
-              />
-            </div>
-          )}
           <Suspense fallback={null}>
             {topPanelView === "raceline" && <RaceLineTab showOverlays={showOverlays} />}
             {topPanelView === "graphview" && <GraphViewTab />}
             {topPanelView === "coach" && showCoach && <CoachTab />}
             {topPanelView === "tools" && showTools && <ToolsTab />}
-            {topPanelView === "setups" && (
-              <div className="h-full flex flex-col max-w-2xl mx-auto w-full">
-                <SetupsTab
-                  vehicles={vehicleManager.vehicles}
-                  setups={setupManager.setups}
-                  vehicleTypes={templateManager.vehicleTypes}
-                  templates={templateManager.templates}
-                  onAdd={setupManager.addSetup}
-                  onUpdate={setupManager.updateSetup}
-                  onRemove={setupManager.removeSetup}
-                  onGetLatestForVehicle={setupManager.getLatestForVehicle}
-                  onAddVehicleType={templateManager.addVehicleType}
-                  onRemoveVehicleType={templateManager.removeVehicleType}
-                />
-              </div>
+            {/* Setups + Notes share one surface: a 50/50 split on tablet/desktop,
+                separate full-width tabs on phones (see SetupsNotesPanel). */}
+            {(topPanelView === "setups" || topPanelView === "notes") && (
+              <SetupsNotesPanel
+                active={topPanelView}
+                setups={
+                  // Own Suspense: the lazy SetupsTab chunk loading must not blank
+                  // out the (eager) Notes half rendered beside it in the split.
+                  <Suspense fallback={null}>
+                    <SetupsTab
+                      vehicles={vehicleManager.vehicles}
+                      setups={setupManager.setups}
+                      vehicleTypes={templateManager.vehicleTypes}
+                      templates={templateManager.templates}
+                      onAdd={setupManager.addSetup}
+                      onUpdate={setupManager.updateSetup}
+                      onRemove={setupManager.removeSetup}
+                      onGetLatestForVehicle={setupManager.getLatestForVehicle}
+                      onAddVehicleType={templateManager.addVehicleType}
+                      onRemoveVehicleType={templateManager.removeVehicleType}
+                    />
+                  </Suspense>
+                }
+                notes={
+                  <NotesTab
+                    fileName={currentFileName}
+                    notes={noteManager.notes}
+                    onAdd={noteManager.addNote}
+                    onUpdate={noteManager.updateNote}
+                    onRemove={noteManager.removeNote}
+                    vehicles={vehicleManager.vehicles}
+                    setups={setupManager.setups}
+                    sessionKartId={sessionKartId}
+                    sessionSetupId={sessionSetupId}
+                    sessionSetupRev={sessionSetupRev}
+                    onSaveSessionSetup={handleSaveSessionSetupWithSnapshot}
+                    postSession={postSession}
+                    onSavePostSession={sessionMeta.handleSavePostSession}
+                  />
+                }
+              />
             )}
           </Suspense>
         </div>
@@ -712,12 +721,15 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
   onSetupIndicatorClick: () => void;
 }) {
   const { t } = useTranslation("session");
-  const tabClass = (view: TopPanelView) =>
-    `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
-      topPanelView === view
-        ? "text-primary border-b-2 border-primary bg-primary/5"
-        : "text-muted-foreground hover:text-foreground"
-    }`;
+  const tabBase = "flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors";
+  const tabState = (active: boolean) =>
+    active
+      ? "text-primary border-b-2 border-primary bg-primary/5"
+      : "text-muted-foreground hover:text-foreground";
+  const tabClass = (view: TopPanelView) => cn(tabBase, tabState(topPanelView === view));
+  // Setups and Notes live on one combined surface; either being active lights
+  // up the small-screen tabs and the merged tablet/desktop tab alike.
+  const setupsNotesActive = topPanelView === "setups" || topPanelView === "notes";
 
   return (
     <div className="flex items-center border-b border-border shrink-0">
@@ -743,11 +755,23 @@ function TabBar({ topPanelView, setTopPanelView, laps, showOverlays, onToggleOve
           <Wrench className="w-4 h-4" /> <span className="hidden sm:inline">{t("tabs.tools")}</span>
         </button>
       )}
-      <button onClick={() => setTopPanelView("setups")} className={tabClass("setups")}>
+      {/* Phones: Setups and Notes are separate tabs. Tablet/desktop: one merged
+          tab opens the 50/50 split (SetupsNotesPanel handles the layout). */}
+      <button onClick={() => setTopPanelView("setups")} className={cn(tabClass("setups"), "md:hidden")}>
         <SlidersHorizontal className="w-4 h-4" /> <span className="hidden sm:inline">{t("tabs.setups")}</span>
       </button>
-      <button onClick={() => setTopPanelView("notes")} className={tabClass("notes")}>
+      <button onClick={() => setTopPanelView("notes")} className={cn(tabClass("notes"), "md:hidden")}>
         <NotebookPen className="w-4 h-4" /> <span className="hidden sm:inline">{t("tabs.notes")}</span>
+      </button>
+      <button
+        onClick={() => setTopPanelView("setups")}
+        className={cn(tabBase, tabState(setupsNotesActive), "hidden md:flex")}
+      >
+        <span className="flex items-center gap-1">
+          <SlidersHorizontal className="w-4 h-4" />
+          <NotebookPen className="w-4 h-4" />
+        </span>
+        {t("tabs.setupsNotes")}
       </button>
       {setupIndicator && (
         <TooltipProvider>


### PR DESCRIPTION
## Summary

Started as "combine Setups + Notes into a 50/50 split on big screens" and grew into a batch of band-aid UX fixes around the garage / setup-creation flow (pending a proper flow overhaul later). All client-side, offline-first, fully i18n'd across the 7 locales.

## What's in here

### 1. Responsive Setups + Notes panel
- New `components/tabs/SetupsNotesPanel.tsx` hosts both panels: **phones** keep separate full-width **Setups** / **Notes** tabs; **tablet/desktop** (`md`+) show one combined **Setups & Notes** tab as a **50/50 split** with a divider, reclaiming the wasted width.
- Pure-CSS visibility — both panels stay mounted across the breakpoint, so rotating/resizing or switching the phone tab never remounts a panel or drops in-progress form state. The lazy `SetupsTab` gets its own Suspense boundary so its chunk load can't blank the Notes half.

### 2. Notes / session-setup conveniences
- **Smart defaults:** on an unlinked session, the session-setup selector pre-fills your only vehicle (and its only setup). Picking a vehicle defaults to its sole setup. Nothing auto-saves — you still tap Save.
- **Clear session data:** once a setup is linked, a button (with an "are you sure / can't be undone" confirm) unlinks it so a mistaken assignment can be re-done. Notes + post-session measurements are kept.

### 3. New-setup form defaults + locking
- With a single **vehicle type**, it's pre-selected **and locked**; with a single candidate **vehicle**, same. Pickers stay visible, just filled in (no more confusing hide/show).
- Adding a vehicle locks the **type** dropdown when only one exists.

### 4. Vehicle-type discoverability
- A **New type** button on the Vehicles tab closes the garage, opens the Setups tab, and drops straight into the vehicle-type creator (one-shot request consumed by `SetupsTab`). Hidden off-session where the Setups tab isn't reachable.

### 5. Off-session Setups access (stopgap)
- Setups now lives in the main toolbar (session-only), which left vehicles/setups/types unreachable from the landing page. So on the **landing page only**, `SetupsTab` is hosted inside the **Garage** drawer via a `ReactNode` slot (drawer stays agnostic of setup props; shared `setupsTabProps` memo avoids duplication). Flagged in code as a deliberate stopgap pending the UI overhaul.

### 6. Setups require a vehicle first
- With no vehicles, the **Add setup** button is disabled and a **First create a vehicle** button routes to the Vehicles tab — no more dead-end.

### 7. Copy setup from another vehicle
- When a same-type vehicle already has a setup, the new-setup form shows **Copy setup from…** (under the vehicle type): a dialog to pick a vehicle (filtered to the current type) and one of its setups, which pre-fills the form to tweak + Save. The per-vehicle preload and this copy share one extracted `applySourceSetup` helper.

### 8. Misc
- **Tighter lap selector:** the session-header lap dropdown sizes to its label instead of a fixed width, so snapshot/overlay toolbar controls stop getting squeezed off-screen on mobile.

## Notes / judgment calls
- Split breakpoint is `md` (768px). Easy to bump to `lg` if portrait tablets feel cramped.
- "Clear session data" is scoped to the setup link only (keeps notes/measurements).
- The Copy dialog's vehicle list includes the current target vehicle if it has setups (matches "filtered by current type"); can be restricted to *other* vehicles if preferred.
- Off-session Setups-in-garage and the New-type relocation are explicitly band-aids for the planned flow overhaul.

## Verification
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test:run` ✅ (124 files, 1819 tests)
- `bun run build` ✅ — `SetupsTab` stays its own lazy chunk

## Commits
1. Combine Setups + Notes into a responsive split panel
2. Notes smart defaults + clear-session escape hatch
3. Populate (not hide) setup defaults + New type shortcut
4. Lock single-option pickers; host Setups in garage off-session
5. Require a vehicle first; copy setup from another vehicle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2ALZK6wjtaD6UzH9j6NtB