### PR TITLE
Hide major toggle on non-major sectors once the 3-major cap is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [2.8.0] - unreleased
+
+### Changed
+- **Course editor sector toggles.** Once all three major sectors are assigned
+  (start/finish counts as one), the **Major** toggle is hidden on the remaining
+  sub-sector rows — the datalogger only ever uses three majors, so there's
+  nothing to promote them to. Un-flag an existing major and the toggles
+  immediately reappear.
+
 ## [2.7.0] - 2026-06-19
 
 ### Added

--- a/src/components/track-editor/SectorListEditor.tsx
+++ b/src/components/track-editor/SectorListEditor.tsx
@@ -15,7 +15,7 @@ import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import { CourseSector, Course } from '@/types/racing';
 import {
-  sectorLabels, validateCourseSectors, isAtSectorLimit, MAX_SECTOR_LINES,
+  sectorLabels, validateCourseSectors, isAtSectorLimit, isAtMajorLimit, MAX_SECTOR_LINES,
 } from '@/lib/courseSectors';
 import type { SelectedLine } from '@/hooks/useTrackEditorForm';
 
@@ -49,6 +49,9 @@ export function SectorListEditor({
   const labels = useMemo(() => sectorLabels(course), [course]);
   const validation = useMemo(() => validateCourseSectors(course), [course]);
   const atLimit = isAtSectorLimit(course);
+  // Once all three majors are taken, only existing majors keep their toggle (so
+  // they can be un-flagged); non-major rows hide it since none can be promoted.
+  const atMajorLimit = isAtMajorLimit(course);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -124,6 +127,9 @@ export function SectorListEditor({
                   label={labels[i + 1] ?? ''}
                   sector={sec}
                   selected={selectedLine === i}
+                  // Hide the major toggle on non-major rows once the 3-major cap
+                  // is hit; major rows always keep it so they can be un-flagged.
+                  showMajorToggle={sec.major || !atMajorLimit}
                   onSelect={() => onSelectLine(i)}
                   onToggleMajor={() => onToggleMajor(i)}
                   onRemove={() => onRemoveSector(i)}
@@ -158,12 +164,15 @@ interface SectorRowProps {
   label: string;
   sector: CourseSector;
   selected: boolean;
+  /** Whether the "major" toggle is shown — hidden on non-major rows once the
+   *  3-major cap is reached (the logger only ever uses three). */
+  showMajorToggle: boolean;
   onSelect: () => void;
   onToggleMajor: () => void;
   onRemove: () => void;
 }
 
-function SectorRow({ index, label, sector, selected, onSelect, onToggleMajor, onRemove }: SectorRowProps) {
+function SectorRow({ index, label, sector, selected, showMajorToggle, onSelect, onToggleMajor, onRemove }: SectorRowProps) {
   const { t } = useTranslation('tracks');
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: sortableId(index) });
   const style = { transform: CSS.Transform.toString(transform), transition };
@@ -193,10 +202,12 @@ function SectorRow({ index, label, sector, selected, onSelect, onToggleMajor, on
       <button type="button" onClick={onSelect} className="flex-1 text-left text-sm">
         {t('sectors.sectorRow', { label })}
       </button>
-      <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-        {t('sectors.major')}
-        <Switch checked={sector.major} onCheckedChange={onToggleMajor} aria-label={t('sectors.markMajor')} />
-      </label>
+      {showMajorToggle && (
+        <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+          {t('sectors.major')}
+          <Switch checked={sector.major} onCheckedChange={onToggleMajor} aria-label={t('sectors.markMajor')} />
+        </label>
+      )}
       <Button
         variant="ghost"
         size="icon"

--- a/src/lib/courseSectors.test.ts
+++ b/src/lib/courseSectors.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Course, SectorLine } from '@/types/racing';
 import {
   normalizeCourseSectors, majorSectorLines, legacyMirror, sectorLabels,
-  validateCourseSectors, isAtSectorLimit, rollupMajorSectors, centeredSectorLine,
+  validateCourseSectors, isAtSectorLimit, isAtMajorLimit, rollupMajorSectors, centeredSectorLine,
   MAX_SECTOR_LINES, MAX_MAJOR_SECTORS, DEFAULT_SECTOR_HALF_LENGTH_DEG,
 } from './courseSectors';
 
@@ -117,6 +117,30 @@ describe('isAtSectorLimit', () => {
     const sectors = Array.from({ length: MAX_SECTOR_LINES - 1 }, (_, i) => ({ line: line(i), major: false }));
     expect(isAtSectorLimit(baseCourse({ sectors }))).toBe(true);
     expect(isAtSectorLimit(baseCourse({ sectors: sectors.slice(0, -1) }))).toBe(false);
+  });
+});
+
+describe('isAtMajorLimit', () => {
+  it('counts start/finish toward the major cap', () => {
+    // No sub-sectors: start/finish alone is 1 of 3 majors — not at the cap.
+    expect(isAtMajorLimit(baseCourse())).toBe(false);
+    expect(isAtMajorLimit(baseCourse({ sectors: [] }))).toBe(false);
+  });
+
+  it('is false while fewer than MAX_MAJOR_SECTORS majors are flagged', () => {
+    // One flagged major + start/finish = 2 of 3.
+    const sectors = [{ line: line(0), major: true }, { line: line(1), major: false }];
+    expect(isAtMajorLimit(baseCourse({ sectors }))).toBe(false);
+  });
+
+  it('is true once start/finish + flagged majors reach the cap', () => {
+    // Two flagged majors + start/finish = 3 of 3.
+    const sectors = [
+      { line: line(0), major: true },
+      { line: line(1), major: false },
+      { line: line(2), major: true },
+    ];
+    expect(isAtMajorLimit(baseCourse({ sectors }))).toBe(true);
   });
 });
 

--- a/src/lib/courseSectors.ts
+++ b/src/lib/courseSectors.ts
@@ -132,6 +132,17 @@ export function isAtSectorLimit(course: Course): boolean {
 }
 
 /**
+ * True once all `MAX_MAJOR_SECTORS` majors are spoken for (start/finish + the
+ * flagged sub-sectors). The logger only ever sees three majors, so the editor
+ * hides the "major" toggle on non-major rows at this point; un-flagging an
+ * existing major drops back below the cap and the toggles return.
+ */
+export function isAtMajorLimit(course: Course): boolean {
+  const flaggedMajors = (course.sectors ?? []).filter((s) => s.major).length;
+  return flaggedMajors + 1 >= MAX_MAJOR_SECTORS; // + start/finish
+}
+
+/**
  * Roll the fine-grained per-segment times up into the classic S1/S2/S3, where
  * each major sector spans from its major line to the next major line. A major
  * sector is `undefined` if any of its constituent segments is missing.


### PR DESCRIPTION
## What

In the course editor's sector list, once all three major sectors are assigned — start/finish (always major) plus two flagged sub-sectors — the **Major** toggle is now hidden on the remaining non-major rows.

Un-flag one of the existing majors and the toggles reappear on the non-major rows immediately, since a major slot has freed up.

## Why

The datalogger only ever uses three major sectors (`MAX_MAJOR_SECTORS`). Once all three are taken there's nothing left to promote a sub-sector to, so showing the toggle is misleading — flipping it would just push the course out of its valid 3-major state.

## How

- New pure helper `isAtMajorLimit(course)` in `lib/courseSectors.ts` — counts start/finish + flagged majors against `MAX_MAJOR_SECTORS`. Single source of truth, unit-tested.
- `SectorListEditor` passes `showMajorToggle = sector.major || !atMajorLimit` to each row; `SectorRow` conditionally renders the `Switch`. Major rows always keep it so they can be un-flagged.

## Tests / checks

- Added `isAtMajorLimit` coverage to `courseSectors.test.ts` (start/finish counts toward the cap; below/at cap cases).
- `bun run lint`, `bun run typecheck`, `bun run test:run`, and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XDUKzbAYqG4CJCjdDvFeg)_