### PR TITLE
Mobile UI cleanup: logo → home + safe-area insets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.8.1] - unreleased
 
+### Added
+- **Safe-area padding on native / installed PWA.** The app shell now respects the
+  device's safe-area insets (status bar / notch) via `env(safe-area-inset-*)` and
+  `viewport-fit=cover`, so header content no longer sits under the phone's status
+  bar. A no-op on browsers and desktops without a safe area.
+
 ### Changed
+- **Header logo returns to the home screen.** Tapping the LapWing logo (top-left)
+  in an open session now closes the session and returns to the landing page.
 - **Purple theme + new logo.** The brand accent moved from teal to **purple**
   (`--primary` and its mirrors `--ring`/`--sidebar-primary`/`--sidebar-ring`, in
   both light and dark), and the gauge glyph in the app/page headers is replaced

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>LapWing — Free Online VBO, MoTeC, AiM & NMEA Telemetry Viewer</title>
     <meta name="description" content="Free online VBO file viewer, MoTeC i2 viewer, AiM & NMEA log viewer. Open-source GPS lap timer and motorsport telemetry analyzer — runs offline in your browser, no upload required.">
     <link rel="canonical" href="https://lapwingdata.com/" />

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -98,7 +98,7 @@ export function LandingPage({
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-background flex flex-col safe-area-inset">
       <header className="border-b border-border px-6 py-4">
         <div className="mx-auto flex w-full max-w-4xl items-center justify-between gap-3">
           <div className="flex items-center gap-3">

--- a/src/hooks/useSessionData.ts
+++ b/src/hooks/useSessionData.ts
@@ -47,6 +47,13 @@ export function useSessionData(
     [applyFieldMappings]
   );
 
+  // Drop the loaded session and return to the landing page (no data).
+  const clearSession = useCallback(() => {
+    setData(null);
+    setCurrentFileName(null);
+    setFieldMappings([]);
+  }, []);
+
   const handleFieldToggle = useCallback((fieldName: string) => {
     setFieldMappings((prev) =>
       prev.map((f) => (f.name === fieldName ? { ...f, enabled: !f.enabled } : f))
@@ -67,6 +74,7 @@ export function useSessionData(
     currentFileName,
     fieldMappings,
     loadParsedData,
+    clearSession,
     handleFieldToggle,
     sessionGpsPoint,
   };

--- a/src/index.css
+++ b/src/index.css
@@ -216,6 +216,19 @@
 }
 
 @layer utilities {
+  /* Keep app chrome clear of device notches / status bars on native (Android
+     WebView / iOS) and installed PWAs, which draw edge-to-edge. Requires
+     `viewport-fit=cover` (set in index.html). Insets resolve to 0 on browsers
+     and desktops without a safe area, so this is a no-op everywhere else.
+     Applied to the app-shell containers, whose `border-box` sizing keeps the
+     padding inside `h-screen`/`min-h-screen` (no overflow) while the shell's
+     background fills the inset region behind the status bar. */
+  .safe-area-inset {
+    padding-top: env(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+
   .scrollbar-thin {
     scrollbar-width: thin;
     scrollbar-color: hsl(var(--muted)) transparent;

--- a/src/locales/de/session.json
+++ b/src/locales/de/session.json
@@ -11,6 +11,7 @@
     "setupsNotes": "Setups & Notizen"
   },
   "header": {
+    "home": "Startseite",
     "play": "Abspielen",
     "pause": "Pause",
     "allLaps": "Alle Runden",

--- a/src/locales/en/session.json
+++ b/src/locales/en/session.json
@@ -10,6 +10,7 @@
     "setupsNotes": "Setups & Notes"
   },
   "header": {
+    "home": "Home",
     "play": "Play",
     "pause": "Pause",
     "allLaps": "All Laps",

--- a/src/locales/es/session.json
+++ b/src/locales/es/session.json
@@ -11,6 +11,7 @@
     "setupsNotes": "Reglajes y notas"
   },
   "header": {
+    "home": "Inicio",
     "play": "Reproducir",
     "pause": "Pausar",
     "allLaps": "Todas las vueltas",

--- a/src/locales/fr/session.json
+++ b/src/locales/fr/session.json
@@ -11,6 +11,7 @@
     "setupsNotes": "Réglages et notes"
   },
   "header": {
+    "home": "Accueil",
     "play": "Lecture",
     "pause": "Pause",
     "allLaps": "Tous les tours",

--- a/src/locales/it/session.json
+++ b/src/locales/it/session.json
@@ -11,6 +11,7 @@
     "setupsNotes": "Assetti e note"
   },
   "header": {
+    "home": "Home",
     "play": "Riproduci",
     "pause": "Pausa",
     "allLaps": "Tutti i giri",

--- a/src/locales/ja/session.json
+++ b/src/locales/ja/session.json
@@ -11,6 +11,7 @@
     "setupsNotes": "セットアップとメモ"
   },
   "header": {
+    "home": "ホーム",
     "play": "再生",
     "pause": "一時停止",
     "allLaps": "すべてのラップ",

--- a/src/locales/pt-BR/session.json
+++ b/src/locales/pt-BR/session.json
@@ -11,6 +11,7 @@
     "setupsNotes": "Acertos e notas"
   },
   "header": {
+    "home": "Início",
     "play": "Reproduzir",
     "pause": "Pausar",
     "allLaps": "Todas as voltas",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -110,7 +110,7 @@ export default function Index() {
 
   // Core session data
   const sessionData = useSessionData(isFieldHiddenByDefault, settings.defaultHiddenFields);
-  const { data, currentFileName, fieldMappings, sessionGpsPoint } = sessionData;
+  const { data, currentFileName, fieldMappings, sessionGpsPoint, clearSession } = sessionData;
 
   const noteManager = useNoteManager(currentFileName);
 
@@ -615,12 +615,17 @@ export default function Index() {
     <SettingsProvider value={settingsContextValue}>
     <SessionProvider value={sessionContextValue}>
     <PlaybackProvider value={playbackContextValue}>
-    <div className="h-screen bg-background flex flex-col overflow-hidden">
+    <div className="h-screen bg-background flex flex-col overflow-hidden safe-area-inset">
       <header className="border-b border-border px-4 py-2 flex items-center justify-between shrink-0">
-        <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={clearSession}
+          aria-label={t("header.home")}
+          className="flex items-center gap-3 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
           <BrandLogo className="w-6 h-6" />
           <span className="font-semibold text-foreground hidden sm:inline">LapWing</span>
-        </div>
+        </button>
 
         <div className="flex items-center gap-2">
           <TooltipProvider>


### PR DESCRIPTION
## What

Two mobile/native UI polish fixes.

### 1. Header logo returns to the home screen
Tapping the LapWing logo (top-left) while a session is open now closes the session and returns to the landing page. Implemented via a new `clearSession` on `useSessionData` (resets `data`/`currentFileName`/`fieldMappings` → the `!data` branch renders the landing page). The logo is now a real `<button>` with a `header.home` aria-label (seeded to all locales) and a focus ring.

### 2. Safe-area padding on native / installed PWAs
The app shell drew edge-to-edge on native (Android WebView / iOS) and installed PWAs, placing header content under the status bar / notch. Fixed with the standard CSS env-inset approach:

- Added `viewport-fit=cover` to the viewport meta (required for `env(safe-area-inset-*)` to report non-zero).
- New reusable `.safe-area-inset` utility (top + left + right insets) applied to the session and landing app-shell containers. Their `border-box` sizing keeps the padding *inside* `h-screen`/`min-h-screen` (no overflow), and the shell's background fills the inset region behind the status bar.
- Insets resolve to `0` on browsers/desktops without a safe area, so this is a no-op everywhere else.

## Testing
- `bun run lint`, `bun run typecheck`, `bun run test:run` (1866 tests), `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpQppp3sdsZXLRUGf1F69g

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpQppp3sdsZXLRUGf1F69g)_