### PR TITLE
Wire up lapwingdata.com + beta.lapwingdata.com proxy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Live App — LapWing
-    url: https://hackthetrack.net
+    url: https://lapwingdata.com
     about: Try the app directly in your browser.
   - name: DovesDataLogger (Hardware)
     url: https://github.com/TheAngryRaven/DovesDataLogger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Renamed to LapWing.** The app's display name is now **LapWing** everywhere
-  (the previous "HackTheTrack" / "HackTheTrack.net" branding). The hosted domain
-  is unchanged for now.
+  (the previous "HackTheTrack" / "HackTheTrack.net" branding).
+- **New domain — lapwingdata.com.** The site now lives at **lapwingdata.com**
+  (canonical URLs, sitemap, social tags, in-app links). Production attaches the
+  domain via a `custom_domain` route in `wrangler.jsonc`; the beta domain
+  **beta.lapwingdata.com** is served by the `beta-proxy/` reverse-proxy Worker.
 - **Privacy Policy & Terms** now describe the Android app's web-only billing, the
   public deletion URL, and the app's foreground-only location use.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 **Dove's DataViewer / LapWing** — Open-source, offline-first motorsport
 telemetry viewer.
-- Live: [hackthetrack.net](https://hackthetrack.net) | Beta: [beta.perchwerks.com](https://beta.perchwerks.com)
+- Live: [lapwingdata.com](https://lapwingdata.com) | Beta: [beta.lapwingdata.com](https://beta.lapwingdata.com)
 - Companion hardware: [DovesDataLogger](https://github.com/TheAngryRaven/DovesDataLogger) (nRF52840 GPS logger with BLE — Seeed XIAO nRF52840, `sense`/`nonsense` IMU variants)
 - PWA with full offline support via service worker + IndexedDB
 
@@ -377,8 +377,13 @@ and the seeder: **→ `docs/i18n.md`**.
 **PWA/deploy detail:** the active offline worker is `/service-worker.js` (registered
 outside preview/iframe contexts); `public/sw.js` is a legacy kill-switch. Static
 hosting is Cloudflare Workers (static-assets-only, `wrangler.jsonc`,
-`bun run build` then `wrangler deploy`). Per-branch preview backend: `vite.config.ts`
-`pick()` prefers `*_PREVIEW` Supabase creds on any non-`main` branch
+`bun run build` then `wrangler deploy`). Production `lapwingdata.com` attaches via
+a `custom_domain` route in `wrangler.jsonc` (auto DNS+TLS — don't also attach it in
+the dashboard). The beta domain `beta.lapwingdata.com` can't bind to a Branch
+Preview URL, so a separate thin reverse-proxy Worker in `beta-proxy/` owns it and
+forwards to `beta-dovesdataviewer.perchwerks.workers.dev` (deployed on its own; see
+`beta-proxy/README.md`). Per-branch preview backend: `vite.config.ts` `pick()`
+prefers `*_PREVIEW` Supabase creds on any non-`main` branch
 (`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`), so beta deployments bake in a preview DB.
 `main` and local dev never read `_PREVIEW`. See README "Deployment".
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/build.yml/badge.svg)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/build.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TheAngryRaven/9c0c31f9c333c565804b26643a2e3aec/raw/coverage-badge.json)](https://github.com/TheAngryRaven/DovesDataViewer/actions/workflows/coverage.yml)
 
-🌐 **Live Demo:** [LapWing](https://hackthetrack.net)  
+🌐 **Live Demo:** [LapWing](https://lapwingdata.com)  
 🔧 **Hardware Project:** [DovesDataLogger on GitHub](https://github.com/TheAngryRaven/DovesDataLogger)
 
 **Now officially in BETA status**
@@ -455,6 +455,20 @@ whenever that branch isn't `main`, and ignores them on `main` and in local dev.
    Any key works the same way (e.g. `HTT_ENABLE_CLOUD_PREVIEW`). `VITE_*_PREVIEW`
    is also accepted. Add the Cloudflare preview URL to the preview branch's
    **Auth → Redirect URLs** so cloud sign-in works there.
+
+#### Custom domains (production + beta)
+
+- **Production — `lapwingdata.com`:** `wrangler.jsonc` declares a
+  `custom_domain` route, so `wrangler deploy` provisions the DNS record and TLS
+  certificate automatically. The zone `lapwingdata.com` must be in the same
+  Cloudflare account; **do not also attach the domain by hand** in the dashboard
+  or the bindings conflict.
+- **Beta — `beta.lapwingdata.com`:** custom domains can't attach to a Branch
+  Preview URL, so a separate thin reverse-proxy Worker owns the beta hostname and
+  forwards to the stable `beta` preview (`beta-dovesdataviewer.perchwerks.workers.dev`).
+  It lives in [`beta-proxy/`](beta-proxy/README.md) and is deployed on its own
+  (`cd beta-proxy && npm install && npm run deploy`). Keep Cloudflare Access
+  **off** on the upstream preview URL — see that README.
 
 ### Android app (Tauri)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Dove's DataViewer is a continuously deployed web app. Security fixes are applied
 to the latest release on the `main` branch, which is what powers
-[hackthetrack.net](https://hackthetrack.net). Older tagged releases are not
+[lapwingdata.com](https://lapwingdata.com). Older tagged releases are not
 separately patched.
 
 | Version | Supported |

--- a/beta-proxy/.gitignore
+++ b/beta-proxy/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+dist/
+package-lock.json

--- a/beta-proxy/README.md
+++ b/beta-proxy/README.md
@@ -1,0 +1,70 @@
+# beta-proxy
+
+A minimal Cloudflare Worker that reverse-proxies **https://beta.lapwingdata.com**
+to the stable `beta` branch preview of the `dovesdataviewer` Worker.
+
+## Why this exists
+
+The `dovesdataviewer` Worker has non-production branch builds enabled. Pushes to
+the `beta` branch publish a **stable Branch Preview URL**:
+
+```
+https://beta-dovesdataviewer.perchwerks.workers.dev
+```
+
+that always serves the latest `beta` push. Cloudflare **custom domains cannot be
+attached directly to a preview URL**, so this thin proxy Worker owns
+`beta.lapwingdata.com` and forwards every request to the preview URL, returning
+the upstream response unchanged (it also rewrites the `Location` header on 3xx
+redirects so the preview hostname never leaks to the client).
+
+The upstream host is a single top-level constant (`UPSTREAM_HOST`) in
+[`src/index.ts`](src/index.ts) — change it there if the target ever moves. (It
+stays on `perchwerks.workers.dev` because the preview URL is derived from the
+Worker name + the account's workers.dev subdomain, which the new public domain
+doesn't change.)
+
+## Prerequisites
+
+- The zone **lapwingdata.com** is already managed in this Cloudflare account.
+- Node.js installed locally.
+
+## Deploy
+
+```bash
+cd beta-proxy
+npm install
+
+# Authenticate (opens a browser; one-time per machine)
+npx wrangler login
+
+# Validate config + bundle without deploying
+npm run dry-run
+
+# Deploy for real
+npm run deploy
+```
+
+> **Note:** this project lives inside the `dovesdataviewer` repo, which has its
+> own root `wrangler.jsonc`. Wrangler's config discovery walks *up* the tree and
+> would otherwise pick up that parent config, so the npm scripts (and any direct
+> invocation) must pass `--config ./wrangler.toml`. The `npm run deploy` /
+> `npm run dry-run` scripts already do this — if you call wrangler directly, run
+> `npx wrangler deploy --config ./wrangler.toml`.
+
+The `custom_domain` route in [`wrangler.toml`](wrangler.toml) makes Cloudflare
+**automatically provision the DNS record and TLS certificate** for
+`beta.lapwingdata.com` on first deploy. **Do not create any DNS records by hand** —
+doing so will conflict with the custom-domain binding.
+
+## ⚠️ Cloudflare Access must be OFF on the upstream preview URL
+
+This proxy makes a server-side `fetch()` to
+`beta-dovesdataviewer.perchwerks.workers.dev`. If **Cloudflare Access** (Zero
+Trust) is enabled on that preview hostname (or on the `*.workers.dev` route),
+the proxy's `fetch` will be redirected to an Access login wall and your users
+will see a Cloudflare login page instead of the app.
+
+**Keep Cloudflare Access disabled on the upstream preview URL** for this proxy
+to work. If you need to gate `beta.lapwingdata.com`, add Access on *this* proxy's
+custom domain instead, not on the upstream.

--- a/beta-proxy/package.json
+++ b/beta-proxy/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "beta-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reverse-proxy Worker serving the dovesdataviewer beta branch preview at beta.lapwingdata.com",
+  "scripts": {
+    "deploy": "wrangler deploy --config ./wrangler.toml",
+    "dry-run": "wrangler deploy --dry-run --config ./wrangler.toml"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250601.0",
+    "wrangler": "^4.20.0"
+  }
+}

--- a/beta-proxy/src/index.ts
+++ b/beta-proxy/src/index.ts
@@ -1,0 +1,75 @@
+/**
+ * beta-proxy — a thin reverse-proxy Worker.
+ *
+ * Cloudflare custom domains cannot attach to a *Branch Preview* URL, so this
+ * Worker owns beta.lapwingdata.com and transparently forwards every request to
+ * the stable `beta` branch preview of the `dovesdataviewer` Worker.
+ *
+ * Change the deployment target by editing UPSTREAM_HOST below.
+ */
+
+// The stable Branch Preview hostname for the `beta` branch of `dovesdataviewer`.
+// It's derived from the Worker name + account workers.dev subdomain, which are
+// unchanged by the new public domain — so this stays on perchwerks.workers.dev.
+const UPSTREAM_HOST = "beta-dovesdataviewer.perchwerks.workers.dev";
+
+// The public hostname this proxy serves on (used to rewrite redirect targets so
+// the preview host never leaks back to the client).
+const PUBLIC_HOST = "beta.lapwingdata.com";
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    // Forward to the upstream preview host, preserving path + query string.
+    url.hostname = UPSTREAM_HOST;
+    url.protocol = "https:";
+    url.port = "";
+
+    // Reconstruct the request so all methods, headers, and the body are
+    // forwarded verbatim. `redirect: "manual"` lets us rewrite Location
+    // headers ourselves rather than letting fetch follow them.
+    const upstreamRequest = new Request(url.toString(), request);
+
+    const upstreamResponse = await fetch(upstreamRequest, { redirect: "manual" });
+
+    // On 3xx redirects, swap the upstream .workers.dev host in the Location
+    // header for our public host so clients never see the preview hostname.
+    if (upstreamResponse.status >= 300 && upstreamResponse.status < 400) {
+      const location = upstreamResponse.headers.get("Location");
+      if (location) {
+        const rewritten = rewriteLocation(location);
+        if (rewritten !== location) {
+          const headers = new Headers(upstreamResponse.headers);
+          headers.set("Location", rewritten);
+          return new Response(upstreamResponse.body, {
+            status: upstreamResponse.status,
+            statusText: upstreamResponse.statusText,
+            headers,
+          });
+        }
+      }
+    }
+
+    return upstreamResponse;
+  },
+} satisfies ExportedHandler;
+
+/**
+ * Rewrite a Location header value, replacing the upstream preview host with the
+ * public host. Handles both absolute URLs and bare/relative values (which are
+ * returned unchanged).
+ */
+function rewriteLocation(location: string): string {
+  try {
+    const target = new URL(location);
+    if (target.hostname === UPSTREAM_HOST) {
+      target.hostname = PUBLIC_HOST;
+      return target.toString();
+    }
+    return location;
+  } catch {
+    // Relative Location (e.g. "/path") — nothing to rewrite.
+    return location;
+  }
+}

--- a/beta-proxy/tsconfig.json
+++ b/beta-proxy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/beta-proxy/wrangler.toml
+++ b/beta-proxy/wrangler.toml
@@ -1,0 +1,10 @@
+name = "beta-proxy"
+main = "src/index.ts"
+compatibility_date = "2025-06-01"
+
+# Attaching a custom_domain route makes Cloudflare provision the DNS record and
+# TLS certificate for beta.lapwingdata.com automatically — do NOT create any DNS
+# records by hand. The zone lapwingdata.com must already be in this account.
+routes = [
+  { pattern = "beta.lapwingdata.com", custom_domain = true }
+]

--- a/docs/android.md
+++ b/docs/android.md
@@ -62,7 +62,7 @@ flow. This repo serves `/delete-account` (`src/pages/DeleteAccount.tsx`), mounte
 **un-gated** in `App.tsx` so the URL resolves on every build. It signs the user in
 (the deletion edge function derives the account from the session), then reuses the
 emailed-code flow in `src/plugins/cloud-sync/accountDeletion.ts`. List
-`https://hackthetrack.net/delete-account` in the Play Console as the deletion URL.
+`https://lapwingdata.com/delete-account` in the Play Console as the deletion URL.
 
 The in-app path remains **Profile → Data & privacy** (`DataPrivacyPanel.tsx`).
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist", "coverage", "src/lib/xrk/wasm"] },
+  { ignores: ["dist", "coverage", "src/lib/xrk/wasm", "beta-proxy"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>LapWing — Free Online VBO, MoTeC, AiM & NMEA Telemetry Viewer</title>
     <meta name="description" content="Free online VBO file viewer, MoTeC i2 viewer, AiM & NMEA log viewer. Open-source GPS lap timer and motorsport telemetry analyzer — runs offline in your browser, no upload required.">
-    <link rel="canonical" href="https://hackthetrack.net/" />
+    <link rel="canonical" href="https://lapwingdata.com/" />
     <meta name="google-site-verification" content="p17Cb_TDcliQFvYwnZqk24geEG4eaJxjitDeGe-P17M" />
 
     <!-- PWA Meta Tags -->
@@ -22,7 +22,7 @@
     <meta property="og:description" content="Free online VBO file viewer, MoTeC i2 viewer, AiM & NMEA log viewer. Open-source GPS lap timer and motorsport telemetry analyzer — runs offline in your browser, no upload required.">
     <meta name="twitter:description" content="Free online VBO file viewer, MoTeC i2 viewer, AiM & NMEA log viewer. Open-source GPS lap timer and motorsport telemetry analyzer — runs offline in your browser, no upload required.">
 
-    <meta property="og:url" content="https://hackthetrack.net/">
+    <meta property="og:url" content="https://lapwingdata.com/">
     <meta property="og:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/4662e3cf-b3ae-4a6f-bc98-063c5777a60c?Expires=1771044008&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=QloYKQKOUWxjp2tiwGclt6daNQW9fmangqiVcW9S32QaVSTQtOA%2FBNGE63azEhblxZQi5yx9JToUQDAm9OijLFqz7n%2Bqae5mgjH24aY9Ozb1aW57YjAzp4KSlcH7j8c3eUuAd3s0PtNlM5fV1kA%2F1SUqErwbr5WObft%2FSNCH4OuA4VkwjMRCfoE8aZMvH9or9ILl8q7V0Bllzd7u29iPMSfOO2go72zbtpBJnh10UX3nnxM5wT3wc9%2B5Yb01qBSjqESIRiNy3Oe8mWBdiy6xgy2KvG4m%2FzgS%2BNr87Tv2vnS0apuE9SrnA06flu2ys6%2BPkEeojZVzis1lF4hwnZDt2w%3D%3D">
     <meta name="twitter:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/4662e3cf-b3ae-4a6f-bc98-063c5777a60c?Expires=1771044008&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=QloYKQKOUWxjp2tiwGclt6daNQW9fmangqiVcW9S32QaVSTQtOA%2FBNGE63azEhblxZQi5yx9JToUQDAm9OijLFqz7n%2Bqae5mgjH24aY9Ozb1aW57YjAzp4KSlcH7j8c3eUuAd3s0PtNlM5fV1kA%2F1SUqErwbr5WObft%2FSNCH4OuA4VkwjMRCfoE8aZMvH9or9ILl8q7V0Bllzd7u29iPMSfOO2go72zbtpBJnh10UX3nnxM5wT3wc9%2B5Yb01qBSjqESIRiNy3Oe8mWBdiy6xgy2KvG4m%2FzgS%2BNr87Tv2vnS0apuE9SrnA06flu2ys6%2BPkEeojZVzis1lF4hwnZDt2w%3D%3D">
     <meta name="twitter:card" content="summary_large_image">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",
-  "homepage": "https://hackthetrack.net",
+  "homepage": "https://lapwingdata.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TheAngryRaven/DovesDataViewer.git"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,4 +13,4 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://hackthetrack.net/sitemap.xml
+Sitemap: https://lapwingdata.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://hackthetrack.net/</loc>
+    <loc>https://lapwingdata.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://hackthetrack.net/privacy</loc>
+    <loc>https://lapwingdata.com/privacy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/src/lib/emailValidation.test.ts
+++ b/src/lib/emailValidation.test.ts
@@ -19,7 +19,7 @@ describe("isDisposableEmail", () => {
   });
   it("allows normal providers", () => {
     expect(isDisposableEmail("a@gmail.com")).toBe(false);
-    expect(isDisposableEmail("racer@hackthetrack.net")).toBe(false);
+    expect(isDisposableEmail("racer@lapwingdata.com")).toBe(false);
   });
   it("is false for malformed input", () => {
     expect(isDisposableEmail("not-an-email")).toBe(false);

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -30,7 +30,7 @@ export default function DeleteAccount() {
   useDocumentHead({
     title: "Delete your account — LapWing",
     description: "Request permanent deletion of your LapWing cloud account and all associated data.",
-    canonical: "https://hackthetrack.net/delete-account",
+    canonical: "https://lapwingdata.com/delete-account",
   });
 
   return (
@@ -77,7 +77,7 @@ function CloudDisabledNote() {
       <p>
         This build of the app doesn’t include cloud accounts, so there is nothing
         to delete here. Account deletion applies to the hosted service at{" "}
-        <strong className="text-foreground">hackthetrack.net</strong>. Data created
+        <strong className="text-foreground">lapwingdata.com</strong>. Data created
         in this app lives only in your browser and can be removed by clearing this
         site’s data.
       </p>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -14,7 +14,7 @@ export default function ForgotPassword() {
   useDocumentHead({
     title: t('forgot.metaTitle'),
     description: t('forgot.metaDescription'),
-    canonical: 'https://hackthetrack.net/forgot-password',
+    canonical: 'https://lapwingdata.com/forgot-password',
   });
   const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -20,7 +20,7 @@ export default function Login() {
   useDocumentHead({
     title: t('login.metaTitle'),
     description: t('login.metaDescription'),
-    canonical: 'https://hackthetrack.net/login',
+    canonical: 'https://lapwingdata.com/login',
   });
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -18,7 +18,7 @@ const Privacy = () => {
     title: "Privacy Policy — LapWing",
     description:
       "How LapWing handles your data: offline-first telemetry stored in your browser, with optional cloud sync and AI features when you create an account.",
-    canonical: "https://hackthetrack.net/privacy",
+    canonical: "https://lapwingdata.com/privacy",
   });
   return (
     <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
@@ -144,7 +144,7 @@ const Privacy = () => {
                 <strong className="text-foreground">On the Android app</strong>,
                 paid plans are not sold or managed in-app: subscriptions are
                 purchased and managed on the web at{" "}
-                <strong className="text-foreground">hackthetrack.net</strong>. The
+                <strong className="text-foreground">lapwingdata.com</strong>. The
                 Android app simply uses cloud sync on whatever plan your account
                 already has.
               </p>
@@ -289,7 +289,7 @@ const Privacy = () => {
                 permanently erased. You can also request account deletion from a
                 public page without opening the app, at{" "}
                 <Link to="/delete-account" className="text-foreground underline hover:no-underline">
-                  hackthetrack.net/delete-account
+                  lapwingdata.com/delete-account
                 </Link>
                 .
               </li>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -26,7 +26,7 @@ export default function Register() {
   useDocumentHead({
     title: t('register.metaTitle'),
     description: t('register.metaDescription'),
-    canonical: 'https://hackthetrack.net/register',
+    canonical: 'https://lapwingdata.com/register',
   });
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -22,7 +22,7 @@ export default function ResetPassword() {
   useDocumentHead({
     title: t('reset.metaTitle'),
     description: t('reset.metaDescription'),
-    canonical: 'https://hackthetrack.net/reset-password',
+    canonical: 'https://lapwingdata.com/reset-password',
   });
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -14,7 +14,7 @@ const Terms = () => {
     title: "Terms of Service — LapWing",
     description:
       "The terms for using LapWing: offline-first telemetry app with optional cloud sync, paid storage plans, and AI coaching.",
-    canonical: "https://hackthetrack.net/terms",
+    canonical: "https://lapwingdata.com/terms",
   });
   return (
     <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
@@ -125,7 +125,7 @@ const Terms = () => {
               </li>
               <li>
                 The Android app does not sell or manage subscriptions in-app: paid
-                plans are purchased and managed on the web at hackthetrack.net. The
+                plans are purchased and managed on the web at lapwingdata.com. The
                 app uses cloud sync on whatever plan your account already has.
               </li>
             </ul>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,14 @@
   // command (npm run build) and then `wrangler deploy`, which uploads ./dist.
   "name": "dovesdataviewer",
   "compatibility_date": "2026-05-30",
+  // Attaching a custom_domain route makes Cloudflare provision the DNS record and
+  // TLS certificate for lapwingdata.com automatically on deploy. The zone
+  // lapwingdata.com must be in this Cloudflare account; do NOT also attach the
+  // domain by hand in the dashboard, or the bindings conflict. The beta domain
+  // (beta.lapwingdata.com) is served by the separate beta-proxy/ Worker.
+  "routes": [
+    { "pattern": "lapwingdata.com", "custom_domain": true }
+  ],
   "assets": {
     "directory": "./dist",
     // React Router runs client-side, so unmatched paths must return the app


### PR DESCRIPTION
Cuts the hosted service over to the new domain **lapwingdata.com** and restores the beta proxy for **beta.lapwingdata.com**.

## Production domain — `lapwingdata.com`
- Rewrote every `hackthetrack.net` reference → `lapwingdata.com`: canonical URLs (all pages), `public/sitemap.xml`, `public/robots.txt`, `index.html` canonical + `og:url`, `package.json` homepage, in-app/legal in-text links (Privacy, Terms, DeleteAccount), `docs/android.md` deletion URL, README, SECURITY, CLAUDE.md, the issue-template link, and the email-validation test's own-domain example.
- **Attaches via `wrangler.jsonc`** — added a `custom_domain` route so `wrangler deploy` auto-provisions DNS + TLS. ⚠️ Don't also attach the domain by hand in the dashboard, or the bindings conflict. The zone must be in the same Cloudflare account.
- **Left as-is:** the historical CHANGELOG entry (accurate for that release) and the conduct-report gmail address (not the domain).

## Beta domain — `beta.lapwingdata.com`
Re-added the **`beta-proxy/`** reverse-proxy Worker (it had been moved to its own repo; per your call it now lives here again). It owns `beta.lapwingdata.com` and forwards to the stable beta Branch Preview `beta-dovesdataviewer.perchwerks.workers.dev`, rewriting `Location` headers on 3xx so the preview host never leaks. Custom domains can't bind to a preview URL, hence the proxy.

- **Upstream host unchanged** — the preview URL derives from the Worker name (`dovesdataviewer`) + the account's `perchwerks.workers.dev` subdomain, neither of which the new public domain changes.
- Deploy separately: `cd beta-proxy && npm install && npm run deploy` (uses `--config ./wrangler.toml` so it doesn't pick up the root config). `custom_domain = true` auto-provisions DNS+TLS — don't add records by hand.
- ⚠️ Keep **Cloudflare Access OFF** on the upstream preview URL (server-side `fetch` would otherwise hit a login wall). See `beta-proxy/README.md`.
- `beta-proxy` is excluded from root ESLint (separate Worker toolchain) and from `tsc -b` (root configs only include `src/` + `vite.config.ts`). No npm lockfile is committed, per the repo's bun-only lockfile rule.

## Verification
`bun run lint`, `typecheck`, `test:run` (1863 pass), and `bun run build` all green.

## Manual follow-ups (Cloudflare, outside the repo)
1. Ensure `lapwingdata.com` zone is in the Cloudflare account; deploy `main`/prod so the `custom_domain` route provisions it (don't dashboard-attach it too).
2. Deploy `beta-proxy` once (`npm run deploy`) to bind `beta.lapwingdata.com`.
3. Optionally set a redirect from the old `hackthetrack.net` → `lapwingdata.com` and add `lapwingdata.com` to Supabase **Auth → Redirect URLs** for cloud sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjporYvTUjrP2a29wKKPo)_