### PR TITLE
Prepare frontend to serve the Tauri/Android shell (Google Play compliance)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,10 @@ VITE_ENABLE_ADMIN="true"
 # Optional: Cloudflare Turnstile site key for the public contact form.
 # Leave empty to skip CAPTCHA.
 VITE_TURNSTILE_SITE_KEY=""
+
+# Set to "true" ONLY for the native (Tauri/Android) shell build. Skips the
+# service worker, hides in-app purchases (paid plans are web-only — Google Play
+# billing policy), and routes external links through the system browser. The web
+# app must leave this unset/"false". See docs/android.md and src/lib/platform.ts.
+# VITE_IS_NATIVE="true"
+# HTT_IS_NATIVE="true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [2.8.0] - unreleased
+
+### Added
+- **Android app groundwork.** The same frontend can now also serve a native
+  Android app (built with Tauri in a separate repo) while the web app is
+  unchanged. A new platform layer (`isNativeApp()`) gates native-only behaviour:
+  the service worker is skipped inside the native WebView, external links open in
+  the system browser, and — to comply with Google Play's billing policy — paid
+  plans are not sold or managed in-app (cloud **sync still works**; subscriptions
+  are purchased and managed on the web). Set `VITE_IS_NATIVE=true` for the native
+  build. See `docs/android.md`.
+- **Public account-deletion page.** A no-login page at **/delete-account** lets
+  you request permanent deletion of your cloud account from the web (Google Play
+  requires a public deletion URL), in addition to the existing in-app flow under
+  Profile → Data & privacy.
+
+### Changed
+- **Privacy Policy & Terms** now describe the Android app's web-only billing, the
+  public deletion URL, and the app's foreground-only location use.
+
 ## [2.7.1] - 2026-06-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,12 @@ unless noted.
 - **Cloud sync, subscriptions, GDPR**: Supabase-backed, touch nothing in the core
   app per Rule 1 → `docs/backend.md`. Documents, logs, and lap snapshots draw from
   **one pooled per-tier byte budget** (`subscription_tiers.total_bytes`).
+- **Android / Tauri shell** (`lib/platform.ts`): the same bundle serves the web app
+  and a native Android app (separate Tauri repo). `isNativeApp()` is the single
+  gate — on native: **no service worker** (`main.tsx`), **no in-app purchases**
+  (paid plans are web-only per Google Play policy; cloud sync still works), and
+  external links open in the system browser (`openExternal`/`interceptExternal`).
+  Public deletion URL at `/delete-account`. → `docs/android.md`.
 
 ---
 
@@ -360,6 +366,7 @@ and the seeder: **→ `docs/i18n.md`**.
 | `VITE_ENABLE_ADMIN` | Client | `"true"` enables admin UI + `/admin`. `/login` is mounted when this OR `VITE_ENABLE_CLOUD` is on. |
 | `VITE_ENABLE_CLOUD` | Client | `"true"` enables public accounts (Cloud Sync + email sign-in + `/register` etc.). Default `"false"`. |
 | `VITE_ENABLE_GOOGLE_AUTH` | Client | `"true"` shows "Continue with Google". Requires `VITE_ENABLE_CLOUD`. Default `"false"`. |
+| `VITE_IS_NATIVE` | Client/Build | `"true"` ONLY for the native (Tauri/Android) shell build. Gates `isNativeApp()` (`lib/platform.ts`): no service worker, no in-app purchases (web-only billing — Google Play policy), external links via the system browser. Default `"false"`. → `docs/android.md`. |
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `VITE_FIRMWARE_MANIFEST_URL` | Client | Override the logger firmware OTA manifest URL. Unset: `main` → production manifest, non-`main`/preview → beta channel (same `isPreviewBuild()` switch). |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ view. Older JSON with only `sector_2_*`/`sector_3_*` is read as the two majors.
 | `VITE_ENABLE_ADMIN` | No | Set to `true` to enable admin UI and `/admin` route. `/login` mounts when admin OR cloud is enabled. Default `false` — a fresh clone ships the public, offline-first app, not admin UI pointed at an upstream backend. |
 | `VITE_ENABLE_CLOUD` | No | Set to `true` to enable public user accounts: Cloud Sync panels, email sign-in/registration, `/register`, `/forgot-password`, `/reset-password`, `/auth/callback`. Default `false` — flag-off builds ship zero cloud auth code (offline-first invariant). |
 | `VITE_ENABLE_GOOGLE_AUTH` | No | Set to `true` to show the "Continue with Google" buttons (login, register, Profile). Requires `VITE_ENABLE_CLOUD`. Default `false`: Google sign-in currently routes through Lovable's hosted OAuth broker, so it stays hidden until native Supabase Google OAuth is configured (Google Cloud OAuth client + Supabase provider). |
+| `VITE_IS_NATIVE` | No | Set to `true` **only** for the native (Tauri/Android) shell build. Skips the service worker, hides in-app purchases (paid plans are web-only — Google Play billing policy; cloud sync still works), and opens external links in the system browser. The web app leaves this unset/`false`. See [`docs/android.md`](docs/android.md). |
 | `VITE_TURNSTILE_SITE_KEY` | No | Cloudflare Turnstile site key for track submission CAPTCHA |
 | `VITE_FIRMWARE_MANIFEST_URL` | No | Override the DovesDataLogger firmware OTA manifest URL used by the in-app firmware updater. When unset: `main` builds use the production manifest (`https://theangryraven.github.io/DovesDataLogger/manifest.json`); non-`main`/preview builds use the **beta channel** (`https://theangryraven.github.io/DovesDataLogger/beta/manifest.json`). Set this to force a specific channel on any branch. |
 | `TURNSTILE_SECRET_KEY` | No | Cloudflare Turnstile secret key (edge function secret — `???`) |
@@ -454,6 +455,16 @@ whenever that branch isn't `main`, and ignores them on `main` and in local dev.
    Any key works the same way (e.g. `HTT_ENABLE_CLOUD_PREVIEW`). `VITE_*_PREVIEW`
    is also accepted. Add the Cloudflare preview URL to the preview branch's
    **Auth → Redirect URLs** so cloud sign-in works there.
