### PR TITLE
Image-based logger picker for "Download from logger"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.8.1] - unreleased
 
 ### Added
+- **Logger picker.** "Download from logger" now opens an image-based chooser of
+  supported loggers instead of jumping straight to Bluetooth: **PerchWerks
+  Fledgling** (DIY, Bluetooth), **AiM MyChron 5 / 5S / 2T** (Wi-Fi, native app
+  required), and **Alfano 6 / 7** (Bluetooth, coming soon). The Fledgling runs the
+  existing Bluetooth download flow; MyChron and Alfano open explanatory dialogs for
+  now (MyChron's copy differs between the native app and the web). Placeholder
+  artwork lives in `public/loggers/` for easy swap-out. New `logger` i18n namespace.
 - **Safe-area padding on native / installed PWA.** The app shell now respects the
   device's safe-area insets (status bar / notch) via `env(safe-area-inset-*)` and
   `viewport-fit=cover`, so header content no longer sits under the phone's status
   bar. A no-op on browsers and desktops without a safe area.
 
 ### Changed
+- **"Download from logger" relabel.** The file-manager button previously labelled
+  "Download from DovesDataLogger" is now "Download from logger" and opens the new
+  logger picker.
 - **Header logo returns to the home screen.** Tapping the LapWing logo (top-left)
   in an open session now closes the session and returns to the landing page.
 - **Purple theme + new logo.** The brand accent moved from teal to **purple**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ src/
 │   ├── RaceLineView.tsx   # Leaflet map: race line, speed heatmap, braking zones
 │   ├── TelemetryChart.tsx # Canvas speed/telemetry chart (simple mode)
 │   ├── VideoPlayer.tsx    # Synced video playback + overlay system (multi-chunk GoPro playlists via lib/videoPlaylist)
-│   └── …                  # FileImport, DataloggerDownload (BLE entry, lazy), LapSnapshot*, …
+│   └── …                  # FileImport, LoggerPicker (image-based logger chooser), DataloggerDownload (BLE entry, lazy), LapSnapshot*, …
 ├── hooks/                 # One concern each; Index.tsx orchestrates.
 │   ├── useSessionData     # Parses imported file → ParsedData
 │   ├── useLapManagement   # Lap calc, selection, visible range

--- a/docs/ble.md
+++ b/docs/ble.md
@@ -6,7 +6,10 @@ of `CLAUDE.md` so it loads only when working on device code. Global BLE connecti
 state lives in `DeviceContext.tsx` (wraps the app tree in `Index.tsx`). Source:
 `src/lib/ble/` (split per-concern; `bleDatalogger.ts` is the legacy barrel).
 Everything here is lazy-loaded — `DataloggerDownload` is the BLE entry point so
-`lib/ble/*` stays out of the initial bundle.
+`lib/ble/*` stays out of the initial bundle. The user reaches it through
+`LoggerPicker` (an image-based chooser of supported loggers); selecting the
+PerchWerks Fledgling tile starts this Bluetooth flow, while the other loggers
+(MyChron, Alfano) open explanatory dialogs and don't touch `lib/ble/*` yet.
 
 ---
 

--- a/public/loggers/alfano.svg
+++ b/public/loggers/alfano.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img" aria-label="Alfano placeholder">
+  <rect width="400" height="300" fill="#1f242a"/>
+  <circle cx="200" cy="140" r="58" fill="#2f3d4a" stroke="#5aa6e0" stroke-width="3"/>
+  <circle cx="200" cy="140" r="6" fill="#5aa6e0"/>
+  <line x1="200" y1="140" x2="200" y2="98" stroke="#5aa6e0" stroke-width="4" stroke-linecap="round"/>
+  <line x1="200" y1="140" x2="232" y2="158" stroke="#9fd0f0" stroke-width="4" stroke-linecap="round"/>
+  <text x="200" y="240" fill="#9fd0f0" font-family="sans-serif" font-size="22" font-weight="700" text-anchor="middle">Alfano</text>
+  <text x="200" y="266" fill="#60788f" font-family="sans-serif" font-size="13" text-anchor="middle">placeholder image</text>
+</svg>

--- a/public/loggers/fledgling.svg
+++ b/public/loggers/fledgling.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img" aria-label="PerchWerks Fledgling placeholder">
+  <rect width="400" height="300" fill="#1f2a24"/>
+  <rect x="120" y="90" width="160" height="110" rx="14" fill="#2f4a3c" stroke="#5fbf8a" stroke-width="3"/>
+  <circle cx="200" cy="135" r="20" fill="#5fbf8a"/>
+  <rect x="150" y="170" width="100" height="10" rx="5" fill="#5fbf8a" opacity="0.6"/>
+  <text x="200" y="240" fill="#9fe3c0" font-family="sans-serif" font-size="22" font-weight="700" text-anchor="middle">Fledgling</text>
+  <text x="200" y="266" fill="#6f8f7f" font-family="sans-serif" font-size="13" text-anchor="middle">placeholder image</text>
+</svg>

--- a/public/loggers/mychron.svg
+++ b/public/loggers/mychron.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img" aria-label="AiM MyChron placeholder">
+  <rect width="400" height="300" fill="#2a1f1f"/>
+  <rect x="110" y="85" width="180" height="120" rx="16" fill="#4a2f2f" stroke="#e07a3c" stroke-width="3"/>
+  <rect x="130" y="105" width="140" height="60" rx="6" fill="#1a1414"/>
+  <path d="M150 140 l20 -20 20 20 20 -25 20 25" fill="none" stroke="#e07a3c" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="200" y="240" fill="#f0a878" font-family="sans-serif" font-size="22" font-weight="700" text-anchor="middle">MyChron</text>
+  <text x="200" y="266" fill="#8f7060" font-family="sans-serif" font-size="13" text-anchor="middle">placeholder image</text>
+</svg>

--- a/src/components/DataloggerDownload.tsx
+++ b/src/components/DataloggerDownload.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback, useEffect, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { Bluetooth, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { LoggerPicker } from "@/components/LoggerPicker";
 import {
   FileInfo,
   DownloadProgress,
@@ -29,16 +30,17 @@ interface DataloggerDownloadProps {
   autoSaveFile?: (name: string, blob: Blob) => Promise<void>;
   /**
    * Optional custom trigger (e.g. a big landing-page ActionTile). Receives the
-   * connect handler and whether Web Bluetooth is supported so the caller can
-   * render its own disabled/hint state. When omitted, the default outline
+   * handler that opens the logger picker. When omitted, the default outline
    * button is rendered.
    */
-  renderTrigger?: (args: { onConnect: () => void; bleSupported: boolean }) => ReactNode;
+  renderTrigger?: (args: { onOpen: () => void }) => ReactNode;
 }
 
 export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTrigger }: DataloggerDownloadProps) {
+  const { t } = useTranslation("logger");
   const device = useDeviceContext();
   const connection = device.connection;
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [state, setState] = useState<DownloadState>("idle");
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [progress, setProgress] = useState<DownloadProgress | null>(null);
@@ -272,48 +274,43 @@ export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, rende
     </Dialog>
   );
 
+  // The logger chooser — shown for every trigger variant before any download
+  // starts. Selecting the Fledgling kicks off the Bluetooth flow; the other
+  // loggers open their own explanatory dialogs from inside the picker.
+  const loggerPicker = (
+    <LoggerPicker
+      open={pickerOpen}
+      onOpenChange={setPickerOpen}
+      bleSupported={bleSupported}
+      onSelectFledgling={() => {
+        setPickerOpen(false);
+        void handleConnect();
+      }}
+    />
+  );
+
+  const openPicker = useCallback(() => setPickerOpen(true), []);
+
   // Custom-trigger mode (e.g. the landing-page ActionTile): caller owns the
-  // disabled/hint presentation; we just wire up the connect handler.
+  // presentation; we just wire up the handler that opens the picker.
   if (renderTrigger) {
     return (
       <>
-        {renderTrigger({ onConnect: handleConnect, bleSupported })}
+        {renderTrigger({ onOpen: openPicker })}
+        {loggerPicker}
         {downloadDialog}
       </>
     );
   }
 
-  // Button disabled if BLE not supported
-  if (!bleSupported) {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span>
-              <Button variant="outline" disabled className="opacity-50">
-                <Bluetooth className="w-4 h-4 mr-2" />
-                Download from DovesDataLogger
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Web Bluetooth not supported in this browser</p>
-            <p className="text-xs text-muted-foreground">
-              Use Chrome, Edge, or Opera on desktop
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-
   return (
     <>
-      <Button variant="outline" onClick={handleConnect}>
+      <Button variant="outline" onClick={openPicker}>
         <Bluetooth className="w-4 h-4 mr-2" />
-        Download from DovesDataLogger
+        {t("title")}
       </Button>
 
+      {loggerPicker}
       {downloadDialog}
     </>
   );

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -189,18 +189,12 @@ export function LandingPage({
                 onDataLoaded={onDataLoaded}
                 autoSave={autoSave}
                 autoSaveFile={autoSaveFile}
-                renderTrigger={({ onConnect, bleSupported }) => (
+                renderTrigger={({ onOpen }) => (
                   <ActionTile
                     icon={Bluetooth}
                     title={t("landing:tiles.logger.title")}
-                    description={
-                      bleSupported
-                        ? t("landing:tiles.logger.description")
-                        : t("landing:tiles.logger.unsupportedDescription")
-                    }
-                    onClick={onConnect}
-                    disabled={!bleSupported}
-                    hint={bleSupported ? undefined : t("landing:tiles.logger.unsupportedHint")}
+                    description={t("landing:tiles.logger.description")}
+                    onClick={onOpen}
                   />
                 )}
               />

--- a/src/components/LoggerPicker.tsx
+++ b/src/components/LoggerPicker.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isNativeApp } from "@/lib/platform";
+import { cn } from "@/lib/utils";
+
+// Placeholder product art — swap these files for real photos when available.
+// Kept in /public so they can be replaced without a code change.
+const FLEDGLING_IMAGE = "/loggers/fledgling.svg";
+const MYCHRON_IMAGE = "/loggers/mychron.svg";
+const ALFANO_IMAGE = "/loggers/alfano.svg";
+
+// Brand display names are proper nouns — intentionally not translated.
+const FLEDGLING_NAME = "PerchWerks Fledgling";
+const MYCHRON_NAME = "AiM MyChron 5 / 5S / 2T";
+const ALFANO_NAME = "Alfano 6 / 7";
+
+interface LoggerPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Whether Web Bluetooth is available — gates the Fledgling (BLE) tile. */
+  bleSupported: boolean;
+  /** Begin the standard Bluetooth download flow (PerchWerks Fledgling). */
+  onSelectFledgling: () => void;
+}
+
+interface LoggerCardProps {
+  image: string;
+  name: string;
+  tag: string;
+  onClick: () => void;
+  disabled?: boolean;
+  badge?: string;
+  hint?: string;
+}
+
+function LoggerCard({ image, name, tag, onClick, disabled, badge, hint }: LoggerCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={hint}
+      className={cn(
+        "group relative flex flex-col overflow-hidden rounded-xl border bg-card text-left transition-colors",
+        "hover:border-primary/50 hover:bg-accent disabled:pointer-events-none disabled:opacity-50",
+      )}
+    >
+      {badge && (
+        <span className="absolute right-2 top-2 z-10 rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+          {badge}
+        </span>
+      )}
+      <img src={image} alt={name} loading="lazy" className="aspect-[4/3] w-full object-cover" />
+      <span className="space-y-0.5 p-3">
+        <span className="block font-semibold text-foreground">{name}</span>
+        <span className="block text-xs text-muted-foreground">{tag}</span>
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Image-based logger chooser shown before any download begins. PerchWerks
+ * Fledgling runs the normal Web Bluetooth flow; MyChron and Alfano are not yet
+ * downloadable and open an explanatory dialog instead (MyChron's copy differs
+ * between the native shell and the web app — see `isNativeApp`).
+ */
+export function LoggerPicker({ open, onOpenChange, bleSupported, onSelectFledgling }: LoggerPickerProps) {
+  const { t } = useTranslation("logger");
+  const [info, setInfo] = useState<"mychron" | "alfano" | null>(null);
+  const native = isNativeApp();
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{t("title")}</DialogTitle>
+            <DialogDescription>{t("subtitle")}</DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <LoggerCard
+              image={FLEDGLING_IMAGE}
+              name={FLEDGLING_NAME}
+              tag={t("tags.fledgling")}
+              onClick={onSelectFledgling}
+              disabled={!bleSupported}
+              hint={bleSupported ? undefined : t("fledglingUnsupported")}
+            />
+            <LoggerCard
+              image={MYCHRON_IMAGE}
+              name={MYCHRON_NAME}
+              tag={t("tags.mychron")}
+              onClick={() => setInfo("mychron")}
+            />
+            <LoggerCard
+              image={ALFANO_IMAGE}
+              name={ALFANO_NAME}
+              tag={t("tags.alfano")}
+              badge={t("comingSoon")}
+              onClick={() => setInfo("alfano")}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* MyChron — native shows the spec'd placeholder; web explains the upcoming app. */}
+      <Dialog open={info === "mychron"} onOpenChange={(o) => !o && setInfo(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{native ? t("mychron.nativeTitle") : t("mychron.webTitle")}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            {native ? t("mychron.nativeBody") : t("mychron.webBody")}
+          </p>
+        </DialogContent>
+      </Dialog>
+
+      {/* Alfano — Bluetooth, no native app needed; coming soon. */}
+      <Dialog open={info === "alfano"} onOpenChange={(o) => !o && setInfo(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("alfano.title")}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">{t("alfano.body")}</p>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -35,7 +35,7 @@ export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
  * migrated (see docs/plans/i18n-translation-system.md). `common` is always
  * loaded; the rest load on demand for their surface.
  */
-export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin"] as const;
+export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin", "logger"] as const;
 export type Namespace = (typeof NAMESPACES)[number];
 
 export const DEFAULT_NAMESPACE: Namespace = "common";

--- a/src/locales/de/landing.json
+++ b/src/locales/de/landing.json
@@ -16,9 +16,7 @@
     },
     "logger": {
       "title": "Vom Logger herunterladen",
-      "description": "Logs per Bluetooth von deinem DovesDataLogger abrufen",
-      "unsupportedDescription": "Erfordert Chrome, Edge oder Opera auf dem Desktop",
-      "unsupportedHint": "Web Bluetooth wird von diesem Browser nicht unterstützt"
+      "description": "Logs direkt von deinem Datenlogger herunterladen"
     },
     "tracks": {
       "title": "Strecken verwalten",

--- a/src/locales/de/logger.json
+++ b/src/locales/de/logger.json
@@ -1,0 +1,22 @@
+{
+  "_machine": true,
+  "title": "Vom Logger herunterladen",
+  "subtitle": "Wähle deinen Logger, um einen Download zu starten.",
+  "comingSoon": "Demnächst",
+  "tags": {
+    "fledgling": "DIY-Logger · Bluetooth",
+    "mychron": "WLAN · native App erforderlich",
+    "alfano": "Bluetooth · demnächst"
+  },
+  "fledglingUnsupported": "Web Bluetooth wird hier nicht unterstützt – nutze Chrome, Edge oder Opera auf dem Desktop.",
+  "mychron": {
+    "nativeTitle": "MyChron-Download",
+    "nativeBody": "Noch offen",
+    "webTitle": "Native App erforderlich",
+    "webBody": "MyChron-Logger übertragen per WLAN, worauf Webbrowser nicht direkt zugreifen können. Eine eigene native App zum Herunterladen von MyChron ist in aktiver Entwicklung und soll um Juli 2026 erscheinen."
+  },
+  "alfano": {
+    "title": "Alfano-Downloads",
+    "body": "Alfano-Downloads werden dank der Bluetooth-Konnektivität des Loggers ohne native App verfügbar sein. Es geht voran – bleib dran (voraussichtlich Anfang Juli 2026)."
+  }
+}

--- a/src/locales/en/landing.json
+++ b/src/locales/en/landing.json
@@ -15,9 +15,7 @@
     },
     "logger": {
       "title": "Download from logger",
-      "description": "Pull logs over Bluetooth from your DovesDataLogger",
-      "unsupportedDescription": "Requires Chrome, Edge or Opera on desktop",
-      "unsupportedHint": "Web Bluetooth is not supported in this browser"
+      "description": "Download logs directly from your data logger"
     },
     "tracks": {
       "title": "Manage tracks",

--- a/src/locales/en/logger.json
+++ b/src/locales/en/logger.json
@@ -1,0 +1,21 @@
+{
+  "title": "Download from logger",
+  "subtitle": "Choose your logger to start a download.",
+  "comingSoon": "Coming soon",
+  "tags": {
+    "fledgling": "DIY logger · Bluetooth",
+    "mychron": "Wi-Fi · native app required",
+    "alfano": "Bluetooth · coming soon"
+  },
+  "fledglingUnsupported": "Web Bluetooth isn't supported here — use Chrome, Edge or Opera on desktop.",
+  "mychron": {
+    "nativeTitle": "MyChron download",
+    "nativeBody": "TBD",
+    "webTitle": "Native app required",
+    "webBody": "MyChron loggers transfer over Wi-Fi, which web browsers can't access directly. A dedicated native app to download from MyChron is in active development and is slated to launch around July 2026."
+  },
+  "alfano": {
+    "title": "Alfano downloads",
+    "body": "Alfano downloads will be available without a native app thanks to the logger's Bluetooth connectivity. Progress is being made — stay tuned for updates (estimated early July '26)."
+  }
+}

--- a/src/locales/es/landing.json
+++ b/src/locales/es/landing.json
@@ -16,9 +16,7 @@
     },
     "logger": {
       "title": "Descargar del registrador",
-      "description": "Descarga registros por Bluetooth desde tu DovesDataLogger",
-      "unsupportedDescription": "Requiere Chrome, Edge u Opera en ordenador",
-      "unsupportedHint": "Web Bluetooth no es compatible con este navegador"
+      "description": "Descarga registros directamente desde tu registrador de datos"
     },
     "tracks": {
       "title": "Gestionar circuitos",

--- a/src/locales/es/logger.json
+++ b/src/locales/es/logger.json
@@ -1,0 +1,22 @@
+{
+  "_machine": true,
+  "title": "Descargar del registrador",
+  "subtitle": "Elige tu registrador para iniciar una descarga.",
+  "comingSoon": "Próximamente",
+  "tags": {
+    "fledgling": "Registrador DIY · Bluetooth",
+    "mychron": "Wi-Fi · requiere app nativa",
+    "alfano": "Bluetooth · próximamente"
+  },
+  "fledglingUnsupported": "Web Bluetooth no es compatible aquí: usa Chrome, Edge u Opera en ordenador.",
+  "mychron": {
+    "nativeTitle": "Descarga de MyChron",
+    "nativeBody": "Por determinar",
+    "webTitle": "Se necesita app nativa",
+    "webBody": "Los registradores MyChron transfieren por Wi-Fi, a lo que los navegadores web no pueden acceder directamente. Hay una app nativa específica para descargar de MyChron en pleno desarrollo, con lanzamiento previsto en torno a julio de 2026."
+  },
+  "alfano": {
+    "title": "Descargas de Alfano",
+    "body": "Las descargas de Alfano estarán disponibles sin una app nativa gracias a la conectividad Bluetooth del registrador. Se está avanzando; mantente atento a las novedades (estimado para principios de julio de 2026)."
+  }
+}

--- a/src/locales/fr/landing.json
+++ b/src/locales/fr/landing.json
@@ -16,9 +16,7 @@
     },
     "logger": {
       "title": "Télécharger depuis l'enregistreur",
-      "description": "Récupérez les enregistrements par Bluetooth depuis votre DovesDataLogger",
-      "unsupportedDescription": "Nécessite Chrome, Edge ou Opera sur ordinateur",
-      "unsupportedHint": "Web Bluetooth n'est pas pris en charge par ce navigateur"
+      "description": "Téléchargez les enregistrements directement depuis votre enregistreur de données"
     },
     "tracks": {
       "title": "Gérer les circuits",

--- a/src/locales/fr/logger.json
+++ b/src/locales/fr/logger.json
@@ -1,0 +1,22 @@
+{
+  "_machine": true,
+  "title": "Télécharger depuis l'enregistreur",
+  "subtitle": "Choisissez votre enregistreur pour lancer un téléchargement.",
+  "comingSoon": "Bientôt disponible",
+  "tags": {
+    "fledgling": "Enregistreur DIY · Bluetooth",
+    "mychron": "Wi-Fi · app native requise",
+    "alfano": "Bluetooth · bientôt disponible"
+  },
+  "fledglingUnsupported": "Web Bluetooth n'est pas pris en charge ici — utilisez Chrome, Edge ou Opera sur ordinateur.",
+  "mychron": {
+    "nativeTitle": "Téléchargement MyChron",
+    "nativeBody": "À définir",
+    "webTitle": "App native requise",
+    "webBody": "Les enregistreurs MyChron transfèrent en Wi-Fi, auquel les navigateurs web ne peuvent pas accéder directement. Une app native dédiée au téléchargement depuis MyChron est en cours de développement et son lancement est prévu vers juillet 2026."
+  },
+  "alfano": {
+    "title": "Téléchargements Alfano",
+    "body": "Les téléchargements Alfano seront disponibles sans app native grâce à la connectivité Bluetooth de l'enregistreur. Des progrès sont en cours — restez à l'écoute (estimé début juillet 2026)."
+  }
+}

--- a/src/locales/it/landing.json
+++ b/src/locales/it/landing.json
@@ -16,9 +16,7 @@
     },
     "logger": {
       "title": "Scarica dal logger",
-      "description": "Scarica i log via Bluetooth dal tuo DovesDataLogger",
-      "unsupportedDescription": "Richiede Chrome, Edge o Opera su desktop",
-      "unsupportedHint": "Web Bluetooth non è supportato in questo browser"
+      "description": "Scarica i log direttamente dal tuo logger di dati"
     },
     "tracks": {
       "title": "Gestisci le piste",

--- a/src/locales/it/logger.json
+++ b/src/locales/it/logger.json
@@ -1,0 +1,22 @@
+{
+  "_machine": true,
+  "title": "Scarica dal logger",
+  "subtitle": "Scegli il tuo logger per avviare un download.",
+  "comingSoon": "Prossimamente",
+  "tags": {
+    "fledgling": "Logger DIY · Bluetooth",
+    "mychron": "Wi-Fi · richiede app nativa",
+    "alfano": "Bluetooth · prossimamente"
+  },
+  "fledglingUnsupported": "Web Bluetooth non è supportato qui: usa Chrome, Edge o Opera su computer.",
+  "mychron": {
+    "nativeTitle": "Download MyChron",
+    "nativeBody": "Da definire",
+    "webTitle": "App nativa richiesta",
+    "webBody": "I logger MyChron trasferiscono via Wi-Fi, a cui i browser web non possono accedere direttamente. Un'app nativa dedicata al download da MyChron è in fase di sviluppo e il lancio è previsto intorno a luglio 2026."
+  },
+  "alfano": {
+    "title": "Download Alfano",
+    "body": "I download Alfano saranno disponibili senza un'app nativa grazie alla connettività Bluetooth del logger. Stiamo facendo progressi: resta sintonizzato per gli aggiornamenti (stimato inizio luglio 2026)."
+  }
+}

--- a/src/locales/ja/landing.json
+++ b/src/locales/ja/landing.json
@@ -16,9 +16,7 @@
     },
     "logger": {
       "title": "ロガーからダウンロード",
-      "description": "DovesDataLogger から Bluetooth でログを取得",
-      "unsupportedDescription": "デスクトップ版の Chrome、Edge、Opera が必要です",
-      "unsupportedHint": "このブラウザーは Web Bluetooth に対応していません"
+      "description": "データロガーから直接ログをダウンロード"
     },
     "tracks": {
       "title": "コースを管理",

--- a/src/locales/ja/logger.json
+++ b/src/locales/ja/logger.json
@@ -1,0 +1,22 @@
+{
+  "_machine": true,
+  "title": "ロガーからダウンロード",
+  "subtitle": "ダウンロードを開始するロガーを選択してください。",
+  "comingSoon": "近日公開",
+  "tags": {
+    "fledgling": "DIYロガー · Bluetooth",
+    "mychron": "Wi-Fi · ネイティブアプリが必要",
+    "alfano": "Bluetooth · 近日公開"
+  },
+  "fledglingUnsupported": "Web Bluetooth はこの環境では非対応です。デスクトップの Chrome、Edge、または Opera をご利用ください。",
+  "mychron": {
+    "nativeTitle": "MyChron のダウンロード",
+    "nativeBody": "未定",
+    "webTitle": "ネイティブアプリが必要です",
+    "webBody": "MyChron ロガーは Wi-Fi で転送するため、Web ブラウザーから直接アクセスできません。MyChron からダウンロードするための専用ネイティブアプリを開発中で、2026年7月頃のリリースを予定しています。"
+  },
+  "alfano": {
+    "title": "Alfano のダウンロード",
+    "body": "Alfano のダウンロードは、ロガーの Bluetooth 接続によりネイティブアプリなしで利用できるようになります。開発は進行中です。最新情報にご注目ください（2026年7月初旬予定）。"
+  }
+}

--- a/src/locales/pt-BR/landing.json
+++ b/src/locales/pt-BR/landing.json
@@ -16,9 +16,7 @@
     },
     "logger": {
       "title": "Baixar do registrador",
-      "description": "Baixe registros via Bluetooth do seu DovesDataLogger",
-      "unsupportedDescription": "Requer Chrome, Edge ou Opera no computador",
-      "unsupportedHint": "Web Bluetooth não é compatível com este navegador"
+      "description": "Baixe registros diretamente do seu registrador de dados"
     },
     "tracks": {
       "title": "Gerenciar pistas",

--- a/src/locales/pt-BR/logger.json
+++ b/src/locales/pt-BR/logger.json
@@ -1,0 +1,22 @@
+{
+  "_machine": true,
+  "title": "Baixar do registrador",
+  "subtitle": "Escolha seu registrador para iniciar um download.",
+  "comingSoon": "Em breve",
+  "tags": {
+    "fledgling": "Registrador DIY · Bluetooth",
+    "mychron": "Wi-Fi · app nativo necessário",
+    "alfano": "Bluetooth · em breve"
+  },
+  "fledglingUnsupported": "Web Bluetooth não é compatível aqui — use Chrome, Edge ou Opera no computador.",
+  "mychron": {
+    "nativeTitle": "Download do MyChron",
+    "nativeBody": "A definir",
+    "webTitle": "App nativo necessário",
+    "webBody": "Os registradores MyChron transferem por Wi-Fi, que os navegadores web não conseguem acessar diretamente. Um app nativo dedicado para baixar do MyChron está em desenvolvimento e tem lançamento previsto para cerca de julho de 2026."
+  },
+  "alfano": {
+    "title": "Downloads do Alfano",
+    "body": "Os downloads do Alfano estarão disponíveis sem um app nativo graças à conectividade Bluetooth do registrador. Estamos progredindo — fique de olho nas novidades (estimado para início de julho de 2026)."
+  }
+}

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -17,6 +17,7 @@ import type tracks from "@/locales/en/tracks.json";
 import type plugins from "@/locales/en/plugins.json";
 import type auth from "@/locales/en/auth.json";
 import type admin from "@/locales/en/admin.json";
+import type logger from "@/locales/en/logger.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -33,6 +34,7 @@ declare module "i18next" {
       plugins: typeof plugins;
       auth: typeof auth;
       admin: typeof admin;
+      logger: typeof logger;
     };
   }
 }


### PR DESCRIPTION
## What & why

"Download from logger" previously jumped straight into the Web Bluetooth download flow. This is the groundwork for supporting multiple logger brands: it now opens an **image-based chooser** of supported loggers, and relabels the file-manager button from "Download from DovesDataLogger" to "Download from logger".

## The picker

Three image tiles (placeholder artwork in `public/loggers/`, easy to swap for real photos):

| Tile | Tag | Behaviour |
|------|-----|-----------|
| **PerchWerks Fledgling** | DIY logger · Bluetooth | Runs the existing Web Bluetooth download flow. Disabled with a hint when Web Bluetooth is unavailable. |
| **AiM MyChron 5 / 5S / 2T** | Wi-Fi · native app required | Explanatory dialog. Copy differs by platform: **native shell** shows a placeholder `TBD` panel (Tauri connection spec is TBD — out of scope for this PR); **web** explains a native app is in development, slated ~July 2026. |
| **Alfano 6 / 7** | Bluetooth · coming soon | Explanatory dialog: Alfano downloads will be available without a native app thanks to Bluetooth; estimated early July '26. |

The native-vs-web split is gated on `isNativeApp()`. (Desktop web is treated like mobile web for MyChron — a browser can't reach the logger's Wi-Fi either way.)

## Notes / decisions
- New `logger` i18n namespace, translated across all 7 locales (registered in `config.ts` + `i18next.d.ts`). Brand names are proper nouns and stay untranslated.
- Removed the now-unused `landing:tiles.logger.unsupported*` keys (BLE-support gating moved into the picker) and made the landing tile description logger-agnostic.
- `LoggerPicker` rides the existing lazy `DataloggerDownload` chunk, so `lib/ble/*` stays off the initial bundle.
- Docs synced: `CLAUDE.md`, `docs/ble.md`, `CHANGELOG.md` (under `[2.8.1] - unreleased`).

## Verification
`bun run lint`, `bun run typecheck`, `bun run test:run` (1878 pass), and `bun run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLRuG1p8vhUXFP5V34WVET

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLRuG1p8vhUXFP5V34WVET)_