### PR TITLE
Add data-export importer (cross-origin migration path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you request permanent deletion of your cloud account from the web (Google Play
   requires a public deletion URL), in addition to the existing in-app flow under
   Profile → Data & privacy.
+- **Import your data.** Profile → Data & privacy gains an **Import data** option
+  that restores files and garage data from a previously downloaded data-export
+  ZIP. This is the migration path when moving between origins (e.g. the old
+  hackthetrack.net site → lapwingdata.com), where per-browser storage doesn't
+  carry over. Existing files are kept; matching names are skipped. Works signed
+  in or out (it's a local restore).
 
 ### Changed
 - **Renamed to LapWing.** The app's display name is now **LapWing** everywhere

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -280,8 +280,11 @@ otherwise the migration raises a NOTICE and it's a documented operator step.
 
 **Client** (cloud-sync plugin): `exportManifest.ts` (pure, unit-tested — assembles
 the zip's text entries), `accountExport.ts` (I/O orchestrator: edge fn + local
-stores + blob download → JSZip), `accountDeletion.ts` (email-OTP gate via
+stores + blob download → JSZip), `accountImport.ts` (the reverse — restores a
+data-export ZIP's local stores + file blobs into this browser via the sync
+accessors; the cross-origin migration path, e.g. old domain → new domain;
+pure entry-classifier unit-tested), `accountDeletion.ts` (email-OTP gate via
 `signInWithOtp`/`verifyOtp` + schedule/cancel), and `DataPrivacyPanel.tsx` (the
-Profile-tab "Data & privacy" panel). Admin `BannedIpsTab` exposes a ban TTL
+Profile-tab "Data & privacy" panel — export, import, and delete). Admin `BannedIpsTab` exposes a ban TTL
 (defaults to 90 days). Privacy policy "Your Rights" / "Data Retention" describe
 all of the above.

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -82,7 +82,14 @@
     "emailedCode": "Wir haben einen Bestätigungscode an {{email}} gesendet.",
     "sendCodeFailed": "Der Code konnte nicht gesendet werden.",
     "scheduledFor": "Löschung geplant für {{date}}.",
-    "codeFailed": "Dieser Code hat nicht funktioniert — versuche es erneut."
+    "codeFailed": "Dieser Code hat nicht funktioniert — versuche es erneut.",
+    "importTitle": "Daten importieren",
+    "importBlurb": "Stelle Dateien und Garagendaten aus einer Export-ZIP wieder her — praktisch beim Wechsel auf ein neues Gerät oder zu lapwingdata.com. Vorhandene Einträge bleiben erhalten; bereits vorhandene Dateien werden übersprungen.",
+    "importButton": "Export-ZIP auswählen",
+    "importing": "Importieren…",
+    "importDone": "{{files}} Datei(en) und {{records}} Datensätze importiert. Zum Anzeigen neu laden.",
+    "importReload": "Neu laden",
+    "importFailed": "Import fehlgeschlagen — ist das eine LapWing-Export-ZIP?"
   },
   "snapshots": {
     "loadFailed": "Snapshots konnten nicht geladen werden",

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -81,7 +81,14 @@
     "emailedCode": "We emailed a confirmation code to {{email}}.",
     "sendCodeFailed": "Couldn't send the code.",
     "scheduledFor": "Deletion scheduled for {{date}}.",
-    "codeFailed": "That code didn't work — try again."
+    "codeFailed": "That code didn't work — try again.",
+    "importTitle": "Import data",
+    "importBlurb": "Restore files and garage data from a data-export ZIP — handy when moving to a new device or to lapwingdata.com. Existing items are kept; files that already exist are skipped.",
+    "importButton": "Choose export ZIP",
+    "importing": "Importing…",
+    "importDone": "Imported {{files}} file(s) and {{records}} record(s). Reload to see them.",
+    "importReload": "Reload",
+    "importFailed": "Import failed — is this a LapWing data-export ZIP?"
   },
   "snapshots": {
     "loadFailed": "Failed to load snapshots",

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -82,7 +82,14 @@
     "emailedCode": "Enviamos un código de confirmación a {{email}}.",
     "sendCodeFailed": "No se pudo enviar el código.",
     "scheduledFor": "Eliminación programada para el {{date}}.",
-    "codeFailed": "Ese código no funcionó: inténtalo de nuevo."
+    "codeFailed": "Ese código no funcionó: inténtalo de nuevo.",
+    "importTitle": "Importar datos",
+    "importBlurb": "Restaura archivos y datos del garaje desde un ZIP de exportación — útil al cambiar de dispositivo o a lapwingdata.com. Se conservan los elementos existentes; los archivos que ya existen se omiten.",
+    "importButton": "Elegir ZIP de exportación",
+    "importing": "Importando…",
+    "importDone": "Se importaron {{files}} archivo(s) y {{records}} registro(s). Recarga para verlos.",
+    "importReload": "Recargar",
+    "importFailed": "Error al importar — ¿es un ZIP de exportación de LapWing?"
   },
   "snapshots": {
     "loadFailed": "No se pudieron cargar las instantáneas",

--- a/src/locales/fr/plugins.json
+++ b/src/locales/fr/plugins.json
@@ -82,7 +82,14 @@
     "emailedCode": "Nous avons envoyé un code de confirmation à {{email}}.",
     "sendCodeFailed": "Impossible d'envoyer le code.",
     "scheduledFor": "Suppression programmée pour le {{date}}.",
-    "codeFailed": "Ce code n'a pas fonctionné — réessayez."
+    "codeFailed": "Ce code n'a pas fonctionné — réessayez.",
+    "importTitle": "Importer des données",
+    "importBlurb": "Restaurez vos fichiers et données du garage depuis un ZIP d'exportation — pratique pour changer d'appareil ou passer à lapwingdata.com. Les éléments existants sont conservés ; les fichiers déjà présents sont ignorés.",
+    "importButton": "Choisir le ZIP d'exportation",
+    "importing": "Importation…",
+    "importDone": "{{files}} fichier(s) et {{records}} enregistrement(s) importés. Rechargez pour les voir.",
+    "importReload": "Recharger",
+    "importFailed": "Échec de l'importation — s'agit-il d'un ZIP d'exportation LapWing ?"
   },
   "snapshots": {
     "loadFailed": "Impossible de charger les instantanés",

--- a/src/locales/it/plugins.json
+++ b/src/locales/it/plugins.json
@@ -82,7 +82,14 @@
     "emailedCode": "Abbiamo inviato un codice di conferma a {{email}}.",
     "sendCodeFailed": "Impossibile inviare il codice.",
     "scheduledFor": "Eliminazione programmata per il {{date}}.",
-    "codeFailed": "Quel codice non ha funzionato: riprova."
+    "codeFailed": "Quel codice non ha funzionato: riprova.",
+    "importTitle": "Importa dati",
+    "importBlurb": "Ripristina file e dati del garage da uno ZIP di esportazione — utile quando passi a un nuovo dispositivo o a lapwingdata.com. Gli elementi esistenti vengono mantenuti; i file già presenti vengono saltati.",
+    "importButton": "Scegli lo ZIP di esportazione",
+    "importing": "Importazione…",
+    "importDone": "Importati {{files}} file e {{records}} record. Ricarica per vederli.",
+    "importReload": "Ricarica",
+    "importFailed": "Importazione non riuscita — è uno ZIP di esportazione LapWing?"
   },
   "snapshots": {
     "loadFailed": "Impossibile caricare le istantanee",

--- a/src/locales/ja/plugins.json
+++ b/src/locales/ja/plugins.json
@@ -82,7 +82,14 @@
     "emailedCode": "{{email}} に確認コードを送信しました。",
     "sendCodeFailed": "コードを送信できませんでした。",
     "scheduledFor": "削除を{{date}}に予定しました。",
-    "codeFailed": "そのコードは無効でした。もう一度お試しください。"
+    "codeFailed": "そのコードは無効でした。もう一度お試しください。",
+    "importTitle": "データをインポート",
+    "importBlurb": "エクスポートした ZIP からファイルとガレージのデータを復元します。新しいデバイスや lapwingdata.com への移行に便利です。既存の項目は保持され、すでに存在するファイルはスキップされます。",
+    "importButton": "エクスポート ZIP を選択",
+    "importing": "インポート中…",
+    "importDone": "{{files}} 個のファイルと {{records}} 件のレコードをインポートしました。再読み込みして表示してください。",
+    "importReload": "再読み込み",
+    "importFailed": "インポートに失敗しました — これは LapWing のエクスポート ZIP ですか？"
   },
   "snapshots": {
     "loadFailed": "スナップショットを読み込めませんでした",

--- a/src/locales/pt-BR/plugins.json
+++ b/src/locales/pt-BR/plugins.json
@@ -82,7 +82,14 @@
     "emailedCode": "Enviamos um código de confirmação para {{email}}.",
     "sendCodeFailed": "Não foi possível enviar o código.",
     "scheduledFor": "Exclusão agendada para {{date}}.",
-    "codeFailed": "Esse código não funcionou — tente novamente."
+    "codeFailed": "Esse código não funcionou — tente novamente.",
+    "importTitle": "Importar dados",
+    "importBlurb": "Restaure arquivos e dados da garagem a partir de um ZIP de exportação — útil ao mudar de dispositivo ou para lapwingdata.com. Os itens existentes são mantidos; arquivos que já existem são ignorados.",
+    "importButton": "Escolher ZIP de exportação",
+    "importing": "Importando…",
+    "importDone": "{{files}} arquivo(s) e {{records}} registro(s) importados. Recarregue para vê-los.",
+    "importReload": "Recarregar",
+    "importFailed": "Falha na importação — este é um ZIP de exportação do LapWing?"
   },
   "snapshots": {
     "loadFailed": "Não foi possível carregar os instantâneos",

--- a/src/plugins/cloud-sync/DataPrivacyPanel.tsx
+++ b/src/plugins/cloud-sync/DataPrivacyPanel.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { AlertTriangle, Download, Loader2, ShieldX, Trash2 } from "lucide-react";
+import { AlertTriangle, Download, Loader2, ShieldX, Trash2, Upload } from "lucide-react";
 import { toast } from "sonner";
 import type { PluginPanelProps } from "@/plugins/panels";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { downloadAccountExport } from "./accountExport";
+import { importAccountArchive, type ImportSummary } from "./accountImport";
 import {
   cancelAccountDeletion,
   getPendingDeletion,
@@ -69,6 +70,9 @@ export default function DataPrivacyPanel(_props: PluginPanelProps) {
         </Button>
       </section>
 
+      <ImportData />
+
+
       {user && (
         <section className="space-y-3">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t("dataPrivacy.deleteAccount")}</p>
@@ -80,6 +84,52 @@ export default function DataPrivacyPanel(_props: PluginPanelProps) {
         </section>
       )}
     </div>
+  );
+}
+
+// Restore a previously exported ZIP into this browser — the migration path for
+// users moving between origins (per-origin local storage doesn't carry over).
+// Works signed in or out (it's a local restore); existing files are never
+// clobbered. A reload surfaces the restored files/garage (read on mount).
+function ImportData() {
+  const { t } = useTranslation("plugins");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<ImportSummary | null>(null);
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // let the same file be re-picked later
+    if (!file) return;
+    setImporting(true);
+    setResult(null);
+    try {
+      setResult(await importAccountArchive(file));
+    } catch {
+      toast.error(t("dataPrivacy.importFailed"));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <section className="space-y-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t("dataPrivacy.importTitle")}</p>
+      <p className="text-xs text-muted-foreground">{t("dataPrivacy.importBlurb")}</p>
+      <input ref={inputRef} type="file" accept=".zip,application/zip" className="hidden" onChange={(e) => void onFile(e)} />
+      <Button variant="outline" disabled={importing} onClick={() => inputRef.current?.click()}>
+        {importing ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Upload className="mr-1.5 h-4 w-4" />}
+        {importing ? t("dataPrivacy.importing") : t("dataPrivacy.importButton")}
+      </Button>
+      {result && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span>{t("dataPrivacy.importDone", { files: result.files, records: result.records })}</span>
+          <Button size="sm" variant="secondary" onClick={() => window.location.reload()}>
+            {t("dataPrivacy.importReload")}
+          </Button>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/plugins/cloud-sync/accountImport.test.ts
+++ b/src/plugins/cloud-sync/accountImport.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { classifyEntry } from "./accountImport";
+
+describe("classifyEntry", () => {
+  it("maps a document-store JSON path to its store", () => {
+    expect(classifyEntry("local/stores/karts.json")).toEqual({ kind: "store", store: "karts" });
+    // Store names can contain hyphens (e.g. graph-prefs, setup-revisions).
+    expect(classifyEntry("local/stores/setup-revisions.json")).toEqual({
+      kind: "store",
+      store: "setup-revisions",
+    });
+  });
+
+  it("maps local and cloud file blobs to a file name", () => {
+    expect(classifyEntry("local/files/session.dovex")).toEqual({ kind: "file", name: "session.dovex" });
+    expect(classifyEntry("cloud/files/2026-01-01 lap.dove")).toEqual({
+      kind: "file",
+      name: "2026-01-01 lap.dove",
+    });
+  });
+
+  it("ignores account JSON, the README, and directory entries", () => {
+    expect(classifyEntry("cloud/account.json")).toBeNull();
+    expect(classifyEntry("local/settings.json")).toBeNull();
+    expect(classifyEntry("README.txt")).toBeNull();
+    expect(classifyEntry("local/files/")).toBeNull();
+  });
+});

--- a/src/plugins/cloud-sync/accountImport.ts
+++ b/src/plugins/cloud-sync/accountImport.ts
@@ -1,0 +1,105 @@
+// Restore a data-export ZIP (produced by accountExport.ts) back into local
+// storage. The migration path for users moving between origins (e.g. the old
+// hackthetrack.net → lapwingdata.com) where per-origin IndexedDB/localStorage
+// does not carry over: export on the old site, import here.
+//
+// Scope is intentionally LOCAL: it writes the document stores + file blobs into
+// this browser via the same accessors the sync engine uses (raw `putOne`, no
+// garage event — same as the pull path). Account holders don't need this (cloud
+// sync already follows them); this is the no-account fallback. The pure
+// entry-classifier is split out so it can be unit-tested without a browser/zip.
+
+import JSZip from "jszip";
+import { saveFile, listFiles } from "@/lib/fileStorage";
+import { getAccessor } from "./storeAccessors";
+import { DOC_STORES } from "./syncStores";
+
+export interface ImportSummary {
+  /** New file blobs written (existing names are skipped, never clobbered). */
+  files: number;
+  /** Document rows written across all stores. */
+  records: number;
+  /** Distinct document stores that received at least one row. */
+  stores: number;
+}
+
+export interface ImportProgress {
+  phase: "stores" | "files";
+}
+
+export type EntryKind =
+  | { kind: "store"; store: string }
+  | { kind: "file"; name: string }
+  | null;
+
+/**
+ * Classify a ZIP entry path from an export archive. Pure — no I/O — so the
+ * path-mapping rules are unit-testable. Recognises the document-store JSON
+ * (`local/stores/<store>.json`) and session-file blobs under either
+ * `local/files/<name>` or `cloud/files/<name>`. Everything else (the cloud/*
+ * account JSON, README, directories) returns null and is ignored on import.
+ */
+export function classifyEntry(path: string): EntryKind {
+  const store = path.match(/^local\/stores\/(.+)\.json$/);
+  if (store) return { kind: "store", store: store[1] };
+  const file = path.match(/^(?:local|cloud)\/files\/(.+)$/);
+  if (file && file[1]) return { kind: "file", name: file[1] };
+  return null;
+}
+
+/**
+ * Read an export ZIP and restore its local data into this browser. Existing
+ * files (by name) are left untouched; document rows are upserted by key.
+ */
+export async function importAccountArchive(
+  blob: Blob,
+  onProgress?: (p: ImportProgress) => void,
+): Promise<ImportSummary> {
+  const zip = await JSZip.loadAsync(blob);
+
+  // Document stores: only restore stores we actually sync, by exact filename, so
+  // an unknown/malicious entry can't be written to an arbitrary store.
+  onProgress?.({ phase: "stores" });
+  let records = 0;
+  let storesTouched = 0;
+  for (const store of DOC_STORES) {
+    const entry = zip.file(`local/stores/${store}.json`);
+    if (!entry) continue;
+    let rows: unknown;
+    try {
+      rows = JSON.parse(await entry.async("string"));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(rows)) continue;
+    const accessor = getAccessor(store);
+    let touched = false;
+    for (const row of rows) {
+      if (row && typeof row === "object") {
+        await accessor.putOne(row as Record<string, unknown>);
+        records++;
+        touched = true;
+      }
+    }
+    if (touched) storesTouched++;
+  }
+
+  // File blobs: add any that don't already exist on this device.
+  onProgress?.({ phase: "files" });
+  const existing = new Set((await listFiles()).map((f) => f.name));
+  const fileEntries: { name: string; entry: JSZip.JSZipObject }[] = [];
+  zip.forEach((path, entry) => {
+    if (entry.dir) return;
+    const c = classifyEntry(path);
+    if (c && c.kind === "file" && !existing.has(c.name)) {
+      fileEntries.push({ name: c.name, entry });
+    }
+  });
+  let files = 0;
+  for (const { name, entry } of fileEntries) {
+    await saveFile(name, await entry.async("blob"));
+    files++;
+  }
+
+  return { files, records, stores: storesTouched };
+}


### PR DESCRIPTION
The no-account migration path that pairs with the hackthetrack.net → lapwingdata.com move. (The banner that tells users to export is PR #259 into `main`.)

## Why
Local files live in **per-origin** IndexedDB/localStorage, so they don't follow users across domains. Export already exists; this adds the **reverse** so someone can export on the old site and restore on the new one — without needing an account.

## What
- **`accountImport.ts`** reverses `accountExport.ts`:
  - Restores document stores (`DOC_STORES`) by writing rows through the sync **accessors** (`getAccessor(store).putOne` — raw, no garage event, same as the pull path). Only **known** stores are restored, matched by exact filename, so a malformed/hostile entry can't write to an arbitrary store.
  - Restores file blobs from `local/files/` and `cloud/files/`, **skipping names that already exist** (never clobbers current data).
  - Pure `classifyEntry()` path-mapper is unit-tested.
- **UI:** an **Import data** section in Profile → Data & privacy (`DataPrivacyPanel.tsx`), next to the existing export. Works **signed in or out** — it's a local restore. After import it shows a count and a **Reload** button (the file browser/garage read on mount).
- New i18n keys added across **all 7 locales** (parity test stays green).
- `docs/backend.md` + `CHANGELOG.md` updated.

## Scope notes
- This is intentionally a **local restore**. Account holders don't need it — cloud sync already carries their data across domains once they sign in. The importer is the fallback for users who never made an account.
- Imported rows are written via the raw pull-path accessor (no garage event), so a signed-in user's import isn't auto-pushed to the cloud; that's fine for the local-migration use case.

## Verification
`lint`, `typecheck`, `test:run` (1866 pass, incl. new `accountImport` tests + locale parity), and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjporYvTUjrP2a29wKKPo)_