### PR TITLE
Pad video panel hints + add bulk-select tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sub-sector rows — the datalogger only ever uses three majors, so there's
   nothing to promote them to. Un-flag an existing major and the toggles
   immediately reappear.
+- **Video panel hints.** The "no video loaded" panel now pads its hint text so
+  the GoPro tip no longer clips against the panel edges on narrow screens, and
+  adds a second tip: you can drop in **all** your files at once — logs and
+  videos together — and the app sorts out which videos go where.
 
 ## [2.7.0] - 2026-06-19
 

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -570,16 +570,17 @@ export const VideoPlayer = memo(function VideoPlayer({
   // No video loaded
   if (!state.videoUrl) {
     return (
-      <div className="h-full flex flex-col items-center justify-center bg-muted/20 gap-4">
+      <div className="h-full flex flex-col items-center justify-center bg-muted/20 gap-4 px-6 text-center">
         <Video className="w-12 h-12 text-muted-foreground/50" />
         <p className="text-muted-foreground text-sm">{t("player.noVideo")}</p>
         {state.videoFileName && (
-          <p className="text-xs text-muted-foreground">{t("player.lastUsed", { name: state.videoFileName })}</p>
+          <p className="text-xs text-muted-foreground max-w-xs break-words">{t("player.lastUsed", { name: state.videoFileName })}</p>
         )}
         <Button variant="outline" size="sm" onClick={actions.loadVideo} className="gap-2">
           <Video className="w-4 h-4" /> {t("player.loadVideo")}
         </Button>
-        <p className="text-xs text-muted-foreground/70">{t("player.goproHint")}</p>
+        <p className="text-xs text-muted-foreground/70 max-w-xs">{t("player.goproHint")}</p>
+        <p className="text-xs text-muted-foreground/70 max-w-xs">{t("player.bulkSelectHint")}</p>
         <RecordingPicker state={state} actions={actions} />
       </div>
     );

--- a/src/locales/de/video.json
+++ b/src/locales/de/video.json
@@ -5,6 +5,7 @@
     "lastUsed": "Zuletzt verwendet: {{name}}",
     "loadVideo": "Video laden",
     "goproHint": "Mit einer GoPro aufgenommen? Wählen Sie alle Kapiteldateien auf einmal aus – sie werden als ein durchgehendes Video abgespielt.",
+    "bulkSelectHint": "Tipp: Sie können alle Ihre Dateien auf einmal auswählen – Logs und Videos zusammen – und wir ordnen die Videos automatisch zu.",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "Kapitel {{current}} von {{total}}",
     "noVideoForPortion": "Kein Video für diesen Abschnitt",

--- a/src/locales/en/video.json
+++ b/src/locales/en/video.json
@@ -4,6 +4,7 @@
     "lastUsed": "Last used: {{name}}",
     "loadVideo": "Load Video",
     "goproHint": "Recorded on a GoPro? Select all the chapter files at once — they'll play as one continuous video.",
+    "bulkSelectHint": "Tip: you can select all your files at once — logs and videos together — and we'll sort out which videos go where.",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "Chapter {{current}} of {{total}}",
     "noVideoForPortion": "No video for this portion",

--- a/src/locales/es/video.json
+++ b/src/locales/es/video.json
@@ -5,6 +5,7 @@
     "lastUsed": "Último usado: {{name}}",
     "loadVideo": "Cargar vídeo",
     "goproHint": "¿Grabaste con una GoPro? Selecciona todos los archivos de capítulos a la vez: se reproducirán como un único vídeo continuo.",
+    "bulkSelectHint": "Consejo: puedes seleccionar todos tus archivos a la vez —registros y vídeos juntos— y nosotros nos encargamos de asignar cada vídeo.",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "Capítulo {{current}} de {{total}}",
     "noVideoForPortion": "No hay vídeo para esta parte",

--- a/src/locales/fr/video.json
+++ b/src/locales/fr/video.json
@@ -5,6 +5,7 @@
     "lastUsed": "Dernière utilisée : {{name}}",
     "loadVideo": "Charger une vidéo",
     "goproHint": "Filmé avec une GoPro ? Sélectionnez tous les fichiers de chapitres à la fois : ils seront lus comme une seule vidéo continue.",
+    "bulkSelectHint": "Astuce : vous pouvez sélectionner tous vos fichiers d'un coup — journaux et vidéos ensemble — et nous nous occupons d'attribuer chaque vidéo.",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "Chapitre {{current}} sur {{total}}",
     "noVideoForPortion": "Aucune vidéo pour cette portion",

--- a/src/locales/it/video.json
+++ b/src/locales/it/video.json
@@ -5,6 +5,7 @@
     "lastUsed": "Ultimo usato: {{name}}",
     "loadVideo": "Carica video",
     "goproHint": "Registrato con una GoPro? Seleziona tutti i file dei capitoli insieme: verranno riprodotti come un unico video continuo.",
+    "bulkSelectHint": "Suggerimento: puoi selezionare tutti i tuoi file in una volta — log e video insieme — e penseremo noi ad assegnare i video.",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "Capitolo {{current}} di {{total}}",
     "noVideoForPortion": "Nessun video per questa parte",

--- a/src/locales/ja/video.json
+++ b/src/locales/ja/video.json
@@ -5,6 +5,7 @@
     "lastUsed": "前回使用：{{name}}",
     "loadVideo": "動画を読み込む",
     "goproHint": "GoProで撮影しましたか？すべてのチャプターファイルをまとめて選択すると、1本の連続した動画として再生されます。",
+    "bulkSelectHint": "ヒント：すべてのファイルを一度にまとめて選択できます。ログと動画を一緒に選べば、どの動画をどこに割り当てるかは自動で処理します。",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "チャプター {{current}} / {{total}}",
     "noVideoForPortion": "この区間の動画はありません",

--- a/src/locales/pt-BR/video.json
+++ b/src/locales/pt-BR/video.json
@@ -5,6 +5,7 @@
     "lastUsed": "Último usado: {{name}}",
     "loadVideo": "Carregar vídeo",
     "goproHint": "Gravou em uma GoPro? Selecione todos os arquivos de capítulos de uma vez — eles serão reproduzidos como um único vídeo contínuo.",
+    "bulkSelectHint": "Dica: você pode selecionar todos os seus arquivos de uma vez — registros e vídeos juntos — e nós cuidamos de organizar os vídeos.",
     "chapterShort": "{{current}}/{{total}}",
     "chapterOf": "Capítulo {{current}} de {{total}}",
     "noVideoForPortion": "Sem vídeo para esta parte",


### PR DESCRIPTION
## What

Two small tweaks to the **"no video loaded"** panel:

1. **Padding fix.** The panel had no horizontal padding, so the "Recorded on a GoPro?" hint clipped against the panel edges on narrow screens. Added `px-6` + centered, `max-w-xs` hint text so it wraps cleanly.
2. **New bulk-select tip.** Added a second hint letting users know they can just select **all** their files at once — logs and videos together — and the app sorts out which videos go where.

## How

- `VideoPlayer.tsx` empty-state container: `px-6 text-center`, hints constrained to `max-w-xs`.
- New `player.bulkSelectHint` i18n key in `en/video.json`, seeded across all locales (es, fr, de, it, pt-BR, ja). The seeder needs an API key (not available here), so translations were added by hand into the existing `_machine` files.

## Checks

`bun run lint`, `bun run typecheck`, `bun run test:run` (1850 pass), and `bun run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XDUKzbAYqG4CJCjdDvFeg)_