+
+### Android app (Tauri)
+
+The same frontend also serves a native **Android** app built with Tauri (in a
+separate repo) — the web app is unchanged. Build the bundle with
+`VITE_IS_NATIVE=true` and the app skips the service worker, hides in-app purchases
+(paid plans stay web-only per Google Play's billing policy; cloud sync still
+works), and opens external links in the system browser. See
+[`docs/android.md`](docs/android.md) for the platform layer, the native bridge
+contract, the Data Safety form, and the Android permission set.
 
 ---
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -1,0 +1,104 @@
+# Android / Tauri shell
+
+The same frontend bundle serves the web app **and** a native Android app built
+with [Tauri](https://tauri.app) (a separate repo wraps this build). This doc
+covers what lives **in this repo** to support that, plus the Google Play
+artifacts (Data Safety form, permission set) the Tauri repo's manifest must
+match. The Tauri repo owns the Android manifest, permissions, CSP allowlist,
+signing, and the native bridge implementation.
+
+## How web-vs-native is decided
+
+`src/lib/platform.ts` is the single source of truth:
+
+- `isNativeBuild()` — the build flag `VITE_IS_NATIVE === "true"` (set by the
+  Tauri build; defaults `"false"`, wired in `vite.config.ts` like the other
+  flags). Deterministic and available at import time.
+- `isTauri()` — runtime check for Tauri's injected globals (`__TAURI_INTERNALS__`
+  v2 / `__TAURI__` v1).
+- `isNativeApp()` = `isNativeBuild() || isTauri()` — **the** predicate everything
+  branches on. The flag is primary because some decisions (service-worker
+  registration in `main.tsx`) run before Tauri injects its globals.
+
+To build the native variant: invoke Vite with `VITE_IS_NATIVE=true` (or the
+Lovable-secret parallel `HTT_IS_NATIVE=true`).
+
+## What changes on native
+
+- **No service worker.** `main.tsx` routes native through the existing
+  `cleanupPreviewServiceWorkers()` path (the shell serves its own packaged
+  assets; a stray SW would only fight it). A Tauri WebView is a *top-level*
+  window, so the prior iframe/preview gate didn't catch it.
+- **No in-app purchases.** Paid cloud-storage plans are bought and managed on the
+  web only (Google Play forbids non-Play billing for in-app digital goods). Cloud
+  **sync stays available** — a user who subscribed on the web keeps their tier in
+  the app. Gating: `pricingCta(... native)` returns no CTA (`src/lib/billing.ts`),
+  paid cards/CTAs are hidden in `PricingCards.tsx`, the plan picker is hidden in
+  `Register.tsx`/`PlanCheckout.tsx`, `PendingCheckoutRedirect` is disabled, the
+  Stripe portal buttons are hidden in `StoragePanel.tsx` (the plan still shows,
+  read-only), and `createCheckout`/`createPortal` throw as a backstop
+  (`billingClient.ts`).
+- **External links** open in the system browser via the native bridge
+  (`openExternal` / `interceptExternal` in `platform.ts`), not the app WebView.
+
+## Native bridge contract
+
+The Tauri repo wires a single global the frontend calls:
+
+```ts
+window.__HTT_NATIVE__ = {
+  // Open a URL in the device's default browser, outside the app WebView.
+  openExternal(url: string): void | Promise<void>;
+};
+```
+
+If the bridge is absent, `openExternal` falls back to `window.open(..., "_blank")`.
+The TypeScript contract is `NativeBridge` in `src/lib/platform.ts`.
+
+## Account deletion (Google Play requirement)
+
+Play requires a publicly reachable account-deletion URL in addition to the in-app
+flow. This repo serves `/delete-account` (`src/pages/DeleteAccount.tsx`), mounted
+**un-gated** in `App.tsx` so the URL resolves on every build. It signs the user in
+(the deletion edge function derives the account from the session), then reuses the
+emailed-code flow in `src/plugins/cloud-sync/accountDeletion.ts`. List
+`https://hackthetrack.net/delete-account` in the Play Console as the deletion URL.
+
+The in-app path remains **Profile → Data & privacy** (`DataPrivacyPanel.tsx`).
+
+## Google Play Data Safety form
+
+Mirror `src/pages/Privacy.tsx`. Summary of what the hosted service collects when a
+user opts into cloud features (the offline app collects nothing off-device):
+
+| Data type | Collected? | Purpose | Notes |
+|-----------|-----------|---------|-------|
+| Email address | Yes (account) | Account management | Required only to create an account |
+| Name (display name) | Yes (account) | Account/app functionality | User-chosen or auto-generated |
+| Precise location | Yes, only if the user syncs a session | App functionality | GPS traces inside telemetry logs the user chooses to sync; **foreground-only** capture |
+| App activity / other content | Yes (account) | App functionality (sync) | Garage data, notes, setups, lap snapshots |
+| Payment info | No (not collected by us) | — | Stripe handles card data on the **web**; no purchases in the Android app |
+
+- **Encrypted in transit:** yes.
+- **User can request deletion:** yes — in-app and at `/delete-account`.
+- **Data shared with third parties / advertisers:** no. Sub-processors (Supabase,
+  Stripe [web only], optional Google sign-in, Cloudflare Turnstile, the AI
+  provider) process data on our behalf; nothing is sold or used for ads.
+
+## Android permissions (declared in the Tauri repo manifest)
+
+| Permission | Why |
+|-----------|-----|
+| `INTERNET` | Optional online features: cloud sync, weather, map/satellite tiles, firmware OTA |
+| `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION` | GPS lap timing / phone-as-datalogger and current-location convenience |
+| `BLUETOOTH_SCAN` + `BLUETOOTH_CONNECT` | Connect to a Dove's Data Logger over BLE (download laps, settings, firmware OTA) |
+| `WAKE_LOCK` | Keep the screen awake during a recording session (`src/lib/wakeLock.ts`) |
+
+**Location is foreground-only** — no `ACCESS_BACKGROUND_LOCATION`, no foreground
+service. GPS is captured only while the app is open and actively timing/logging,
+which keeps the Play review simple (no background-location declaration). If
+background logging is ever added, it requires `ACCESS_BACKGROUND_LOCATION`, a
+persistent foreground-service notification, and extra Play Console justification.
+
+No camera/microphone permission: video export reuses files the user imports; audio
+is read from the source video, never the mic.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
 import i18n from "@/lib/i18n";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { isNativeApp } from "@/lib/platform";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 
