### PR TITLE
Edit vehicle types: add a "Manage Vehicle Types" editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.7.0] - unreleased
 
 ### Added
+- **Edit your vehicle types.** The Setups tab gains a **Manage Vehicle Types**
+  button (below *New Vehicle Type*) that opens the type editor: pick an existing
+  type from the dropdown — it starts empty so editing is a deliberate choice —
+  tweak its sections, fields, wheel count or tires, then **Update**. Renaming a
+  field is always safe (your saved setups stay attached to it); but if an edit
+  *removes* a field or flips its data type (number ↔ text) and existing setups
+  already hold values there, a warning lists exactly which fields are affected.
+  Cancel that warning and the risky changes are rolled back and highlighted in
+  orange so you can see what was restored. Edits sync to the cloud like the rest
+  of your garage (newest edit wins).
 - **Collapsible Pro panel + relocatable Video/Mini-Map on mobile.** The Pro
   view's left column (info/vehicle/video + mini-map) is roomy on tablet and
   desktop but cramped on a phone. On mobile a small flag tab now sits at the top

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *removes* a field or flips its data type (number ↔ text) and existing setups
   already hold values there, a warning lists exactly which fields are affected.
   Cancel that warning and the risky changes are rolled back and highlighted in
-  orange so you can see what was restored. Edits sync to the cloud like the rest
-  of your garage (newest edit wins).
+  orange so you can see what was restored. The editor can also **delete** a
+  vehicle type — but only when nothing depends on it (no saved setups, and not
+  the built-in default). Edits sync to the cloud like the rest of your garage
+  (newest edit wins).
 - **Collapsible Pro panel + relocatable Video/Mini-Map on mobile.** The Pro
   view's left column (info/vehicle/video + mini-map) is roomy on tablet and
   desktop but cramped on a phone. On mobile a small flag tab now sits at the top

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -12,6 +12,7 @@ import { Vehicle } from "@/lib/vehicleStorage";
 import { VehicleSetup } from "@/lib/setupStorage";
 import { VehicleType, SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
 import { TemplateCreator } from "@/components/drawer/TemplateCreator";
+import { VehicleTypeEditor } from "@/components/drawer/VehicleTypeEditor";
 import { ModeToggle } from "@/components/drawer/ModeToggle";
 import { computeSetupHash, shortRevHash } from "@/lib/setupRevision";
 import { SetupHistoryPanel } from "@/components/drawer/SetupHistoryPanel";
@@ -28,6 +29,7 @@ interface SetupsTabProps {
   onGetLatestForVehicle: (vehicleId: string) => Promise<VehicleSetup | null>;
   onAddVehicleType: (name: string, wheelCount: 2 | 4, includeTires: boolean, sections: TemplateSection[]) => Promise<unknown>;
   onRemoveVehicleType: (vehicleTypeId: string, templateId: string) => Promise<void>;
+  onUpdateVehicleType: (vehicleType: VehicleType, template: SetupTemplate) => Promise<void>;
   /** When toggled true, jump straight into the vehicle-type creator (e.g. from
    *  the Vehicles tab's "New type" shortcut). Cleared via onRequestNewTypeHandled. */
   requestNewType?: boolean;
@@ -36,7 +38,7 @@ interface SetupsTabProps {
   onCreateVehicle?: () => void;
 }
 
-type FormMode = "list" | "new" | "edit" | "new-type" | "history";
+type FormMode = "list" | "new" | "edit" | "new-type" | "manage-type" | "history";
 
 const emptyForm = (): Omit<VehicleSetup, "id" | "createdAt" | "updatedAt"> => ({
   vehicleId: "",
@@ -65,7 +67,7 @@ const emptyForm = (): Omit<VehicleSetup, "id" | "createdAt" | "updatedAt"> => ({
 export function SetupsTab({
   vehicles, setups, vehicleTypes, templates,
   onAdd, onUpdate, onRemove, onGetLatestForVehicle,
-  onAddVehicleType, onRemoveVehicleType,
+  onAddVehicleType, onRemoveVehicleType, onUpdateVehicleType,
   requestNewType, onRequestNewTypeHandled,
   onCreateVehicle,
 }: SetupsTabProps) {
@@ -361,6 +363,19 @@ export function SetupsTab({
     );
   }
 
+  // ── Vehicle Type Editor ──
+  if (mode === "manage-type") {
+    return (
+      <VehicleTypeEditor
+        vehicleTypes={vehicleTypes}
+        templates={templates}
+        setups={setups}
+        onUpdate={onUpdateVehicleType}
+        onDone={() => setMode("list")}
+      />
+    );
+  }
+
   // ── List View ──
   if (mode === "list") {
     return (
@@ -425,6 +440,9 @@ export function SetupsTab({
         <div className="shrink-0 px-3 py-3 border-t border-border space-y-2">
           <Button variant="secondary" className="w-full gap-2" onClick={() => setMode("new-type")}>
             <Car className="w-4 h-4" /> {t("setups.newVehicleType")}
+          </Button>
+          <Button variant="outline" className="w-full gap-2" onClick={() => setMode("manage-type")}>
+            <Pencil className="w-4 h-4" /> {t("setups.manageVehicleTypes")}
           </Button>
           {/* A setup must attach to a vehicle — block new setups until one exists
               and point the user at the Vehicles tab. */}

--- a/src/components/drawer/SetupsTab.tsx
+++ b/src/components/drawer/SetupsTab.tsx
@@ -371,6 +371,7 @@ export function SetupsTab({
         templates={templates}
         setups={setups}
         onUpdate={onUpdateVehicleType}
+        onRemove={onRemoveVehicleType}
         onDone={() => setMode("list")}
       />
     );

--- a/src/components/drawer/TemplateCreator.tsx
+++ b/src/components/drawer/TemplateCreator.tsx
@@ -1,13 +1,14 @@
 import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, Plus, Trash2, GripVertical } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
-import { NumberInput } from "@/components/ui/number-input";
-import { SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
+import { SetupTemplate, TemplateSection } from "@/lib/templateStorage";
+import { useTemplateFields } from "@/hooks/useTemplateFields";
+import { cleanSections } from "@/lib/templateEdit";
+import { TemplateFieldsEditor } from "@/components/drawer/TemplateFieldsEditor";
 
 interface TemplateCreatorProps {
   existingTemplates: SetupTemplate[];
@@ -16,77 +17,18 @@ interface TemplateCreatorProps {
   onCancel: () => void;
 }
 
-const makeId = () => crypto.randomUUID();
-
-const emptyField = (): TemplateFieldDef => ({
-  id: makeId(),
-  name: "",
-  type: "number",
-});
-
-const emptySection = (): TemplateSection => ({
-  id: makeId(),
-  name: "",
-  fields: [emptyField()],
-});
-
 export function TemplateCreator({ existingTemplates, existingTypeNames, onSave, onCancel }: TemplateCreatorProps) {
   const { t } = useTranslation("drawer");
-  const [name, setName] = useState("");
-  const [wheelCount, setWheelCount] = useState<2 | 4>(4);
-  const [includeTires, setIncludeTires] = useState(true);
-  const [sections, setSections] = useState<TemplateSection[]>([emptySection()]);
+  const fields = useTemplateFields();
+  const { name, setName, wheelCount, includeTires, sections } = fields;
   const [copyFrom, setCopyFrom] = useState<string>("");
   const [nameError, setNameError] = useState("");
 
   const handleCopyFrom = useCallback((templateId: string) => {
     setCopyFrom(templateId);
     const tpl = existingTemplates.find(tt => tt.id === templateId);
-    if (tpl) {
-      // Deep clone sections with new IDs
-      const cloned = tpl.sections.map(s => ({
-        id: makeId(),
-        name: s.name,
-        fields: s.fields.map(f => ({ ...f, id: makeId() })),
-      }));
-      setSections(cloned);
-      setWheelCount(tpl.wheelCount);
-      setIncludeTires(tpl.includeTires);
-    }
-  }, [existingTemplates]);
-
-  const addSection = useCallback(() => {
-    setSections(prev => [...prev, emptySection()]);
-  }, []);
-
-  const removeSection = useCallback((secId: string) => {
-    setSections(prev => prev.filter(s => s.id !== secId));
-  }, []);
-
-  const updateSection = useCallback((secId: string, update: Partial<TemplateSection>) => {
-    setSections(prev => prev.map(s => s.id === secId ? { ...s, ...update } : s));
-  }, []);
-
-  const addField = useCallback((secId: string) => {
-    setSections(prev => prev.map(s =>
-      s.id === secId ? { ...s, fields: [...s.fields, emptyField()] } : s
-    ));
-  }, []);
-
-  const removeField = useCallback((secId: string, fieldId: string) => {
-    setSections(prev => prev.map(s =>
-      s.id === secId ? { ...s, fields: s.fields.filter(f => f.id !== fieldId) } : s
-    ));
-  }, []);
-
-  const updateField = useCallback((secId: string, fieldId: string, update: Partial<TemplateFieldDef>) => {
-    setSections(prev => prev.map(s =>
-      s.id === secId ? {
-        ...s,
-        fields: s.fields.map(f => f.id === fieldId ? { ...f, ...update } : f),
-      } : s
-    ));
-  }, []);
+    if (tpl) fields.loadSections(tpl, { cloneIds: true });
+  }, [existingTemplates, fields]);
 
   const handleSave = useCallback(async () => {
     const trimmed = name.trim();
@@ -95,17 +37,7 @@ export function TemplateCreator({ existingTemplates, existingTypeNames, onSave, 
       setNameError(t("templateCreator.nameExists"));
       return;
     }
-    // Filter out empty sections/fields
-    const cleaned = sections
-      .filter(s => s.name.trim())
-      .map(s => ({
-        ...s,
-        name: s.name.trim(),
-        fields: s.fields.filter(f => f.name.trim()).map(f => ({ ...f, name: f.name.trim() })),
-      }))
-      .filter(s => s.fields.length > 0);
-
-    await onSave(trimmed, wheelCount, includeTires, cleaned);
+    await onSave(trimmed, wheelCount, includeTires, cleanSections(sections));
   }, [name, wheelCount, includeTires, sections, existingTypeNames, onSave, t]);
 
   return (
@@ -144,113 +76,7 @@ export function TemplateCreator({ existingTemplates, existingTypeNames, onSave, 
           </Select>
         </div>
 
-        {/* Wheel count */}
-        <div className="space-y-1">
-          <Label className="text-xs">{t("templateCreator.wheelConfig")}</Label>
-          <div className="flex gap-1 bg-muted/50 rounded-md p-0.5">
-            <button type="button" onClick={() => setWheelCount(2)} className={`flex-1 px-3 py-1.5 text-xs font-medium rounded transition-colors ${wheelCount === 2 ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}>{t("templateCreator.wheels2")}</button>
-            <button type="button" onClick={() => setWheelCount(4)} className={`flex-1 px-3 py-1.5 text-xs font-medium rounded transition-colors ${wheelCount === 4 ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}>{t("templateCreator.wheels4")}</button>
-          </div>
-        </div>
-
-        {/* Include tires */}
-        <div className="flex items-center justify-between">
-          <Label className="text-xs">{t("templateCreator.includeTires")}</Label>
-          <Switch checked={includeTires} onCheckedChange={setIncludeTires} className="scale-90" />
-        </div>
-
-        {/* Sections */}
-        <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">{t("templateCreator.setupSections")}</span>
-            <div className="flex-1 h-px bg-border" />
-          </div>
-
-          {sections.map((section, si) => (
-            <div key={section.id} className="border border-border rounded-md p-3 space-y-2 bg-muted/20">
-              <div className="flex items-center gap-2">
-                <Input
-                  value={section.name}
-                  onChange={e => updateSection(section.id, { name: e.target.value })}
-                  placeholder={t("templateCreator.sectionNamePlaceholder")}
-                  className="h-8 text-sm flex-1"
-                />
-                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive shrink-0" onClick={() => removeSection(section.id)} disabled={sections.length <= 1}>
-                  <Trash2 className="w-3.5 h-3.5" />
-                </Button>
-              </div>
-
-              {section.fields.map((field, fi) => (
-                <div key={field.id} className="flex items-start gap-2 pl-2 border-l-2 border-border">
-                  <div className="flex-1 space-y-1">
-                    <div className="grid grid-cols-2 gap-2">
-                      <Input
-                        value={field.name}
-                        onChange={e => updateField(section.id, field.id, { name: e.target.value })}
-                        placeholder={t("templateCreator.fieldName")}
-                        className="h-8 text-sm"
-                      />
-                      <Select
-                        value={field.type}
-                        onValueChange={v => updateField(section.id, field.id, { type: v as "number" | "string" })}
-                      >
-                        <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="number">{t("templateCreator.number")}</SelectItem>
-                          <SelectItem value="string">{t("templateCreator.text")}</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="grid grid-cols-3 gap-2">
-                      <div className="space-y-0.5">
-                        <Label className="text-[10px] text-muted-foreground">{t("templateCreator.unit")}</Label>
-                        <Input
-                          value={field.unit ?? ""}
-                          onChange={e => updateField(section.id, field.id, { unit: e.target.value || undefined })}
-                          placeholder={t("templateCreator.unitPlaceholder")}
-                          className="h-7 text-xs"
-                        />
-                      </div>
-                      {field.type === "number" && (
-                        <>
-                          <div className="space-y-0.5">
-                            <Label className="text-[10px] text-muted-foreground">{t("templateCreator.min")}</Label>
-                            <Input
-                              type="number"
-                              value={field.min ?? ""}
-                              onChange={e => updateField(section.id, field.id, { min: e.target.value === "" ? undefined : Number(e.target.value) })}
-                              className="h-7 text-xs"
-                            />
-                          </div>
-                          <div className="space-y-0.5">
-                            <Label className="text-[10px] text-muted-foreground">{t("templateCreator.max")}</Label>
-                            <Input
-                              type="number"
-                              value={field.max ?? ""}
-                              onChange={e => updateField(section.id, field.id, { max: e.target.value === "" ? undefined : Number(e.target.value) })}
-                              className="h-7 text-xs"
-                            />
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive shrink-0 mt-0.5" onClick={() => removeField(section.id, field.id)} disabled={section.fields.length <= 1}>
-                    <Trash2 className="w-3 h-3" />
-                  </Button>
-                </div>
-              ))}
-
-              <Button variant="ghost" size="sm" className="h-7 text-xs gap-1" onClick={() => addField(section.id)}>
-                <Plus className="w-3 h-3" /> {t("templateCreator.addField")}
-              </Button>
-            </div>
-          ))}
-
-          <Button variant="outline" size="sm" className="w-full gap-1" onClick={addSection}>
-            <Plus className="w-3.5 h-3.5" /> {t("templateCreator.addSection")}
-          </Button>
-        </div>
+        <TemplateFieldsEditor {...fields} />
       </div>
 
       <div className="shrink-0 px-3 py-3 border-t border-border flex gap-2">

--- a/src/components/drawer/TemplateFieldsEditor.tsx
+++ b/src/components/drawer/TemplateFieldsEditor.tsx
@@ -1,0 +1,151 @@
+import { useTranslation } from "react-i18next";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
+
+interface TemplateFieldsEditorProps {
+  wheelCount: 2 | 4;
+  setWheelCount: (n: 2 | 4) => void;
+  includeTires: boolean;
+  setIncludeTires: (v: boolean) => void;
+  sections: TemplateSection[];
+  addSection: () => void;
+  removeSection: (secId: string) => void;
+  updateSection: (secId: string, update: Partial<TemplateSection>) => void;
+  addField: (secId: string) => void;
+  removeField: (secId: string, fieldId: string) => void;
+  updateField: (secId: string, fieldId: string, update: Partial<TemplateFieldDef>) => void;
+  /** Field ids to flag in orange (e.g. restored after a cancelled destructive edit). */
+  highlightedFieldIds?: Set<string>;
+}
+
+/**
+ * Presentational wheel-config + tires + sections/fields editor. Shared by the
+ * vehicle-type creator and editor; owns no state of its own.
+ */
+export function TemplateFieldsEditor({
+  wheelCount, setWheelCount, includeTires, setIncludeTires,
+  sections, addSection, removeSection, updateSection, addField, removeField, updateField,
+  highlightedFieldIds,
+}: TemplateFieldsEditorProps) {
+  const { t } = useTranslation("drawer");
+
+  return (
+    <>
+      {/* Wheel count */}
+      <div className="space-y-1">
+        <Label className="text-xs">{t("templateCreator.wheelConfig")}</Label>
+        <div className="flex gap-1 bg-muted/50 rounded-md p-0.5">
+          <button type="button" onClick={() => setWheelCount(2)} className={`flex-1 px-3 py-1.5 text-xs font-medium rounded transition-colors ${wheelCount === 2 ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}>{t("templateCreator.wheels2")}</button>
+          <button type="button" onClick={() => setWheelCount(4)} className={`flex-1 px-3 py-1.5 text-xs font-medium rounded transition-colors ${wheelCount === 4 ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}>{t("templateCreator.wheels4")}</button>
+        </div>
+      </div>
+
+      {/* Include tires */}
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">{t("templateCreator.includeTires")}</Label>
+        <Switch checked={includeTires} onCheckedChange={setIncludeTires} className="scale-90" />
+      </div>
+
+      {/* Sections */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">{t("templateCreator.setupSections")}</span>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+
+        {sections.map(section => (
+          <div key={section.id} className="border border-border rounded-md p-3 space-y-2 bg-muted/20">
+            <div className="flex items-center gap-2">
+              <Input
+                value={section.name}
+                onChange={e => updateSection(section.id, { name: e.target.value })}
+                placeholder={t("templateCreator.sectionNamePlaceholder")}
+                className="h-8 text-sm flex-1"
+              />
+              <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive shrink-0" onClick={() => removeSection(section.id)} disabled={sections.length <= 1}>
+                <Trash2 className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+
+            {section.fields.map(field => {
+              const highlighted = highlightedFieldIds?.has(field.id);
+              return (
+                <div key={field.id} className={`flex items-start gap-2 pl-2 border-l-2 rounded-r-sm ${highlighted ? "border-warning bg-warning/10" : "border-border"}`}>
+                  <div className="flex-1 space-y-1">
+                    <div className="grid grid-cols-2 gap-2">
+                      <Input
+                        value={field.name}
+                        onChange={e => updateField(section.id, field.id, { name: e.target.value })}
+                        placeholder={t("templateCreator.fieldName")}
+                        className="h-8 text-sm"
+                      />
+                      <Select
+                        value={field.type}
+                        onValueChange={v => updateField(section.id, field.id, { type: v as "number" | "string" })}
+                      >
+                        <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="number">{t("templateCreator.number")}</SelectItem>
+                          <SelectItem value="string">{t("templateCreator.text")}</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2">
+                      <div className="space-y-0.5">
+                        <Label className="text-[10px] text-muted-foreground">{t("templateCreator.unit")}</Label>
+                        <Input
+                          value={field.unit ?? ""}
+                          onChange={e => updateField(section.id, field.id, { unit: e.target.value || undefined })}
+                          placeholder={t("templateCreator.unitPlaceholder")}
+                          className="h-7 text-xs"
+                        />
+                      </div>
+                      {field.type === "number" && (
+                        <>
+                          <div className="space-y-0.5">
+                            <Label className="text-[10px] text-muted-foreground">{t("templateCreator.min")}</Label>
+                            <Input
+                              type="number"
+                              value={field.min ?? ""}
+                              onChange={e => updateField(section.id, field.id, { min: e.target.value === "" ? undefined : Number(e.target.value) })}
+                              className="h-7 text-xs"
+                            />
+                          </div>
+                          <div className="space-y-0.5">
+                            <Label className="text-[10px] text-muted-foreground">{t("templateCreator.max")}</Label>
+                            <Input
+                              type="number"
+                              value={field.max ?? ""}
+                              onChange={e => updateField(section.id, field.id, { max: e.target.value === "" ? undefined : Number(e.target.value) })}
+                              className="h-7 text-xs"
+                            />
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive shrink-0 mt-0.5" onClick={() => removeField(section.id, field.id)} disabled={section.fields.length <= 1}>
+                    <Trash2 className="w-3 h-3" />
+                  </Button>
+                </div>
+              );
+            })}
+
+            <Button variant="ghost" size="sm" className="h-7 text-xs gap-1" onClick={() => addField(section.id)}>
+              <Plus className="w-3 h-3" /> {t("templateCreator.addField")}
+            </Button>
+          </div>
+        ))}
+
+        <Button variant="outline" size="sm" className="w-full gap-1" onClick={addSection}>
+          <Plus className="w-3.5 h-3.5" /> {t("templateCreator.addSection")}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/components/drawer/VehicleTypeEditor.tsx
+++ b/src/components/drawer/VehicleTypeEditor.tsx
@@ -1,0 +1,188 @@
+import { useState, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { VehicleType, SetupTemplate } from "@/lib/templateStorage";
+import { VehicleSetup } from "@/lib/setupStorage";
+import { useTemplateFields } from "@/hooks/useTemplateFields";
+import {
+  cleanSections, buildTemplateUpdate, findDestructiveChanges,
+  revertDestructive, usedFieldIds, type DestructiveChange,
+} from "@/lib/templateEdit";
+import { TemplateFieldsEditor } from "@/components/drawer/TemplateFieldsEditor";
+
+interface VehicleTypeEditorProps {
+  vehicleTypes: VehicleType[];
+  templates: SetupTemplate[];
+  setups: VehicleSetup[];
+  onUpdate: (vehicleType: VehicleType, template: SetupTemplate) => Promise<void>;
+  onDone: () => void;
+}
+
+export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, onDone }: VehicleTypeEditorProps) {
+  const { t } = useTranslation("drawer");
+  const fields = useTemplateFields();
+  const { name, setName, wheelCount, includeTires, sections } = fields;
+
+  const [selectedTypeId, setSelectedTypeId] = useState<string>("");
+  const [originalTemplate, setOriginalTemplate] = useState<SetupTemplate | null>(null);
+  const [highlightedFieldIds, setHighlightedFieldIds] = useState<Set<string>>(new Set());
+  const [nameError, setNameError] = useState("");
+  const [pending, setPending] = useState<{ cleaned: ReturnType<typeof cleanSections>; changes: DestructiveChange[] } | null>(null);
+
+  const selectedType = useMemo(
+    () => vehicleTypes.find(vt => vt.id === selectedTypeId) ?? null,
+    [vehicleTypes, selectedTypeId],
+  );
+
+  // Field ids that existing setups actually hold data in — only these make an
+  // edit destructive (an unused field can be removed/retyped freely).
+  const used = useMemo(
+    () => originalTemplate ? usedFieldIds(setups, originalTemplate.id) : new Set<string>(),
+    [setups, originalTemplate],
+  );
+
+  const handleSelectType = useCallback((typeId: string) => {
+    setSelectedTypeId(typeId);
+    setNameError("");
+    setHighlightedFieldIds(new Set());
+    const vt = vehicleTypes.find(v => v.id === typeId);
+    const tpl = vt ? templates.find(tt => tt.id === vt.templateId) : null;
+    if (tpl) {
+      setOriginalTemplate(tpl);
+      fields.loadSections(tpl, { cloneIds: false });
+      setName(tpl.name);
+    } else {
+      setOriginalTemplate(null);
+    }
+  }, [vehicleTypes, templates, fields, setName]);
+
+  const doUpdate = useCallback(async (cleaned: ReturnType<typeof cleanSections>) => {
+    if (!selectedType || !originalTemplate) return;
+    const built = buildTemplateUpdate(selectedType, originalTemplate, {
+      name: name.trim(), wheelCount, includeTires, sections: cleaned,
+    });
+    await onUpdate(built.vehicleType, built.template);
+    onDone();
+  }, [selectedType, originalTemplate, name, wheelCount, includeTires, onUpdate, onDone]);
+
+  const handleUpdate = useCallback(async () => {
+    if (!selectedType || !originalTemplate) return;
+    const trimmed = name.trim();
+    if (!trimmed) { setNameError(t("templateCreator.nameRequired")); return; }
+    const clash = vehicleTypes.some(vt => vt.id !== selectedType.id && vt.name.toLowerCase() === trimmed.toLowerCase());
+    if (clash) { setNameError(t("templateCreator.nameExists")); return; }
+
+    const cleaned = cleanSections(sections);
+    const changes = findDestructiveChanges(originalTemplate.sections, cleaned, used);
+    if (changes.length > 0) {
+      setPending({ cleaned, changes });
+      return;
+    }
+    await doUpdate(cleaned);
+  }, [selectedType, originalTemplate, name, sections, used, vehicleTypes, t, doUpdate]);
+
+  const handleConfirmDestructive = useCallback(async () => {
+    if (!pending) return;
+    const { cleaned } = pending;
+    setPending(null);
+    await doUpdate(cleaned);
+  }, [pending, doUpdate]);
+
+  // Cancel the warning: stomp the destructive edits back to their original
+  // definitions (re-add removed fields, reset flipped types) and flag them
+  // orange so the user sees what was rolled back. Stays in the editor.
+  const handleCancelDestructive = useCallback(() => {
+    if (!pending || !originalTemplate) return;
+    const { sections: reverted, restoredIds } = revertDestructive(originalTemplate.sections, sections, pending.changes);
+    fields.setSections(reverted);
+    setHighlightedFieldIds(restoredIds);
+    setPending(null);
+  }, [pending, originalTemplate, sections, fields]);
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-border">
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onDone}>
+          <ArrowLeft className="w-4 h-4" />
+        </Button>
+        <h3 className="text-sm font-semibold text-foreground flex-1">{t("vehicleTypeEditor.title")}</h3>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-4">
+        {/* Vehicle type picker — starts empty so editing is a deliberate choice. */}
+        <div className="space-y-1">
+          <Label className="text-xs">{t("vehicleTypeEditor.selectType")}</Label>
+          <Select value={selectedTypeId} onValueChange={handleSelectType}>
+            <SelectTrigger className="h-9"><SelectValue placeholder={t("vehicleTypeEditor.selectTypePlaceholder")} /></SelectTrigger>
+            <SelectContent>
+              {vehicleTypes.map(vt => (
+                <SelectItem key={vt.id} value={vt.id}>{vt.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {!selectedType ? (
+          <p className="text-xs text-muted-foreground px-1 py-8 text-center">{t("vehicleTypeEditor.pickPrompt")}</p>
+        ) : (
+          <>
+            {/* Name */}
+            <div className="space-y-1">
+              <Label className="text-xs">{t("templateCreator.vehicleTypeName")}</Label>
+              <Input
+                value={name}
+                onChange={e => { setName(e.target.value); setNameError(""); }}
+                placeholder={t("templateCreator.vehicleTypeNamePlaceholder")}
+                className={`h-9 ${nameError ? "border-destructive" : ""}`}
+              />
+              {nameError && <p className="text-xs text-destructive">{nameError}</p>}
+            </div>
+
+            <TemplateFieldsEditor {...fields} highlightedFieldIds={highlightedFieldIds} />
+          </>
+        )}
+      </div>
+
+      <div className="shrink-0 px-3 py-3 border-t border-border flex gap-2">
+        <Button variant="outline" className="flex-1" onClick={onDone}>{t("templateCreator.cancel")}</Button>
+        <Button className="flex-1" onClick={handleUpdate} disabled={!selectedType || !name.trim()}>{t("vehicleTypeEditor.update")}</Button>
+      </div>
+
+      {/* Destructive-change warning */}
+      <Dialog open={!!pending} onOpenChange={open => { if (!open) handleCancelDestructive(); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="w-4 h-4 text-warning" /> {t("vehicleTypeEditor.warningTitle")}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">{t("vehicleTypeEditor.warningBody")}</p>
+            <ul className="space-y-1 text-sm">
+              {pending?.changes.map(c => (
+                <li key={c.field.id} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-warning shrink-0" />
+                  <span>
+                    <span className="font-medium text-foreground">{c.field.name}</span>{" "}
+                    <span className="text-muted-foreground">
+                      {c.reason === "removed" ? t("vehicleTypeEditor.warningRemoved") : t("vehicleTypeEditor.warningTypeChanged")}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCancelDestructive}>{t("vehicleTypeEditor.warningCancel")}</Button>
+            <Button variant="destructive" onClick={handleConfirmDestructive}>{t("vehicleTypeEditor.warningConfirm")}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/drawer/VehicleTypeEditor.tsx
+++ b/src/components/drawer/VehicleTypeEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, AlertTriangle } from "lucide-react";
+import { ArrowLeft, AlertTriangle, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,10 +20,11 @@ interface VehicleTypeEditorProps {
   templates: SetupTemplate[];
   setups: VehicleSetup[];
   onUpdate: (vehicleType: VehicleType, template: SetupTemplate) => Promise<void>;
+  onRemove: (vehicleTypeId: string, templateId: string) => Promise<void>;
   onDone: () => void;
 }
 
-export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, onDone }: VehicleTypeEditorProps) {
+export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, onRemove, onDone }: VehicleTypeEditorProps) {
   const { t } = useTranslation("drawer");
   const fields = useTemplateFields();
   const { name, setName, wheelCount, includeTires, sections } = fields;
@@ -33,6 +34,7 @@ export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, o
   const [highlightedFieldIds, setHighlightedFieldIds] = useState<Set<string>>(new Set());
   const [nameError, setNameError] = useState("");
   const [pending, setPending] = useState<{ cleaned: ReturnType<typeof cleanSections>; changes: DestructiveChange[] } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const selectedType = useMemo(
     () => vehicleTypes.find(vt => vt.id === selectedTypeId) ?? null,
@@ -46,10 +48,19 @@ export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, o
     [setups, originalTemplate],
   );
 
+  // A type with saved setups isn't safe to delete yet (the setups would dangle);
+  // the built-in default would just re-seed on next load.
+  const hasSetups = useMemo(
+    () => !!originalTemplate && setups.some(s => s.templateId === originalTemplate.id),
+    [setups, originalTemplate],
+  );
+  const canDelete = !!selectedType && !selectedType.isDefault && !hasSetups;
+
   const handleSelectType = useCallback((typeId: string) => {
     setSelectedTypeId(typeId);
     setNameError("");
     setHighlightedFieldIds(new Set());
+    setConfirmDelete(false);
     const vt = vehicleTypes.find(v => v.id === typeId);
     const tpl = vt ? templates.find(tt => tt.id === vt.templateId) : null;
     if (tpl) {
@@ -104,6 +115,12 @@ export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, o
     setPending(null);
   }, [pending, originalTemplate, sections, fields]);
 
+  const handleDelete = useCallback(async () => {
+    if (!selectedType || !canDelete) return;
+    await onRemove(selectedType.id, selectedType.templateId);
+    onDone();
+  }, [selectedType, canDelete, onRemove, onDone]);
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-border">
@@ -144,6 +161,27 @@ export function VehicleTypeEditor({ vehicleTypes, templates, setups, onUpdate, o
             </div>
 
             <TemplateFieldsEditor {...fields} highlightedFieldIds={highlightedFieldIds} />
+
+            {/* Danger zone — delete the type, but only when nothing depends on it. */}
+            <div className="pt-2 mt-2 border-t border-border">
+              {canDelete ? (
+                confirmDelete ? (
+                  <div className="p-2 rounded-md bg-destructive/10 border border-destructive/30 flex items-center gap-2">
+                    <span className="text-xs text-destructive flex-1">{t("vehicleTypeEditor.deleteConfirm")}</span>
+                    <Button size="sm" variant="destructive" className="h-7 text-xs px-2" onClick={handleDelete}>{t("vehicleTypeEditor.deleteConfirmBtn")}</Button>
+                    <Button size="sm" variant="ghost" className="h-7 text-xs px-2" onClick={() => setConfirmDelete(false)}>{t("templateCreator.cancel")}</Button>
+                  </div>
+                ) : (
+                  <Button variant="ghost" size="sm" className="w-full gap-2 text-destructive hover:text-destructive" onClick={() => setConfirmDelete(true)}>
+                    <Trash2 className="w-4 h-4" /> {t("vehicleTypeEditor.delete")}
+                  </Button>
+                )
+              ) : (
+                <p className="text-xs text-muted-foreground text-center px-2">
+                  {selectedType?.isDefault ? t("vehicleTypeEditor.deleteDefault") : t("vehicleTypeEditor.deleteHasSetups")}
+                </p>
+              )}
+            </div>
           </>
         )}
       </div>

--- a/src/hooks/useTemplateFields.ts
+++ b/src/hooks/useTemplateFields.ts
@@ -1,0 +1,81 @@
+import { useState, useCallback } from "react";
+import { SetupTemplate, TemplateSection, TemplateFieldDef } from "@/lib/templateStorage";
+
+const makeId = () => crypto.randomUUID();
+
+export const emptyField = (): TemplateFieldDef => ({ id: makeId(), name: "", type: "number" });
+export const emptySection = (): TemplateSection => ({ id: makeId(), name: "", fields: [emptyField()] });
+
+/**
+ * Draft state + mutators for the section/field editor, shared by the
+ * vehicle-type creator and editor. Owns name, wheel config, tires and the
+ * section list so both screens stay thin wrappers around one source of truth.
+ */
+export function useTemplateFields() {
+  const [name, setName] = useState("");
+  const [wheelCount, setWheelCount] = useState<2 | 4>(4);
+  const [includeTires, setIncludeTires] = useState(true);
+  const [sections, setSections] = useState<TemplateSection[]>([emptySection()]);
+
+  const addSection = useCallback(() => setSections(prev => [...prev, emptySection()]), []);
+
+  const removeSection = useCallback((secId: string) => {
+    setSections(prev => prev.filter(s => s.id !== secId));
+  }, []);
+
+  const updateSection = useCallback((secId: string, update: Partial<TemplateSection>) => {
+    setSections(prev => prev.map(s => s.id === secId ? { ...s, ...update } : s));
+  }, []);
+
+  const addField = useCallback((secId: string) => {
+    setSections(prev => prev.map(s =>
+      s.id === secId ? { ...s, fields: [...s.fields, emptyField()] } : s
+    ));
+  }, []);
+
+  const removeField = useCallback((secId: string, fieldId: string) => {
+    setSections(prev => prev.map(s =>
+      s.id === secId ? { ...s, fields: s.fields.filter(f => f.id !== fieldId) } : s
+    ));
+  }, []);
+
+  const updateField = useCallback((secId: string, fieldId: string, update: Partial<TemplateFieldDef>) => {
+    setSections(prev => prev.map(s =>
+      s.id === secId ? {
+        ...s,
+        fields: s.fields.map(f => f.id === fieldId ? { ...f, ...update } : f),
+      } : s
+    ));
+  }, []);
+
+  /**
+   * Load a template's structure into the draft. `cloneIds` mints fresh ids
+   * (copy-from-scratch, so the new type is independent); leaving it false
+   * preserves `field.id`s so an in-place edit keeps existing setups mapped.
+   * Does not touch `name` — the caller decides.
+   */
+  const loadSections = useCallback((tpl: SetupTemplate, opts: { cloneIds: boolean }) => {
+    setSections(tpl.sections.map(s => ({
+      id: opts.cloneIds ? makeId() : s.id,
+      name: s.name,
+      fields: s.fields.map(f => opts.cloneIds ? { ...f, id: makeId() } : { ...f }),
+    })));
+    setWheelCount(tpl.wheelCount);
+    setIncludeTires(tpl.includeTires);
+  }, []);
+
+  const reset = useCallback(() => {
+    setName("");
+    setWheelCount(4);
+    setIncludeTires(true);
+    setSections([emptySection()]);
+  }, []);
+
+  return {
+    name, setName, wheelCount, setWheelCount, includeTires, setIncludeTires,
+    sections, setSections, addSection, removeSection, updateSection,
+    addField, removeField, updateField, loadSections, reset,
+  };
+}
+
+export type TemplateFieldsState = ReturnType<typeof useTemplateFields>;

--- a/src/hooks/useTemplateManager.ts
+++ b/src/hooks/useTemplateManager.ts
@@ -3,7 +3,7 @@ import {
   VehicleType, SetupTemplate, TemplateSection,
   listVehicleTypes, listTemplates, getTemplate,
   createVehicleTypeWithTemplate, deleteVehicleTypeWithTemplate,
-  saveTemplate, ensureDefaults,
+  updateVehicleTypeWithTemplate, saveTemplate, ensureDefaults,
 } from "@/lib/templateStorage";
 
 export function useTemplateManager() {
@@ -42,6 +42,11 @@ export function useTemplateManager() {
     await refresh();
   }, [refresh]);
 
+  const updateVehicleType = useCallback(async (vehicleType: VehicleType, template: SetupTemplate) => {
+    await updateVehicleTypeWithTemplate(vehicleType, template);
+    await refresh();
+  }, [refresh]);
+
   const getTemplateForType = useCallback((vehicleTypeId: string): SetupTemplate | null => {
     const vt = vehicleTypes.find(v => v.id === vehicleTypeId);
     if (!vt) return null;
@@ -50,7 +55,7 @@ export function useTemplateManager() {
 
   return {
     vehicleTypes, templates, ready,
-    addVehicleType, removeVehicleType, updateTemplate,
+    addVehicleType, removeVehicleType, updateTemplate, updateVehicleType,
     getTemplateForType, refresh,
   };
 }

--- a/src/lib/templateEdit.test.ts
+++ b/src/lib/templateEdit.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  usedFieldIds, findDestructiveChanges, revertDestructive,
+  cleanSections, buildTemplateUpdate, locateFields,
+} from "./templateEdit";
+import { SetupTemplate, TemplateSection } from "./templateStorage";
+
+const original: TemplateSection[] = [
+  {
+    id: "secA", name: "Alignment", fields: [
+      { id: "f-toe", name: "Toe", type: "number" },
+      { id: "f-camber", name: "Camber", type: "number" },
+    ],
+  },
+  {
+    id: "secB", name: "Notes", fields: [
+      { id: "f-note", name: "Note", type: "string" },
+    ],
+  },
+];
+
+const setups: { templateId: string; customFields: Record<string, string | number | null> }[] = [
+  { templateId: "tpl1", customFields: { "f-toe": 2, "f-camber": null, "f-note": "soft" } },
+  { templateId: "tpl1", customFields: { "f-toe": 3 } },
+  { templateId: "other", customFields: { "f-toe": 99 } },
+];
+
+describe("usedFieldIds", () => {
+  it("collects only fields with non-empty values for the given template", () => {
+    const used = usedFieldIds(setups, "tpl1");
+    expect(used.has("f-toe")).toBe(true);   // has values
+    expect(used.has("f-note")).toBe(true);  // "soft"
+    expect(used.has("f-camber")).toBe(false); // only null
+  });
+
+  it("ignores setups belonging to other templates", () => {
+    const used = usedFieldIds([{ templateId: "other", customFields: { "f-x": 1 } }], "tpl1");
+    expect(used.size).toBe(0);
+  });
+});
+
+describe("findDestructiveChanges", () => {
+  const used = new Set(["f-toe", "f-note"]);
+
+  it("treats a rename as non-destructive (setups key on id, not name)", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [
+        { id: "f-toe", name: "Front Toe", type: "number" },
+        { id: "f-camber", name: "Camber", type: "number" },
+      ] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    expect(findDestructiveChanges(original, edited, used)).toEqual([]);
+  });
+
+  it("flags a removed in-use field", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [{ id: "f-camber", name: "Camber", type: "number" }] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    const changes = findDestructiveChanges(original, edited, used);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ field: { id: "f-toe" }, reason: "removed", sectionId: "secA" });
+  });
+
+  it("flags a type flip on an in-use field", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [
+        { id: "f-toe", name: "Toe", type: "string" },
+        { id: "f-camber", name: "Camber", type: "number" },
+      ] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    const changes = findDestructiveChanges(original, edited, used);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ field: { id: "f-toe" }, reason: "typeChanged" });
+  });
+
+  it("does not flag removal/retype of a field no setup uses", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [{ id: "f-toe", name: "Toe", type: "number" }] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    // f-camber removed but it's unused → not destructive
+    expect(findDestructiveChanges(original, edited, used)).toEqual([]);
+  });
+});
+
+describe("revertDestructive", () => {
+  const used = new Set(["f-toe", "f-note"]);
+
+  it("re-adds a removed field to its original section and marks it restored", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [{ id: "f-camber", name: "Camber", type: "number" }] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    const changes = findDestructiveChanges(original, edited, used);
+    const { sections, restoredIds } = revertDestructive(original, edited, changes);
+    expect(restoredIds.has("f-toe")).toBe(true);
+    expect(locateFields(sections).get("f-toe")).toMatchObject({ sectionId: "secA", field: { name: "Toe", type: "number" } });
+  });
+
+  it("recreates a section that was deleted along with its in-use field", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [
+        { id: "f-toe", name: "Toe", type: "number" },
+        { id: "f-camber", name: "Camber", type: "number" },
+      ] },
+      // secB (with f-note) removed entirely
+    ];
+    const changes = findDestructiveChanges(original, edited, used);
+    const { sections, restoredIds } = revertDestructive(original, edited, changes);
+    expect(restoredIds.has("f-note")).toBe(true);
+    const located = locateFields(sections).get("f-note");
+    expect(located).toMatchObject({ sectionId: "secB", sectionName: "Notes" });
+  });
+
+  it("resets a flipped field's type back to the original", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Alignment", fields: [
+        { id: "f-toe", name: "Toe", type: "string" },
+        { id: "f-camber", name: "Camber", type: "number" },
+      ] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    const changes = findDestructiveChanges(original, edited, used);
+    const { sections, restoredIds } = revertDestructive(original, edited, changes);
+    expect(restoredIds.has("f-toe")).toBe(true);
+    expect(locateFields(sections).get("f-toe")!.field.type).toBe("number");
+  });
+
+  it("keeps benign edits (a rename) untouched while reverting the bad field", () => {
+    const edited: TemplateSection[] = [
+      { id: "secA", name: "Suspension", fields: [ // section renamed (benign)
+        { id: "f-camber", name: "Camber Angle", type: "number" }, // field renamed (benign)
+      ] },
+      { id: "secB", name: "Notes", fields: [{ id: "f-note", name: "Note", type: "string" }] },
+    ];
+    const changes = findDestructiveChanges(original, edited, used); // f-toe removed
+    const { sections } = revertDestructive(original, edited, changes);
+    const located = locateFields(sections);
+    expect(located.get("f-camber")!.field.name).toBe("Camber Angle"); // rename kept
+    expect(located.get("f-toe")).toBeTruthy(); // restored
+  });
+});
+
+describe("cleanSections", () => {
+  it("drops blank sections and fields and trims names", () => {
+    const messy: TemplateSection[] = [
+      { id: "s1", name: "  Real  ", fields: [
+        { id: "a", name: " Keep ", type: "number" },
+        { id: "b", name: "   ", type: "number" },
+      ] },
+      { id: "s2", name: "   ", fields: [{ id: "c", name: "Gone", type: "number" }] },
+      { id: "s3", name: "Empty", fields: [{ id: "d", name: "", type: "number" }] },
+    ];
+    const out = cleanSections(messy);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("Real");
+    expect(out[0].fields).toEqual([{ id: "a", name: "Keep", type: "number" }]);
+  });
+});
+
+describe("buildTemplateUpdate", () => {
+  it("carries the new name into both records and replaces template fields", () => {
+    const vt = { id: "vt1", name: "Old", templateId: "tpl1" };
+    const tpl: SetupTemplate = {
+      id: "tpl1", vehicleTypeId: "vt1", name: "Old", sections: original,
+      wheelCount: 4, includeTires: true, isDefault: false, createdAt: 1, updatedAt: 1,
+    };
+    const next: TemplateSection[] = [{ id: "secA", name: "A", fields: [{ id: "f-toe", name: "Toe", type: "number" }] }];
+    const { vehicleType, template } = buildTemplateUpdate(vt, tpl, { name: "New", wheelCount: 2, includeTires: false, sections: next });
+    expect(vehicleType.name).toBe("New");
+    expect(template.name).toBe("New");
+    expect(template.wheelCount).toBe(2);
+    expect(template.includeTires).toBe(false);
+    expect(template.sections).toBe(next);
+    expect(template.id).toBe("tpl1"); // identity preserved
+  });
+});

--- a/src/lib/templateEdit.ts
+++ b/src/lib/templateEdit.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure helpers for *editing* an existing vehicle-type template.
+ *
+ * Setups store their values in `customFields` keyed by the template's
+ * `field.id` (never by the display name), so a rename is harmless — the value
+ * stays mapped. A field that is **removed** or whose data **type flips**
+ * (number ↔ text) would orphan or invalidate values already saved in existing
+ * setups; those are the only "destructive" edits we warn about.
+ */
+
+import { SetupTemplate, TemplateSection, TemplateFieldDef } from "./templateStorage";
+
+/** A field together with the section it lives in. */
+export interface LocatedField {
+  field: TemplateFieldDef;
+  sectionId: string;
+  sectionName: string;
+}
+
+/** Map every field id → its definition + owning section. */
+export function locateFields(sections: TemplateSection[]): Map<string, LocatedField> {
+  const map = new Map<string, LocatedField>();
+  for (const section of sections) {
+    for (const field of section.fields) {
+      map.set(field.id, { field, sectionId: section.id, sectionName: section.name });
+    }
+  }
+  return map;
+}
+
+/** Field ids that at least one setup actually holds a (non-empty) value for. */
+export function usedFieldIds(
+  setups: { templateId: string; customFields: Record<string, string | number | null> }[],
+  templateId: string,
+): Set<string> {
+  const used = new Set<string>();
+  for (const setup of setups) {
+    if (setup.templateId !== templateId) continue;
+    for (const [fieldId, value] of Object.entries(setup.customFields)) {
+      if (value !== null && value !== undefined && value !== "") used.add(fieldId);
+    }
+  }
+  return used;
+}
+
+export type DestructiveReason = "removed" | "typeChanged";
+
+/** An edit that would discard data existing setups already hold. */
+export interface DestructiveChange {
+  /** The ORIGINAL field definition (what we'd restore on cancel). */
+  field: TemplateFieldDef;
+  sectionId: string;
+  sectionName: string;
+  reason: DestructiveReason;
+}
+
+/**
+ * Compare an edited template's sections against the original, restricted to
+ * fields existing setups actually use. A rename is never destructive (setups
+ * key on `field.id`); a removal or a type flip is.
+ */
+export function findDestructiveChanges(
+  original: TemplateSection[],
+  edited: TemplateSection[],
+  used: Set<string>,
+): DestructiveChange[] {
+  const editedFields = locateFields(edited);
+  const changes: DestructiveChange[] = [];
+  for (const { field, sectionId, sectionName } of locateFields(original).values()) {
+    if (!used.has(field.id)) continue;
+    const stillThere = editedFields.get(field.id);
+    if (!stillThere) {
+      changes.push({ field, sectionId, sectionName, reason: "removed" });
+    } else if (stillThere.field.type !== field.type) {
+      changes.push({ field, sectionId, sectionName, reason: "typeChanged" });
+    }
+  }
+  return changes;
+}
+
+/**
+ * Roll the destructive edits back to their original definitions: re-insert a
+ * removed field into its original section (recreating that section if it too
+ * was removed) and reset a flipped field's type. Benign edits (renames, added
+ * fields, reordering, wheel/tire changes) are left untouched. Returns the
+ * patched sections plus the set of restored field ids (for the orange
+ * highlight).
+ */
+export function revertDestructive(
+  original: TemplateSection[],
+  edited: TemplateSection[],
+  destructive: DestructiveChange[],
+): { sections: TemplateSection[]; restoredIds: Set<string> } {
+  const restoredIds = new Set<string>();
+  // Deep-ish clone so callers can drop the result straight into state.
+  const sections: TemplateSection[] = edited.map((s) => ({
+    ...s,
+    fields: s.fields.map((f) => ({ ...f })),
+  }));
+  const sectionById = new Map(sections.map((s) => [s.id, s]));
+
+  for (const change of destructive) {
+    restoredIds.add(change.field.id);
+    if (change.reason === "typeChanged") {
+      const target = sectionById.get(change.sectionId)?.fields.find((f) => f.id === change.field.id)
+        ?? sections.flatMap((s) => s.fields).find((f) => f.id === change.field.id);
+      if (target) target.type = change.field.type;
+      continue;
+    }
+    // Removed: ensure the original section exists, then re-add the field.
+    let section = sectionById.get(change.sectionId);
+    if (!section) {
+      section = { id: change.sectionId, name: change.sectionName, fields: [] };
+      sectionById.set(section.id, section);
+      sections.push(section);
+    }
+    if (!section.fields.some((f) => f.id === change.field.id)) {
+      section.fields.push({ ...change.field });
+    }
+  }
+
+  return { sections, restoredIds };
+}
+
+/** Drop blank sections/fields and trim names — shared by create + edit save. */
+export function cleanSections(sections: TemplateSection[]): TemplateSection[] {
+  return sections
+    .filter((s) => s.name.trim())
+    .map((s) => ({
+      ...s,
+      name: s.name.trim(),
+      fields: s.fields.filter((f) => f.name.trim()).map((f) => ({ ...f, name: f.name.trim() })),
+    }))
+    .filter((s) => s.fields.length > 0);
+}
+
+/** Build the next vehicle-type + template records for an in-place edit. */
+export function buildTemplateUpdate<V extends { id: string; name: string; templateId: string; wheelCount?: 2 | 4 }>(
+  vehicleType: V,
+  template: SetupTemplate,
+  edits: { name: string; wheelCount: 2 | 4; includeTires: boolean; sections: TemplateSection[] },
+): { vehicleType: V; template: SetupTemplate } {
+  return {
+    // Keep the vehicle type's own wheelCount mirror in sync with the template.
+    vehicleType: { ...vehicleType, name: edits.name, wheelCount: edits.wheelCount },
+    template: {
+      ...template,
+      name: edits.name,
+      wheelCount: edits.wheelCount,
+      includeTires: edits.includeTires,
+      sections: edits.sections,
+    },
+  };
+}

--- a/src/lib/templateStorage.test.ts
+++ b/src/lib/templateStorage.test.ts
@@ -17,6 +17,7 @@ import {
   saveTemplate,
   createVehicleTypeWithTemplate,
   deleteVehicleTypeWithTemplate,
+  updateVehicleTypeWithTemplate,
   DEFAULT_KART_VEHICLE_TYPE_ID,
   DEFAULT_KART_TEMPLATE_ID,
   type TemplateSection,
@@ -100,6 +101,41 @@ describe("createVehicleTypeWithTemplate / deleteVehicleTypeWithTemplate", () => 
     const seen = vi.fn();
     const off = onGarageChange(seen);
     const { vehicleType, template } = await createVehicleTypeWithTemplate("S", 2, false, sections);
+    off();
+    expect(seen).toHaveBeenCalledWith({ store: "vehicle-types", key: vehicleType.id, type: "put" });
+    expect(seen).toHaveBeenCalledWith({ store: "setup-templates", key: template.id, type: "put" });
+  });
+});
+
+describe("updateVehicleTypeWithTemplate", () => {
+  it("rewrites both halves in place, keeping ids and bumping updatedAt", async () => {
+    const { vehicleType, template } = await createVehicleTypeWithTemplate("Shifter", 4, true, sections);
+    const before = (await getTemplate(template.id))!.updatedAt;
+    await new Promise(r => setTimeout(r, 2));
+
+    const renamedSections: TemplateSection[] = [
+      { id: "sec1", name: "Geometry", fields: [{ id: "f-toe", name: "Toe Angle", type: "number" }] },
+    ];
+    await updateVehicleTypeWithTemplate(
+      { ...vehicleType, name: "Shifter 125" },
+      { ...template, name: "Shifter 125", sections: renamedSections },
+    );
+
+    const vt = (await getVehicleType(vehicleType.id))!;
+    const tpl = (await getTemplate(template.id))!;
+    expect(vt.id).toBe(vehicleType.id);
+    expect(tpl.id).toBe(template.id);
+    expect(vt.name).toBe("Shifter 125");
+    expect(tpl.sections[0].fields[0].id).toBe("f-toe"); // field id preserved
+    expect(tpl.sections[0].fields[0].name).toBe("Toe Angle");
+    expect(tpl.updatedAt).toBeGreaterThan(before);
+  });
+
+  it("emits a put for both stores", async () => {
+    const { vehicleType, template } = await createVehicleTypeWithTemplate("S", 2, false, sections);
+    const seen = vi.fn();
+    const off = onGarageChange(seen);
+    await updateVehicleTypeWithTemplate(vehicleType, template);
     off();
     expect(seen).toHaveBeenCalledWith({ store: "vehicle-types", key: vehicleType.id, type: "put" });
     expect(seen).toHaveBeenCalledWith({ store: "setup-templates", key: template.id, type: "put" });

--- a/src/lib/templateStorage.ts
+++ b/src/lib/templateStorage.ts
@@ -291,6 +291,33 @@ export async function createVehicleTypeWithTemplate(
 }
 
 /**
+ * Update an existing vehicle type and its template atomically. Both records
+ * keep their ids (and the template keeps its `field.id`s, so existing setups
+ * stay mapped). Stamps `updatedAt` on both so the cloud's last-write-wins
+ * reconcile pushes the edit up.
+ */
+export async function updateVehicleTypeWithTemplate(
+  vehicleType: VehicleType,
+  template: SetupTemplate,
+): Promise<void> {
+  const now = Date.now();
+  const vt: VehicleType = { ...vehicleType, updatedAt: now };
+  const tpl: SetupTemplate = { ...template, updatedAt: now };
+
+  const db = await openDB();
+  const tx = db.transaction([STORE_NAMES.VEHICLE_TYPES, STORE_NAMES.SETUP_TEMPLATES], "readwrite");
+  tx.objectStore(STORE_NAMES.VEHICLE_TYPES).put(vt);
+  tx.objectStore(STORE_NAMES.SETUP_TEMPLATES).put(tpl);
+  await new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+  emitGarageChange({ store: STORE_NAMES.VEHICLE_TYPES, key: vt.id, type: "put" });
+  emitGarageChange({ store: STORE_NAMES.SETUP_TEMPLATES, key: tpl.id, type: "put" });
+}
+
+/**
  * Delete a vehicle type and its template atomically.
  */
 export async function deleteVehicleTypeWithTemplate(vehicleTypeId: string, templateId: string): Promise<void> {

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -94,6 +94,7 @@
     "confirm": "Bestätigen",
     "cancel": "Abbrechen",
     "newVehicleType": "Neuer Fahrzeugtyp",
+    "manageVehicleTypes": "Fahrzeugtypen verwalten",
     "addNewSetup": "Neues Setup hinzufügen",
     "editSetup": "Setup bearbeiten",
     "newSetup": "Neues Setup",
@@ -339,5 +340,18 @@
     "startLineDistance": "Abstand der Startlinie:",
     "sendToDevice": "An das Gerät senden",
     "downloadToApp": "In die App herunterladen"
+  },
+  "vehicleTypeEditor": {
+    "title": "Fahrzeugtypen verwalten",
+    "selectType": "Fahrzeugtyp",
+    "selectTypePlaceholder": "Fahrzeugtyp auswählen…",
+    "pickPrompt": "Wähle oben einen Fahrzeugtyp aus, um mit der Bearbeitung zu beginnen.",
+    "update": "Aktualisieren",
+    "warningTitle": "Betrifft vorhandene Setups",
+    "warningBody": "Diese Felder enthalten Daten in vorhandenen Setups. Beim Anwenden gehen sie verloren:",
+    "warningRemoved": "entfernt – gespeicherte Werte ausgeblendet",
+    "warningTypeChanged": "Typ geändert – gespeicherte Werte gelöscht",
+    "warningConfirm": "Trotzdem anwenden",
+    "warningCancel": "Abbrechen"
   }
 }

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -352,6 +352,11 @@
     "warningRemoved": "entfernt – gespeicherte Werte ausgeblendet",
     "warningTypeChanged": "Typ geändert – gespeicherte Werte gelöscht",
     "warningConfirm": "Trotzdem anwenden",
-    "warningCancel": "Abbrechen"
+    "warningCancel": "Abbrechen",
+    "delete": "Diesen Fahrzeugtyp löschen",
+    "deleteConfirm": "Diesen Fahrzeugtyp löschen? Das kann nicht rückgängig gemacht werden.",
+    "deleteConfirmBtn": "Löschen",
+    "deleteHasSetups": "Dieser Typ hat gespeicherte Setups – lösche diese zuerst.",
+    "deleteDefault": "Der integrierte Standardtyp kann nicht gelöscht werden."
   }
 }

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -93,6 +93,7 @@
     "confirm": "Confirm",
     "cancel": "Cancel",
     "newVehicleType": "New Vehicle Type",
+    "manageVehicleTypes": "Manage Vehicle Types",
     "addNewSetup": "Add New Setup",
     "editSetup": "Edit Setup",
     "newSetup": "New Setup",
@@ -338,5 +339,18 @@
     "startLineDistance": "Start line distance:",
     "sendToDevice": "Send to Device",
     "downloadToApp": "Download to App"
+  },
+  "vehicleTypeEditor": {
+    "title": "Manage Vehicle Types",
+    "selectType": "Vehicle Type",
+    "selectTypePlaceholder": "Select a vehicle type…",
+    "pickPrompt": "Select a vehicle type above to start editing.",
+    "update": "Update",
+    "warningTitle": "Affects existing setups",
+    "warningBody": "These fields hold data in existing setups. Applying will discard it:",
+    "warningRemoved": "removed — saved values hidden",
+    "warningTypeChanged": "type changed — saved values cleared",
+    "warningConfirm": "Apply anyway",
+    "warningCancel": "Cancel"
   }
 }

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -351,6 +351,11 @@
     "warningRemoved": "removed — saved values hidden",
     "warningTypeChanged": "type changed — saved values cleared",
     "warningConfirm": "Apply anyway",
-    "warningCancel": "Cancel"
+    "warningCancel": "Cancel",
+    "delete": "Delete this vehicle type",
+    "deleteConfirm": "Delete this vehicle type? This can't be undone.",
+    "deleteConfirmBtn": "Delete",
+    "deleteHasSetups": "This type has saved setups — delete those first.",
+    "deleteDefault": "The built-in default type can't be deleted."
   }
 }

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -352,6 +352,11 @@
     "warningRemoved": "eliminado: los valores guardados se ocultarán",
     "warningTypeChanged": "tipo cambiado: los valores guardados se borrarán",
     "warningConfirm": "Aplicar de todos modos",
-    "warningCancel": "Cancelar"
+    "warningCancel": "Cancelar",
+    "delete": "Eliminar este tipo de vehículo",
+    "deleteConfirm": "¿Eliminar este tipo de vehículo? No se puede deshacer.",
+    "deleteConfirmBtn": "Eliminar",
+    "deleteHasSetups": "Este tipo tiene configuraciones guardadas: elimínalas primero.",
+    "deleteDefault": "El tipo predeterminado integrado no se puede eliminar."
   }
 }

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -94,6 +94,7 @@
     "confirm": "Confirmar",
     "cancel": "Cancelar",
     "newVehicleType": "Nuevo tipo de vehículo",
+    "manageVehicleTypes": "Gestionar tipos de vehículo",
     "addNewSetup": "Añadir nuevo reglaje",
     "editSetup": "Editar reglaje",
     "newSetup": "Nuevo reglaje",
@@ -339,5 +340,18 @@
     "startLineDistance": "Distancia de la línea de salida:",
     "sendToDevice": "Enviar al dispositivo",
     "downloadToApp": "Descargar a la app"
+  },
+  "vehicleTypeEditor": {
+    "title": "Gestionar tipos de vehículo",
+    "selectType": "Tipo de vehículo",
+    "selectTypePlaceholder": "Selecciona un tipo de vehículo…",
+    "pickPrompt": "Selecciona un tipo de vehículo arriba para empezar a editar.",
+    "update": "Actualizar",
+    "warningTitle": "Afecta a configuraciones existentes",
+    "warningBody": "Estos campos contienen datos en configuraciones existentes. Aplicar los cambios los descartará:",
+    "warningRemoved": "eliminado: los valores guardados se ocultarán",
+    "warningTypeChanged": "tipo cambiado: los valores guardados se borrarán",
+    "warningConfirm": "Aplicar de todos modos",
+    "warningCancel": "Cancelar"
   }
 }

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -352,6 +352,11 @@
     "warningRemoved": "supprimé — valeurs enregistrées masquées",
     "warningTypeChanged": "type modifié — valeurs enregistrées effacées",
     "warningConfirm": "Appliquer quand même",
-    "warningCancel": "Annuler"
+    "warningCancel": "Annuler",
+    "delete": "Supprimer ce type de véhicule",
+    "deleteConfirm": "Supprimer ce type de véhicule ? Cette action est irréversible.",
+    "deleteConfirmBtn": "Supprimer",
+    "deleteHasSetups": "Ce type a des configurations enregistrées — supprimez-les d'abord.",
+    "deleteDefault": "Le type par défaut intégré ne peut pas être supprimé."
   }
 }

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -94,6 +94,7 @@
     "confirm": "Confirmer",
     "cancel": "Annuler",
     "newVehicleType": "Nouveau type de véhicule",
+    "manageVehicleTypes": "Gérer les types de véhicule",
     "addNewSetup": "Ajouter un réglage",
     "editSetup": "Modifier le réglage",
     "newSetup": "Nouveau réglage",
@@ -339,5 +340,18 @@
     "startLineDistance": "Distance de la ligne de départ :",
     "sendToDevice": "Envoyer à l'appareil",
     "downloadToApp": "Télécharger dans l'app"
+  },
+  "vehicleTypeEditor": {
+    "title": "Gérer les types de véhicule",
+    "selectType": "Type de véhicule",
+    "selectTypePlaceholder": "Sélectionnez un type de véhicule…",
+    "pickPrompt": "Sélectionnez un type de véhicule ci-dessus pour commencer la modification.",
+    "update": "Mettre à jour",
+    "warningTitle": "Affecte les configurations existantes",
+    "warningBody": "Ces champs contiennent des données dans des configurations existantes. Les appliquer les supprimera :",
+    "warningRemoved": "supprimé — valeurs enregistrées masquées",
+    "warningTypeChanged": "type modifié — valeurs enregistrées effacées",
+    "warningConfirm": "Appliquer quand même",
+    "warningCancel": "Annuler"
   }
 }

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -94,6 +94,7 @@
     "confirm": "Conferma",
     "cancel": "Annulla",
     "newVehicleType": "Nuovo tipo di veicolo",
+    "manageVehicleTypes": "Gestisci tipi di veicolo",
     "addNewSetup": "Aggiungi nuovo assetto",
     "editSetup": "Modifica assetto",
     "newSetup": "Nuovo assetto",
@@ -339,5 +340,18 @@
     "startLineDistance": "Distanza della linea di partenza:",
     "sendToDevice": "Invia al dispositivo",
     "downloadToApp": "Scarica nell'app"
+  },
+  "vehicleTypeEditor": {
+    "title": "Gestisci tipi di veicolo",
+    "selectType": "Tipo di veicolo",
+    "selectTypePlaceholder": "Seleziona un tipo di veicolo…",
+    "pickPrompt": "Seleziona un tipo di veicolo qui sopra per iniziare la modifica.",
+    "update": "Aggiorna",
+    "warningTitle": "Influisce sulle configurazioni esistenti",
+    "warningBody": "Questi campi contengono dati in configurazioni esistenti. Applicando le modifiche andranno persi:",
+    "warningRemoved": "rimosso — valori salvati nascosti",
+    "warningTypeChanged": "tipo modificato — valori salvati cancellati",
+    "warningConfirm": "Applica comunque",
+    "warningCancel": "Annulla"
   }
 }

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -352,6 +352,11 @@
     "warningRemoved": "rimosso — valori salvati nascosti",
     "warningTypeChanged": "tipo modificato — valori salvati cancellati",
     "warningConfirm": "Applica comunque",
-    "warningCancel": "Annulla"
+    "warningCancel": "Annulla",
+    "delete": "Elimina questo tipo di veicolo",
+    "deleteConfirm": "Eliminare questo tipo di veicolo? L'azione è irreversibile.",
+    "deleteConfirmBtn": "Elimina",
+    "deleteHasSetups": "Questo tipo ha configurazioni salvate: eliminale prima.",
+    "deleteDefault": "Il tipo predefinito integrato non può essere eliminato."
   }
 }

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -352,6 +352,11 @@
     "warningRemoved": "削除 — 保存された値は非表示になります",
     "warningTypeChanged": "タイプ変更 — 保存された値は消去されます",
     "warningConfirm": "それでも適用",
-    "warningCancel": "キャンセル"
+    "warningCancel": "キャンセル",
+    "delete": "この車両タイプを削除",
+    "deleteConfirm": "この車両タイプを削除しますか？元に戻せません。",
+    "deleteConfirmBtn": "削除",
+    "deleteHasSetups": "このタイプには保存されたセットアップがあります。先に削除してください。",
+    "deleteDefault": "組み込みの既定タイプは削除できません。"
   }
 }

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -94,6 +94,7 @@
     "confirm": "確定",
     "cancel": "キャンセル",
     "newVehicleType": "新しい車両の種類",
