### PR TITLE
Rename phone Datalogger tool to Lap Timer + keep screen awake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,14 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tools on the home screen.** A new **Tools** tile on the landing page opens the
   trackside tools (the seat-position visualizer and more) in a full-screen panel —
   no datalog needed.
-- **Datalogger (early/experimental).** A new tool that turns your phone's GPS into
+- **Lap Timer (early/experimental).** A new tool that turns your phone's GPS into
   a live lap timer: a big delta to your best lap (red when you're slower, green
   when faster), current/best/last/optimal lap times, speed, and a **Lap Times**
-  list with major-sector splits. It starts recording once you're moving above
-  5 mph and saves the session as a `.dovep` log to your files when you end it
-  (auto-ends after 5 minutes stopped, or tap **End**) — then opens and reviews
-  exactly like any other log. Early days: the timing and UI will be refined in
-  upcoming updates.
+  list with major-sector splits. It keeps your screen awake for the whole
+  session, starts recording once you're moving above 5 mph, and saves the session
+  as a `.dovep` log to your files when you end it (auto-ends after 5 minutes
+  stopped, or tap **End**) — then opens and reviews exactly like any other log.
+  Early days: the timing and UI will be refined in upcoming updates.
 - **Translations / multi-language support (foundation).** The app now has an
   internationalization system (built on i18next) with a **Language** picker in
   Settings. It auto-detects your browser language on first run and ships
@@ -250,7 +250,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fonts are now self-hosted (via Fontsource) and bundled into the offline
   precache like the rest of the app, so they render correctly from the first paint
   with no network. This also removes a third-party request on every page load.
-- **Datalogger looked like it didn't recognise the track while parked.** Sitting
+- **Lap Timer looked like it didn't recognise the track while parked.** Sitting
   still at a known venue, the tool shows a plain speedometer (lap timing only arms
   once you're moving above 5 mph) — but it gave no sign the track had been
   detected, so it was indistinguishable from the genuine "no tracks found nearby"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ src/
 ├── plugins/               # ★ Plugin framework (auto-discovered) — see src/plugins/README.md
 │   ├── (framework)        # types, registry, index, panels, mounts, fileSources, storage + hosts
 │   ├── cloud-sync/        # ★ First-party plugin: Supabase file + garage sync (→ docs/backend.md)
-│   ├── tools/             # ★ First-party plugin: Tools tab (kart seat-position viz; phone Datalogger)
+│   ├── tools/             # ★ First-party plugin: Tools tab (kart seat-position viz; phone Lap Timer)
 │   └── coaching/          # Gitignored slot for the AI coach (npm pkg in production)
 ├── types/racing.ts        # ★ Core types: GpsSample, ParsedData, Lap, Course, Track, …
 ├── contexts/              # SettingsContext, SessionContext, PlaybackContext, DeviceContext, AuthContext
@@ -254,7 +254,7 @@ A plugin default-exports `{ id, name, version?, priority?, setup?(ctx) }`. In
   into the host browser as inline `cloud` rows without coupling the host to cloud.
 
 First-party plugins: **cloud-sync** (Supabase file + garage sync → `docs/backend.md`)
-and **tools** (Tools tab: kart seat-position visualizer + phone Datalogger built on
+and **tools** (Tools tab: kart seat-position visualizer + phone Lap Timer built on
 `lib/gps/`). New slots/points are just new strings — no framework change.
 
 > ## ⚠️ SUPER IMPORTANT — coach source differs by branch (DO NOT MERGE BLINDLY)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All formats are auto-detected on import:
 | VBO | Racelogic VBOX, RaceBox | `.vbo` |
 | Dove CSV | DovesDataLogger | `.dove` |
 | Dovex | DovesDataLogger (extended with metadata) | `.dovex` |
-| Dovep | Phone Datalogger tool (Dove-phone; `.dovex`-compatible) | `.dovep` |
+| Dovep | Phone Lap Timer tool (Dove-phone; `.dovex`-compatible) | `.dovep` |
 | Alfano CSV | Alfano ADA app, Off Camber Data | `.csv` |
 | AiM CSV | MyChron 5/6, Race Studio 3 | `.csv` |
 | AiM XRK/XRZ | MyChron / SoloDL native binary | `.xrk`, `.xrz` |

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,0 +1,32 @@
+/**
+ * Holds a screen wake lock (keeps the phone awake) while `active` is true,
+ * re-acquiring it after the OS releases it on tab-hide. A no-op where the Wake
+ * Lock API is unavailable (older browsers / non-secure contexts). The lifecycle
+ * logic lives in the unit-tested `WakeLockController`; this is the browser glue.
+ */
+import { useEffect } from "react";
+import { WakeLockController, type WakeLockRequester } from "@/lib/wakeLock";
+
+export function useWakeLock(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+
+    const wakeLock = (navigator as Navigator & { wakeLock?: { request: WakeLockRequester } }).wakeLock;
+    const request: WakeLockRequester | null = wakeLock
+      ? (type) => wakeLock.request(type)
+      : null;
+
+    const controller = new WakeLockController(request);
+    void controller.enable();
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void controller.onVisible();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      void controller.disable();
+    };
+  }, [active]);
+}