@@ -25,6 +26,9 @@ const Admin = lazy(() => import("./pages/Admin"));
 const Register = lazy(() => import("./pages/Register"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const Terms = lazy(() => import("./pages/Terms"));
+// Public, no-login account-deletion request page. Mounted un-gated (below) so the
+// URL Google Play requires resolves on every build, even offline-only ones.
+const DeleteAccount = lazy(() => import("./pages/DeleteAccount"));
 const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const AuthCallback = lazy(() => import("./pages/AuthCallback"));
@@ -60,11 +64,14 @@ const App = () => {
         <DebugConsole />
         <BrowserRouter>
           <Suspense fallback={null}>
-            {enableCloud && <PendingCheckoutRedirect />}
+            {enableCloud && !isNativeApp() && <PendingCheckoutRedirect />}
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/terms" element={<Terms />} />
+              {/* Un-gated: Google Play requires a publicly reachable account-deletion
+                  URL. The page itself adapts when cloud accounts are disabled. */}
+              <Route path="/delete-account" element={<DeleteAccount />} />
               {(enableAdmin || enableCloud) && <Route path="/login" element={<Login />} />}
               {enableAdmin && <Route path="/admin" element={<Admin />} />}
               {enableCloud && <Route path="/register" element={<Register />} />}

--- a/src/components/ActionTile.tsx
+++ b/src/components/ActionTile.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { interceptExternal } from "@/lib/platform";
 
 interface ActionTileProps {
   icon: LucideIcon;
@@ -77,6 +78,7 @@ export function ActionTile({
         rel="noopener noreferrer"
         className={classes}
         title={hint}
+        onClick={(e) => interceptExternal(e, href)}
       >
         {content}
       </a>

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
+import { interceptExternal } from "@/lib/platform";
 
 const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
   ["React", "https://react.dev"],
@@ -59,6 +60,7 @@ export function CreditsDialog() {
               href={url}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => interceptExternal(e, url)}
               className="flex items-center justify-between px-3 py-2 rounded-md hover:bg-accent transition-colors text-sm"
             >
               <span className="font-medium text-foreground">{name}</span>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -30,6 +30,7 @@ import { PluginMount } from "@/plugins/PluginMount";
 import { MountSlot } from "@/plugins/mounts";
 import { useAuth } from "@/contexts/AuthContext";
 import { buildInfo, formatBuildLabel, commitUrl, isPreviewBuild } from "@/lib/buildInfo";
+import { interceptExternal } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { ParsedData } from "@/types/racing";
 
@@ -127,6 +128,7 @@ export function LandingPage({
               href="https://github.com/sponsors/TheAngryRaven"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => interceptExternal(e, "https://github.com/sponsors/TheAngryRaven")}
             >
               <Button variant="outline" size="sm" className="gap-2">
                 <Heart className="w-4 h-4 text-pink-500" />
@@ -282,6 +284,7 @@ export function LandingPage({
                 href={link.href}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={(e) => interceptExternal(e, link.href)}
                 className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
               >
                 <Github className="w-4 h-4" />
@@ -325,6 +328,7 @@ export function LandingPage({
             href="https://PerchWerks.com"
             target="_blank"
             rel="noopener noreferrer"
+            onClick={(e) => interceptExternal(e, "https://PerchWerks.com")}
             className="font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
           >
             PerchWerks LLC
@@ -342,6 +346,7 @@ export function LandingPage({
               href={commitUrl()!}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => interceptExternal(e, commitUrl()!)}
               className={cn(
                 "underline-offset-4 transition-colors hover:underline",
                 isPreviewBuild() ? "hover:text-warning/80" : "hover:text-muted-foreground",

--- a/src/components/PendingCheckoutRedirect.tsx
+++ b/src/components/PendingCheckoutRedirect.tsx
@@ -6,6 +6,7 @@ import { useSubscription } from "@/hooks/useSubscription";
 import { isPaidTier } from "@/lib/billing";
 import { createCheckout } from "@/lib/billingClient";
 import { clearPendingCheckout, getPendingCheckout } from "@/lib/pendingCheckout";
+import { isNativeApp } from "@/lib/platform";
 
 /**
  * Resumes a paid plan chosen at sign-up. Sign-up creates the account first
@@ -22,6 +23,9 @@ export function PendingCheckoutRedirect() {
 
   useEffect(() => {
     if (started.current) return;
+    // Never resume a web checkout inside the native app (Google Play billing
+    // policy). A plan stashed on the web stays dormant here.
+    if (isNativeApp()) return;
     if (authLoading || subLoading || !user || !online) return;
     if (currentTier !== "free") {
       // Already on a paid tier — the intent (if any) is satisfied; drop it.

--- a/src/components/PlanCheckout.tsx
+++ b/src/components/PlanCheckout.tsx
@@ -20,6 +20,7 @@ import {
   TIER_DISPLAY_LABEL,
   TIER_STORAGE_LABEL,
 } from "@/lib/billing";
+import { isNativeApp } from "@/lib/platform";
 
 export interface PlanSelection {
   tier: string;
@@ -51,6 +52,8 @@ export function PlanCheckout({
   config: StripeConfig;
 }) {
   const { t } = useTranslation("auth");
+  // No in-app plan picker on native — paid plans are bought on the web.
+  if (isNativeApp()) return null;
   if (!paidTiersVisible(config)) return null;
   const tiers = selectableTiers(config);
   if (tiers.length <= 1) return null; // only "free" — nothing to choose
@@ -117,6 +120,7 @@ export function PlanCheckoutSummary({
   config: StripeConfig;
 }) {
   const { t } = useTranslation("auth");
+  if (isNativeApp()) return null;
   if (!paidTiersVisible(config)) return null;
 
   if (value.tier === "free") {

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -15,6 +15,7 @@ import {
   pricingCta,
   tiersWithPrices,
 } from "@/lib/billing";
+import { isNativeApp } from "@/lib/platform";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -169,7 +170,10 @@ export function PricingCards({ className, variant = "home" }: { className?: stri
   const [busy, setBusy] = useState<string | null>(null);
 
   const signedIn = !!user;
-  const showPaid = paidTiersVisible(config);
+  // The native (Android) app sells nothing in-app (Google Play billing policy):
+  // hide the paid cards and every CTA — the offline/free cards stay informational.
+  const native = isNativeApp();
+  const showPaid = paidTiersVisible(config) && !native;
   const purchasable = tiersWithPrices(config.prices);
   // The cards' interval: the toggle on home, fixed monthly on sign-up.
   const cardInterval: BillingInterval = variant === "register" ? "monthly" : interval;
@@ -239,6 +243,7 @@ export function PricingCards({ className, variant = "home" }: { className?: stri
       cloudEnabled: enableCloud,
       currentTier,
       purchasable: purchasable.has(slug),
+      native,
     });
     if (kind === "current") {
       return (

--- a/src/components/SupportedFilesDialog.tsx
+++ b/src/components/SupportedFilesDialog.tsx
@@ -4,6 +4,10 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
+import { interceptExternal } from "@/lib/platform";
+
+const LOGGER_URL = "https://github.com/TheAngryRaven/DovesDataLogger";
+const LIBXRK_URL = "https://github.com/m3rlin45/libxrk";
 
 // Format ids in display order; their name/body text lives in the `landing`
 // locale (supportedFiles.primary.<id> / .secondary.<id>). Format names,
@@ -17,10 +21,10 @@ const EXPERIMENTAL = new Set(["motecLd", "motecCsv", "alfano", "aimCsv"]);
 const FORMAT_COMPONENTS = {
   code: <code className="text-primary" />,
   logger: (
-    <a href="https://github.com/TheAngryRaven/DovesDataLogger" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline" />
+    <a href={LOGGER_URL} target="_blank" rel="noopener noreferrer" onClick={(e) => interceptExternal(e, LOGGER_URL)} className="text-primary hover:underline" />
   ),
   libxrk: (
-    <a href="https://github.com/m3rlin45/libxrk" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline" />
+    <a href={LIBXRK_URL} target="_blank" rel="noopener noreferrer" onClick={(e) => interceptExternal(e, LIBXRK_URL)} className="text-primary hover:underline" />
   ),
 };
 

--- a/src/lib/billing.test.ts
+++ b/src/lib/billing.test.ts
@@ -150,6 +150,12 @@ describe("pricingCta", () => {
   it("still keeps an unconfigured paid tier non-actionable even when on a paid tier", () => {
     expect(pricingCta({ ...base, slug: "pro", currentTier: "plus", purchasable: false })).toBe("none");
   });
+
+  it("shows no CTA on native (Android) — purchases are web-only, even for would-be upgrades/current", () => {
+    expect(pricingCta({ ...base, slug: "plus", currentTier: "free", purchasable: true, native: true })).toBe("none");
+    expect(pricingCta({ ...base, slug: "plus", currentTier: "plus", purchasable: true, native: true })).toBe("none");
+    expect(pricingCta({ ...base, slug: "premium", currentTier: "plus", purchasable: true, native: true })).toBe("none");
+  });
 });
 
 describe("lookupKey", () => {

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -215,6 +215,11 @@ export interface PricingCtaInput {
   currentTier: string;
   /** Whether this tier has a Stripe Price configured (purchasable). */
   purchasable: boolean;
+  /**
+   * True on the native (Android) app, where nothing is sold in-app — billing is
+   * web-only to stay within Google Play's policy. Suppresses every CTA.
+   */
+  native?: boolean;
 }
 
 /**
@@ -225,6 +230,9 @@ export interface PricingCtaInput {
  * new Checkout Session.
  */
 export function pricingCta(i: PricingCtaInput): PricingCtaKind {
+  // The native (Android) app sells nothing in-app — paid plans are purchased and
+  // managed on the web (Google Play billing policy). Render no CTA at all.
+  if (i.native) return "none";
   if (!i.slug || !i.cloudEnabled || !i.signedIn) return "none";
   if (i.slug === i.currentTier) return "current";
   if (i.slug === "free") return "none";

--- a/src/lib/billingClient.ts
+++ b/src/lib/billingClient.ts
@@ -9,6 +9,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { isNativeApp } from "@/lib/platform";
 import type {
   BillingInterval,
   StripeConfig,
@@ -57,6 +58,10 @@ export async function createCheckout(
   interval: BillingInterval,
   returnUrl: string,
 ): Promise<string> {
+  // Belt-and-suspenders: the native (Android) app hides every purchase surface,
+  // so this should never be reached there — but never start a web checkout from
+  // inside the app (Google Play billing policy). Plans are bought on the web.
+  if (isNativeApp()) throw new Error("Purchases are managed on the web.");
   const { data, error } = await supabase.functions.invoke("create-checkout-session", {
     body: { tier, interval, returnUrl },
   });
@@ -76,6 +81,9 @@ export async function createPortal(
   returnUrl: string,
   flow?: "update",
 ): Promise<string> {
+  // As with checkout: the billing portal is a web-only surface (subscriptions
+  // are managed on the web), never opened from inside the native app.
+  if (isNativeApp()) throw new Error("Subscriptions are managed on the web.");
   const { data, error } = await supabase.functions.invoke("create-portal-session", {
     body: { returnUrl, ...(flow ? { flow } : {}) },
   });

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isTauri,
+  isNativeBuild,
+  isNativeApp,
+  openExternal,
+  interceptExternal,
+  type NativeBridge,
+} from "./platform";
+
+// A minimal stand-in for `window`; only the bits each helper touches are set.
+const fakeWindow = (over: Partial<Window> = {}): Window => over as unknown as Window;
+
+describe("isTauri", () => {
+  it("is true when the Tauri v2 global is present", () => {
+    expect(isTauri(fakeWindow({ __TAURI_INTERNALS__: {} }))).toBe(true);
+  });
+  it("is true when the legacy v1 global is present", () => {
+    expect(isTauri(fakeWindow({ __TAURI__: {} }))).toBe(true);
+  });
+  it("is false without either global, or with no window", () => {
+    expect(isTauri(fakeWindow())).toBe(false);
+    expect(isTauri(undefined)).toBe(false);
+  });
+});
+
+describe("isNativeBuild", () => {
+  it("is true only when VITE_IS_NATIVE is the string 'true'", () => {
+    expect(isNativeBuild({ VITE_IS_NATIVE: "true" })).toBe(true);
+    expect(isNativeBuild({ VITE_IS_NATIVE: "false" })).toBe(false);
+    expect(isNativeBuild({})).toBe(false);
+  });
+});
+
+describe("isNativeApp", () => {
+  it("is true for a native build regardless of the runtime", () => {
+    expect(isNativeApp({ VITE_IS_NATIVE: "true" }, fakeWindow())).toBe(true);
+  });
+  it("is true for a Tauri runtime regardless of the build flag", () => {
+    expect(isNativeApp({ VITE_IS_NATIVE: "false" }, fakeWindow({ __TAURI_INTERNALS__: {} }))).toBe(true);
+  });
+  it("is false on the plain web (no flag, no runtime)", () => {
+    expect(isNativeApp({ VITE_IS_NATIVE: "false" }, fakeWindow())).toBe(false);
+  });
+});
+
+describe("openExternal", () => {
+  it("opens a new tab on the web", () => {
+    const open = vi.fn();
+    openExternal("https://example.com", fakeWindow({ open }));
+    expect(open).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+  });
+
+  it("routes through the native bridge inside a Tauri runtime", () => {
+    const bridge: NativeBridge = { openExternal: vi.fn() };
+    const open = vi.fn();
+    openExternal("https://example.com", fakeWindow({ __TAURI_INTERNALS__: {}, __HTT_NATIVE__: bridge, open }));
+    expect(bridge.openExternal).toHaveBeenCalledWith("https://example.com");
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a new tab on native when no bridge is wired up", () => {
+    const open = vi.fn();
+    openExternal("https://example.com", fakeWindow({ __TAURI_INTERNALS__: {}, open }));
+    expect(open).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+  });
+});
+
+describe("interceptExternal", () => {
+  it("cancels the anchor and routes to the bridge on native", () => {
+    const bridge: NativeBridge = { openExternal: vi.fn() };
+    const preventDefault = vi.fn();
+    interceptExternal({ preventDefault }, "https://example.com", fakeWindow({ __TAURI_INTERNALS__: {}, __HTT_NATIVE__: bridge }));
+    expect(preventDefault).toHaveBeenCalled();
+    expect(bridge.openExternal).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("is a no-op on the web (lets the anchor open a new tab itself)", () => {
+    const preventDefault = vi.fn();
+    interceptExternal({ preventDefault }, "https://example.com", fakeWindow());
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,88 @@
+// Platform detection + the native-shell bridge.
+//
+// One frontend bundle serves both the web app and the Tauri/Android shell. A
+// handful of behaviours must branch on which one is running:
+//   - the service worker must NOT register inside the native WebView (the shell
+//     serves packaged assets; a stray SW would fight it — see main.tsx),
+//   - in-app purchases are disabled on native — paid plans are bought and
+//     managed on the web, to stay within Google Play's billing policy, and
+//   - external links open in the system browser, not the app WebView.
+// `isNativeApp()` is the single predicate the rest of the app gates on.
+//
+// Detection OR's two signals: a deterministic build flag (VITE_IS_NATIVE, set by
+// the Tauri build) and a runtime check for Tauri's injected globals. The flag is
+// primary because some decisions run at import time (the SW gate in main.tsx),
+// before the Tauri runtime injects its globals.
+
+/** The contract the native shell (the Tauri repo) wires onto `window`. */
+export interface NativeBridge {
+  /** Open a URL in the device's default browser, outside the app WebView. */
+  openExternal(url: string): void | Promise<void>;
+}
+
+declare global {
+  interface Window {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+    __HTT_NATIVE__?: NativeBridge;
+  }
+}
+
+const currentWindow = (): Window | undefined => (typeof window !== "undefined" ? window : undefined);
+
+/**
+ * True when running inside a Tauri WebView. Tauri v2 injects
+ * `__TAURI_INTERNALS__`; v1 used `__TAURI__` — we accept either.
+ */
+export function isTauri(w: Window | undefined = currentWindow()): boolean {
+  return !!w && ("__TAURI_INTERNALS__" in w || "__TAURI__" in w);
+}
+
+/** True for a bundle built for the native shell (VITE_IS_NATIVE === "true"). */
+export function isNativeBuild(env: { VITE_IS_NATIVE?: string } = import.meta.env): boolean {
+  return env.VITE_IS_NATIVE === "true";
+}
+
+/**
+ * The single gate for native-only behaviour: a native build OR a live Tauri
+ * runtime. Everything that must differ between web and the Android app branches
+ * on this.
+ */
+export function isNativeApp(
+  env: { VITE_IS_NATIVE?: string } = import.meta.env,
+  w: Window | undefined = currentWindow(),
+): boolean {
+  return isNativeBuild(env) || isTauri(w);
+}
+
+/**
+ * Open a URL outside the app shell. On native, hand it to the shell's bridge so
+ * it lands in the system browser (a WebView would otherwise navigate the app
+ * away); on web, open a new tab. Falls back to a new tab if the native bridge
+ * isn't wired up.
+ */
+export function openExternal(url: string, w: Window | undefined = currentWindow()): void {
+  if (!w) return;
+  const bridge = w.__HTT_NATIVE__;
+  if (bridge && isNativeApp(import.meta.env, w)) {
+    void bridge.openExternal(url);
+    return;
+  }
+  w.open(url, "_blank", "noopener,noreferrer");
+}
+
+/**
+ * onClick handler for an external `<a target="_blank">`: on native, cancel the
+ * in-WebView navigation and route the URL to the system browser instead. On web
+ * it's a no-op — the anchor's default opens a new tab. Framework-agnostic (takes
+ * only the part of the event it needs) so this module stays React-free.
+ */
+export function interceptExternal(
+  e: { preventDefault(): void },
+  url: string,
+  w: Window | undefined = currentWindow(),
+): void {
+  if (!isNativeApp(import.meta.env, w)) return;
+  e.preventDefault();
+  openExternal(url, w);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { toast } from "@/components/ui/sonner";
 import { registerSW } from "virtual:pwa-register";
 import { initPlugins } from "@/plugins";
 import { initDebugConsole } from "@/lib/debugConsole";
+import { isNativeApp } from "@/lib/platform";
 // Initialize i18next before render so the chosen language is active on first
 // paint (no English flash). The default export is the configured instance.
 import i18n from "@/lib/i18n";
@@ -53,7 +54,11 @@ const cleanupPreviewServiceWorkers = async () => {
   await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
 };
 
-if (isInIframe || isPreviewHost) {
+// The native (Tauri/Android) shell is a top-level window — not an iframe — so it
+// slips past the checks above. It serves its own packaged assets, so a service
+// worker has nothing useful to do and would only fight the shell's caching;
+// route native through the same cleanup path as preview hosts.
+if (isInIframe || isPreviewHost || isNativeApp()) {
   void cleanupPreviewServiceWorkers();
 } else {
   const updateSW = registerSW({

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -1,0 +1,291 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertTriangle, ArrowLeft, Loader2, ShieldX, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import { useDocumentHead } from "@/hooks/useDocumentHead";
+import {
+  cancelAccountDeletion,
+  getPendingDeletion,
+  scheduleAccountDeletion,
+  sendDeletionCode,
+  type PendingDeletion,
+} from "@/plugins/cloud-sync/accountDeletion";
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+// Public, no-app-shell page that lets someone request deletion of their cloud
+// account — the web URL Google Play requires alongside the in-app flow. It signs
+// the user in first (the deletion edge function derives the account from the
+// session), then reuses the same emailed-code flow as the in-app panel. The page
+// is English-only by design, like the Privacy and Terms pages it sits beside.
+//
+// The page is mounted un-gated in App.tsx so the published URL always resolves;
+// when the build has no cloud accounts it shows an explanatory note instead.
+export default function DeleteAccount() {
+  useDocumentHead({
+    title: "Delete your account — HackTheTrack",
+    description: "Request permanent deletion of your HackTheTrack cloud account and all associated data.",
+    canonical: "https://hackthetrack.net/delete-account",
+  });
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-2xl mx-auto">
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        <span className="text-sm">Back to app</span>
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">Delete your account</h1>
+
+      <div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
+        <p>
+          Deleting your account permanently removes your cloud data — synced
+          session logs, garage data (vehicles, setups, notes), lap snapshots, your
+          profile, and any subscription record. Data stored only on your device is
+          not affected and can be cleared separately from your browser.
+        </p>
+        <p>
+          To protect you against someone else using a stolen session, deletion is
+          confirmed with a one-time code emailed to your account address, then
+          scheduled <strong className="text-foreground">7 days</strong> out. You
+          can cancel any time before then; after that, the data is permanently
+          erased.
+        </p>
+        <p>
+          If you are signed in on a device, you can also do this from{" "}
+          <strong className="text-foreground">Profile → Data &amp; privacy</strong>{" "}
+          inside the app.
+        </p>
+
+        {enableCloud ? <DeletionFlow /> : <CloudDisabledNote />}
+      </div>
+    </div>
+  );
+}
+
+function CloudDisabledNote() {
+  return (
+    <div className="rounded-md border border-border bg-card p-4 text-sm">
+      <p>
+        This build of the app doesn’t include cloud accounts, so there is nothing
+        to delete here. Account deletion applies to the hosted service at{" "}
+        <strong className="text-foreground">hackthetrack.net</strong>. Data created
+        in this app lives only in your browser and can be removed by clearing this
+        site’s data.
+      </p>
+    </div>
+  );
+}
+
+// Signs the visitor in (required by the deletion edge function), then runs the
+// emailed-code deletion flow.
+function DeletionFlow() {
+  const { user, login, logout } = useAuth();
+  const online = useOnlineStatus();
+  const [pending, setPending] = useState<PendingDeletion | null>(null);
+
+  const refreshPending = useCallback(async () => {
+    if (!user) return setPending(null);
+    try {
+      setPending(await getPendingDeletion(user.id));
+    } catch {
+      /* non-fatal: leave as-is */
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refreshPending();
+  }, [refreshPending]);
+
+  if (!user) return <SignIn login={login} online={online} />;
+
+  return (
+    <div className="space-y-4 rounded-md border border-border bg-card p-4">
+      <p className="text-xs">
+        Signed in as <strong className="text-foreground">{user.email}</strong>.{" "}
+        <button onClick={() => void logout()} className="underline hover:no-underline">
+          Sign out
+        </button>
+      </p>
+      {pending ? (
+        <PendingNotice pending={pending} userId={user.id} online={online} onChange={refreshPending} />
+      ) : (
+        <DeleteSteps email={user.email ?? ""} online={online} onScheduled={refreshPending} />
+      )}
+    </div>
+  );
+}
+
+function SignIn({
+  login,
+  online,
+}: {
+  login: (email: string, password: string) => Promise<{ error: Error | null }>;
+  online: boolean;
+}) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    const { error } = await login(email, password);
+    setBusy(false);
+    if (error) toast.error(error.message || "Sign-in failed.");
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-3 rounded-md border border-border bg-card p-4">
+      <p className="text-xs text-muted-foreground">Sign in to confirm it’s your account.</p>
+      <div className="space-y-1.5">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="password">Password</Label>
+        <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+      </div>
+      <Button type="submit" disabled={busy || !online}>
+        {busy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+        Sign in
+      </Button>
+      {!online && <p className="text-xs text-muted-foreground">You’re offline — reconnect to continue.</p>}
+    </form>
+  );
+}
+
+function PendingNotice({
+  pending,
+  userId,
+  online,
+  onChange,
+}: {
+  pending: PendingDeletion;
+  userId: string;
+  online: boolean;
+  onChange: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const when = new Date(pending.scheduled_for).toLocaleString();
+
+  const cancel = async () => {
+    setBusy(true);
+    try {
+      await cancelAccountDeletion(userId);
+      toast.success("Deletion cancelled.");
+      await onChange();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn’t cancel deletion.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/10 p-3">
+      <div className="flex items-start gap-2 text-sm text-destructive">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>
+          Your account is scheduled for deletion on <strong>{when}</strong>. Cancel
+          before then to keep it.
+        </span>
+      </div>
+      <Button variant="outline" size="sm" disabled={busy || !online} onClick={() => void cancel()}>
+        {busy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+        Cancel deletion
+      </Button>
+    </div>
+  );
+}
+
+type Step = "idle" | "code" | "working";
+
+function DeleteSteps({
+  email,
+  online,
+  onScheduled,
+}: {
+  email: string;
+  online: boolean;
+  onScheduled: () => Promise<void>;
+}) {
+  const [step, setStep] = useState<Step>("idle");
+  const [code, setCode] = useState("");
+
+  const startCode = async () => {
+    setStep("working");
+    try {
+      await sendDeletionCode(email);
+      toast.success(`We emailed a code to ${email}.`);
+      setStep("code");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn’t send the code.");
+      setStep("idle");
+    }
+  };
+
+  const confirm = async () => {
+    setStep("working");
+    try {
+      // The edge function verifies the code server-side, so pass it straight
+      // through rather than consuming it with a client-side verify first.
+      const result = await scheduleAccountDeletion(code);
+      toast.success(`Deletion scheduled for ${new Date(result.scheduled_for).toLocaleDateString()}.`);
+      setCode("");
+      setStep("idle");
+      await onScheduled();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "That code didn’t work.");
+      setStep("code");
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {step === "idle" && (
+        <Button variant="destructive" size="sm" disabled={!online} onClick={() => void startCode()}>
+          <Trash2 className="mr-1.5 h-4 w-4" /> Delete my account
+        </Button>
+      )}
+
+      {step === "working" && (
+        <Button variant="destructive" size="sm" disabled>
+          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> Working…
+        </Button>
+      )}
+
+      {step === "code" && (
+        <div className="space-y-2">
+          <Input
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="Emailed code"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={10}
+            className="h-9 w-40"
+          />
+          <div className="flex gap-2">
+            <Button variant="destructive" size="sm" disabled={!code.trim() || !online} onClick={() => void confirm()}>
+              <ShieldX className="mr-1.5 h-4 w-4" /> Confirm deletion
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => { setCode(""); setStep("idle"); }}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!online && <p className="text-xs text-muted-foreground">You’re offline — reconnect to continue.</p>}
+    </div>
+  );
+}

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
+import { interceptExternal } from "@/lib/platform";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === "true";
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
@@ -132,11 +133,20 @@ const Privacy = () => {
                   href="https://stripe.com/privacy"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => interceptExternal(e, "https://stripe.com/privacy")}
                   className="text-foreground underline hover:no-underline"
                 >
                   Stripe’s Privacy Policy
                 </a>
                 .
+              </p>
+              <p className="mt-2">
+                <strong className="text-foreground">On the Android app</strong>,
+                paid plans are not sold or managed in-app: subscriptions are
+                purchased and managed on the web at{" "}
+                <strong className="text-foreground">hackthetrack.net</strong>. The
+                Android app simply uses cloud sync on whatever plan your account
+                already has.
               </p>
             </section>
 
@@ -280,7 +290,12 @@ const Privacy = () => {
                 deletion is confirmed by an emailed code and then scheduled{" "}
                 <strong className="text-foreground">7 days</strong> out — you can
                 cancel any time before then, after which all your data is
-                permanently erased.
+                permanently erased. You can also request account deletion from a
+                public page without opening the app, at{" "}
+                <Link to="/delete-account" className="text-foreground underline hover:no-underline">
+                  hackthetrack.net/delete-account
+                </Link>
+                .
               </li>
               <li>
                 <strong className="text-foreground">Objection / restriction:</strong>{" "}
@@ -349,6 +364,25 @@ const Privacy = () => {
 
         <section>
           <h2 className="text-base font-semibold text-foreground mb-2">
+            Mobile App Permissions
+          </h2>
+          <p>
+            The Android app may ask for a few device permissions, each only for a
+            specific feature:{" "}
+            <strong className="text-foreground">Location</strong> is used to record
+            GPS while you are actively timing or logging a session — it is{" "}
+            <strong className="text-foreground">foreground-only</strong> (we do not
+            collect location in the background or while the app is closed);{" "}
+            <strong className="text-foreground">Bluetooth</strong> is used to
+            connect to a Dove’s Data Logger device to download laps and update its
+            firmware; and network access is used only for the optional online
+            features described above. GPS traces stay on your device unless you
+            choose to sync a session to your account.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-semibold text-foreground mb-2">
             Self-Hosting
           </h2>
           <p>
@@ -386,7 +420,7 @@ const Privacy = () => {
       </div>
 
       <p className="mt-10 text-xs text-muted-foreground/60">
-        Last updated: May 2026
+        Last updated: June 2026
       </p>
     </div>
   );

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -8,10 +8,10 @@ const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
 // NOTE FOR THE OPERATOR: this policy adapts to the build flags. With cloud
 // features off it describes the offline-only app; with VITE_ENABLE_CLOUD on it
-// also covers accounts, payments and AI. Placeholders to confirm before relying
-// on this for the hosted service: the operating entity's legal name, a contact
-// email, and the specific AI provider used by the coaching plugin. This is a
-// drafted policy, not legal advice — have it reviewed for your jurisdiction.
+// also covers accounts, payments and AI. The official hosted service is operated
+// by PERCHWERKS LLC (Windermere, Florida, USA); AI coaching uses Anthropic;
+// interim contact champagne@perchwerks.com. This is a drafted policy, not legal
+// advice — have it reviewed for your jurisdiction.
 
 const Privacy = () => {
   useDocumentHead({
@@ -157,11 +157,9 @@ const Privacy = () => {
               <p>
                 If you use the optional AI coaching feature, the telemetry needed
                 to generate feedback (such as GPS traces and lap data, and any
-                driver name attached to the session) is sent to a{" "}
-                <strong className="text-foreground">
-                  third-party AI provider
-                </strong>{" "}
-                to be processed. We send this only when you choose to run the
+                driver name attached to the session) is sent to{" "}
+                <strong className="text-foreground">Anthropic</strong>, our
+                third-party AI provider, to be processed. We send this only when you choose to run the
                 coach. AI output is generated automatically and may be inaccurate
                 — it is informational only and must not be relied on for safety
                 decisions (see our{" "}
@@ -230,10 +228,8 @@ const Privacy = () => {
                 — bot/abuse protection on sign-up.
               </li>
               <li>
-                <strong className="text-foreground">
-                  The AI coaching provider
-                </strong>{" "}
-                — only if you use AI coaching.
+                <strong className="text-foreground">Anthropic</strong> — powers AI
+                coaching, only if you use it.
               </li>
             </ul>
             <p className="mt-2">
@@ -412,9 +408,12 @@ const Privacy = () => {
             Changes &amp; Contact
           </h2>
           <p>
-            We may update this policy as the app evolves; material changes will be
-            reflected by the “Last updated” date below. Questions or requests can
-            be sent through the in-app contact form.
+            The official hosted service is operated by{" "}
+            <strong className="text-foreground">PERCHWERKS LLC</strong> (Windermere,
+            Florida, USA). We may update this policy as the app evolves; material
+            changes will be reflected by the “Last updated” date below. Questions
+            or requests can be sent through the in-app contact form or to
+            champagne@perchwerks.com.
           </p>
         </section>
       </div>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -15,6 +15,7 @@ import { useStripePrices } from '@/hooks/useStripePrices';
 import { isDisposableEmail, looksLikeEmail } from '@/lib/emailValidation';
 import { isPaidTier } from '@/lib/billing';
 import { setPendingCheckout } from '@/lib/pendingCheckout';
+import { isNativeApp } from '@/lib/platform';
 
 // Google sign-in is gated separately: it currently routes through Lovable's OAuth
 // broker, so it stays off until native Supabase Google OAuth is configured.
@@ -37,6 +38,9 @@ export default function Register() {
   const { signUp, signInWithGoogle } = useAuth();
   const { config } = useStripePrices();
   const navigate = useNavigate();
+  // The native (Android) app signs up on the free tier only — paid plans are
+  // bought on the web (Google Play billing policy), so the plan picker is hidden.
+  const native = isNativeApp();
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,8 +77,9 @@ export default function Register() {
       toast({ title: t('register.failed'), description: error.message, variant: 'destructive' });
     } else {
       // Account-first paid flow: stash the chosen plan so checkout resumes on
-      // the user's first sign-in after confirming their email.
-      if (isPaidTier(plan.tier)) {
+      // the user's first sign-in after confirming their email. Never on native —
+      // there's no in-app checkout to resume.
+      if (!native && isPaidTier(plan.tier)) {
         setPendingCheckout(plan.tier, plan.interval);
         toast({
           title: t('register.accountCreated'),
@@ -126,7 +131,7 @@ export default function Register() {
               <Label htmlFor="confirmPassword">{t('register.confirmPassword')}</Label>
               <Input id="confirmPassword" type="password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} required />
             </div>
-            <PlanCheckout value={plan} onChange={setPlan} config={config} />
+            {!native && <PlanCheckout value={plan} onChange={setPlan} config={config} />}
             <Turnstile onToken={setCaptchaToken} className="flex justify-center" />
             <label htmlFor="confirmAge" className="flex items-start gap-2 text-xs text-muted-foreground">
               <input
@@ -148,7 +153,7 @@ export default function Register() {
               </span>
             </label>
             <div className="flex items-center gap-3">
-              <PlanCheckoutSummary value={plan} config={config} />
+              {!native && <PlanCheckoutSummary value={plan} config={config} />}
               <Button type="submit" className="flex-1" disabled={isLoading || !confirmAge}>
                 {isLoading ? t('pleaseWait') : t('register.submit')}
               </Button>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -4,10 +4,10 @@ import { useDocumentHead } from "@/hooks/useDocumentHead";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
-// NOTE FOR THE OPERATOR: drafted Terms, not legal advice. Before relying on
-// these for the hosted service, confirm: the operating entity's legal name, a
-// contact email, and the governing-law jurisdiction (left as a placeholder
-// below). Have them reviewed by a lawyer for your jurisdiction.
+// NOTE FOR THE OPERATOR: drafted Terms, not legal advice — have them reviewed by
+// a lawyer for your jurisdiction. The official hosted service is operated by
+// PERCHWERKS LLC, based in Windermere, Florida, USA; contact
+// champagne@perchwerks.com (interim) until dedicated support addresses exist.
 
 const Terms = () => {
   useDocumentHead({
@@ -237,9 +237,12 @@ const Terms = () => {
             14. Governing Law &amp; Contact
           </h2>
           <p>
-            These Terms are governed by the laws of [JURISDICTION TO BE
-            CONFIRMED], without regard to conflict-of-laws rules. Questions about
-            these Terms can be sent through the in-app contact form.
+            The official hosted Service is operated by{" "}
+            <strong className="text-foreground">PERCHWERKS LLC</strong>, based in
+            Windermere, Florida, USA. These Terms are governed by the laws of the
+            State of Florida, United States, without regard to conflict-of-laws
+            rules. Questions about these Terms can be sent through the in-app
+            contact form or to champagne@perchwerks.com.
           </p>
         </section>
       </div>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -123,6 +123,11 @@ const Terms = () => {
                 If a payment fails or a subscription lapses, online storage limits
                 revert to the free tier; your data on your device is unaffected.
               </li>
+              <li>
+                The Android app does not sell or manage subscriptions in-app: paid
+                plans are purchased and managed on the web at hackthetrack.net. The
+                app uses cloud sync on whatever plan your account already has.
+              </li>
             </ul>
           </section>
         )}
@@ -240,7 +245,7 @@ const Terms = () => {
       </div>
 
       <p className="mt-10 text-xs text-muted-foreground/60">
-        Last updated: May 2026
+        Last updated: June 2026
       </p>
     </div>
   );

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -14,6 +14,7 @@ import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { useSubscription } from "@/hooks/useSubscription";
 import { isPaidTier, isComped, hasCompGrant, daysUntilTrim } from "@/lib/billing";
 import { createPortal } from "@/lib/billingClient";
+import { isNativeApp } from "@/lib/platform";
 import { onGarageChange } from "@/lib/garageEvents";
 import { getStorageUsage } from "./syncEngine";
 import { getLocalStorageUsage } from "./localUsage";
@@ -273,7 +274,10 @@ function PlanSection() {
   const inGrace = !subscribed && !!graceUntil;
   const trimDays = daysUntilTrim(subscription?.grace_until);
   // A comp (active or lapsed) has no Stripe customer, so the portal can't open.
-  const canManage = !hasCompGrant(subscription) && (!!subscription?.current_period_end || subscribed || inGrace);
+  // The native (Android) app never manages billing in-app (Google Play policy) —
+  // the plan still shows (read-only), but the Stripe portal buttons are hidden;
+  // subscriptions are managed on the web.
+  const canManage = !isNativeApp() && !hasCompGrant(subscription) && (!!subscription?.current_period_end || subscribed || inGrace);
 
   // Open the Stripe portal — generic (cancel / payment methods) or, with
   // flow "update", deep-linked into the change-plan screen.
@@ -317,7 +321,7 @@ function PlanSection() {
                 : t("plan.trimmed")}
             </p>
           )}
-          {!subscribed && !inGrace && (
+          {!subscribed && !inGrace && !isNativeApp() && (
             <p className="text-[11px] text-muted-foreground">{t("plan.upgrade")}</p>
           )}
         </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,6 +12,12 @@ interface ImportMetaEnv {
   readonly VITE_GIT_BRANCH?: string;
   /** ISO commit (committer) date of the build's commit. */
   readonly VITE_GIT_COMMIT_DATE?: string;
+  /**
+   * "true" for a bundle built for the native (Tauri/Android) shell. Gates
+   * native-only behaviour (no service worker, no in-app purchases, external
+   * links via the system browser). Defaults to "false" — see lib/platform.ts.
+   */
+  readonly VITE_IS_NATIVE?: string;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,6 +101,11 @@ const PUBLIC_BACKEND_FALLBACKS = {
   // until the operator explicitly opts in via VITE_*/HTT_* env. The production
   // deploy sets this to "true".
   VITE_ENABLE_CLOUD: "false",
+  // The web app is the default target; the Tauri/Android build sets this to
+  // "true" (VITE_IS_NATIVE / HTT_IS_NATIVE) so the bundle skips the service
+  // worker, hides in-app purchases (web-only billing for Google Play), and
+  // routes external links through the system browser. See lib/platform.ts.
+  VITE_IS_NATIVE: "false",
 } as const;
 
 // https://vitejs.dev/config/
@@ -176,6 +181,9 @@ export default defineConfig(({ mode }) => {
       ),
       "import.meta.env.VITE_ENABLE_CLOUD": JSON.stringify(
         pick("VITE_ENABLE_CLOUD", "HTT_ENABLE_CLOUD", PUBLIC_BACKEND_FALLBACKS.VITE_ENABLE_CLOUD),
+      ),
+      "import.meta.env.VITE_IS_NATIVE": JSON.stringify(
+        pick("VITE_IS_NATIVE", "HTT_IS_NATIVE", PUBLIC_BACKEND_FALLBACKS.VITE_IS_NATIVE),
       ),
       "import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
       "import.meta.env.VITE_GIT_HASH": JSON.stringify(gitHash),


### PR DESCRIPTION
The same bundle now serves the web app **and** a native Android app (wrapped by a separate Tauri repo) without changing web behaviour. This adds a single platform gate plus the Google Play compliance pieces this repo owns. The Tauri repo still owns the Android manifest, permissions, CSP allowlist, signing, and native bridge implementation (see `docs/android.md`).

**Decisions:** purchases disabled on Android (cloud sync kept; paid plans web-only), GPS foreground-only.

## What's in here

- **Platform layer** — `src/lib/platform.ts`: `isNativeApp()` (build flag `VITE_IS_NATIVE` + runtime Tauri globals), plus `openExternal()`/`interceptExternal()` over an injected `window.__HTT_NATIVE__` bridge (no `@tauri-apps/*` dep in this repo). Flag wired in `vite.config.ts` + `src/vite-env.d.ts`. Unit-tested.
- **Service worker** — `src/main.tsx` skips registration (and cleans up existing) on native. A Tauri WebView is a *top-level* window that the prior iframe/preview gate missed.
- **In-app purchases disabled on native** (cloud sync stays) — `pricingCta` gains a native gate (`billing.ts`); `PricingCards`, `Register`, `PlanCheckout`, `PendingCheckoutRedirect`, and `StoragePanel` hide every buy/upgrade/portal surface (the plan still shows read-only so subscribed web users see their tier); `createCheckout`/`createPortal` throw as a backstop. Paid plans are purchased/managed on the web.
- **External links** open in the system browser on native — `ActionTile`, `CreditsDialog`, `SupportedFilesDialog`, `LandingPage`, `Privacy`.
- **Public account-deletion page** — `src/pages/DeleteAccount.tsx` at `/delete-account`, mounted un-gated so the URL Google Play requires always resolves. Reuses the existing emailed-code deletion flow (`accountDeletion.ts`).
- **Privacy/Terms** — Android web-only-billing note, the public deletion URL, and a foreground-only location/permissions note.
- **Docs** — new `docs/android.md` (Data Safety form, permission set — foreground-only location, no background; BLE scan/connect; wake lock; internet — and the native bridge contract). `README`, `CLAUDE.md`, `.env.example`, `CHANGELOG` updated; version `2.8.0` (unreleased).

## Verification

`bun run lint`, `typecheck`, `test:run` (1863 pass, incl. new `platform.test.ts` + billing native cases), and both `bun run build` and `VITE_IS_NATIVE=true bun run build` all green.

## Operator follow-ups (not code — left as placeholders)

- Fill the Privacy/Terms legal-entity name, contact email, AI-provider name, and governing-law jurisdiction.
- List `https://hackthetrack.net/delete-account` as the Play Console deletion URL.
- Tauri repo: manifest permissions, CSP allowlist, signing, and wire `window.__HTT_NATIVE__.openExternal`; build with `VITE_IS_NATIVE=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjporYvTUjrP2a29wKKPo)_