### PR TITLE
Mobile Pro panel: collapsible left column + relocatable Video/Mini-Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [2.7.0] - unreleased
+
+### Added
+- **Collapsible Pro panel + relocatable Video/Mini-Map on mobile.** The Pro
+  view's left column (info/vehicle/video + mini-map) is roomy on tablet and
+  desktop but cramped on a phone. On mobile a small flag tab now sits at the top
+  of the divider between the two columns — tap it to collapse the left column so
+  the graphs get the full screen width, tap again to bring it back. So you don't
+  lose the video or the map when collapsed, the graph picker (the "Add Graph"
+  dropdown) gains two extra options at the top on mobile — **Video** and **Mini
+  Map** — that drop the video player or the track map into the regular,
+  resizable graph stack alongside your data channels. Tablet/desktop are
+  unchanged.
+
 ## [2.6.0] - unreleased
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 │   ├── ui/                # shadcn/ui primitives
 │   ├── admin/             # Admin tabs (Tracks, Courses, Submissions, Users, BannedIps, Tools, Messages)
 │   ├── tabs/              # View tabs (GraphView, RaceLine, LapTimes, Coach, Tools; Setups + Notes live in drawer/ but are main-view tabs)
-│   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox
+│   ├── graphview/         # Pro mode: GraphPanel, GraphViewPanel, MiniMap, SingleSeriesChart, GGDiagram, InfoBox, PanelCard (resizable card chrome for relocated Video/Mini-Map panels). On mobile the left column collapses via a divider flag tab, and Video/Mini-Map can be relocated into the resizable graph stack from the top of the "Add Graph" picker (GraphPanel reports which are active so the host drops its duplicate VideoPlayer — single shared video ref).
 │   ├── drawer/            # File-manager drawer tabs (Files, Vehicles/Karts, Device*); SetupsTab + NotesTab also here but mounted as main-view tabs
 │   ├── track-editor/      # Track editor: VisualEditor, SectorListEditor, CourseSectorEditor, Add*Dialog
 │   ├── video-overlays/    # Video-export overlay system: registry + themes + per-widget *Overlay

--- a/src/components/graphview/GraphPanel.tsx
+++ b/src/components/graphview/GraphPanel.tsx
@@ -6,6 +6,7 @@ import { RangeSlider } from '@/components/RangeSlider';
 import { SectorCropSelect } from '@/components/SectorCropSelect';
 import { SingleSeriesChart } from './SingleSeriesChart';
 import { GGDiagram } from './GGDiagram';
+import { PanelCard } from './PanelCard';
 import { GpsSample, FieldMapping, Course, Lap } from '@/types/racing';
 import type { OverlayLine } from '@/lib/lapOverlays';
 import { calculatePace, calculateReferenceSpeed, calculateDistanceArray } from '@/lib/referenceUtils';
@@ -19,6 +20,12 @@ const SERIES_COLORS = [
   'hsl(280, 60%, 60%)', 'hsl(120, 60%, 50%)', 'hsl(30, 80%, 55%)',
   'hsl(200, 80%, 60%)', 'hsl(340, 80%, 55%)',
 ];
