### PR TITLE
Migration banner on hackthetrack.net → LapWing (emergency, into main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [2.7.2] - 2026-06-20
+
+### Added
+- **Migration notice (hackthetrack.net).** The site is moving to **LapWing** at
+  **lapwingdata.com**. Because files are stored only in your browser per-domain,
+  they don't carry to the new address — so a banner on hackthetrack.net warns of
+  the **July 20, 2026** shutdown and offers a one-click data export and (where
+  accounts are enabled) a "create a free account" path so your data follows you
+  via cloud sync. The banner only appears on the old domain.
+
 ## [2.7.1] - 2026-06-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / HackTheTrack).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
 import i18n from "@/lib/i18n";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { MigrationBanner } from "@/components/MigrationBanner";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 
@@ -59,6 +60,9 @@ const App = () => {
         <FileLoadingOverlay />
         <DebugConsole />
         <BrowserRouter>
+          {/* Old-domain-only migration notice (hackthetrack.net → lapwingdata.com).
+              Renders nothing on the new site. Inside the router so it can navigate. */}
+          <MigrationBanner />
           <Suspense fallback={null}>
             {enableCloud && <PendingCheckoutRedirect />}
             <Routes>

--- a/src/components/MigrationBanner.tsx
+++ b/src/components/MigrationBanner.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AlertTriangle, Download, Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+// Emergency migration notice for the OLD domain. HackTheTrack is moving to
+// LapWing (lapwingdata.com), which is a different origin — so local-only files
+// (IndexedDB/localStorage) do NOT carry over. This banner warns users on the old
+// host to create an account (cloud sync follows them) or export a copy before the
+// old site is shut down.
+//
+// Host-gated: only renders on hackthetrack.net. The new domain never shows it.
+// `?migrate=preview` forces it on any host for testing.
+
+const NEW_SITE = "https://lapwingdata.com";
+// The day the old site (hackthetrack.net) is taken down. Local-only data is lost
+// after this unless exported or moved to an account.
+const KILL_DATE = new Date("2026-07-20T00:00:00Z");
+const KILL_DATE_LABEL = "July 20, 2026";
+const DISMISS_KEY = "htt-migration-dismissed"; // session-only, so it returns next visit
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+/** True on the legacy domain (or when explicitly previewed). */
+function onOldSite(): boolean {
+  if (typeof window === "undefined") return false;
+  const host = window.location.hostname.toLowerCase();
+  const isOld = host === "hackthetrack.net" || host === "www.hackthetrack.net";
+  const preview = window.location.search.includes("migrate=preview");
+  return isOld || preview;
+}
+
+function daysUntilKill(now: number = Date.now()): number {
+  return Math.max(0, Math.ceil((KILL_DATE.getTime() - now) / 86_400_000));
+}
+
+export function MigrationBanner() {
+  const navigate = useNavigate();
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  const [exporting, setExporting] = useState(false);
+
+  if (!onOldSite() || dismissed) return null;
+
+  const days = daysUntilKill();
+  const closed = days <= 0;
+
+  const dismiss = () => {
+    try {
+      sessionStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setDismissed(true);
+  };
+
+  const runExport = async () => {
+    setExporting(true);
+    try {
+      // Dynamic import keeps the cloud-sync/export + Supabase chunk off the
+      // eager graph; the export gathers local data even when signed out.
+      const { downloadAccountExport } = await import("@/plugins/cloud-sync/accountExport");
+      await downloadAccountExport();
+      toast.success("Your data export has started downloading.");
+    } catch {
+      toast.error("Couldn't export here — open Profile → Data & privacy to download your data.");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div className="w-full border-b border-warning/60 bg-warning/10 px-4 py-3 text-warning">
+      <div className="mx-auto flex w-full max-w-4xl items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p className="text-sm font-medium">
+            HackTheTrack is moving to <span className="font-bold">LapWing</span> at{" "}
+            <span className="font-bold">lapwingdata.com</span>.{" "}
+            {closed
+              ? "This site (hackthetrack.net) is closing."
+              : `This site (hackthetrack.net) shuts down on ${KILL_DATE_LABEL} (${days} day${days === 1 ? "" : "s"} left).`}
+          </p>
+          <p className="text-xs">
+            Your files are saved only in this browser and <strong>won't carry over</strong> to the
+            new site. Keep them by {enableCloud ? "creating a free account (your data syncs to the new site) or " : ""}
+            exporting a copy now.
+          </p>
+          <div className="flex flex-wrap gap-2 pt-0.5">
+            {enableCloud && (
+              <Button size="sm" onClick={() => navigate("/register")}>
+                Create free account
+              </Button>
+            )}
+            <Button size="sm" variant="outline" disabled={exporting} onClick={() => void runExport()}>
+              {exporting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Download className="mr-1.5 h-4 w-4" />}
+              Export my data
+            </Button>
+            <Button size="sm" variant="ghost" asChild>
+              <a href={NEW_SITE} target="_blank" rel="noopener noreferrer">Go to LapWing →</a>
+            </Button>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss"
+          className="shrink-0 rounded p-1 text-warning/80 transition-colors hover:bg-warning/20 hover:text-warning"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Emergency fix to production** so existing hackthetrack.net users are warned before the move to LapWing.

## Why
Local files live in **per-origin** IndexedDB/localStorage. `hackthetrack.net` and `lapwingdata.com` are different origins, so **local-only users' files do not follow them** to the new domain. They need to be told to export or make an account *before* the old site goes away.

## What
- New `MigrationBanner` (`src/components/MigrationBanner.tsx`), mounted app-wide in `App.tsx`.
- **Host-gated to `hackthetrack.net`** (`window.location.hostname`) — renders nothing on `lapwingdata.com` or anywhere else. `?migrate=preview` forces it on for testing.
- Copy: moving to LapWing at lapwingdata.com; **shuts down July 20, 2026** with a live day countdown.
- Actions: **Create free account** (→ `/register`; only when cloud is enabled — data follows via cloud sync), **Export my data** (one-click; dynamically imports the existing `downloadAccountExport`, works signed-out, falls back to a Profile → Data & privacy hint), and **Go to LapWing →**.
- Dismissable per session (returns on next visit, since the message is important).
- Version bump `2.7.2` + changelog.

## Notes
- This branches off **`main`** (still HackTheTrack branding) — correct for the old site. The LapWing rename + lapwingdata.com domain live on `BETA` and are not part of this PR.
- ⚠️ Do **not** add a redirect or take down hackthetrack.net yet — that's what would strand data. This PR only adds the warning. The account **importer** (the no-account migration path) is coming separately on `BETA`.
- After merge, the hackthetrack.net deployment needs a redeploy from `main` to pick up the banner. Also add `lapwingdata.com` to Supabase **Auth → Redirect URLs** so the "create account" path works on the new site.

## Verification
`lint`, `typecheck`, `test:run` (1850 pass), and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjporYvTUjrP2a29wKKPo)_