### PR TITLE
Release cut 2.7.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [2.7.0] - unreleased
+## [2.7.0] - 2026-06-19
 
 ### Added
 - **Setup history.** Each setup in the Garage now has a **history** (book) icon

--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,7 @@
         "vitest": "^4.1.6",
       },
       "optionalDependencies": {
-        "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA",
+        "@perchwerks/eye-in-the-sky": "0.5.0",
       },
     },
   },
@@ -389,6 +389,8 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 
+    "@perchwerks/eye-in-the-sky": ["@perchwerks/eye-in-the-sky@0.5.0", "", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-fwIfgSLf9llZMOUsyVYC74xADiKV8IXBgGiDUIDzoMqQjDKDa2VchZtNCNN4TNrhcntgGjKLVDcxM35cjwBz2w=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
@@ -604,8 +606,6 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
-
-    "@theangryraven/eye-in-the-sky": ["@theangryraven/eye-in-the-sky@github:TheAngryRaven/DataViewer_coach#25ebf08", { "dependencies": { "uplot": "^1.6.32" }, "peerDependencies": { "i18next": "^23.0.0 || ^24.0.0 || ^25.0.0 || ^26.0.0", "leaflet": "^1.9.4", "react": "^18.3 || ^19.0.0", "react-dom": "^18.3 || ^19.0.0", "react-i18next": "^15.0.0 || ^16.0.0 || ^17.0.0" } }, "TheAngryRaven-DataViewer_coach-25ebf08", "sha512-siK7iocn6ukWdqLVe96ZYCFKMemnc8uuoNAFasfEHy8zsNzqpPSfvKhrH46uTgsJft7GOZjaNR5w8oBMxNmQsg=="],
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",
@@ -92,6 +92,6 @@
     "vitest": "^4.1.6"
   },
   "optionalDependencies": {
-    "@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"
+    "@perchwerks/eye-in-the-sky": "0.5.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,7 @@ export default defineConfig(({ mode }) => {
   const branch = gitBranch();
   const commitDate = gitCommitDate();
 
-  const DEFAULT_PLUGIN_PACKAGES = "@theangryraven/eye-in-the-sky";
+  const DEFAULT_PLUGIN_PACKAGES = "@perchwerks/eye-in-the-sky";
   const pluginPackages = (env.DOVE_PLUGIN_PACKAGES || DEFAULT_PLUGIN_PACKAGES)
     .split(",")
     .map((s) => s.trim())


### PR DESCRIPTION
## 2.7.0 — release cut 🏁

Cuts **2.7.0** from `BETA` (@ latest, including the vehicle-type editor #248 and the
changelog fix #250) to `main`, dated **2026-06-19**.

### This branch (release prep only)
- **Changelog:** `## [2.7.0]` dated `2026-06-19`.
- **Version:** `package.json` `2.6.0` → `2.7.0`.
- **Coach product-cut dance** (per the CLAUDE.md "coach source differs by branch"
  note): flipped the coach off the BETA git dep onto the published npm release —
  - `package.json`: `@theangryraven/eye-in-the-sky` (`github:…#BETA`) → `@perchwerks/eye-in-the-sky@0.5.0`
  - `vite.config.ts`: `DEFAULT_PLUGIN_PACKAGES` → `@perchwerks/eye-in-the-sky`
  - `bun.lock` refreshed (`bun install`) — now matches main's `@perchwerks@0.5.0`
    entry (identical integrity hash). The coach is at `0.5.0` on both sides, so no
    version bump was needed.

Total diff is just those 4 files (CHANGELOG, package.json, vite.config.ts, bun.lock);
all the actual 2.7.0 feature work is already on `BETA`.

> 🔁 **After this merges:** flip `BETA` back to the git coach dep
> (`@theangryraven/eye-in-the-sky": "github:TheAngryRaven/DataViewer_coach#BETA"`
> + `DEFAULT_PLUGIN_PACKAGES`) so beta keeps tracking the coach `BETA` branch. I did
> this on a dedicated release branch rather than flipping `BETA` directly, so `BETA`
> itself is untouched and still on the git dep — no revert needed there.

### What's in 2.7.0
Setup + vehicle history cards (with jump-to-session), GoPro chunked-video playback
& export, post-session tire/weight, logger Device Name, home-screen roadmap,
track-contribution attribution + admin Users + storage-trim warning + comp badge,
the Setups/Notes toolbar move & setup-flow polish, mobile Pro-panel collapse,
track-manager drill-down, sample-as-normal-log, per-session weather caching, Labs
removal, and fully-offline fonts. Full detail in `CHANGELOG.md` under `## [2.7.0]`.

✅ Green locally: `lint` · `typecheck` · `test:run` (1847 tests) · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxjiciDHWqjB4axmoSbKMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxjiciDHWqjB4axmoSbKMH)_