### PR TITLE
Vehicle history cards (shared, modular history-card module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.7.0] - unreleased
 
 ### Added
+- **Vehicle history cards.** Vehicles in the Garage now have a little **history**
+  button, just like setups. It opens a panel that gathers every setup you've run
+  on that vehicle — one card per frozen setup revision — showing the setup name,
+  its content hash, and the fastest lap turned on it. Cards are ordered fastest
+  lap first (so your quickest setup is on top), the fastest overall is
+  highlighted, and each card is collapsed by default — expand it to see the full
+  frozen setup (no diff). A course filter narrows the view to a single track and
+  course. Built on a shared history-card module reused by both the setup- and
+  vehicle-history panels.
 - **Collapsible Pro panel + relocatable Video/Mini-Map on mobile.** The Pro
   view's left column (info/vehicle/video + mini-map) is roomy on tablet and
   desktop but cramped on a phone. On mobile a small flag tab now sits at the top

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frozen setup (no diff). A course filter narrows the view to a single track and
   course. Built on a shared history-card module reused by both the setup- and
   vehicle-history panels.
+- **Jump to a history card's session.** In both the setup- and vehicle-history
+  panels, the fastest-lap time and each session in a card's "Fastest laps" list
+  are now tappable — they load that session straight into the viewer (closing the
+  garage drawer), so you can go from "which setup was quickest" to the actual
+  telemetry in one tap. The fastest-lap value is read from each session's own
+  cached best lap, so it always points back to a real, openable log.
 - **Collapsible Pro panel + relocatable Video/Mini-Map on mobile.** The Pro
   view's left column (info/vehicle/video + mini-map) is roomy on tablet and
   desktop but cramped on a phone. On mobile a small flag tab now sits at the top

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ src/
 │   ├── lapSnapshot*.ts    # ★ Snapshot types/buffer + IndexedDB CRUD (→ docs/subsystems.md)
 │   ├── setupRevision*.ts  # ★ Content-addressed setup history + IndexedDB CRUD (→ docs/subsystems.md)
 │   ├── setupHistory.ts    # ★ Pure setup-history view-model (diff + fastest-lap aggregation) → drawer/SetupHistoryPanel (→ docs/subsystems.md)
+│   ├── vehicleHistory.ts  # ★ Pure vehicle-history view-model (per-vehicle setup revisions, fastest-lap first, course filter) → drawer/VehicleHistoryPanel; reuses setupHistory primitives; shared card chrome in drawer/HistoryCard.tsx
 │   ├── trackSubmission.ts # ★ Community-DB upload plan (→ docs/subsystems.md)
 │   ├── dbUtils.ts         # ★ Shared IndexedDB: DB_NAME, DB_VERSION, openDB(), tx helpers
 │   ├── garageEvents.ts    # ★ Host pub/sub: storage emits {store,key,put|delete}; cloud-sync syncs off it

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -237,6 +237,19 @@ exactly as it was the day it ran, even after the live setup is later edited.
   **kart + course filter** (drops non-matching revisions). Field flattening
   (`flattenRevisionFields`) reads each revision's *frozen* template so old history
   renders with the labels it had that day.
+- **Vehicle history panel.** Each **VehiclesTab** row has the same history icon
+  opening `drawer/VehicleHistoryPanel.tsx`, built by the pure `lib/vehicleHistory.ts`
+  (`buildVehicleHistory`). Where setup history fixes one setup and walks its
+  revisions, vehicle history fixes one *vehicle* and gathers **every setup revision
+  run on it** (one card per revision, joined via `sessionKartId` + `sessionSetupRev`),
+  ordered **fastest lap first** so the quickest setup is on top (overall fastest
+  highlighted). Each card shows the setup **name + #hash**, is **collapsed by
+  default** (expand for the full frozen setup — **no diff**), and a **course filter**
+  narrows the view. It reuses setupHistory's `buildUsage`/`byFastestLap`/
+  `flattenRevisionFields` primitives, and both panels render through the shared
+  **`drawer/HistoryCard.tsx`** card chrome (`HistoryCard` + `FullSetup`/`DiffList`:
+  fastest-lap highlight, hash/date header, kart/course bubbles, collapsible body,
+  fastest-laps footer).
 - **Orphan prune (GC).** A revision is an orphan once no
   `FileMetadata.sessionSetupRev` points at it. `pruneSetupRevisions()` deletes
   orphans (pure split: `findOrphanRevisionIds`); `maybePruneSetupRevisions()`

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -250,6 +250,13 @@ exactly as it was the day it ran, even after the live setup is later edited.
   **`drawer/HistoryCard.tsx`** card chrome (`HistoryCard` + `FullSetup`/`DiffList`:
   fastest-lap highlight, hash/date header, kart/course bubbles, collapsible body,
   fastest-laps footer).
+- **Jump to the session.** Both panels' fastest-lap values come from each
+  session's cached `FileMetadata.fastestLapMs` (computed from the session's own
+  `Lap[]` at load/detect time — **not** from lap snapshots), so every usage
+  carries a real `fileName`. Passing an `onOpenFile(fileName)` handler down from
+  `Index.tsx` (load blob → `parseDatalogFile` → `handleDataLoaded` → close drawer,
+  dropping a doc-style tab back to the race line) makes the header lap time and
+  each "Fastest laps" row tappable to open that session directly.
 - **Orphan prune (GC).** A revision is an orphan once no
   `FileMetadata.sessionSetupRev` points at it. `pruneSetupRevisions()` deletes
   orphans (pure split: `findOrphanRevisionIds`); `maybePruneSetupRevisions()`

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -43,6 +43,8 @@ interface FileManagerDrawerProps {
   onAddVehicle: (vehicle: Omit<Vehicle, "id">) => Promise<void>;
   onUpdateVehicle: (vehicle: Vehicle) => Promise<void>;
   onRemoveVehicle: (id: string) => Promise<void>;
+  // Open a saved session by file name (vehicle history → fastest-lap session).
+  onOpenFile: (fileName: string) => void | Promise<void>;
   // Current session context (the browser opens at this track/course)
   currentTrackName: string | null;
   currentCourseName: string | null;
@@ -56,6 +58,7 @@ export function FileManagerDrawer({
   showProfile,
   vehicles, vehicleTypes,
   onAddVehicle, onUpdateVehicle, onRemoveVehicle,
+  onOpenFile,
   currentTrackName, currentCourseName,
 }: FileManagerDrawerProps) {
   const { t } = useTranslation("drawer");
@@ -172,7 +175,7 @@ export function FileManagerDrawer({
               <FilesTab files={files} fileMetadataMap={fileMetadataMap} vehicles={vehicles} currentTrackName={currentTrackName} currentCourseName={currentCourseName} isOpen={isOpen} storageUsed={storageUsed} storageQuota={storageQuota} onLoadFile={onLoadFile} onDeleteFile={onDeleteFile} onExportFile={onExportFile} onSaveFile={onSaveFile} onDataLoaded={onDataLoaded} onClose={onClose} autoSave={autoSave} showSampleFiles={showSampleFiles} />
             )}
             {garageTab === "vehicles" && (
-              <VehiclesTab vehicles={vehicles} vehicleTypes={vehicleTypes} onAdd={onAddVehicle} onUpdate={onUpdateVehicle} onRemove={onRemoveVehicle} />
+              <VehiclesTab vehicles={vehicles} vehicleTypes={vehicleTypes} onAdd={onAddVehicle} onUpdate={onUpdateVehicle} onRemove={onRemoveVehicle} onOpenFile={onOpenFile} />
             )}
           </>
         )}