+    "manageVehicleTypes": "車両タイプを管理",
     "addNewSetup": "セットアップを追加",
     "editSetup": "セットアップを編集",
     "newSetup": "新しいセットアップ",
@@ -339,5 +340,18 @@
     "startLineDistance": "スタートライン距離：",
     "sendToDevice": "デバイスに送信",
     "downloadToApp": "アプリにダウンロード"
+  },
+  "vehicleTypeEditor": {
+    "title": "車両タイプを管理",
+    "selectType": "車両タイプ",
+    "selectTypePlaceholder": "車両タイプを選択…",
+    "pickPrompt": "編集を始めるには、上で車両タイプを選択してください。",
+    "update": "更新",
+    "warningTitle": "既存のセットアップに影響します",
+    "warningBody": "これらのフィールドには既存のセットアップのデータが含まれています。適用すると失われます:",
+    "warningRemoved": "削除 — 保存された値は非表示になります",
+    "warningTypeChanged": "タイプ変更 — 保存された値は消去されます",
+    "warningConfirm": "それでも適用",
+    "warningCancel": "キャンセル"
   }
 }

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -94,6 +94,7 @@
     "confirm": "Confirmar",
     "cancel": "Cancelar",
     "newVehicleType": "Novo tipo de veículo",
+    "manageVehicleTypes": "Gerenciar tipos de veículo",
     "addNewSetup": "Adicionar novo acerto",
     "editSetup": "Editar acerto",
     "newSetup": "Novo acerto",