+
+/** Synthetic source keys for panels relocated into the graph stack (mobile). */
+const VIDEO_KEY = '__video__';
+const MINIMAP_KEY = '__minimap__';
+const VIDEO_DEFAULT_HEIGHT = 300;
+const MINIMAP_DEFAULT_HEIGHT = 280;
 
 interface GraphPanelProps {
   samples: GpsSample[];
@@ -35,12 +42,21 @@ interface GraphPanelProps {
   course?: Course | null;
   laps?: Lap[];
   selectedLapNumber?: number | null;
+  /** When set, the video/mini-map can be relocated here as resizable panels
+   *  (mobile: lets the user collapse the left panel and still reach them). */
+  enableMobilePanels?: boolean;
+  renderVideo?: () => React.ReactNode;
+  renderMiniMap?: () => React.ReactNode;
+  /** Reports which relocated panels are active, so the host can avoid mounting
+   *  a duplicate (the video player binds a single shared element ref). */
+  onMobilePanelsChange?: (active: { video: boolean; miniMap: boolean }) => void;
 }
 
 export function GraphPanel({
   samples, filteredSamples, referenceSamples, fieldMappings, onScrub,
   visibleRange, onRangeChange, minRange, formatRangeLabel, sessionFileName, overlayLines = [],
   course = null, laps = [], selectedLapNumber = null,
+  enableMobilePanels = false, renderVideo, renderMiniMap, onMobilePanelsChange,
 }: GraphPanelProps) {
   const { t } = useTranslation('session');
   const { useKph, useMetricDistance, brakingZoneSettings } = useSettingsContext();
@@ -162,11 +178,18 @@ export function GraphPanel({
 
   const hasBothSources = hasHwAccel && hasGpsG;
 
+  const hasVideoPanel = enableMobilePanels && !!renderVideo;
+  const hasMiniMapPanel = enableMobilePanels && !!renderMiniMap;
+
   // Available data sources
   const availableSources = useMemo(() => {
-    const sources: { key: string; label: string }[] = [
+    const sources: { key: string; label: string }[] = [];
+    // Relocated panels sit at the top of the picker on mobile.
+    if (hasVideoPanel) sources.push({ key: VIDEO_KEY, label: t('infoBox.tabVideo') });
+    if (hasMiniMapPanel) sources.push({ key: MINIMAP_KEY, label: t('graphs.miniMap') });
+    sources.push(
       { key: 'speed', label: t('graphs.speed', { unit: useKph ? 'KPH' : 'MPH' }) },
-    ];
+    );
     if (hasReference) {
       sources.push({ key: '__pace__', label: t('graphs.pace') });
     }
@@ -190,11 +213,20 @@ export function GraphPanel({
       sources.push({ key: f.name, label });
     });
     return sources;
-  }, [fieldMappings, useKph, useMetricDistance, hasReference, hasBothSources, hasGForce, t]);
+  }, [fieldMappings, useKph, useMetricDistance, hasReference, hasBothSources, hasGForce, hasVideoPanel, hasMiniMapPanel, t]);
 
   const unusedSources = useMemo(() => {
     return availableSources.filter(s => !activeGraphs.includes(s.key));
   }, [availableSources, activeGraphs]);
+
+  // Report which relocated panels are live so the host can drop its own copy
+  // (the video player binds a single shared element ref — two would collide).
+  useEffect(() => {
+    onMobilePanelsChange?.({
+      video: hasVideoPanel && activeGraphs.includes(VIDEO_KEY),
+      miniMap: hasMiniMapPanel && activeGraphs.includes(MINIMAP_KEY),
+    });
+  }, [activeGraphs, hasVideoPanel, hasMiniMapPanel, onMobilePanelsChange]);
 
   const addGraph = useCallback((key: string) => {
     if (key && !activeGraphs.includes(key)) {
@@ -249,7 +281,33 @@ export function GraphPanel({
         ) : (
           <>
             {activeGraphs.map(key => (
-              key === '__gg__' ? (
+              key === VIDEO_KEY ? (
+                hasVideoPanel ? (
+                  <PanelCard
+                    key={key}
+                    label={t('infoBox.tabVideo')}
+                    onDelete={() => removeGraph(key)}
+                    height={graphHeights[key]}
+                    defaultHeight={VIDEO_DEFAULT_HEIGHT}
+                    onHeightChange={(h) => setGraphHeight(key, h)}
+                  >
+                    <div className="h-full">{renderVideo!()}</div>
+                  </PanelCard>
+                ) : null
+              ) : key === MINIMAP_KEY ? (
+                hasMiniMapPanel ? (
+                  <PanelCard
+                    key={key}
+                    label={t('graphs.miniMap')}
+                    onDelete={() => removeGraph(key)}
+                    height={graphHeights[key]}
+                    defaultHeight={MINIMAP_DEFAULT_HEIGHT}
+                    onHeightChange={(h) => setGraphHeight(key, h)}
+                  >
+                    <div className="h-full">{renderMiniMap!()}</div>
+                  </PanelCard>
+                ) : null
+              ) : key === '__gg__' ? (
                 <GGDiagram
                   key={key}
                   samples={samples}

--- a/src/components/graphview/GraphViewPanel.tsx
+++ b/src/components/graphview/GraphViewPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GpsSample, Course, FieldMapping, Lap } from '@/types/racing';
 import type { OverlayLine } from '@/lib/lapOverlays';
@@ -10,9 +10,11 @@ import type { VideoSyncState, VideoSyncActions } from '@/hooks/useVideoSync';
 import { InfoBox } from './InfoBox';
 import { MiniMap } from './MiniMap';
 import { GraphPanel } from './GraphPanel';
+import { VideoPlayer } from '@/components/VideoPlayer';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
-import { Map as MapIcon, EyeOff } from 'lucide-react';
+import { Map as MapIcon, EyeOff, ChevronLeft, ChevronRight } from 'lucide-react';
 import { ImperativePanelHandle } from 'react-resizable-panels';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 export interface GraphViewPanelProps {
   // Data
@@ -74,9 +76,18 @@ export interface GraphViewPanelProps {
 
 export function GraphViewPanel(props: GraphViewPanelProps) {
   const { t } = useTranslation('session');
+  const isMobile = useIsMobile();
   const [mapVisible, setMapVisible] = useState(true);
   const mapPanelRef = useRef<ImperativePanelHandle>(null);
   const savedSizeRef = useRef(30);
+
+  // Mobile: the left InfoBox/MiniMap column can be collapsed so the graphs get
+  // the full screen width. Video + mini-map are then reachable as graph panels.
+  const leftPanelRef = useRef<ImperativePanelHandle>(null);
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  // Relocated panels active in the graph stack (reported by GraphPanel) — used
+  // to avoid mounting a duplicate VideoPlayer (it binds a single shared ref).
+  const [relocated, setRelocated] = useState({ video: false, miniMap: false });
 
   const toggleMap = () => {
     const panel = mapPanelRef.current;
@@ -92,13 +103,72 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
     }
   };
 
+  const toggleLeftPanel = () => {
+    const panel = leftPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  };
+
+  // Never leave the left panel collapsed once we're back on a wide layout.
+  useEffect(() => {
+    if (!isMobile) leftPanelRef.current?.expand();
+  }, [isMobile]);
+
+  const { videoState, videoActions, onVideoLoadedMetadata } = props;
+  const canRenderVideo = !!(videoState && videoActions && onVideoLoadedMetadata);
+  const renderVideo = useCallback(() => (
+    <VideoPlayer
+      state={videoState!}
+      actions={videoActions!}
+      onLoadedMetadata={onVideoLoadedMetadata!}
+      samples={props.visibleSamples}
+      allSamples={props.allSamples}
+      fieldMappings={props.fieldMappings}
+      laps={props.laps}
+      selectedLapNumber={props.selectedLapNumber}
+      course={props.course}
+      referenceSamples={props.referenceSamples}
+      paceData={props.paceData}
+      sessionFileName={props.sessionFileName}
+    />
+  ), [videoState, videoActions, onVideoLoadedMetadata, props.visibleSamples, props.allSamples, props.fieldMappings, props.laps, props.selectedLapNumber, props.course, props.referenceSamples, props.paceData, props.sessionFileName]);
+
+  const renderMiniMap = useCallback(() => (
+    <MiniMap
+      samples={props.visibleSamples}
+      allSamples={props.filteredSamples}
+      referenceSamples={props.referenceSamples}
+      course={props.course}
+      bounds={props.bounds}
+      isAllLaps={props.isAllLaps}
+      overlayLines={props.overlayLines}
+      rangeStart={props.visibleRange[0]}
+      onRemoveOverlay={props.onRemoveOverlay}
+      alignOverlays={props.alignOverlays}
+      onToggleAlignOverlays={props.onToggleAlignOverlays}
+      showOverlayLegend={props.showOverlayLegend}
+      onToggleOverlayLegend={props.onToggleOverlayLegend}
+    />
+  ), [props.visibleSamples, props.filteredSamples, props.referenceSamples, props.course, props.bounds, props.isAllLaps, props.overlayLines, props.visibleRange, props.onRemoveOverlay, props.alignOverlays, props.onToggleAlignOverlays, props.showOverlayLegend, props.onToggleOverlayLegend]);
+
   return (
     <ResizablePanelGroup direction="horizontal" className="h-full">
-      <ResizablePanel defaultSize={30} minSize={20} maxSize={45}>
+      <ResizablePanel
+        ref={leftPanelRef}
+        defaultSize={30}
+        minSize={20}
+        maxSize={45}
+        collapsible
+        collapsedSize={0}
+        onCollapse={() => setLeftCollapsed(true)}
+        onExpand={() => setLeftCollapsed(false)}
+      >
         <div className="h-full relative">
           <ResizablePanelGroup direction="vertical" className="h-full">
             <ResizablePanel defaultSize={70} minSize={30}>
               <InfoBox
+                hideVideoTab={relocated.video}
                 filteredSamples={props.filteredSamples}
                 course={props.course}
                 lapTimeMs={props.lapTimeMs}
@@ -176,22 +246,38 @@ export function GraphViewPanel(props: GraphViewPanelProps) {
       <ResizableHandle />
 
       <ResizablePanel defaultSize={70} minSize={40}>
-        <GraphPanel
-          samples={props.visibleSamples}
-          filteredSamples={props.filteredSamples}
-          referenceSamples={props.referenceSamples}
-          fieldMappings={props.fieldMappings}
-          onScrub={props.onScrub}
-          visibleRange={props.visibleRange}
-          onRangeChange={props.onRangeChange}
-          minRange={props.minRange}
-          formatRangeLabel={props.formatRangeLabel}
-          sessionFileName={props.sessionFileName}
-          overlayLines={props.overlayLines}
-          course={props.course}
-          laps={props.laps}
-          selectedLapNumber={props.selectedLapNumber}
-        />
+        <div className="relative h-full">
+          {isMobile && (
+            <button
+              onClick={toggleLeftPanel}
+              className="absolute top-2 left-0 z-[1100] flex items-center py-3 pl-0.5 pr-1 rounded-r-md bg-primary text-primary-foreground shadow-md hover:bg-primary/90"
+              title={leftCollapsed ? t('graphs.expandPanel') : t('graphs.collapsePanel')}
+              aria-label={leftCollapsed ? t('graphs.expandPanel') : t('graphs.collapsePanel')}
+            >
+              {leftCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+            </button>
+          )}
+          <GraphPanel
+            samples={props.visibleSamples}
+            filteredSamples={props.filteredSamples}
+            referenceSamples={props.referenceSamples}
+            fieldMappings={props.fieldMappings}
+            onScrub={props.onScrub}
+            visibleRange={props.visibleRange}
+            onRangeChange={props.onRangeChange}
+            minRange={props.minRange}
+            formatRangeLabel={props.formatRangeLabel}
+            sessionFileName={props.sessionFileName}
+            overlayLines={props.overlayLines}
+            course={props.course}
+            laps={props.laps}
+            selectedLapNumber={props.selectedLapNumber}
+            enableMobilePanels={isMobile}
+            renderVideo={canRenderVideo ? renderVideo : undefined}
+            renderMiniMap={renderMiniMap}
+            onMobilePanelsChange={setRelocated}
+          />
+        </div>
       </ResizablePanel>
     </ResizablePanelGroup>
   );

--- a/src/components/graphview/InfoBox.tsx
+++ b/src/components/graphview/InfoBox.tsx
@@ -49,6 +49,9 @@ interface InfoBoxProps {
   referenceSamples?: GpsSample[];
   paceData?: (number | null)[];
   sessionFileName?: string | null;
+  /** Hide the Video tab — the player was relocated into the graph stack (mobile),
+   *  and two players can't share the single video element ref. */
+  hideVideoTab?: boolean;
 }
 
 type InfoTab = 'data' | 'vehicle' | 'video';
@@ -60,7 +63,7 @@ export function InfoBox({
   vehicles, setups, templates, sessionKartId, sessionSetupId, onSaveSessionSetup, onOpenSetupEditor, onOpenGarage,
   videoState, videoActions, onVideoLoadedMetadata,
   visibleSamples, allSamples, fieldMappings, laps, selectedLapNumber,
-  referenceSamples, paceData, sessionFileName,
+  referenceSamples, paceData, sessionFileName, hideVideoTab,
 }: InfoBoxProps) {
   const { t } = useTranslation('session');
   const { useKph } = useSettingsContext();
@@ -69,6 +72,9 @@ export function InfoBox({
   const [selectedSetupId, setSelectedSetupId] = useState<string | null>(sessionSetupId);
 
   useEffect(() => { setSelectedVehicleId(sessionKartId); setSelectedSetupId(sessionSetupId); }, [sessionKartId, sessionSetupId]);
+
+  // If the video panel was relocated while this tab was open, fall back to data.
+  useEffect(() => { if (hideVideoTab && tab === 'video') setTab('data'); }, [hideVideoTab, tab]);
 
   const unit = useKph ? 'kph' : 'mph';
   const convertSpeed = (speed: number) => useKph ? speed * 1.60934 : speed;
@@ -110,7 +116,9 @@ export function InfoBox({
       <div className="flex shrink-0 border-b border-border">
         <button onClick={() => setTab('data')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'data' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabData')}</button>
         <button onClick={() => setTab('vehicle')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'vehicle' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabVehicle')}</button>
-        <button onClick={() => setTab('video')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'video' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabVideo')}</button>
+        {!hideVideoTab && (
+          <button onClick={() => setTab('video')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'video' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabVideo')}</button>
+        )}
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto">

--- a/src/components/graphview/PanelCard.tsx
+++ b/src/components/graphview/PanelCard.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
+import { GraphResizeHandle } from './GraphResizeHandle';
+
+interface PanelCardProps {
+  /** Title shown in the slim header bar. */
+  label: string;
+  /** Remove this panel from the graph stack. */
+  onDelete: () => void;
+  /** Committed card height (px); seeds the live height. */
+  height?: number;
+  /** Fallback height when none is committed yet. */
+  defaultHeight: number;
+  /** Persist a new card height (fired on resize-drag release). */
+  onHeightChange?: (height: number) => void;
+  children: React.ReactNode;
+}
+
+/**
+ * A resizable graph-stack card for relocated panels (video / mini-map). Unlike
+ * SingleSeriesChart's canvas overlay header, these own complex UI of their own
+ * (Leaflet controls, video toolbar) with corner widgets, so the title + remove
+ * live in a slim non-overlapping header bar instead of floating on the content.
+ */
+export function PanelCard({ label, onDelete, height, defaultHeight, onHeightChange, children }: PanelCardProps) {
+  const { t } = useTranslation('session');
+  const committedHeight = height ?? defaultHeight;
+  const [cardHeight, setCardHeight] = useState(committedHeight);
+  useEffect(() => { setCardHeight(committedHeight); }, [committedHeight]);
+
+  return (
+    <div className="relative border-b border-border flex flex-col" style={{ height: `${cardHeight}px` }}>
+      <div className="shrink-0 flex items-center justify-between px-2 py-1 border-b border-border bg-muted/30">
+        <span className="text-xs font-mono text-muted-foreground">{label}</span>
+        <button
+          onClick={onDelete}
+          className="p-1 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
+          title={t('graphs.removeGraph')}
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="relative flex-1 w-full min-h-0 overflow-hidden">
+        {children}
+      </div>
+      <GraphResizeHandle
+        height={cardHeight}
+        onResize={setCardHeight}
+        onCommit={(h) => { setCardHeight(h); onHeightChange?.(h); }}
+      />
+    </div>
+  );
+}

--- a/src/locales/de/session.json
+++ b/src/locales/de/session.json
@@ -157,7 +157,10 @@
     "brakeGps": "Bremse % (GPS)",
     "brakeComputed": "Bremse % (berechnet)",
     "ggDiagram": "G-G-Diagramm",
-    "removeGraph": "Diagramm entfernen"
+    "removeGraph": "Diagramm entfernen",
+    "miniMap": "Minikarte",
+    "collapsePanel": "Bereich einklappen",
+    "expandPanel": "Bereich ausklappen"
   },
   "gg": {
     "noData": "Keine G-Kraft-Daten",

--- a/src/locales/en/session.json
+++ b/src/locales/en/session.json
@@ -156,7 +156,10 @@
     "brakeGps": "Brake % (GPS)",
     "brakeComputed": "Brake % (computed)",
     "ggDiagram": "G-G Diagram",
-    "removeGraph": "Remove graph"
+    "removeGraph": "Remove graph",
+    "miniMap": "Mini Map",
+    "collapsePanel": "Collapse panel",
+    "expandPanel": "Expand panel"
   },
   "gg": {
     "noData": "No G-force data",

--- a/src/locales/es/session.json
+++ b/src/locales/es/session.json
@@ -157,7 +157,10 @@
     "brakeGps": "Freno % (GPS)",
     "brakeComputed": "Freno % (calculado)",
     "ggDiagram": "Diagrama G-G",
-    "removeGraph": "Quitar gráfico"
+    "removeGraph": "Quitar gráfico",
+    "miniMap": "Minimapa",
+    "collapsePanel": "Contraer panel",
+    "expandPanel": "Expandir panel"
   },
   "gg": {
     "noData": "Sin datos de fuerza G",

--- a/src/locales/fr/session.json
+++ b/src/locales/fr/session.json
@@ -157,7 +157,10 @@
     "brakeGps": "Frein % (GPS)",
     "brakeComputed": "Frein % (calculé)",
     "ggDiagram": "Diagramme G-G",
-    "removeGraph": "Supprimer le graphique"
+    "removeGraph": "Supprimer le graphique",
+    "miniMap": "Mini-carte",
+    "collapsePanel": "Réduire le panneau",
+    "expandPanel": "Agrandir le panneau"
   },
   "gg": {
     "noData": "Aucune donnée de force G",

--- a/src/locales/it/session.json
+++ b/src/locales/it/session.json
@@ -157,7 +157,10 @@
     "brakeGps": "Freno % (GPS)",
     "brakeComputed": "Freno % (calcolato)",
     "ggDiagram": "Diagramma G-G",
-    "removeGraph": "Rimuovi grafico"
+    "removeGraph": "Rimuovi grafico",
+    "miniMap": "Mini mappa",
+    "collapsePanel": "Comprimi pannello",
+    "expandPanel": "Espandi pannello"
   },
   "gg": {
     "noData": "Nessun dato di forza G",

--- a/src/locales/ja/session.json
+++ b/src/locales/ja/session.json
@@ -157,7 +157,10 @@
     "brakeGps": "ブレーキ % (GPS)",
     "brakeComputed": "ブレーキ % (計算値)",
     "ggDiagram": "G-G ダイアグラム",
-    "removeGraph": "グラフを削除"
+    "removeGraph": "グラフを削除",
+    "miniMap": "ミニマップ",
+    "collapsePanel": "パネルを折りたたむ",
+    "expandPanel": "パネルを展開"
   },
   "gg": {
     "noData": "G フォースのデータなし",

--- a/src/locales/pt-BR/session.json
+++ b/src/locales/pt-BR/session.json
@@ -157,7 +157,10 @@
     "brakeGps": "Freio % (GPS)",
     "brakeComputed": "Freio % (calculado)",
     "ggDiagram": "Diagrama G-G",
-    "removeGraph": "Remover gráfico"
+    "removeGraph": "Remover gráfico",
+    "miniMap": "Minimapa",
+    "collapsePanel": "Recolher painel",
+    "expandPanel": "Expandir painel"
   },
   "gg": {
     "noData": "Sem dados de força G",


### PR DESCRIPTION
## Why

The Pro view's left column (info/vehicle/video tabs + the mini-map) is roomy on tablet and desktop but **cramped on a phone** — the graphs end up squeezed into ~70% of an already-narrow screen. Tablet/desktop are fine and stay unchanged.

## What

**On mobile only:**

- A small **flag tab** now sits at the top of the divider between the two columns. Tap it to **collapse the left column** so the graphs fill the full screen width; tap again to bring it back.
- So nothing is lost when the column is hidden, the **"Add Graph" picker** gains two options pinned to the top — **Video** and **Mini Map** — that relocate the video player / track map into the regular **resizable graph stack** alongside your data channels (each with its own resize handle + remove button).

This lets mobile users collapse the panel and still reach all of their graphs, the video editor, and the map.

## How

- **`GraphViewPanel`** — left `ResizablePanel` is now `collapsible` (driven by a ref + the mobile-only flag tab); supplies `renderVideo` / `renderMiniMap` render props to `GraphPanel` and reads back which panels are relocated so it **drops its own duplicate `VideoPlayer`** (they share a single video element ref, so two can't mount at once).
- **`GraphPanel`** — lists Video/Mini-Map at the top of the source picker when `enableMobilePanels` is set, and renders them as resizable cards via new **`PanelCard`** chrome (reuses `GraphResizeHandle`; height persists in graph-prefs like any other graph). Reports active relocated panels via `onMobilePanelsChange`.
- **`InfoBox`** — hides its Video tab when the player has been relocated (and falls back to the Data tab if it was open).
- **i18n** — new `graphs.miniMap` / `graphs.collapsePanel` / `graphs.expandPanel` keys added across all 7 locales.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test:run` (1819 tests), and `bun run build` all pass. No bundle regression — `VideoPlayer`/`MiniMap` already rode the `GraphViewTab` chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUJzATy4xwoAduBHcVUG7t)_