--- a/src/components/drawer/HistoryCard.tsx
+++ b/src/components/drawer/HistoryCard.tsx
@@ -1,0 +1,200 @@
+import { ArrowDown, ArrowUp, Trophy, Car, MapPin, ChevronDown, ChevronUp } from "lucide-react";
+import { formatLapTime } from "@/lib/lapCalculation";
+import type { SetupField, SetupFieldDiff, SetupUsage } from "@/lib/setupHistory";
+
+/** A small kart/course pill rendered under the card header. */
+export interface HistoryCardBubble {
+  icon: "car" | "map";
+  text: string;
+}
+
+/** Collapsible body toggle; omit to render the body without a control. */
+export interface HistoryCardToggle {
+  expanded: boolean;
+  onToggle: () => void;
+  expandLabel: string;
+  collapseLabel: string;
+}
+
+interface HistoryCardProps {
+  /** Highlights the card green when it holds the fastest lap in view. */
+  isFastestOverall: boolean;
+  /** Left header content — a badge (setup history) or the setup name (vehicle history). */
+  header: React.ReactNode;
+  /** Short content hash, rendered as #hash. */
+  hash: string;
+  /** Pre-formatted date string. */
+  date: string;
+  fastestLapMs: number | null;
+  fastestTagLabel: string;
+  noLapLabel: string;
+  bubbles?: HistoryCardBubble[];
+  /** Card body (full setup table or diff list); may be null when collapsed. */
+  children?: React.ReactNode;
+  toggle?: HistoryCardToggle;
+  /** Sessions completed with this revision, fastest lap first. */
+  usages: SetupUsage[];
+  lapsHeaderLabel: string;
+}
+
+/**
+ * Shared history card chrome for both the setup- and vehicle-history panels:
+ * fastest-lap highlight, header (hash/date/fastest tag/lap time), kart/course
+ * bubbles, a caller-supplied collapsible body, and the fastest-laps footer.
+ */
+export function HistoryCard({
+  isFastestOverall,
+  header,
+  hash,
+  date,
+  fastestLapMs,
+  fastestTagLabel,
+  noLapLabel,
+  bubbles,
+  children,
+  toggle,
+  usages,
+  lapsHeaderLabel,
+}: HistoryCardProps) {
+  const visibleBubbles = bubbles?.filter((b) => b.text) ?? [];
+  return (
+    <div
+      className={`rounded-lg border p-3 space-y-2.5 ${
+        isFastestOverall ? "border-success/60 bg-success/5" : "border-border"
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {header}
+            <span className="font-mono text-[10px] text-muted-foreground">#{hash}</span>
+            <span className="text-[10px] text-muted-foreground">{date}</span>
+            {isFastestOverall && (
+              <span className="flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-success/15 text-success">
+                <Trophy className="w-3 h-3" /> {fastestTagLabel}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          {fastestLapMs !== null ? (
+            <span className="font-mono text-sm font-semibold text-foreground">{formatLapTime(fastestLapMs)}</span>
+          ) : (
+            <span className="text-xs text-muted-foreground">{noLapLabel}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Kart/course bubbles */}
+      {visibleBubbles.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {visibleBubbles.map((b, i) => (
+            <span
+              key={`${b.icon}-${i}`}
+              className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground"
+            >
+              {b.icon === "car" ? <Car className="w-3 h-3" /> : <MapPin className="w-3 h-3" />} {b.text}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Body */}
+      {children}
+
+      {/* Collapse/expand toggle */}
+      {toggle && (
+        <button
+          type="button"
+          onClick={toggle.onToggle}
+          className="flex items-center gap-1 text-[11px] text-primary hover:underline"
+        >
+          {toggle.expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          {toggle.expanded ? toggle.collapseLabel : toggle.expandLabel}
+        </button>
+      )}
+
+      {/* Fastest laps completed with this revision */}
+      {usages.length > 0 && (
+        <div className="pt-1.5 border-t border-border/60 space-y-0.5">
+          <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
+            {lapsHeaderLabel}
+          </p>
+          {usages.slice(0, 6).map((u) => (
+            <div key={u.fileName} className="flex items-center justify-between gap-2 text-[11px]">
+              <span className="text-muted-foreground truncate">
+                {[u.courseLabel, u.kartName].filter(Boolean).join(" · ") || u.fileName}
+              </span>
+              <span className="font-mono text-foreground shrink-0">
+                {u.fastestLapMs !== undefined ? formatLapTime(u.fastestLapMs) : noLapLabel}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Full flattened setup table — shared by both history panels. */
+export function FullSetup({
+  fields,
+  labelFor,
+  noDataLabel,
+}: {
+  fields: SetupField[];
+  labelFor: (f: { label?: string; labelKey?: string }) => string;
+  noDataLabel: string;
+}) {
+  if (fields.length === 0) {
+    return <p className="text-xs text-muted-foreground">{noDataLabel}</p>;
+  }
+  return (
+    <div className="space-y-0.5">
+      {fields.map((f) => (
+        <div key={f.key} className="flex justify-between gap-2 text-xs">
+          <span className="text-muted-foreground truncate">{labelFor(f)}</span>
+          <span className="font-mono text-foreground shrink-0">
+            {f.display}{f.unit ? ` ${f.unit}` : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Changed-fields-only diff list — used by the setup-history panel. */
+export function DiffList({
+  diff,
+  labelFor,
+}: {
+  diff: SetupFieldDiff[];
+  labelFor: (f: { label?: string; labelKey?: string }) => string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      {diff.map((d) => {
+        const color =
+          d.direction === "up" ? "text-success" : d.direction === "down" ? "text-destructive" : "text-foreground";
+        const Arrow = d.direction === "up" ? ArrowUp : d.direction === "down" ? ArrowDown : null;
+        return (
+          <div key={d.key} className="flex justify-between gap-2 text-xs items-center">
+            <span className="text-muted-foreground truncate">{labelFor(d)}</span>
+            <span className="flex items-center gap-1 font-mono shrink-0">
+              {d.prevDisplay !== null && (
+                <span className="text-muted-foreground/70 line-through decoration-muted-foreground/40">
+                  {d.prevDisplay}
+                </span>
+              )}
+              <span className={`flex items-center gap-0.5 ${color}`}>
+                {Arrow && <Arrow className="w-3 h-3" />}
+                {d.nextDisplay !== null ? `${d.nextDisplay}${d.unit ? ` ${d.unit}` : ""}` : "—"}
+              </span>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/drawer/HistoryCard.tsx
+++ b/src/components/drawer/HistoryCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, Trophy, Car, MapPin, ChevronDown, ChevronUp } from "lucide-react";
+import { ArrowDown, ArrowUp, Trophy, Car, MapPin, ChevronDown, ChevronUp, SquareArrowOutUpRight } from "lucide-react";
 import { formatLapTime } from "@/lib/lapCalculation";
 import type { SetupField, SetupFieldDiff, SetupUsage } from "@/lib/setupHistory";
 
@@ -94,8 +94,9 @@ export function HistoryCard({
                 type="button"
                 onClick={() => onOpenFile!(fastestFileName!)}
                 title={openSessionLabel}
-                className="font-mono text-sm font-semibold text-primary hover:underline"
+                className="inline-flex items-center gap-1 font-mono text-sm font-semibold text-primary hover:underline"
               >
+                <SquareArrowOutUpRight className="w-3 h-3" />
                 {formatLapTime(fastestLapMs)}
               </button>
             ) : (
@@ -152,9 +153,12 @@ export function HistoryCard({
                   type="button"
                   onClick={() => onOpenFile(u.fileName)}
                   title={openSessionLabel}
-                  className="w-full flex items-center justify-between gap-2 text-[11px] rounded px-1 -mx-1 py-0.5 hover:bg-muted/60"
+                  className="group w-full flex items-center justify-between gap-2 text-[11px] rounded px-1 -mx-1 py-0.5 hover:bg-muted/60"
                 >
-                  <span className="text-muted-foreground truncate text-left hover:text-foreground">{label}</span>
+                  <span className="flex items-center gap-1 min-w-0 text-muted-foreground group-hover:text-foreground">
+                    <SquareArrowOutUpRight className="w-3 h-3 shrink-0 opacity-60 group-hover:opacity-100" />
+                    <span className="truncate text-left">{label}</span>
+                  </span>
                   <span className="font-mono text-foreground shrink-0">{lap}</span>
                 </button>
               );

--- a/src/components/drawer/HistoryCard.tsx
+++ b/src/components/drawer/HistoryCard.tsx
@@ -35,6 +35,12 @@ interface HistoryCardProps {
   /** Sessions completed with this revision, fastest lap first. */
   usages: SetupUsage[];
   lapsHeaderLabel: string;
+  /** When set, the fastest lap time + each session row open that session. */
+  onOpenFile?: (fileName: string) => void | Promise<void>;
+  /** The session file holding this card's fastest lap (the header lap time). */
+  fastestFileName?: string | null;
+  /** Tooltip for the open-session affordances. */
+  openSessionLabel?: string;
 }
 
 /**
@@ -55,8 +61,12 @@ export function HistoryCard({
   toggle,
   usages,
   lapsHeaderLabel,
+  onOpenFile,
+  fastestFileName,
+  openSessionLabel,
 }: HistoryCardProps) {
   const visibleBubbles = bubbles?.filter((b) => b.text) ?? [];
+  const canOpenFastest = !!(onOpenFile && fastestFileName && fastestLapMs !== null);
   return (
     <div
       className={`rounded-lg border p-3 space-y-2.5 ${
@@ -79,7 +89,18 @@ export function HistoryCard({
         </div>
         <div className="text-right shrink-0">
           {fastestLapMs !== null ? (
-            <span className="font-mono text-sm font-semibold text-foreground">{formatLapTime(fastestLapMs)}</span>
+            canOpenFastest ? (
+              <button
+                type="button"
+                onClick={() => onOpenFile!(fastestFileName!)}
+                title={openSessionLabel}
+                className="font-mono text-sm font-semibold text-primary hover:underline"
+              >
+                {formatLapTime(fastestLapMs)}
+              </button>
+            ) : (
+              <span className="font-mono text-sm font-semibold text-foreground">{formatLapTime(fastestLapMs)}</span>
+            )
           ) : (
             <span className="text-xs text-muted-foreground">{noLapLabel}</span>
           )}
@@ -121,16 +142,30 @@ export function HistoryCard({
           <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
             {lapsHeaderLabel}
           </p>
-          {usages.slice(0, 6).map((u) => (
-            <div key={u.fileName} className="flex items-center justify-between gap-2 text-[11px]">
-              <span className="text-muted-foreground truncate">
-                {[u.courseLabel, u.kartName].filter(Boolean).join(" · ") || u.fileName}
-              </span>
-              <span className="font-mono text-foreground shrink-0">
-                {u.fastestLapMs !== undefined ? formatLapTime(u.fastestLapMs) : noLapLabel}
-              </span>
-            </div>
-          ))}
+          {usages.slice(0, 6).map((u) => {
+            const label = [u.courseLabel, u.kartName].filter(Boolean).join(" · ") || u.fileName;
+            const lap = u.fastestLapMs !== undefined ? formatLapTime(u.fastestLapMs) : noLapLabel;
+            if (onOpenFile) {
+              return (
+                <button
+                  key={u.fileName}
+                  type="button"
+                  onClick={() => onOpenFile(u.fileName)}
+                  title={openSessionLabel}
+                  className="w-full flex items-center justify-between gap-2 text-[11px] rounded px-1 -mx-1 py-0.5 hover:bg-muted/60"
+                >
+                  <span className="text-muted-foreground truncate text-left hover:text-foreground">{label}</span>
+                  <span className="font-mono text-foreground shrink-0">{lap}</span>
+                </button>
+              );
+            }
+            return (
+              <div key={u.fileName} className="flex items-center justify-between gap-2 text-[11px]">
+                <span className="text-muted-foreground truncate">{label}</span>
+                <span className="font-mono text-foreground shrink-0">{lap}</span>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/drawer/SetupHistoryPanel.tsx
+++ b/src/components/drawer/SetupHistoryPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
-import { ArrowLeft, ArrowDown, ArrowUp, Trophy, Car, MapPin, ChevronDown, ChevronUp, History } from "lucide-react";
+import { ArrowLeft, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Vehicle } from "@/lib/vehicleStorage";
@@ -9,13 +9,8 @@ import { VehicleSetup } from "@/lib/setupStorage";
 import { FileMetadata, listAllMetadata } from "@/lib/fileStorage";
 import { SetupRevision, shortRevHash } from "@/lib/setupRevision";
 import { listSetupRevisions } from "@/lib/setupRevisionStorage";
-import { formatLapTime } from "@/lib/lapCalculation";
-import {
-  buildSetupHistory,
-  type SetupField,
-  type SetupFieldDiff,
-  type SetupHistoryEntry,
-} from "@/lib/setupHistory";
+import { buildSetupHistory, type SetupHistoryEntry } from "@/lib/setupHistory";
+import { HistoryCard, FullSetup, DiffList } from "@/components/drawer/HistoryCard";
 
 interface SetupHistoryPanelProps {
   setup: VehicleSetup;
@@ -162,153 +157,49 @@ function RevisionCard({
   const { revision, fastestLapMs, fastestUsage, isFastestOverall, diff, usages } = entry;
   const date = new Date(revision.createdAt).toLocaleDateString();
 
+  const body = showFull ? (
+    <FullSetup fields={entry.fields} labelFor={labelFor} noDataLabel={t("setupHistory.noSetupData")} />
+  ) : diff && diff.length > 0 ? (
+    <DiffList diff={diff} labelFor={labelFor} />
+  ) : (
+    <p className="text-xs text-muted-foreground italic">{t("setupHistory.noChanges")}</p>
+  );
+
   return (
-    <div
-      className={`rounded-lg border p-3 space-y-2.5 ${
-        isFastestOverall ? "border-success/60 bg-success/5" : "border-border"
-      }`}
-    >
-      {/* Header */}
-      <div className="flex items-start gap-2">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <span
-              className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
-                isOriginal ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground"
-              }`}
-            >
-              {isOriginal ? t("setupHistory.original") : t("setupHistory.revision")}
-            </span>
-            <span className="font-mono text-[10px] text-muted-foreground">#{shortRevHash(revision.id)}</span>
-            <span className="text-[10px] text-muted-foreground">{date}</span>
-            {isFastestOverall && (
-              <span className="flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-success/15 text-success">
-                <Trophy className="w-3 h-3" /> {t("setupHistory.fastestTag")}
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="text-right shrink-0">
-          {fastestLapMs !== null ? (
-            <span className="font-mono text-sm font-semibold text-foreground">{formatLapTime(fastestLapMs)}</span>
-          ) : (
-            <span className="text-xs text-muted-foreground">{t("setupHistory.noLap")}</span>
-          )}
-        </div>
-      </div>
-
-      {/* Bubbles for the fastest usage's kart/course (the dimensions not filtered) */}
-      {(((!hideKartBubble && fastestUsage?.kartName) || (!hideCourseBubble && fastestUsage?.courseLabel))) && (
-        <div className="flex flex-wrap gap-1">
-          {!hideKartBubble && fastestUsage?.kartName && (
-            <span className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              <Car className="w-3 h-3" /> {fastestUsage.kartName}
-            </span>
-          )}
-          {!hideCourseBubble && fastestUsage?.courseLabel && (
-            <span className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              <MapPin className="w-3 h-3" /> {fastestUsage.courseLabel}
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* Setup content: full table, or diff-only for later revisions */}
-      {showFull ? (
-        <FullSetup fields={entry.fields} labelFor={labelFor} t={t} />
-      ) : diff && diff.length > 0 ? (
-        <DiffList diff={diff} labelFor={labelFor} />
-      ) : (
-        <p className="text-xs text-muted-foreground italic">{t("setupHistory.noChanges")}</p>
-      )}
-
-      {/* Full/diff toggle (original is always full) */}
-      {!isOriginal && (
-        <button
-          type="button"
-          onClick={onToggleFull}
-          className="flex items-center gap-1 text-[11px] text-primary hover:underline"
+    <HistoryCard
+      isFastestOverall={isFastestOverall}
+      header={
+        <span
+          className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+            isOriginal ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground"
+          }`}
         >
-          {showFull ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-          {showFull ? t("setupHistory.showChanges") : t("setupHistory.showFull")}
-        </button>
-      )}
-
-      {/* Fastest laps completed with this revision */}
-      {usages.length > 0 && (
-        <div className="pt-1.5 border-t border-border/60 space-y-0.5">
-          <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
-            {t("setupHistory.lapsHeader")}
-          </p>
-          {usages.slice(0, 6).map((u) => (
-            <div key={u.fileName} className="flex items-center justify-between gap-2 text-[11px]">
-              <span className="text-muted-foreground truncate">
-                {[u.courseLabel, u.kartName].filter(Boolean).join(" · ") || u.fileName}
-              </span>
-              <span className="font-mono text-foreground shrink-0">
-                {u.fastestLapMs !== undefined ? formatLapTime(u.fastestLapMs) : t("setupHistory.noLap")}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function FullSetup({
-  fields, labelFor, t,
-}: {
-  fields: SetupField[];
-  labelFor: (f: { label?: string; labelKey?: string }) => string;
-  t: TFunction<"drawer">;
-}) {
-  if (fields.length === 0) {
-    return <p className="text-xs text-muted-foreground">{t("setupHistory.noSetupData")}</p>;
-  }
-  return (
-    <div className="space-y-0.5">
-      {fields.map((f) => (
-        <div key={f.key} className="flex justify-between gap-2 text-xs">
-          <span className="text-muted-foreground truncate">{labelFor(f)}</span>
-          <span className="font-mono text-foreground shrink-0">
-            {f.display}{f.unit ? ` ${f.unit}` : ""}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function DiffList({
-  diff, labelFor,
-}: {
-  diff: SetupFieldDiff[];
-  labelFor: (f: { label?: string; labelKey?: string }) => string;
-}) {
-  return (
-    <div className="space-y-0.5">
-      {diff.map((d) => {
-        const color =
-          d.direction === "up" ? "text-success" : d.direction === "down" ? "text-destructive" : "text-foreground";
-        const Arrow = d.direction === "up" ? ArrowUp : d.direction === "down" ? ArrowDown : null;
-        return (
-          <div key={d.key} className="flex justify-between gap-2 text-xs items-center">
-            <span className="text-muted-foreground truncate">{labelFor(d)}</span>
-            <span className="flex items-center gap-1 font-mono shrink-0">
-              {d.prevDisplay !== null && (
-                <span className="text-muted-foreground/70 line-through decoration-muted-foreground/40">
-                  {d.prevDisplay}
-                </span>
-              )}
-              <span className={`flex items-center gap-0.5 ${color}`}>
-                {Arrow && <Arrow className="w-3 h-3" />}
-                {d.nextDisplay !== null ? `${d.nextDisplay}${d.unit ? ` ${d.unit}` : ""}` : "—"}
-              </span>
-            </span>
-          </div>
-        );
-      })}
-    </div>
+          {isOriginal ? t("setupHistory.original") : t("setupHistory.revision")}
+        </span>
+      }
+      hash={shortRevHash(revision.id)}
+      date={date}
+      fastestLapMs={fastestLapMs}
+      fastestTagLabel={t("setupHistory.fastestTag")}
+      noLapLabel={t("setupHistory.noLap")}
+      bubbles={[
+        ...(!hideKartBubble && fastestUsage?.kartName ? [{ icon: "car" as const, text: fastestUsage.kartName }] : []),
+        ...(!hideCourseBubble && fastestUsage?.courseLabel ? [{ icon: "map" as const, text: fastestUsage.courseLabel }] : []),
+      ]}
+      toggle={
+        isOriginal
+          ? undefined
+          : {
+              expanded: showFull,
+              onToggle: onToggleFull,
+              expandLabel: t("setupHistory.showFull"),
+              collapseLabel: t("setupHistory.showChanges"),
+            }
+      }
+      usages={usages}
+      lapsHeaderLabel={t("setupHistory.lapsHeader")}
+    >
+      {body}
+    </HistoryCard>
   );
 }

--- a/src/components/drawer/SetupHistoryPanel.tsx
+++ b/src/components/drawer/SetupHistoryPanel.tsx
@@ -16,10 +16,12 @@ interface SetupHistoryPanelProps {
   setup: VehicleSetup;
   vehicles: Vehicle[];
   onBack: () => void;
+  /** Open a saved session by file name (a card's fastest-lap session). */
+  onOpenFile?: (fileName: string) => void | Promise<void>;
 }
 
 /** Full-panel chronological history of a setup's frozen revisions. */
-export function SetupHistoryPanel({ setup, vehicles, onBack }: SetupHistoryPanelProps) {
+export function SetupHistoryPanel({ setup, vehicles, onBack, onOpenFile }: SetupHistoryPanelProps) {
   const { t } = useTranslation("drawer");
   const [revisions, setRevisions] = useState<SetupRevision[]>([]);
   const [metas, setMetas] = useState<FileMetadata[]>([]);
@@ -131,6 +133,7 @@ export function SetupHistoryPanel({ setup, vehicles, onBack }: SetupHistoryPanel
               hideKartBubble={!!kartFilter}
               hideCourseBubble={!!courseFilter}
               labelFor={labelFor}
+              onOpenFile={onOpenFile}
               t={t}
             />
           ))
@@ -148,11 +151,12 @@ interface RevisionCardProps {
   hideKartBubble: boolean;
   hideCourseBubble: boolean;
   labelFor: (f: { label?: string; labelKey?: string }) => string;
+  onOpenFile?: (fileName: string) => void | Promise<void>;
   t: TFunction<"drawer">;
 }
 
 function RevisionCard({
-  entry, isOriginal, showFull, onToggleFull, hideKartBubble, hideCourseBubble, labelFor, t,
+  entry, isOriginal, showFull, onToggleFull, hideKartBubble, hideCourseBubble, labelFor, onOpenFile, t,
 }: RevisionCardProps) {
   const { revision, fastestLapMs, fastestUsage, isFastestOverall, diff, usages } = entry;
   const date = new Date(revision.createdAt).toLocaleDateString();
@@ -198,6 +202,9 @@ function RevisionCard({
       }
       usages={usages}
       lapsHeaderLabel={t("setupHistory.lapsHeader")}
+      onOpenFile={onOpenFile}
+      fastestFileName={fastestUsage?.fileName}
+      openSessionLabel={t("setupHistory.openSession")}
     >
       {body}
     </HistoryCard>

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -27,6 +27,8 @@ interface SetupsTabProps {
   onGetLatestForVehicle: (vehicleId: string) => Promise<VehicleSetup | null>;
   onAddVehicleType: (name: string, wheelCount: 2 | 4, includeTires: boolean, sections: TemplateSection[]) => Promise<unknown>;
   onRemoveVehicleType: (vehicleTypeId: string, templateId: string) => Promise<void>;
+  /** Open a saved session by file name (history card → fastest-lap session). */
+  onOpenFile?: (fileName: string) => void | Promise<void>;
 }
 
 type FormMode = "list" | "new" | "edit" | "new-type" | "history";
@@ -58,7 +60,7 @@ const emptyForm = (): Omit<VehicleSetup, "id" | "createdAt" | "updatedAt"> => ({
 export function SetupsTab({
   vehicles, setups, vehicleTypes, templates,
   onAdd, onUpdate, onRemove, onGetLatestForVehicle,
-  onAddVehicleType, onRemoveVehicleType,
+  onAddVehicleType, onRemoveVehicleType, onOpenFile,
 }: SetupsTabProps) {
   const { t } = useTranslation("drawer");
   const [mode, setMode] = useState<FormMode>("list");
@@ -275,6 +277,7 @@ export function SetupsTab({
         setup={historySetup}
         vehicles={vehicles}
         onBack={() => { setHistorySetup(null); setMode("list"); }}
+        onOpenFile={onOpenFile}
       />
     );
   }

--- a/src/components/drawer/VehicleHistoryPanel.tsx
+++ b/src/components/drawer/VehicleHistoryPanel.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, History } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Vehicle } from "@/lib/vehicleStorage";
+import { FileMetadata, listAllMetadata } from "@/lib/fileStorage";
+import { SetupRevision, shortRevHash } from "@/lib/setupRevision";
+import { listSetupRevisions } from "@/lib/setupRevisionStorage";
+import { buildVehicleHistory } from "@/lib/vehicleHistory";
+import { HistoryCard, FullSetup } from "@/components/drawer/HistoryCard";
+
+interface VehicleHistoryPanelProps {
+  vehicle: Vehicle;
+  vehicles: Vehicle[];
+  onBack: () => void;
+}
+
+/** Full-panel history of every setup revision run on one vehicle, fastest first. */
+export function VehicleHistoryPanel({ vehicle, vehicles, onBack }: VehicleHistoryPanelProps) {
+  const { t } = useTranslation("drawer");
+  const [revisions, setRevisions] = useState<SetupRevision[]>([]);
+  const [metas, setMetas] = useState<FileMetadata[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [courseFilter, setCourseFilter] = useState<string>("");
+  // Each card is collapsed by default; expanded ids are tracked here.
+  const [openCards, setOpenCards] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [revs, m] = await Promise.all([listSetupRevisions(), listAllMetadata()]);
+      if (!cancelled) {
+        setRevisions(revs);
+        setMetas(m);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const history = useMemo(
+    () =>
+      buildVehicleHistory({
+        vehicleId: vehicle.id,
+        vehicleName: vehicle.name,
+        revisions,
+        metas,
+        vehicles,
+        filter: { courseKey: courseFilter || null },
+      }),
+    [vehicle.id, vehicle.name, revisions, metas, vehicles, courseFilter],
+  );
+
+  const labelFor = (f: { label?: string; labelKey?: string }): string =>
+    f.label ?? (f.labelKey ? t(f.labelKey as never) : "");
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-border">
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onBack}>
+          <ArrowLeft className="w-4 h-4" />
+        </Button>
+        <div className="flex items-center gap-1.5 flex-1 min-w-0">
+          <History className="w-4 h-4 text-muted-foreground shrink-0" />
+          <h3 className="text-sm font-semibold text-foreground truncate">{t("vehicleHistory.title")}</h3>
+        </div>
+        <span className="text-xs text-muted-foreground truncate max-w-[40%]">{vehicle.name}</span>
+      </div>
+
+      {/* Course filter */}
+      {history.courseOptions.length > 0 && (
+        <div className="shrink-0 flex gap-2 px-3 py-2 border-b border-border">
+          <Select value={courseFilter || "__all__"} onValueChange={(v) => setCourseFilter(v === "__all__" ? "" : v)}>
+            <SelectTrigger className="h-8 text-xs flex-1">
+              <SelectValue placeholder={t("vehicleHistory.allCourses")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">{t("vehicleHistory.allCourses")}</SelectItem>
+              {history.courseOptions.map((c) => (
+                <SelectItem key={c.key} value={c.key}>{c.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
+        {loading ? (
+          <p className="text-center text-xs text-muted-foreground py-8">{t("vehicleHistory.loading")}</p>
+        ) : history.entries.length === 0 ? (
+          <div className="flex flex-col items-center justify-center text-muted-foreground gap-3 py-16">
+            <History className="w-12 h-12 opacity-30" />
+            <p className="text-sm font-medium">{t("vehicleHistory.empty")}</p>
+            <p className="text-xs text-center">{t("vehicleHistory.emptyHint")}</p>
+          </div>
+        ) : (
+          history.entries.map((entry) => {
+            const expanded = !!openCards[entry.revision.id];
+            return (
+              <HistoryCard
+                key={entry.revision.id}
+                isFastestOverall={entry.isFastestOverall}
+                header={
+                  <span className="text-xs font-semibold text-foreground truncate max-w-[12rem]">
+                    {entry.setupName}
+                  </span>
+                }
+                hash={shortRevHash(entry.revision.id)}
+                date={new Date(entry.revision.createdAt).toLocaleDateString()}
+                fastestLapMs={entry.fastestLapMs}
+                fastestTagLabel={t("vehicleHistory.fastestTag")}
+                noLapLabel={t("vehicleHistory.noLap")}
+                bubbles={
+                  !courseFilter && entry.fastestUsage?.courseLabel
+                    ? [{ icon: "map", text: entry.fastestUsage.courseLabel }]
+                    : []
+                }
+                toggle={{
+                  expanded,
+                  onToggle: () =>
+                    setOpenCards((prev) => ({ ...prev, [entry.revision.id]: !prev[entry.revision.id] })),
+                  expandLabel: t("vehicleHistory.showFull"),
+                  collapseLabel: t("vehicleHistory.hideFull"),
+                }}
+                usages={entry.usages}
+                lapsHeaderLabel={t("vehicleHistory.lapsHeader")}
+              >
+                {expanded && (
+                  <FullSetup
+                    fields={entry.fields}
+                    labelFor={labelFor}
+                    noDataLabel={t("vehicleHistory.noSetupData")}
+                  />
+                )}
+              </HistoryCard>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/drawer/VehicleHistoryPanel.tsx
+++ b/src/components/drawer/VehicleHistoryPanel.tsx
@@ -14,10 +14,12 @@ interface VehicleHistoryPanelProps {
   vehicle: Vehicle;
   vehicles: Vehicle[];
   onBack: () => void;
+  /** Open a saved session by file name (a card's fastest-lap session). */
+  onOpenFile?: (fileName: string) => void | Promise<void>;
 }
 
 /** Full-panel history of every setup revision run on one vehicle, fastest first. */
-export function VehicleHistoryPanel({ vehicle, vehicles, onBack }: VehicleHistoryPanelProps) {
+export function VehicleHistoryPanel({ vehicle, vehicles, onBack, onOpenFile }: VehicleHistoryPanelProps) {
   const { t } = useTranslation("drawer");
   const [revisions, setRevisions] = useState<SetupRevision[]>([]);
   const [metas, setMetas] = useState<FileMetadata[]>([]);
@@ -129,6 +131,9 @@ export function VehicleHistoryPanel({ vehicle, vehicles, onBack }: VehicleHistor
                 }}
                 usages={entry.usages}
                 lapsHeaderLabel={t("vehicleHistory.lapsHeader")}
+                onOpenFile={onOpenFile}
+                fastestFileName={entry.fastestUsage?.fileName}
+                openSessionLabel={t("vehicleHistory.openSession")}
               >
                 {expanded && (
                   <FullSetup

--- a/src/components/drawer/VehiclesTab.tsx
+++ b/src/components/drawer/VehiclesTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Pencil, Trash2, Car } from "lucide-react";
+import { Pencil, Trash2, Car, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -10,6 +10,7 @@ import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleType } from "@/lib/templateStorage";
 import { useEngineManager } from "@/hooks/useEngineManager";
 import { EngineCombobox } from "./EngineCombobox";
+import { VehicleHistoryPanel } from "./VehicleHistoryPanel";
 
 interface VehiclesTabProps {
   vehicles: Vehicle[];
@@ -34,6 +35,7 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState(emptyForm(defaultTypeId));
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [historyVehicle, setHistoryVehicle] = useState<Vehicle | null>(null);
 
   const { engines, addEngine, importEngines, removeEngine } = useEngineManager();
 
@@ -87,6 +89,16 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
     if (editingId === confirmDelete) resetForm();
   }, [confirmDelete, onRemove, editingId, resetForm]);
 
+  if (historyVehicle) {
+    return (
+      <VehicleHistoryPanel
+        vehicle={historyVehicle}
+        vehicles={vehicles}
+        onBack={() => setHistoryVehicle(null)}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       {confirmDelete && (
@@ -122,6 +134,9 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
                     {vt?.name ?? t("vehicles.unknownType")} · {vehicle.engine} · {vehicle.weight} {vehicle.weightUnit}
                   </div>
                 </div>
+                <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100" onClick={() => setHistoryVehicle(vehicle)} title={t("vehicleHistory.openTitle")}>
+                  <History className="w-3.5 h-3.5" />
+                </Button>
                 <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0 opacity-60 hover:opacity-100" onClick={() => handleEdit(vehicle)} title={t("vehicles.edit")}>
                   <Pencil className="w-3.5 h-3.5" />
                 </Button>

--- a/src/components/drawer/VehiclesTab.tsx
+++ b/src/components/drawer/VehiclesTab.tsx
@@ -18,6 +18,8 @@ interface VehiclesTabProps {
   onAdd: (vehicle: Omit<Vehicle, "id">) => Promise<void>;
   onUpdate: (vehicle: Vehicle) => Promise<void>;
   onRemove: (id: string) => Promise<void>;
+  /** Open a saved session by file name (history card → fastest-lap session). */
+  onOpenFile?: (fileName: string) => void | Promise<void>;
 }
 
 const emptyForm = (defaultTypeId: string): Omit<Vehicle, "id"> => ({
@@ -29,7 +31,7 @@ const emptyForm = (defaultTypeId: string): Omit<Vehicle, "id"> => ({
   weightUnit: "lb",
 });
 
-export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove }: VehiclesTabProps) {
+export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove, onOpenFile }: VehiclesTabProps) {
   const { t } = useTranslation("drawer");
   const defaultTypeId = vehicleTypes[0]?.id ?? "";
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -95,6 +97,7 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove 
         vehicle={historyVehicle}
         vehicles={vehicles}
         onBack={() => setHistoryVehicle(null)}
+        onOpenFile={onOpenFile}
       />
     );
   }

--- a/src/lib/setupHistory.ts
+++ b/src/lib/setupHistory.ts
@@ -14,7 +14,7 @@ import type { FileMetadata } from "./fileStorage";
 import type { Vehicle } from "./vehicleStorage";
 
 /** Separator for the composite course key (never appears in track/course names). */
-const COURSE_KEY_SEP = "\x1f";
+export const COURSE_KEY_SEP = "\x1f";
 
 /** A single flattened setup value, ready to render or diff. */
 export interface SetupField {
@@ -291,7 +291,8 @@ export function diffRevisionFields(prev: SetupField[], next: SetupField[]): Setu
   return diffs;
 }
 
-function buildUsage(meta: FileMetadata, vehicles: Vehicle[]): SetupUsage {
+/** Convert one session's metadata into a `SetupUsage` (kart/course resolved). */
+export function buildUsage(meta: FileMetadata, vehicles: Vehicle[]): SetupUsage {
   const vehicle = meta.sessionKartId ? vehicles.find((v) => v.id === meta.sessionKartId) : undefined;
   const trackName = meta.trackName || undefined;
   const courseName = meta.courseName || undefined;
@@ -316,14 +317,14 @@ function buildUsage(meta: FileMetadata, vehicles: Vehicle[]): SetupUsage {
 }
 
 /** Sort usages fastest lap first; sessions without a lap time sink to the bottom. */
-function byFastestLap(a: SetupUsage, b: SetupUsage): number {
+export function byFastestLap(a: SetupUsage, b: SetupUsage): number {
   const av = a.fastestLapMs ?? Infinity;
   const bv = b.fastestLapMs ?? Infinity;
   if (av !== bv) return av - bv;
   return (a.sessionStartTime ?? 0) - (b.sessionStartTime ?? 0);
 }
 
-function distinct<T>(values: (T | undefined)[]): T[] {
+export function distinct<T>(values: (T | undefined)[]): T[] {
   return Array.from(new Set(values.filter((v): v is T => v !== undefined && v !== "")));
 }
 

--- a/src/lib/vehicleHistory.test.ts
+++ b/src/lib/vehicleHistory.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { VehicleSetup } from "./setupStorage";
+import type { SetupRevision, FrozenTemplate } from "./setupRevision";
+import type { FileMetadata } from "./fileStorage";
+import type { Vehicle } from "./vehicleStorage";
+import { buildVehicleHistory } from "./vehicleHistory";
+
+const TEMPLATE: FrozenTemplate = {
+  id: "tpl-1",
+  name: "Kart",
+  wheelCount: 4,
+  includeTires: true,
+  sections: [
+    {
+      id: "sec",
+      name: "Alignment",
+      fields: [{ id: "f-toe", name: "Toe", type: "number" }],
+    },
+  ],
+};
+
+function makeSetup(name: string, overrides: Partial<VehicleSetup> = {}): VehicleSetup {
+  return {
+    id: "setup-1",
+    vehicleId: "veh-1",
+    templateId: "tpl-1",
+    name,
+    unitSystem: "mm",
+    tireBrand: "MG",
+    psiMode: "single",
+    psiFrontLeft: 12,
+    psiFrontRight: 12,
+    psiRearLeft: 12,
+    psiRearRight: 12,
+    tireWidthMode: "halves",
+    tireWidthFrontLeft: null,
+    tireWidthFrontRight: null,
+    tireWidthRearLeft: null,
+    tireWidthRearRight: null,
+    tireDiameterMode: "halves",
+    tireDiameterFrontLeft: null,
+    tireDiameterFrontRight: null,
+    tireDiameterRearLeft: null,
+    tireDiameterRearRight: null,
+    customFields: { "f-toe": 1 },
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeRevision(id: string, createdAt: number, setup: VehicleSetup): SetupRevision {
+  return {
+    id,
+    setupId: setup.id,
+    vehicleId: setup.vehicleId,
+    name: setup.name,
+    setup,
+    template: TEMPLATE,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function makeMeta(overrides: Partial<FileMetadata> & { fileName: string }): FileMetadata {
+  return { trackName: "", courseName: "", ...overrides };
+}
+
+const VEHICLES: Vehicle[] = [
+  { id: "veh-1", name: "Kart #7", vehicleTypeId: "vt", engine: "X30", number: 7, weight: 80, weightUnit: "kg" },
+  { id: "veh-2", name: "Kart #9", vehicleTypeId: "vt", engine: "KA100", number: 9, weight: 82, weightUnit: "kg" },
+];
+
+const revDry = makeRevision("rev-dry", 1000, makeSetup("Dry", { customFields: { "f-toe": 1 } }));
+const revWet = makeRevision("rev-wet", 2000, makeSetup("Wet", { customFields: { "f-toe": 2 } }));
+
+const metas = [
+  // veh-1 / Dry / Track A CW — 65000
+  makeMeta({ fileName: "s1", sessionSetupRev: "rev-dry", sessionKartId: "veh-1", trackName: "Track A", courseName: "CW", fastestLapMs: 65000, sessionStartTime: 100 }),
+  // veh-1 / Wet / Track A CW — 61000 (fastest overall on veh-1)
+  makeMeta({ fileName: "s2", sessionSetupRev: "rev-wet", sessionKartId: "veh-1", trackName: "Track A", courseName: "CW", fastestLapMs: 61000, sessionStartTime: 200 }),
+  // veh-1 / Dry / Track B CCW — 63000
+  makeMeta({ fileName: "s3", sessionSetupRev: "rev-dry", sessionKartId: "veh-1", trackName: "Track B", courseName: "CCW", fastestLapMs: 63000, sessionStartTime: 300 }),
+  // veh-2 session — must never appear in veh-1's history
+  makeMeta({ fileName: "s4", sessionSetupRev: "rev-wet", sessionKartId: "veh-2", trackName: "Track A", courseName: "CW", fastestLapMs: 50000, sessionStartTime: 400 }),
+];
+
+describe("buildVehicleHistory", () => {
+  it("orders cards fastest lap first and flags the overall fastest", () => {
+    const h = buildVehicleHistory({ vehicleId: "veh-1", vehicleName: "Kart #7", revisions: [revWet, revDry], metas, vehicles: VEHICLES });
+    expect(h.entries.map((e) => e.revision.id)).toEqual(["rev-wet", "rev-dry"]);
+    expect(h.entries[0].fastestLapMs).toBe(61000);
+    // rev-dry's fastest across its sessions on veh-1 (65000, 63000) is 63000
+    expect(h.entries[1].fastestLapMs).toBe(63000);
+    expect(h.overallFastestLapMs).toBe(61000);
+    expect(h.entries[0].isFastestOverall).toBe(true);
+    expect(h.entries[1].isFastestOverall).toBe(false);
+  });
+
+  it("only includes sessions run on this vehicle", () => {
+    const h = buildVehicleHistory({ vehicleId: "veh-1", vehicleName: "Kart #7", revisions: [revWet, revDry], metas, vehicles: VEHICLES });
+    const allFiles = h.entries.flatMap((e) => e.usages.map((u) => u.fileName));
+    expect(allFiles).not.toContain("s4");
+    expect(allFiles.sort()).toEqual(["s1", "s2", "s3"]);
+  });
+
+  it("exposes course filter options across the vehicle", () => {
+    const h = buildVehicleHistory({ vehicleId: "veh-1", vehicleName: "Kart #7", revisions: [revWet, revDry], metas, vehicles: VEHICLES });
+    expect(h.courseOptions.map((c) => c.label)).toContain("Track A — CW");
+    expect(h.courseOptions.map((c) => c.label)).toContain("Track B — CCW");
+  });
+
+  it("filters by course, dropping revisions with no matching session", () => {
+    const courseKey = `Track B\x1fCCW`;
+    const h = buildVehicleHistory({
+      vehicleId: "veh-1",
+      vehicleName: "Kart #7",
+      revisions: [revWet, revDry],
+      metas,
+      vehicles: VEHICLES,
+      filter: { courseKey },
+    });
+    // Only Dry ran on Track B CCW
+    expect(h.entries.map((e) => e.revision.id)).toEqual(["rev-dry"]);
+    expect(h.entries[0].fastestLapMs).toBe(63000);
+  });
+
+  it("flattens the frozen setup for the collapsible body", () => {
+    const h = buildVehicleHistory({ vehicleId: "veh-1", vehicleName: "Kart #7", revisions: [revWet, revDry], metas, vehicles: VEHICLES });
+    const wet = h.entries.find((e) => e.revision.id === "rev-wet")!;
+    expect(wet.setupName).toBe("Wet");
+    expect(wet.fields.find((f) => f.key === "tpl:f-toe")?.value).toBe(2);
+  });
+
+  it("skips sessions whose frozen revision is no longer in the store", () => {
+    const h = buildVehicleHistory({ vehicleId: "veh-1", vehicleName: "Kart #7", revisions: [revWet], metas, vehicles: VEHICLES });
+    // rev-dry pruned → only rev-wet survives
+    expect(h.entries.map((e) => e.revision.id)).toEqual(["rev-wet"]);
+  });
+});

--- a/src/lib/vehicleHistory.ts
+++ b/src/lib/vehicleHistory.ts
@@ -1,0 +1,135 @@
+// Pure view-model for the vehicle-history panel.
+//
+// Where setup history fixes one setup and walks its revisions over time (see
+// setupHistory.ts), vehicle history fixes one *vehicle* and gathers every frozen
+// setup revision that has been run on it — one card per revision, ordered fastest
+// lap first — so the question it answers is "which setup was quickest on this
+// kart?". It reuses setupHistory's flatten/usage/sort primitives so the two
+// histories stay byte-identical where they overlap.
+//
+// Kept pure (no IndexedDB / React) so the aggregation is unit-tested.
+
+import type { SetupRevision } from "./setupRevision";
+import type { FileMetadata } from "./fileStorage";
+import type { Vehicle } from "./vehicleStorage";
+import {
+  buildUsage,
+  byFastestLap,
+  distinct,
+  flattenRevisionFields,
+  type SetupField,
+  type SetupUsage,
+} from "./setupHistory";
+
+export interface VehicleHistoryEntry {
+  revision: SetupRevision;
+  /** Setup name at capture time. */
+  setupName: string;
+  /** Fully flattened fields, in template order then tires (for the collapsed body). */
+  fields: SetupField[];
+  /** Filtered sessions this revision was run on, fastest lap first. */
+  usages: SetupUsage[];
+  fastestLapMs: number | null;
+  fastestUsage: SetupUsage | null;
+  /** Distinct course labels across the (filtered) usages. */
+  courses: string[];
+  /** True when this revision holds the fastest lap in the current view. */
+  isFastestOverall: boolean;
+}
+
+export interface VehicleHistory {
+  vehicleId: string;
+  vehicleName: string;
+  /** Cards ordered fastest lap first; revisions with no lap sink to the bottom. */
+  entries: VehicleHistoryEntry[];
+  /** Every course this vehicle has been run on (for the filter). */
+  courseOptions: { key: string; label: string }[];
+  overallFastestLapMs: number | null;
+}
+
+export interface VehicleHistoryFilter {
+  courseKey?: string | null;
+}
+
+export interface BuildVehicleHistoryInput {
+  vehicleId: string;
+  vehicleName: string;
+  /** All revisions in the store; matched by id to the sessions' frozen setup. */
+  revisions: SetupRevision[];
+  /** All session metadata; only those run on this vehicle with a setup are used. */
+  metas: FileMetadata[];
+  vehicles: Vehicle[];
+  filter?: VehicleHistoryFilter;
+}
+
+/** Build the fastest-first history view-model for one vehicle. */
+export function buildVehicleHistory(input: BuildVehicleHistoryInput): VehicleHistory {
+  const { vehicleId, vehicleName, revisions, metas, vehicles, filter } = input;
+
+  const revById = new Map(revisions.map((r) => [r.id, r]));
+
+  // Every session run on this vehicle that froze a (still-present) setup revision,
+  // grouped by that revision.
+  const usagesByRev = new Map<string, SetupUsage[]>();
+  for (const meta of metas) {
+    if (meta.sessionKartId !== vehicleId) continue;
+    const revId = meta.sessionSetupRev;
+    if (!revId || !revById.has(revId)) continue;
+    const list = usagesByRev.get(revId) ?? [];
+    list.push(buildUsage(meta, vehicles));
+    usagesByRev.set(revId, list);
+  }
+
+  // Course filter spans every (unfiltered) usage on this vehicle.
+  const allUsages = Array.from(usagesByRev.values()).flat();
+  const courseMap = new Map<string, string>();
+  for (const u of allUsages) {
+    if (u.courseKey) courseMap.set(u.courseKey, u.courseLabel ?? u.courseKey);
+  }
+  const courseOptions = Array.from(courseMap, ([key, label]) => ({ key, label })).sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+
+  const matchesFilter = (u: SetupUsage): boolean =>
+    !filter?.courseKey || u.courseKey === filter.courseKey;
+
+  const built = Array.from(usagesByRev.entries())
+    .map(([revId, rawUsages]) => {
+      const revision = revById.get(revId)!;
+      const usages = rawUsages.filter(matchesFilter).sort(byFastestLap);
+      const laps = usages.map((u) => u.fastestLapMs).filter((v): v is number => v !== undefined);
+      const fastestLapMs = laps.length ? Math.min(...laps) : null;
+      const fastestUsage = usages.find((u) => u.fastestLapMs !== undefined) ?? null;
+      return {
+        revision,
+        setupName: revision.name,
+        fields: flattenRevisionFields(revision),
+        usages,
+        fastestLapMs,
+        fastestUsage,
+        courses: distinct(usages.map((u) => u.courseLabel)),
+      };
+    })
+    // When a course filter is active, only keep revisions actually run there.
+    .filter((e) => e.usages.length > 0);
+
+  const overallFastestLapMs = built.reduce<number | null>((min, e) => {
+    if (e.fastestLapMs === null) return min;
+    return min === null ? e.fastestLapMs : Math.min(min, e.fastestLapMs);
+  }, null);
+
+  // Fastest lap first; revisions without a lap sink to the bottom, then by name.
+  const entries: VehicleHistoryEntry[] = built
+    .map((e) => ({
+      ...e,
+      isFastestOverall: overallFastestLapMs !== null && e.fastestLapMs === overallFastestLapMs,
+    }))
+    .sort((a, b) => {
+      const av = a.fastestLapMs ?? Infinity;
+      const bv = b.fastestLapMs ?? Infinity;
+      if (av !== bv) return av - bv;
+      return a.setupName.localeCompare(b.setupName);
+    });
+
+  return { vehicleId, vehicleName, entries, courseOptions, overallFastestLapMs };
+}

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -140,6 +140,20 @@
     "showChanges": "Nur Änderungen anzeigen",
     "lapsHeader": "Schnellste Runden"
   },
+  "vehicleHistory": {
+    "title": "Fahrzeugverlauf",
+    "openTitle": "Fahrzeugverlauf anzeigen",
+    "loading": "Verlauf wird geladen…",
+    "empty": "Noch kein Verlauf",
+    "emptyHint": "Fahre eine Sitzung mit diesem Fahrzeug und weise ein Setup zu, um den Verlauf aufzubauen.",
+    "allCourses": "Alle Strecken",
+    "fastestTag": "Schnellste Runde",
+    "noLap": "—",
+    "noSetupData": "Keine Setup-Daten",
+    "showFull": "Setup anzeigen",
+    "hideFull": "Setup ausblenden",
+    "lapsHeader": "Schnellste Runden"
+  },
   "notes": {
     "loadSession": "Lade eine Session, um Notizen hinzuzufügen",
     "sessionSetup": "Session-Setup",

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -138,7 +138,8 @@
     "noSetupData": "Keine Setup-Daten",
     "showFull": "Vollständiges Setup anzeigen",
     "showChanges": "Nur Änderungen anzeigen",
-    "lapsHeader": "Schnellste Runden"
+    "lapsHeader": "Schnellste Runden",
+    "openSession": "Diese Sitzung öffnen"
   },
   "vehicleHistory": {
     "title": "Fahrzeugverlauf",
@@ -152,7 +153,8 @@
     "noSetupData": "Keine Setup-Daten",
     "showFull": "Setup anzeigen",
     "hideFull": "Setup ausblenden",
-    "lapsHeader": "Schnellste Runden"
+    "lapsHeader": "Schnellste Runden",
+    "openSession": "Diese Sitzung öffnen"
   },
   "notes": {
     "loadSession": "Lade eine Session, um Notizen hinzuzufügen",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -139,6 +139,20 @@
     "showChanges": "Show changes only",
     "lapsHeader": "Fastest laps"
   },
+  "vehicleHistory": {
+    "title": "Vehicle History",
+    "openTitle": "View vehicle history",
+    "loading": "Loading history…",
+    "empty": "No history yet",
+    "emptyHint": "Run a session with this vehicle and assign a setup to start building its history.",
+    "allCourses": "All courses",
+    "fastestTag": "Fastest lap",
+    "noLap": "—",
+    "noSetupData": "No setup data",
+    "showFull": "Show setup",
+    "hideFull": "Hide setup",
+    "lapsHeader": "Fastest laps"
+  },
   "notes": {
     "loadSession": "Load a session to add notes",
     "sessionSetup": "Session Setup",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -137,7 +137,8 @@
     "noSetupData": "No setup data",
     "showFull": "Show full setup",
     "showChanges": "Show changes only",
-    "lapsHeader": "Fastest laps"
+    "lapsHeader": "Fastest laps",
+    "openSession": "Open this session"
   },
   "vehicleHistory": {
     "title": "Vehicle History",
@@ -151,7 +152,8 @@
     "noSetupData": "No setup data",
     "showFull": "Show setup",
     "hideFull": "Hide setup",
-    "lapsHeader": "Fastest laps"
+    "lapsHeader": "Fastest laps",
+    "openSession": "Open this session"
   },
   "notes": {
     "loadSession": "Load a session to add notes",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -140,6 +140,20 @@
     "showChanges": "Mostrar solo cambios",
     "lapsHeader": "Vueltas más rápidas"
   },
+  "vehicleHistory": {
+    "title": "Historial del vehículo",
+    "openTitle": "Ver historial del vehículo",
+    "loading": "Cargando historial…",
+    "empty": "Aún no hay historial",
+    "emptyHint": "Ejecuta una sesión con este vehículo y asígnale una configuración para empezar a crear su historial.",
+    "allCourses": "Todos los circuitos",
+    "fastestTag": "Vuelta más rápida",
+    "noLap": "—",
+    "noSetupData": "Sin datos de configuración",
+    "showFull": "Mostrar configuración",
+    "hideFull": "Ocultar configuración",
+    "lapsHeader": "Vueltas más rápidas"
+  },
   "notes": {
     "loadSession": "Carga una sesión para añadir notas",
     "sessionSetup": "Reglaje de la sesión",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -138,7 +138,8 @@
     "noSetupData": "Sin datos de configuración",
     "showFull": "Mostrar configuración completa",
     "showChanges": "Mostrar solo cambios",
-    "lapsHeader": "Vueltas más rápidas"
+    "lapsHeader": "Vueltas más rápidas",
+    "openSession": "Abrir esta sesión"
   },
   "vehicleHistory": {
     "title": "Historial del vehículo",
@@ -152,7 +153,8 @@
     "noSetupData": "Sin datos de configuración",
     "showFull": "Mostrar configuración",
     "hideFull": "Ocultar configuración",
-    "lapsHeader": "Vueltas más rápidas"
+    "lapsHeader": "Vueltas más rápidas",
+    "openSession": "Abrir esta sesión"
   },
   "notes": {
     "loadSession": "Carga una sesión para añadir notas",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -140,6 +140,20 @@
     "showChanges": "Afficher uniquement les changements",
     "lapsHeader": "Meilleurs tours"
   },
+  "vehicleHistory": {
+    "title": "Historique du véhicule",
+    "openTitle": "Voir l'historique du véhicule",
+    "loading": "Chargement de l'historique…",
+    "empty": "Pas encore d'historique",
+    "emptyHint": "Effectuez une session avec ce véhicule et associez-lui un réglage pour commencer à construire son historique.",
+    "allCourses": "Tous les circuits",
+    "fastestTag": "Meilleur tour",
+    "noLap": "—",
+    "noSetupData": "Aucune donnée de réglage",
+    "showFull": "Afficher le réglage",
+    "hideFull": "Masquer le réglage",
+    "lapsHeader": "Meilleurs tours"
+  },
   "notes": {
     "loadSession": "Chargez une session pour ajouter des notes",
     "sessionSetup": "Réglage de la session",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -138,7 +138,8 @@
     "noSetupData": "Aucune donnée de réglage",
     "showFull": "Afficher le réglage complet",
     "showChanges": "Afficher uniquement les changements",
-    "lapsHeader": "Meilleurs tours"
+    "lapsHeader": "Meilleurs tours",
+    "openSession": "Ouvrir cette session"
   },
   "vehicleHistory": {
     "title": "Historique du véhicule",
@@ -152,7 +153,8 @@
     "noSetupData": "Aucune donnée de réglage",
     "showFull": "Afficher le réglage",
     "hideFull": "Masquer le réglage",
-    "lapsHeader": "Meilleurs tours"
+    "lapsHeader": "Meilleurs tours",
+    "openSession": "Ouvrir cette session"
   },
   "notes": {
     "loadSession": "Chargez une session pour ajouter des notes",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -140,6 +140,20 @@
     "showChanges": "Mostra solo le modifiche",
     "lapsHeader": "Giri più veloci"
   },
+  "vehicleHistory": {
+    "title": "Cronologia veicolo",
+    "openTitle": "Visualizza cronologia veicolo",
+    "loading": "Caricamento cronologia…",
+    "empty": "Nessuna cronologia",
+    "emptyHint": "Esegui una sessione con questo veicolo e assegna un assetto per iniziare a creare la sua cronologia.",
+    "allCourses": "Tutti i circuiti",
+    "fastestTag": "Giro più veloce",
+    "noLap": "—",
+    "noSetupData": "Nessun dato dell'assetto",
+    "showFull": "Mostra assetto",
+    "hideFull": "Nascondi assetto",
+    "lapsHeader": "Giri più veloci"
+  },
   "notes": {
     "loadSession": "Carica una sessione per aggiungere note",
     "sessionSetup": "Assetto della sessione",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -138,7 +138,8 @@
     "noSetupData": "Nessun dato dell'assetto",
     "showFull": "Mostra assetto completo",
     "showChanges": "Mostra solo le modifiche",
-    "lapsHeader": "Giri più veloci"
+    "lapsHeader": "Giri più veloci",
+    "openSession": "Apri questa sessione"
   },
   "vehicleHistory": {
     "title": "Cronologia veicolo",
@@ -152,7 +153,8 @@
     "noSetupData": "Nessun dato dell'assetto",
     "showFull": "Mostra assetto",
     "hideFull": "Nascondi assetto",
-    "lapsHeader": "Giri più veloci"
+    "lapsHeader": "Giri più veloci",
+    "openSession": "Apri questa sessione"
   },
   "notes": {
     "loadSession": "Carica una sessione per aggiungere note",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -140,6 +140,20 @@
     "showChanges": "変更のみ表示",
     "lapsHeader": "最速ラップ"
   },
+  "vehicleHistory": {
+    "title": "車両履歴",
+    "openTitle": "車両履歴を表示",
+    "loading": "履歴を読み込み中…",
+    "empty": "まだ履歴がありません",
+    "emptyHint": "この車両でセッションを実行しセットアップを割り当てると履歴の作成が始まります。",
+    "allCourses": "すべてのコース",
+    "fastestTag": "最速ラップ",
+    "noLap": "—",
+    "noSetupData": "セットアップデータなし",
+    "showFull": "セットアップを表示",
+    "hideFull": "セットアップを非表示",
+    "lapsHeader": "最速ラップ"
+  },
   "notes": {
     "loadSession": "メモを追加するにはセッションを読み込んでください",
     "sessionSetup": "セッションのセットアップ",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -138,7 +138,8 @@
     "noSetupData": "セットアップデータなし",
     "showFull": "セットアップ全体を表示",
     "showChanges": "変更のみ表示",
-    "lapsHeader": "最速ラップ"
+    "lapsHeader": "最速ラップ",
+    "openSession": "このセッションを開く"
   },
   "vehicleHistory": {
     "title": "車両履歴",
@@ -152,7 +153,8 @@
     "noSetupData": "セットアップデータなし",
     "showFull": "セットアップを表示",
     "hideFull": "セットアップを非表示",
-    "lapsHeader": "最速ラップ"
+    "lapsHeader": "最速ラップ",
+    "openSession": "このセッションを開く"
   },
   "notes": {
     "loadSession": "メモを追加するにはセッションを読み込んでください",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -140,6 +140,20 @@
     "showChanges": "Mostrar apenas alterações",
     "lapsHeader": "Voltas mais rápidas"
   },
+  "vehicleHistory": {
+    "title": "Histórico do veículo",
+    "openTitle": "Ver histórico do veículo",
+    "loading": "Carregando histórico…",
+    "empty": "Ainda não há histórico",
+    "emptyHint": "Faça uma sessão com este veículo e atribua uma configuração para começar a criar o histórico.",
+    "allCourses": "Todas as pistas",
+    "fastestTag": "Volta mais rápida",
+    "noLap": "—",
+    "noSetupData": "Sem dados de configuração",
+    "showFull": "Mostrar configuração",
+    "hideFull": "Ocultar configuração",
+    "lapsHeader": "Voltas mais rápidas"
+  },
   "notes": {
     "loadSession": "Carregue uma sessão para adicionar notas",
     "sessionSetup": "Acerto da sessão",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -138,7 +138,8 @@
     "noSetupData": "Sem dados de configuração",
     "showFull": "Mostrar configuração completa",
     "showChanges": "Mostrar apenas alterações",
-    "lapsHeader": "Voltas mais rápidas"
+    "lapsHeader": "Voltas mais rápidas",
+    "openSession": "Abrir esta sessão"
   },
   "vehicleHistory": {
     "title": "Histórico do veículo",
@@ -152,7 +153,8 @@
     "noSetupData": "Sem dados de configuração",
     "showFull": "Mostrar configuração",
     "hideFull": "Ocultar configuração",
-    "lapsHeader": "Voltas mais rápidas"
+    "lapsHeader": "Voltas mais rápidas",
+    "openSession": "Abrir esta sessão"
   },
   "notes": {
     "loadSession": "Carregue uma sessão para adicionar notas",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -40,6 +40,7 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ParsedData } from "@/types/racing";
+import { parseDatalogFile } from "@/lib/datalogParser";
 import { calculateDistanceArray } from "@/lib/referenceUtils";
 import { formatAxisDistance } from "@/lib/chartAxis";
 import { usePanelsForSlot, PanelSlot } from "@/plugins/panels";
@@ -203,6 +204,24 @@ export default function Index() {
     trackPromptOpen, setTrackPromptOpen, detectedTrack, detectionResult,
     allTracks, gpsCenter,
   } = dataLoader;
+
+  // Open a saved session by file name — used by the setup/vehicle history cards to
+  // jump straight to the session that holds a card's fastest lap. Loads + parses
+  // the blob like FilesTab does, closes the garage drawer, and (when sitting on a
+  // doc-style tab that shows no telemetry) drops back to the race line so the
+  // freshly-loaded session is actually visible.
+  const handleOpenFile = useCallback(async (fileName: string) => {
+    try {
+      const blob = await fileManager.loadFile(fileName);
+      if (!blob) return;
+      const parsed = await parseDatalogFile(new File([blob], fileName));
+      handleDataLoaded(parsed, fileName);
+      fileManager.close();
+      setTopPanelView((v) => (v === "setups" || v === "notes" ? "raceline" : v));
+    } catch (e) {
+      console.error("Failed to open session:", e);
+    }
+  }, [fileManager, handleDataLoaded]);
 
   // Lap snapshots: frozen "course fastest lap" captures, loaded as a comparison
   // overlay through the same external-reference slot (so they never auto-play or
@@ -504,6 +523,7 @@ export default function Index() {
     onAddVehicle: vehicleManager.addVehicle,
     onUpdateVehicle: vehicleManager.updateVehicle,
     onRemoveVehicle: vehicleManager.removeVehicle,
+    onOpenFile: handleOpenFile,
     currentTrackName: lapMgmt.selection?.trackName ?? null,
     currentCourseName: lapMgmt.selection?.courseName ?? null,
   }), [
@@ -513,6 +533,7 @@ export default function Index() {
     handleDataLoaded, settings.autoSaveFiles, effectiveShowSampleFiles, showProfile,
     vehicleManager.vehicles, vehicleManager.addVehicle, vehicleManager.updateVehicle, vehicleManager.removeVehicle,
     templateManager.vehicleTypes,
+    handleOpenFile,
     lapMgmt.selection,
   ]);
 
@@ -665,6 +686,7 @@ export default function Index() {
                   onGetLatestForVehicle={setupManager.getLatestForVehicle}
                   onAddVehicleType={templateManager.addVehicleType}
                   onRemoveVehicleType={templateManager.removeVehicleType}
+                  onOpenFile={handleOpenFile}
                 />
               </div>
             )}


### PR DESCRIPTION
## What

Vehicles in the Garage now have a little **history** button, just like setups. It opens a panel that gathers **every setup you've run on that vehicle** — one card per frozen setup revision.

Each card shows:
- the **setup name** + its content **#hash** (no diff)
- the **fastest lap** turned on it
- **collapsed by default** — expand to see the full frozen setup

Behaviour requested:
- Cards are ordered **fastest lap first** (your quickest setup on top); the overall fastest is highlighted.
- A **course filter** narrows the view to a single track + course (mirrors setup history's kart/course filter, minus kart since the vehicle is fixed).

## Modularity

Per the request to make the card reusable since the data is mostly the same:
- New **`src/components/drawer/HistoryCard.tsx`** holds the shared card chrome (`HistoryCard` + `FullSetup`/`DiffList`): fastest-lap highlight, hash/date header, kart/course bubbles, collapsible body, and the fastest-laps footer.
- **`SetupHistoryPanel`** was refactored onto it (no behaviour change).
- **`VehicleHistoryPanel`** is the new consumer.
- Pure aggregation in **`src/lib/vehicleHistory.ts`** reuses setupHistory's `buildUsage` / `byFastestLap` / `flattenRevisionFields` primitives (now exported).

## Tests / docs

- Added `src/lib/vehicleHistory.test.ts` (ordering, per-vehicle isolation, course filter, pruned-revision tolerance, flatten).
- i18n: new `vehicleHistory` keys across all 7 `drawer.json` locales (parity test green).
- Updated `CHANGELOG.md` (2.7.0 unreleased), `CLAUDE.md`, and `docs/subsystems.md`.

All four gates pass locally: `lint`, `typecheck`, `test:run` (1825 tests), `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxjiciDHWqjB4axmoSbKMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxjiciDHWqjB4axmoSbKMH)_