@@ -339,5 +340,18 @@
     "startLineDistance": "Distância da linha de largada:",
     "sendToDevice": "Enviar ao dispositivo",
     "downloadToApp": "Baixar para o app"
+  },
+  "vehicleTypeEditor": {
+    "title": "Gerenciar tipos de veículo",
+    "selectType": "Tipo de veículo",
+    "selectTypePlaceholder": "Selecione um tipo de veículo…",
+    "pickPrompt": "Selecione um tipo de veículo acima para começar a editar.",
+    "update": "Atualizar",
+    "warningTitle": "Afeta configurações existentes",
+    "warningBody": "Estes campos têm dados em configurações existentes. Aplicar irá descartá-los:",
+    "warningRemoved": "removido — valores salvos ocultados",
+    "warningTypeChanged": "tipo alterado — valores salvos apagados",
+    "warningConfirm": "Aplicar mesmo assim",
+    "warningCancel": "Cancelar"
   }
 }

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -352,6 +352,11 @@
     "warningRemoved": "removido — valores salvos ocultados",
     "warningTypeChanged": "tipo alterado — valores salvos apagados",
     "warningConfirm": "Aplicar mesmo assim",
-    "warningCancel": "Cancelar"
+    "warningCancel": "Cancelar",
+    "delete": "Excluir este tipo de veículo",
+    "deleteConfirm": "Excluir este tipo de veículo? Isso não pode ser desfeito.",
+    "deleteConfirmBtn": "Excluir",
+    "deleteHasSetups": "Este tipo tem configurações salvas — exclua-as primeiro.",
+    "deleteDefault": "O tipo padrão integrado não pode ser excluído."
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -548,11 +548,12 @@ export default function Index() {
     onGetLatestForVehicle: setupManager.getLatestForVehicle,
     onAddVehicleType: templateManager.addVehicleType,
     onRemoveVehicleType: templateManager.removeVehicleType,
+    onUpdateVehicleType: templateManager.updateVehicleType,
     onCreateVehicle: openVehiclesGarage,
   }), [
     vehicleManager.vehicles, setupManager.setups, templateManager.vehicleTypes, templateManager.templates,
     setupManager.addSetup, setupManager.updateSetup, setupManager.removeSetup, setupManager.getLatestForVehicle,
-    templateManager.addVehicleType, templateManager.removeVehicleType, openVehiclesGarage,
+    templateManager.addVehicleType, templateManager.removeVehicleType, templateManager.updateVehicleType, openVehiclesGarage,
   ]);
 
   // No data loaded - show import UI