--- a/src/lib/wakeLock.test.ts
+++ b/src/lib/wakeLock.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { WakeLockController, type WakeLockSentinelLike } from "./wakeLock";
+
+/** A controllable fake of the Wake Lock sentinel + requester. */
+function makeApi() {
+  const sentinels: FakeSentinel[] = [];
+  const request = vi.fn(async (_type: "screen") => {
+    const s = new FakeSentinel();
+    sentinels.push(s);
+    return s as unknown as WakeLockSentinelLike;
+  });
+  return { request, sentinels };
+}
+
+class FakeSentinel {
+  released = false;
+  private releaseListeners: Array<() => void> = [];
+  release = vi.fn(async () => {
+    this.released = true;
+    for (const l of this.releaseListeners) l();
+  });
+  addEventListener(_type: "release", listener: () => void): void {
+    this.releaseListeners.push(listener);
+  }
+  /** Simulate the OS dropping the lock (page hidden / battery saver). */
+  osRelease(): void {
+    this.released = true;
+    for (const l of this.releaseListeners) l();
+  }
+}
+
+describe("WakeLockController", () => {
+  it("acquires a sentinel on enable and reports held", async () => {
+    const { request } = makeApi();
+    const c = new WakeLockController(request);
+    await c.enable();
+    expect(request).toHaveBeenCalledWith("screen");
+    expect(c.isHeld).toBe(true);
+  });
+
+  it("releases the held sentinel on disable", async () => {
+    const { request, sentinels } = makeApi();
+    const c = new WakeLockController(request);
+    await c.enable();
+    await c.disable();
+    expect(sentinels[0].release).toHaveBeenCalledTimes(1);
+    expect(c.isHeld).toBe(false);
+  });
+
+  it("re-acquires on visibility after the OS releases the lock", async () => {
+    const { request, sentinels } = makeApi();
+    const c = new WakeLockController(request);
+    await c.enable();
+    sentinels[0].osRelease(); // OS drops it while hidden
+    expect(c.isHeld).toBe(false);
+    await c.onVisible();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(c.isHeld).toBe(true);
+  });
+
+  it("does not re-acquire on visibility while still holding the lock", async () => {
+    const { request } = makeApi();
+    const c = new WakeLockController(request);
+    await c.enable();
+    await c.onVisible();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-acquire on visibility when disabled", async () => {
+    const { request } = makeApi();
+    const c = new WakeLockController(request);
+    await c.onVisible();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("is a safe no-op when the Wake Lock API is unavailable", async () => {
+    const c = new WakeLockController(null);
+    await c.enable();
+    expect(c.isHeld).toBe(false);
+    await c.disable();
+    await c.onVisible();
+    expect(c.isHeld).toBe(false);
+  });
+
+  it("releases immediately if disabled while the request is in flight", async () => {
+    let resolveRequest!: (s: WakeLockSentinelLike) => void;
+    const sentinel = new FakeSentinel();
+    const request = vi.fn(
+      () => new Promise<WakeLockSentinelLike>((res) => { resolveRequest = res; }),
+    );
+    const c = new WakeLockController(request);
+    const enabling = c.enable();
+    await c.disable(); // lands before the request resolves
+    resolveRequest(sentinel as unknown as WakeLockSentinelLike);
+    await enabling;
+    expect(sentinel.release).toHaveBeenCalledTimes(1);
+    expect(c.isHeld).toBe(false);
+  });
+
+  it("swallows a rejected request without throwing", async () => {
+    const request = vi.fn(async () => { throw new Error("not allowed"); });
+    const c = new WakeLockController(request);
+    await expect(c.enable()).resolves.toBeUndefined();
+    expect(c.isHeld).toBe(false);
+  });
+});

--- a/src/lib/wakeLock.ts
+++ b/src/lib/wakeLock.ts
@@ -1,0 +1,77 @@
+/**
+ * Screen Wake Lock controller — keeps the device's screen awake while enabled.
+ *
+ * The browser's Wake Lock is fragile: the OS silently releases it whenever the
+ * page is hidden/backgrounded (tab switch, screen-off), so a long-running view
+ * like the Lap Timer has to re-acquire it on every return to visibility. This
+ * controller owns that "held vs. should-be-held" state. It's pure of React and
+ * DOM globals — the wake-lock requester is injected — so it's unit-testable;
+ * `useWakeLock` is the thin browser adapter that wires it to the real
+ * `navigator.wakeLock` + `visibilitychange`.
+ */
+
+/** The subset of `WakeLockSentinel` we depend on. */
+export interface WakeLockSentinelLike {
+  release(): Promise<void>;
+  addEventListener(type: "release", listener: () => void): void;
+}
+
+/** A function shaped like `navigator.wakeLock.request`. */
+export type WakeLockRequester = (type: "screen") => Promise<WakeLockSentinelLike>;
+
+export class WakeLockController {
+  private sentinel: WakeLockSentinelLike | null = null;
+  private enabled = false;
+
+  /** `request` is `null` where the Wake Lock API is unavailable — a no-op then. */
+  constructor(private readonly request: WakeLockRequester | null) {}
+
+  get isHeld(): boolean {
+    return this.sentinel != null;
+  }
+
+  /** Mark the lock as wanted and acquire it now. */
+  async enable(): Promise<void> {
+    this.enabled = true;
+    await this.acquire();
+  }
+
+  /** Mark the lock as no longer wanted and release any held sentinel. */
+  async disable(): Promise<void> {
+    this.enabled = false;
+    await this.releaseHeld();
+  }
+
+  /**
+   * Call when the page becomes visible again. The OS drops the lock while hidden,
+   * so re-acquire it if we still want it but no longer hold it.
+   */
+  async onVisible(): Promise<void> {
+    if (this.enabled && !this.sentinel) await this.acquire();
+  }
+
+  private async acquire(): Promise<void> {
+    if (!this.request || this.sentinel) return;
+    try {
+      const sentinel = await this.request("screen");
+      // Guard against a disable() that landed while the request was in flight.
+      if (!this.enabled) {
+        await sentinel.release().catch(() => {});
+        return;
+      }
+      this.sentinel = sentinel;
+      // The OS can release it out from under us (hide/low-battery); track that.
+      sentinel.addEventListener("release", () => {
+        this.sentinel = null;
+      });
+    } catch {
+      // Request can reject (unsupported, not visible, battery saver) — non-fatal.
+    }
+  }
+
+  private async releaseHeld(): Promise<void> {
+    const held = this.sentinel;
+    this.sentinel = null;
+    if (held) await held.release().catch(() => {});
+  }
+}

--- a/src/plugins/tools/laptimer/LapTimerTool.tsx
+++ b/src/plugins/tools/laptimer/LapTimerTool.tsx
@@ -1,11 +1,11 @@
 /**
- * Datalogger tool — live GPS lap timing using the phone as the logger.
+ * Lap Timer tool — live GPS lap timing using the phone as the logger.
  *
- * PHASE 1 UI: a laptimer-style readout (no map — this is a heads-up timer, not a
+ * PHASE 1 UI: a lap-timer readout (no map — this is a heads-up timer, not a
  * map view), with the delta to your best lap as the dominant field. A "Lap Times"
  * view lists completed laps with their major-sector splits (fine-grained sectors
  * live in the full session viewer). The capture + timing engine is the real
- * foundation (`@/lib/gps`, `useDatalogger`); visuals get tuned in a later phase.
+ * foundation (`@/lib/gps`, `useLapTimer`); visuals get tuned in a later phase.
  *
  * Behavior: starts capturing the moment it opens, begins recording above 5 mph,
  * auto-ends after 5 min stopped, and saves a `.dovep` log to IndexedDB on end
@@ -26,7 +26,8 @@ import {
 import type { PluginPanelProps } from "@/plugins/panels";
 import type { Lap } from "@/types/racing";
 import { formatLapTime, formatSectorTime } from "@/lib/lapCalculation";
-import { useDatalogger } from "./useDatalogger";
+import { useWakeLock } from "@/hooks/useWakeLock";
+import { useLapTimer } from "./useLapTimer";
 import { useToolsT, type ToolsKey } from "../i18n";
 import type { TimingState, GpsObservation, SessionPhase } from "@/lib/gps";
 
@@ -37,12 +38,16 @@ function fmtLap(ms: number | null | undefined): string {
   return ms != null ? formatLapTime(ms) : "—:—.———";
 }
 
-export default function DataloggerTool(props: PluginPanelProps) {
+export default function LapTimerTool(props: PluginPanelProps) {
   const t = useToolsT();
-  const logger = useDatalogger();
+  const logger = useLapTimer();
   const { phase, timing, laps, latest, saving, savedFileName, error, endSession, reset } = logger;
   const [view, setView] = useState<View>("live");
   const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Keep the screen awake while a session is live — a lap timer is useless if the
+  // phone sleeps mid-session. Released once the session has ended.
+  useWakeLock(phase !== "ended");
 
   const useKph = props.useKph;
   const speedMps = latest?.fix.speed ?? latest?.motion.speedMps ?? 0;
@@ -61,8 +66,8 @@ export default function DataloggerTool(props: PluginPanelProps) {
         <div className="flex gap-1">
           {!speedoOnly && (
             <>
-              <Tab active={effectiveView === "live"} onClick={() => setView("live")}>{t("datalogger.tabLive")}</Tab>
-              <Tab active={effectiveView === "laps"} onClick={() => setView("laps")}>{t("datalogger.tabLaps")}</Tab>
+              <Tab active={effectiveView === "live"} onClick={() => setView("live")}>{t("laptimer.tabLive")}</Tab>
+              <Tab active={effectiveView === "laps"} onClick={() => setView("laps")}>{t("laptimer.tabLaps")}</Tab>
             </>
           )}
         </div>
@@ -70,7 +75,7 @@ export default function DataloggerTool(props: PluginPanelProps) {
           <Status phase={phase} courseName={timing.courseName} trackName={timing.trackName} />
           {phase !== "ended" && (
             <Button variant="destructive" size="sm" className="h-8 gap-1" onClick={() => setConfirmOpen(true)}>
-              <Square className="h-3.5 w-3.5 fill-current" /> {t("datalogger.end")}
+              <Square className="h-3.5 w-3.5 fill-current" /> {t("laptimer.end")}
             </Button>
           )}
         </div>
@@ -97,21 +102,21 @@ export default function DataloggerTool(props: PluginPanelProps) {
             {saving ? (
               <>
                 <Loader2 className="mx-auto h-10 w-10 animate-spin text-muted-foreground" />
-                <p className="text-sm text-muted-foreground">{t("datalogger.saving")}</p>
+                <p className="text-sm text-muted-foreground">{t("laptimer.saving")}</p>
               </>
             ) : savedFileName ? (
               <>
                 <CheckCircle2 className="mx-auto h-10 w-10 text-success" />
-                <p className="text-sm font-medium text-foreground">{t("datalogger.savedTitle")}</p>
+                <p className="text-sm font-medium text-foreground">{t("laptimer.savedTitle")}</p>
                 <p className="break-all text-xs text-muted-foreground">{savedFileName}</p>
-                <p className="text-xs text-muted-foreground">{t("datalogger.savedHint")}</p>
-                <Button size="sm" onClick={reset}>{t("datalogger.newSession")}</Button>
+                <p className="text-xs text-muted-foreground">{t("laptimer.savedHint")}</p>
+                <Button size="sm" onClick={reset}>{t("laptimer.newSession")}</Button>
               </>
             ) : (
               <>
-                <p className="text-sm font-medium text-foreground">{t("datalogger.noDataTitle")}</p>
-                <p className="text-xs text-muted-foreground">{t("datalogger.noDataBody")}</p>
-                <Button size="sm" onClick={reset}>{t("datalogger.startNewSession")}</Button>
+                <p className="text-sm font-medium text-foreground">{t("laptimer.noDataTitle")}</p>
+                <p className="text-xs text-muted-foreground">{t("laptimer.noDataBody")}</p>
+                <Button size="sm" onClick={reset}>{t("laptimer.startNewSession")}</Button>
               </>
             )}
           </div>
@@ -121,13 +126,13 @@ export default function DataloggerTool(props: PluginPanelProps) {
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t("datalogger.endDialogTitle")}</DialogTitle>
-            <DialogDescription>{t("datalogger.endDialogBody")}</DialogDescription>
+            <DialogTitle>{t("laptimer.endDialogTitle")}</DialogTitle>
+            <DialogDescription>{t("laptimer.endDialogBody")}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmOpen(false)}>{t("datalogger.cancel")}</Button>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>{t("laptimer.cancel")}</Button>
             <Button variant="destructive" onClick={() => { setConfirmOpen(false); void endSession(); }}>
-              {t("datalogger.endSession")}
+              {t("laptimer.endSession")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -161,15 +166,15 @@ function LiveView({
   // identical to being nowhere near one).
   if (waiting || farFromTrack) {
     let title: string | undefined;
-    if (farFromTrack) title = t("datalogger.speedometerMode");
-    else if (timing.nearbyTrackName) title = t("datalogger.trackDetected", { track: timing.nearbyTrackName });
+    if (farFromTrack) title = t("laptimer.speedometerMode");
+    else if (timing.nearbyTrackName) title = t("laptimer.trackDetected", { track: timing.nearbyTrackName });
     return (
       <SpeedometerView
         speed={speed}
         speedUnit={speedUnit}
         latest={latest}
         title={title}
-        hint={waiting ? t("datalogger.waitingHint") : t("datalogger.farHint")}
+        hint={waiting ? t("laptimer.waitingHint") : t("laptimer.farHint")}
       />
     );
   }
@@ -182,33 +187,33 @@ function LiveView({
     <div className="flex h-full flex-col">
       {/* Delta — the dominant field */}
       <div className="flex flex-col items-center justify-center py-6">
-        <div className="text-[11px] uppercase tracking-widest text-muted-foreground">{t("datalogger.deltaLabel")}</div>
+        <div className="text-[11px] uppercase tracking-widest text-muted-foreground">{t("laptimer.deltaLabel")}</div>
         <div className={`font-mono text-7xl font-bold leading-none tabular-nums sm:text-8xl ${deltaColor}`}>
           {deltaText}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
-          {delta != null && t(delta > 0 ? "datalogger.secondsSlower" : "datalogger.secondsFaster")}
+          {delta != null && t(delta > 0 ? "laptimer.secondsSlower" : "laptimer.secondsFaster")}
         </div>
       </div>
 
       {/* Current lap, large */}
       <div className="flex flex-col items-center pb-4">
-        <div className="text-[11px] uppercase tracking-widest text-muted-foreground">{t("datalogger.currentLap")}</div>
+        <div className="text-[11px] uppercase tracking-widest text-muted-foreground">{t("laptimer.currentLap")}</div>
         <div className="font-mono text-4xl font-semibold tabular-nums text-foreground">{fmtLap(timing.currentLapMs)}</div>
       </div>
 
       {/* Supporting fields */}
       <div className="grid grid-cols-2 gap-px border-t border-border bg-border/60 sm:grid-cols-4">
-        <Cell label={t("datalogger.best")} value={fmtLap(timing.bestLapMs)} />
-        <Cell label={t("datalogger.last")} value={fmtLap(timing.lastLapMs)} />
-        <Cell label={t("datalogger.optimal")} value={fmtLap(timing.optimalMs)} />
-        <Cell label={t("datalogger.speed")} value={speed.toFixed(0)} unit={speedUnit} />
+        <Cell label={t("laptimer.best")} value={fmtLap(timing.bestLapMs)} />
+        <Cell label={t("laptimer.last")} value={fmtLap(timing.lastLapMs)} />
+        <Cell label={t("laptimer.optimal")} value={fmtLap(timing.optimalMs)} />
+        <Cell label={t("laptimer.speed")} value={speed.toFixed(0)} unit={speedUnit} />
       </div>
 
       {timing.majorSectors.length > 0 && (
         <div className="grid grid-cols-3 gap-px border-t border-border bg-border/60">
           {timing.majorSectors.map((s, i) => (
-            <Cell key={i} label={t("datalogger.sectorBest", { n: i + 1 })} value={s.best != null ? formatSectorTime(s.best) : "—"} />
+            <Cell key={i} label={t("laptimer.sectorBest", { n: i + 1 })} value={s.best != null ? formatSectorTime(s.best) : "—"} />
           ))}
         </div>
       )}
@@ -226,7 +231,7 @@ const LapTimesView = memo(function LapTimesView({ laps, bestLapNumber }: { laps:
   if (laps.length === 0) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-center">
-        <p className="text-sm text-muted-foreground">{t("datalogger.noLaps")}</p>
+        <p className="text-sm text-muted-foreground">{t("laptimer.noLaps")}</p>
       </div>
     );
   }
@@ -235,8 +240,8 @@ const LapTimesView = memo(function LapTimesView({ laps, bestLapNumber }: { laps:
     <table className="w-full text-sm">
       <thead className="sticky top-0 bg-background text-[11px] uppercase tracking-wide text-muted-foreground">
         <tr className="border-b border-border">
-          <th className="px-3 py-2 text-left font-medium">{t("datalogger.colLap")}</th>
-          <th className="px-3 py-2 text-right font-medium">{t("datalogger.colTime")}</th>
+          <th className="px-3 py-2 text-left font-medium">{t("laptimer.colLap")}</th>
+          <th className="px-3 py-2 text-right font-medium">{t("laptimer.colTime")}</th>
           {hasSectors && <th className="px-2 py-2 text-right font-medium">S1</th>}
           {hasSectors && <th className="px-2 py-2 text-right font-medium">S2</th>}
           {hasSectors && <th className="px-2 py-2 text-right font-medium">S3</th>}
@@ -249,7 +254,7 @@ const LapTimesView = memo(function LapTimesView({ laps, bestLapNumber }: { laps:
             <tr key={lap.lapNumber} className={`border-b border-border/40 ${best ? "bg-primary/10" : ""}`}>
               <td className="px-3 py-1.5 font-sans">
                 {lap.lapNumber}
-                {best && <span className="ml-1 text-[10px] text-primary">{t("datalogger.bestTag")}</span>}
+                {best && <span className="ml-1 text-[10px] text-primary">{t("laptimer.bestTag")}</span>}
               </td>
               <td className="px-3 py-1.5 text-right font-semibold">{fmtLap(lap.lapTimeMs)}</td>
               {hasSectors && <td className="px-2 py-1.5 text-right text-muted-foreground">{lap.sectors?.s1 != null ? formatSectorTime(lap.sectors.s1) : "—"}</td>}
@@ -282,7 +287,7 @@ function SpeedometerView({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">{t("datalogger.acquiringGps")}</p>
+        <p className="text-sm text-muted-foreground">{t("laptimer.acquiringGps")}</p>
       </div>
     );
   }
@@ -290,7 +295,7 @@ function SpeedometerView({
     <div className="flex h-full flex-col">
       {/* Speed — centered and dominant */}
       <div className="flex flex-1 flex-col items-center justify-center text-center">
-        <div className="text-[11px] uppercase tracking-widest text-muted-foreground">{t("datalogger.speed")}</div>
+        <div className="text-[11px] uppercase tracking-widest text-muted-foreground">{t("laptimer.speed")}</div>
         <div className="font-mono text-8xl font-bold leading-none tabular-nums text-foreground">
           {speed.toFixed(0)}
           <span className="ml-2 text-2xl font-normal text-muted-foreground">{speedUnit}</span>
@@ -301,7 +306,7 @@ function SpeedometerView({
         {title && <p className="text-sm font-semibold text-foreground">{title}</p>}
         <p className="mx-auto mt-1 max-w-xs text-sm text-muted-foreground">{hint}</p>
         <p className="mt-2 text-xs text-muted-foreground/70">
-          {t("datalogger.gpsQuality", { accuracy: latest.fix.accuracy.toFixed(0), quality: latest.fix.quality })}
+          {t("laptimer.gpsQuality", { accuracy: latest.fix.accuracy.toFixed(0), quality: latest.fix.quality })}
         </p>
       </div>
     </div>
@@ -327,12 +332,12 @@ function Status({ phase, courseName, trackName }: { phase: string; courseName: s
     return (
       <span className="text-xs text-destructive">
         <span className="mr-1 inline-block h-2 w-2 animate-pulse rounded-full bg-destructive align-middle" />
-        {trackName ?? t("datalogger.statusRecording")}{courseName ? ` · ${courseName}` : ""}
+        {trackName ?? t("laptimer.statusRecording")}{courseName ? ` · ${courseName}` : ""}
       </span>
     );
   }
-  if (phase === "ended") return <span className="text-xs text-muted-foreground">{t("datalogger.statusEnded")}</span>;
-  return <span className="text-xs text-muted-foreground">{t("datalogger.statusWaiting")}</span>;
+  if (phase === "ended") return <span className="text-xs text-muted-foreground">{t("laptimer.statusEnded")}</span>;
+  return <span className="text-xs text-muted-foreground">{t("laptimer.statusWaiting")}</span>;
 }
 
 function Cell({ label, value, unit }: { label: string; value: string; unit?: string }) {

--- a/src/plugins/tools/laptimer/lapTimerSession.test.ts
+++ b/src/plugins/tools/laptimer/lapTimerSession.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { DataloggerSession, type DataloggerSnapshot } from "./dataloggerSession";
+import { LapTimerSession, type LapTimerSnapshot } from "./lapTimerSession";
 import { CustomGps, RealtimeLapTimer, AUTO_END_STOPPED_MS } from "@/lib/gps";
 import type { Track } from "@/types/racing";
 
@@ -58,8 +58,8 @@ function setup(saveLog = vi.fn().mockResolvedValue(undefined)) {
   const gps = new CustomGps({ geolocation: geo as unknown as Geolocation, retainBuffer: false });
   const timer = new RealtimeLapTimer();
   const saveMeta = vi.fn().mockResolvedValue(undefined);
-  const session = new DataloggerSession({ gps, timer, saveLog, saveMeta });
-  const snapshots: DataloggerSnapshot[] = [];
+  const session = new LapTimerSession({ gps, timer, saveLog, saveMeta });
+  const snapshots: LapTimerSnapshot[] = [];
   session.subscribe((s) => snapshots.push(s));
   return { geo, gps, timer, saveLog, saveMeta, session, snapshots };
 }
@@ -69,7 +69,7 @@ function drive(geo: FakeGeo, n: number, speed = 10, startTs = BASE_TS): void {
   for (let i = 0; i < n; i++) geo.emit({ latitude: 45 + i * 0.0001, speed }, startTs + i * 1_000);
 }
 
-describe("DataloggerSession", () => {
+describe("LapTimerSession", () => {
   it("stays in waiting below the arm speed", () => {
     const { geo, session } = setup();
     session.start();

--- a/src/plugins/tools/laptimer/lapTimerSession.ts
+++ b/src/plugins/tools/laptimer/lapTimerSession.ts
@@ -1,5 +1,5 @@
 /**
- * DataloggerSession — the framework-free orchestration for the Datalogger tool.
+ * LapTimerSession — the framework-free orchestration for the Lap Timer tool.
  *
  * Holds the session lifecycle that used to live inside the React hook: it drives
  * the GPS source through the session gate (arm above 5 mph / auto-idle), feeds
@@ -28,7 +28,7 @@ import type { Lap } from "@/types/racing";
 import type { FileMetadata } from "@/lib/fileStorage";
 import { MPS_TO_MPH } from "@/lib/parserUtils";
 
-export interface DataloggerSnapshot {
+export interface LapTimerSnapshot {
   phase: SessionPhase;
   timing: TimingState;
   /** Completed laps with major-sector rollup. */
@@ -42,7 +42,7 @@ export interface DataloggerSnapshot {
   error: string | null;
 }
 
-export const INITIAL_SNAPSHOT: DataloggerSnapshot = {
+export const INITIAL_SNAPSHOT: LapTimerSnapshot = {
   phase: "waiting",
   timing: EMPTY_TIMING_STATE,
   laps: [],
@@ -52,7 +52,7 @@ export const INITIAL_SNAPSHOT: DataloggerSnapshot = {
   error: null,
 };
 
-export interface DataloggerSessionDeps {
+export interface LapTimerSessionDeps {
   gps: CustomGps;
   timer: RealtimeLapTimer;
   /** Persist the raw log blob (e.g. fileStorage.saveFile). */
@@ -61,19 +61,19 @@ export interface DataloggerSessionDeps {
   saveMeta: (meta: FileMetadata) => Promise<void>;
 }
 
-type Listener = (snapshot: DataloggerSnapshot) => void;
+type Listener = (snapshot: LapTimerSnapshot) => void;
 
-export class DataloggerSession {
+export class LapTimerSession {
   private gate: SessionGateState = initSessionGate();
   private recorded: GpsObservation[] = [];
-  private snapshot: DataloggerSnapshot = INITIAL_SNAPSHOT;
+  private snapshot: LapTimerSnapshot = INITIAL_SNAPSHOT;
   private readonly listeners = new Set<Listener>();
   private offFix: (() => void) | null = null;
   private offErr: (() => void) | null = null;
 
-  constructor(private readonly deps: DataloggerSessionDeps) {}
+  constructor(private readonly deps: LapTimerSessionDeps) {}
 
-  getSnapshot(): DataloggerSnapshot {
+  getSnapshot(): LapTimerSnapshot {
     return this.snapshot;
   }
 
@@ -125,7 +125,7 @@ export class DataloggerSession {
     const step = stepSessionGate(this.gate, speedMps * MPS_TO_MPH, obs.fix.timestamp);
     this.gate = step.state;
 
-    const patch: Partial<DataloggerSnapshot> = { latest: obs };
+    const patch: Partial<LapTimerSnapshot> = { latest: obs };
     if (step.justArmed) patch.phase = "recording";
 
     if (this.gate.phase === "recording") {
@@ -185,7 +185,7 @@ export class DataloggerSession {
     }
   }
 
-  private patch(partial: Partial<DataloggerSnapshot>): void {
+  private patch(partial: Partial<LapTimerSnapshot>): void {
     this.snapshot = { ...this.snapshot, ...partial };
     this.emit();
   }

--- a/src/plugins/tools/laptimer/useLapTimer.ts
+++ b/src/plugins/tools/laptimer/useLapTimer.ts
@@ -1,5 +1,5 @@
 /**
- * Thin React adapter over `DataloggerSession`. The lifecycle/persistence logic
+ * Thin React adapter over `LapTimerSession`. The lifecycle/persistence logic
  * lives in the (unit-tested) controller; this hook just instantiates it with the
  * real browser dependencies (geolocation source, lap timer, IndexedDB save fns),
  * loads tracks, and re-renders on snapshot changes.
@@ -9,21 +9,21 @@ import { CustomGps, RealtimeLapTimer } from "@/lib/gps";
 import { loadTracks } from "@/lib/trackStorage";
 import { saveFile, saveFileMetadata } from "@/lib/fileStorage";
 import {
-  DataloggerSession,
+  LapTimerSession,
   INITIAL_SNAPSHOT,
-  type DataloggerSnapshot,
-} from "./dataloggerSession";
+  type LapTimerSnapshot,
+} from "./lapTimerSession";
 
-export interface DataloggerController extends DataloggerSnapshot {
+export interface LapTimerController extends LapTimerSnapshot {
   /** Manually end + save the session (red "End" action). */
   endSession: () => Promise<void>;
   /** Discard the ended session and start a fresh capture. */
   reset: () => void;
 }
 
-export function useDatalogger(): DataloggerController {
-  const [snapshot, setSnapshot] = useState<DataloggerSnapshot>(INITIAL_SNAPSHOT);
-  const sessionRef = useRef<DataloggerSession | null>(null);
+export function useLapTimer(): LapTimerController {
+  const [snapshot, setSnapshot] = useState<LapTimerSnapshot>(INITIAL_SNAPSHOT);
+  const sessionRef = useRef<LapTimerSession | null>(null);
 
   useEffect(() => {
     const timer = new RealtimeLapTimer();
@@ -32,7 +32,7 @@ export function useDatalogger(): DataloggerController {
 
     // The session keeps its own recorded buffer; don't double-retain in the source.
     const gps = new CustomGps({ retainBuffer: false });
-    const session = new DataloggerSession({ gps, timer, saveLog: saveFile, saveMeta: saveFileMetadata });
+    const session = new LapTimerSession({ gps, timer, saveLog: saveFile, saveMeta: saveFileMetadata });
     sessionRef.current = session;
 
     const off = session.subscribe(setSnapshot);

--- a/src/plugins/tools/locales/de.json
+++ b/src/plugins/tools/locales/de.json
@@ -83,11 +83,11 @@
     "tileDescription": "Rechner und Werkzeuge für die Strecke – kein Datenlog nötig.",
     "noTools": "In diesem Build sind keine Werkzeuge verfügbar."
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "Rundenzeitnehmer",
     "description": "Mach aus dem GPS deines Handys einen Live-Rundenzeitnehmer – Delta, Rundenzeiten und Sektor-Splits, gespeichert als auswertbares Log.",
     "badge": "Experimentell",
-    "tabLive": "Datalogger",
+    "tabLive": "Live",
     "tabLaps": "Rundenzeiten",
     "end": "Beenden",
     "endDialogTitle": "Sitzung beenden?",

--- a/src/plugins/tools/locales/en.json
+++ b/src/plugins/tools/locales/en.json
@@ -82,11 +82,11 @@
     "tileDescription": "Trackside calculators and utilities — no datalog needed.",
     "noTools": "No tools are available in this build."
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "Lap Timer",
     "description": "Turn your phone's GPS into a live lap timer — delta, lap times and sector splits, saved as a log you can review.",
     "badge": "Experimental",
-    "tabLive": "Datalogger",
+    "tabLive": "Live",
     "tabLaps": "Lap Times",
     "end": "End",
     "endDialogTitle": "End session?",

--- a/src/plugins/tools/locales/es.json
+++ b/src/plugins/tools/locales/es.json
@@ -83,11 +83,11 @@
     "tileDescription": "Calculadoras y utilidades para la pista, sin necesidad de un registro.",
     "noTools": "No hay herramientas disponibles en esta versión."
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "Cronómetro de vueltas",
     "description": "Convierte el GPS de tu teléfono en un cronómetro de vueltas en vivo: delta, tiempos de vuelta y parciales por sector, guardados como un registro que puedes revisar.",
     "badge": "Experimental",
-    "tabLive": "Datalogger",
+    "tabLive": "En vivo",
     "tabLaps": "Tiempos de vuelta",
     "end": "Finalizar",
     "endDialogTitle": "¿Finalizar la sesión?",

--- a/src/plugins/tools/locales/fr.json
+++ b/src/plugins/tools/locales/fr.json
@@ -83,11 +83,11 @@
     "tileDescription": "Calculatrices et utilitaires pour la piste, sans relevé nécessaire.",
     "noTools": "Aucun outil disponible dans cette version."
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "Chrono de tours",
     "description": "Transformez le GPS de votre téléphone en chrono de tours en direct : delta, temps au tour et intermédiaires par secteur, enregistrés dans un relevé consultable.",
     "badge": "Expérimental",
-    "tabLive": "Datalogger",
+    "tabLive": "En direct",
     "tabLaps": "Temps au tour",
     "end": "Terminer",
     "endDialogTitle": "Terminer la session ?",

--- a/src/plugins/tools/locales/it.json
+++ b/src/plugins/tools/locales/it.json
@@ -83,11 +83,11 @@
     "tileDescription": "Calcolatori e strumenti per la pista, senza bisogno di un registro.",
     "noTools": "Nessuno strumento disponibile in questa build."
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "Cronometro giri",
     "description": "Trasforma il GPS del telefono in un cronometro giri dal vivo: delta, tempi sul giro e intermedi di settore, salvati come registro da rivedere.",
     "badge": "Sperimentale",
-    "tabLive": "Datalogger",
+    "tabLive": "Dal vivo",
     "tabLaps": "Tempi sul giro",
     "end": "Termina",
     "endDialogTitle": "Terminare la sessione?",

--- a/src/plugins/tools/locales/ja.json
+++ b/src/plugins/tools/locales/ja.json
@@ -83,11 +83,11 @@
     "tileDescription": "コース脇で使える計算ツール。データログは不要です。",
     "noTools": "このビルドで利用できるツールはありません。"
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "ラップタイマー",
     "description": "スマホのGPSをリアルタイムのラップタイマーに。デルタ、ラップタイム、セクター区間を、あとで見返せるログとして保存します。",
     "badge": "実験的",
-    "tabLive": "Datalogger",
+    "tabLive": "ライブ",
     "tabLaps": "ラップタイム",
     "end": "終了",
     "endDialogTitle": "セッションを終了しますか？",

--- a/src/plugins/tools/locales/pt-BR.json
+++ b/src/plugins/tools/locales/pt-BR.json
@@ -83,11 +83,11 @@
     "tileDescription": "Calculadoras e utilitários para a pista, sem precisar de um registro.",
     "noTools": "Nenhuma ferramenta disponível nesta versão."
   },
-  "datalogger": {
-    "name": "Datalogger",
+  "laptimer": {
+    "name": "Cronômetro de voltas",
     "description": "Transforme o GPS do seu telefone em um cronômetro de voltas ao vivo: delta, tempos de volta e parciais por setor, salvos como um registro que você pode revisar.",
     "badge": "Experimental",
-    "tabLive": "Datalogger",
+    "tabLive": "Ao vivo",
     "tabLaps": "Tempos de volta",
     "end": "Encerrar",
     "endDialogTitle": "Encerrar a sessão?",

--- a/src/plugins/tools/toolList.ts
+++ b/src/plugins/tools/toolList.ts
@@ -32,11 +32,11 @@ export const TOOLS: ToolDef[] = [
     component: lazy(() => import("./seat-position/SeatPositionTool")),
   },
   {
-    id: "datalogger",
-    nameKey: "datalogger.name",
-    descriptionKey: "datalogger.description",
-    badgeKey: "datalogger.badge",
+    id: "laptimer",
+    nameKey: "laptimer.name",
+    descriptionKey: "laptimer.description",
+    badgeKey: "laptimer.badge",
     icon: Satellite,
-    component: lazy(() => import("./datalogger/DataloggerTool")),
+    component: lazy(() => import("./laptimer/LapTimerTool")),
   },
 ];


### PR DESCRIPTION
## What & why

The phone tool presents as a lap timer (it saves a `.dovep` log but the UI is a heads-up timer + lap-times list, not a data viewer), so this renames it from **Datalogger** to **Lap Timer** to match what users actually see — and keeps the device's screen awake for the whole session so the phone doesn't sleep mid-stint.

The **hardware** DovesDataLogger (BLE device, firmware OTA, `DataloggerDownload`, `lib/ble/*`, the `.dove`/`.dovex` formats) is **untouched** — only the phone *tool* was renamed.

## Changes

**Rename the tool**
- `src/plugins/tools/datalogger/` → `laptimer/`
- `DataloggerTool` → `LapTimerTool`, `useDatalogger` → `useLapTimer`, controller `DataloggerSession` → `LapTimerSession`
- tool `id` and i18n section `datalogger` → `laptimer` across all 7 locales
- the live tab is relabeled **"Live"** (it no longer collides with the **"Lap Times"** tab), and the display name is now **"Lap Timer"** (localized per language instead of the literal "Datalogger" the seeder had left)

**Keep the phone awake**
- new reusable, pure + unit-tested `WakeLockController` (`lib/wakeLock.ts`) that re-acquires the screen wake lock after the OS drops it on tab-hide, plus a thin `useWakeLock` hook
- held while a Lap Timer session is live (`phase !== "ended"`), released when the session ends; a safe no-op where the Wake Lock API is unavailable

**Docs**
- CHANGELOG (renamed the unreleased entry in place + noted the wake lock), README format table, CLAUDE.md

## Checks
`bun run lint`, `bun run typecheck`, `bun run test:run` (1833 passed, incl. new `wakeLock` tests + the renamed session/i18n-parity tests), and `bun run build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYHd8FwmQtFzLAAg1uF9Ce)_