### PR TITLE
Rename production Worker → lapwing (isolate from old site)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,7 +381,7 @@ hosting is Cloudflare Workers (static-assets-only, `wrangler.jsonc`,
 a `custom_domain` route in `wrangler.jsonc` (auto DNS+TLS — don't also attach it in
 the dashboard). The beta domain `beta.lapwingdata.com` can't bind to a Branch
 Preview URL, so a separate thin reverse-proxy Worker in `beta-proxy/` owns it and
-forwards to `beta-dovesdataviewer.perchwerks.workers.dev` (deployed on its own; see
+forwards to `beta-lapwing.perchwerks.workers.dev` (deployed on its own; see
 `beta-proxy/README.md`). Per-branch preview backend: `vite.config.ts` `pick()`
 prefers `*_PREVIEW` Supabase creds on any non-`main` branch
 (`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`), so beta deployments bake in a preview DB.

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ whenever that branch isn't `main`, and ignores them on `main` and in local dev.
   or the bindings conflict.
 - **Beta — `beta.lapwingdata.com`:** custom domains can't attach to a Branch
   Preview URL, so a separate thin reverse-proxy Worker owns the beta hostname and
-  forwards to the stable `beta` preview (`beta-dovesdataviewer.perchwerks.workers.dev`).
+  forwards to the stable `beta` preview (`beta-lapwing.perchwerks.workers.dev`).
   It lives in [`beta-proxy/`](beta-proxy/README.md) and is deployed on its own
   (`cd beta-proxy && npm install && npm run deploy`). Keep Cloudflare Access
   **off** on the upstream preview URL — see that README.

--- a/beta-proxy/README.md
+++ b/beta-proxy/README.md
@@ -1,15 +1,15 @@
 # beta-proxy
 
 A minimal Cloudflare Worker that reverse-proxies **https://beta.lapwingdata.com**
-to the stable `beta` branch preview of the `dovesdataviewer` Worker.
+to the stable `beta` branch preview of the `lapwing` Worker.
 
 ## Why this exists
 
-The `dovesdataviewer` Worker has non-production branch builds enabled. Pushes to
+The `lapwing` Worker has non-production branch builds enabled. Pushes to
 the `beta` branch publish a **stable Branch Preview URL**:
 
 ```
-https://beta-dovesdataviewer.perchwerks.workers.dev
+https://beta-lapwing.perchwerks.workers.dev
 ```
 
 that always serves the latest `beta` push. Cloudflare **custom domains cannot be
@@ -45,7 +45,7 @@ npm run dry-run
 npm run deploy
 ```
 
-> **Note:** this project lives inside the `dovesdataviewer` repo, which has its
+> **Note:** this project lives inside the `DovesDataViewer` repo, which has its
 > own root `wrangler.jsonc`. Wrangler's config discovery walks *up* the tree and
 > would otherwise pick up that parent config, so the npm scripts (and any direct
 > invocation) must pass `--config ./wrangler.toml`. The `npm run deploy` /
@@ -60,7 +60,7 @@ doing so will conflict with the custom-domain binding.
 ## ⚠️ Cloudflare Access must be OFF on the upstream preview URL
 
 This proxy makes a server-side `fetch()` to
-`beta-dovesdataviewer.perchwerks.workers.dev`. If **Cloudflare Access** (Zero
+`beta-lapwing.perchwerks.workers.dev`. If **Cloudflare Access** (Zero
 Trust) is enabled on that preview hostname (or on the `*.workers.dev` route),
 the proxy's `fetch` will be redirected to an Access login wall and your users
 will see a Cloudflare login page instead of the app.

--- a/beta-proxy/package.json
+++ b/beta-proxy/package.json
@@ -2,7 +2,7 @@
   "name": "beta-proxy",
   "version": "1.0.0",
   "private": true,
-  "description": "Reverse-proxy Worker serving the dovesdataviewer beta branch preview at beta.lapwingdata.com",
+  "description": "Reverse-proxy Worker serving the lapwing beta branch preview at beta.lapwingdata.com",
   "scripts": {
     "deploy": "wrangler deploy --config ./wrangler.toml",
     "dry-run": "wrangler deploy --dry-run --config ./wrangler.toml"

--- a/beta-proxy/src/index.ts
+++ b/beta-proxy/src/index.ts
@@ -3,15 +3,15 @@
  *
  * Cloudflare custom domains cannot attach to a *Branch Preview* URL, so this
  * Worker owns beta.lapwingdata.com and transparently forwards every request to
- * the stable `beta` branch preview of the `dovesdataviewer` Worker.
+ * the stable `beta` branch preview of the `lapwing` Worker.
  *
  * Change the deployment target by editing UPSTREAM_HOST below.
  */
 
-// The stable Branch Preview hostname for the `beta` branch of `dovesdataviewer`.
+// The stable Branch Preview hostname for the `beta` branch of `lapwing`.
 // It's derived from the Worker name + account workers.dev subdomain, which are
 // unchanged by the new public domain — so this stays on perchwerks.workers.dev.
-const UPSTREAM_HOST = "beta-dovesdataviewer.perchwerks.workers.dev";
+const UPSTREAM_HOST = "beta-lapwing.perchwerks.workers.dev";
 
 // The public hostname this proxy serves on (used to rewrite redirect targets so
 // the preview host never leaks back to the client).

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
   // The app is a pure static site — no Worker script (`main`) is needed; the
   // assets binding serves ./dist directly. Workers Builds runs the build
   // command (npm run build) and then `wrangler deploy`, which uploads ./dist.
-  "name": "dovesdataviewer",
+  "name": "lapwing",
   "compatibility_date": "2026-05-30",
   // Attaching a custom_domain route makes Cloudflare provision the DNS record and
   // TLS certificate for lapwingdata.com automatically on deploy. The zone


### PR DESCRIPTION
Renames the production Cloudflare Worker from **`dovesdataviewer`** to **`lapwing`** so the new Workers Builds connection deploys to its own Worker and can't collide with / overwrite the (now Git-disconnected, frozen) Worker still serving the old hackthetrack.net site.

## Changes
- `wrangler.jsonc` → `"name": "lapwing"` (still binds `lapwingdata.com` via the `custom_domain` route).
- Renaming the Worker changes its branch-preview hostname, so the **beta-proxy upstream** is updated to `beta-lapwing.perchwerks.workers.dev` (`beta-proxy/src/index.ts` + its README/package description).
- Doc references (`CLAUDE.md`, `README.md`) updated.
- **Untouched:** the GitHub repo (`DovesDataViewer`) and npm package (`doves-dataviewer`) names — only the Cloudflare Worker name + preview host changed.

## After this merges — create the Worker
Dash → **Workers & Pages → Create → Import a repository** → DovesDataViewer, branch `main`, build `bun run build`, deploy `npx wrangler deploy`. It deploys to the **`lapwing`** Worker and provisions `lapwingdata.com`. Enable non-production branch builds so `beta` publishes `beta-lapwing.perchwerks.workers.dev` for the proxy.

lint / typecheck / build green. (No app-code changes — config + docs only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjporYvTUjrP2a29wKKPo)_