### PR DESCRIPTION
## What & why

We could *create* vehicle types but never *edit* them. This adds a **Manage Vehicle Types** button on the Setups tab (directly below **New Vehicle Type**) that opens an editor:

- A **dropdown** at the top selects an existing vehicle type. It starts **empty** so editing is a deliberate, intentional choice ("select one first").
- The form below is the same one used by the creator (sections, fields, wheel count, tires), prefilled from the chosen type.
- The bottom action is **Update** instead of *Save*.

## Modularization

The creator screen was refactored so create + edit share one source of truth:

| New | Role |
|-----|------|
| `hooks/useTemplateFields.ts` | draft state + section/field mutators |
| `components/drawer/TemplateFieldsEditor.tsx` | shared wheel/tires/sections editor (now with an orange "highlighted fields" flag) |
| `components/drawer/VehicleTypeEditor.tsx` | the new manage/edit screen |
| `lib/templateEdit.ts` | pure edit logic (destructive-change detection, revert, `cleanSections`, `buildTemplateUpdate`) |

`TemplateCreator` is now a thin wrapper over `useTemplateFields` + `TemplateFieldsEditor` (~196 → ~90 lines).

## How edits affect existing setups & the cloud

This was the open design question. Findings:

- Setups store values in `customFields` keyed by the template's **`field.id`**, *not* the display name — so **renames are always safe**, the saved value stays attached.
- Vehicle types + templates already sync as cloud documents keyed by stable `id`, resolved by **last-write-wins on `updatedAt`**. The edit is atomic across both stores and stamps `updatedAt`, so the existing reconcile pushes it up — **no new sync logic**.

We went with **in-place edit + a destructive-change warning** (the option chosen in discussion). An edit is "destructive" only when it **removes** a field or **flips its data type** (number ↔ text) *and* existing setups already hold values there. That pops a dialog listing exactly which fields are affected:

- **Apply anyway** → saves; removed-field values are orphaned (harmless), type-flipped values cleared.
- **Cancel** → the risky changes are *stomped* back to their original definitions (removed fields re-added, flipped types reset) and those fields are **highlighted orange** so you can see what was rolled back. Benign edits (renames, new fields, reordering) are kept.

Frozen setup *revisions* are content-addressed and immutable, so history is never disturbed by a template edit.

## Tests / checks

- `lib/templateEdit.test.ts` — full coverage of used-field detection, destructive-change detection (rename safe, removal, type-flip, unused-field ignored), revert (re-add, section recreation, type reset, benign edits preserved), `cleanSections`, `buildTemplateUpdate`.
- `lib/templateStorage.test.ts` — new `updateVehicleTypeWithTemplate` (ids/field-ids preserved, `updatedAt` bumped, garage events).
- Translations added to all 7 locales (i18n parity test passes).
- `lint`, `typecheck`, `test:run` (1833 passed), `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CANyTkiXiH3iKghpdJVEWM)_