### PR TITLE
Purple theme + LapWing header logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [2.8.1] - unreleased
+
+### Changed
+- **Purple theme + new logo.** The brand accent moved from teal to **purple**
+  (`--primary` and its mirrors `--ring`/`--sidebar-primary`/`--sidebar-ring`, in
+  both light and dark), and the gauge glyph in the app/page headers is replaced
+  with the new **LapWing logo** (`web-logo.png`, via a shared `BrandLogo`
+  component). Pairs with the refreshed app icons and favicon. Data-viz colors
+  (speed/telemetry scales) are unchanged.
+
 ## [2.8.0] - 2026-06-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -1,0 +1,6 @@
+// The LapWing brand mark shown in app/page headers (replaces the old gauge
+// glyph). The asset lives in public/ — precached by the service worker — so it's
+// referenced by absolute path. Size/spacing come from the caller's className.
+export function BrandLogo({ className }: { className?: string }) {
+  return <img src="/web-logo.png" alt="LapWing" className={className} />;
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,6 +1,5 @@
 import { Fragment, lazy, Suspense } from "react";
 import {
-  Gauge,
   Github,
   Heart,
   Shield,
@@ -14,6 +13,7 @@ import {
   Bluetooth,
   Route,
 } from "lucide-react";
+import { BrandLogo } from "@/components/BrandLogo";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -102,7 +102,7 @@ export function LandingPage({
       <header className="border-b border-border px-6 py-4">
         <div className="mx-auto flex w-full max-w-4xl items-center justify-between gap-3">
           <div className="flex items-center gap-3">
-            <Gauge className="w-8 h-8 text-primary" />
+            <BrandLogo className="w-8 h-8" />
             <div>
               <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
               <p className="text-sm text-muted-foreground">{t("landing:tagline")}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,7 @@
     --popover: 0 0% 100%;
     --popover-foreground: 220 20% 12%;
 
-    --primary: 180 70% 35%;
+    --primary: 276 44% 49%;
     --primary-foreground: 0 0% 100%;
 
     --secondary: 220 15% 92%;
@@ -51,7 +51,7 @@
 
     --border: 220 15% 85%;
     --input: 220 15% 88%;
-    --ring: 180 70% 35%;
+    --ring: 276 44% 49%;
 
     --radius: 0.5rem;
 
@@ -73,12 +73,12 @@
 
     --sidebar-background: 0 0% 100%;
     --sidebar-foreground: 220 20% 12%;
-    --sidebar-primary: 180 70% 35%;
+    --sidebar-primary: 276 44% 49%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 220 15% 92%;
     --sidebar-accent-foreground: 220 15% 25%;
     --sidebar-border: 220 15% 85%;
-    --sidebar-ring: 180 70% 35%;
+    --sidebar-ring: 276 44% 49%;
   }
 
   .dark {
@@ -91,7 +91,7 @@
     --popover: 220 18% 8%;
     --popover-foreground: 210 20% 92%;
 
-    --primary: 180 70% 45%;
+    --primary: 276 44% 59%;
     --primary-foreground: 220 20% 6%;
 
     --secondary: 220 15% 18%;
@@ -116,7 +116,7 @@
 
     --border: 220 15% 20%;
     --input: 220 15% 18%;
-    --ring: 180 70% 45%;
+    --ring: 276 44% 59%;
 
     /* Racing-specific colors */
     --speed-slow: 120 60% 45%;
@@ -136,12 +136,12 @@
 
     --sidebar-background: 220 18% 10%;
     --sidebar-foreground: 210 20% 92%;
-    --sidebar-primary: 180 70% 45%;
+    --sidebar-primary: 276 44% 59%;
     --sidebar-primary-foreground: 220 20% 6%;
     --sidebar-accent: 220 15% 18%;
     --sidebar-accent-foreground: 210 20% 85%;
     --sidebar-border: 220 15% 20%;
-    --sidebar-ring: 180 70% 45%;
+    --sidebar-ring: 276 44% 59%;
   }
 }
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/contexts/AuthContext';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { Gauge, LogOut, ArrowLeft } from 'lucide-react';
+import { LogOut, ArrowLeft } from 'lucide-react';
+import { BrandLogo } from "@/components/BrandLogo";
 import { SubmissionsTab } from '@/components/admin/SubmissionsTab';
 import { TracksTab } from '@/components/admin/TracksTab';
 import { CoursesTab } from '@/components/admin/CoursesTab';
@@ -38,7 +39,7 @@ export default function Admin() {
       <header className="border-b border-border px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Gauge className="w-8 h-8 text-primary" />
+            <BrandLogo className="w-8 h-8" />
             <div>
               <h1 className="text-xl font-semibold text-foreground">{t('panelTitle')}</h1>
               <p className="text-sm text-muted-foreground">{user.email}</p>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -6,7 +6,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
-import { Gauge, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
+import { BrandLogo } from "@/components/BrandLogo";
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 
 export default function ForgotPassword() {
@@ -38,7 +39,7 @@ export default function ForgotPassword() {
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8">
       <div className="w-full max-w-sm space-y-6">
         <div className="flex items-center gap-3 justify-center">
-          <Gauge className="w-8 h-8 text-primary" />
+          <BrandLogo className="w-8 h-8" />
           <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
         </div>
         <div className="racing-card p-6 space-y-4">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, AlertCircle, Wrench, NotebookPen, SlidersHorizontal } from "lucide-react";
+import { BrandLogo } from "@/components/BrandLogo";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
 import { LapTimesTab } from "@/components/tabs/LapTimesTab";
@@ -617,7 +618,7 @@ export default function Index() {
     <div className="h-screen bg-background flex flex-col overflow-hidden">
       <header className="border-b border-border px-4 py-2 flex items-center justify-between shrink-0">
         <div className="flex items-center gap-3">
-          <Gauge className="w-6 h-6 text-primary" />
+          <BrandLogo className="w-6 h-6" />
           <span className="font-semibold text-foreground hidden sm:inline">LapWing</span>
         </div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,7 +7,8 @@ import { Label } from '@/components/ui/label';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
-import { Gauge, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
+import { BrandLogo } from "@/components/BrandLogo";
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
@@ -67,7 +68,7 @@ export default function Login() {
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8">
       <div className="w-full max-w-sm space-y-6">
         <div className="flex items-center gap-3 justify-center">
-          <Gauge className="w-8 h-8 text-primary" />
+          <BrandLogo className="w-8 h-8" />
           <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
         </div>
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -6,7 +6,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
-import { Gauge, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
+import { BrandLogo } from "@/components/BrandLogo";
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 import { Turnstile, turnstileEnabled } from '@/components/Turnstile';
 import { PricingCards } from '@/components/PricingCards';
@@ -108,7 +109,7 @@ export default function Register() {
   return (
     <div className="min-h-screen bg-background flex flex-col items-center p-8 gap-12">
       <div className="flex items-center gap-3 justify-center mt-4">
-        <Gauge className="w-8 h-8 text-primary" />
+        <BrandLogo className="w-8 h-8" />
         <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
       </div>
 

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -6,7 +6,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
-import { Gauge, ArrowLeft } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
+import { BrandLogo } from "@/components/BrandLogo";
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 
 /** True when the current page load arrived via a Supabase password-recovery link. */
@@ -78,7 +79,7 @@ export default function ResetPassword() {
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8">
       <div className="w-full max-w-sm space-y-6">
         <div className="flex items-center gap-3 justify-center">
-          <Gauge className="w-8 h-8 text-primary" />
+          <BrandLogo className="w-8 h-8" />
           <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
         </div>
         <div className="racing-card p-6 space-y-4">


### PR DESCRIPTION
Finishes the visual side of the LapWing rebrand: purple accent + the new header logo. Builds on the icon/favicon/`web-logo.png` assets already on BETA.

## Recolor (teal → purple)
Set `--primary` to **`#8746b3` = HSL `276 44% 49%`** and its mirrors `--ring`, `--sidebar-primary`, `--sidebar-ring`, in **both** `:root` and `.dark` (`src/index.css`):
- Light: `276 44% 49%` · Dark: `276 44% 59%` — keeps the existing +10% light/dark lightness split, and both pass AA against their respective primary-foreground (white in light, near-black in dark).
- **Untouched:** the gold `--accent`, the semantic `--success/--warning/--destructive`, and all data-viz scales (`--speed-*`, `--telemetry-*`, `--chart-*`). The teal `--telemetry-speed` (`180 70%`) stays.

## Logo (gauge glyph → web-logo.png)
New `src/components/BrandLogo.tsx` renders `web-logo.png`. Swapped the gauge **only where it's the brand mark** in headers: `LandingPage`, `Index`, `Login`, `Register`, `ForgotPassword`, `ResetPassword`, `Admin`. **Functional** gauge icons (weather pressure, g-force setting, garage tab, Coach empty-state/tab, the analog-gauge overlay) are deliberately left as `lucide` `Gauge`.

## Version
`2.8.1` (unreleased) + changelog. (If you'd rather this ride the bigger **3.0** cut instead of a 2.8.1, it's a one-line renumber — say the word.)

## Verification
`lint`, `typecheck`, `test:run` (1866), and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjporYvTUjrP2a29wKKPo)_