### PR TITLE
Fix home download button + generic logger-connection layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.8.1] - unreleased
 
 ### Added
+- **Generic logger-connection layer.** Downloads now go through one
+  `LoggerConnection` interface (`listLogs` / `downloadLog` / `disconnect`) in
+  `src/lib/loggers/`, with `createFledglingConnection()` adapting the Web Bluetooth
+  transport. This is the seam future loggers plug into — MyChron over the native
+  (Tauri) shell, Alfano over BLE — without the download UI having to branch on
+  transport. `DeviceContext` now tracks the connected `loggerKind`.
 - **Logger picker.** "Download from logger" now opens an image-based chooser of
   supported loggers instead of jumping straight to Bluetooth: **PerchWerks
   Fledgling** (DIY, Bluetooth), **AiM MyChron 5 / 5S / 2T** (Wi-Fi, native app
@@ -30,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"Download from logger" relabel.** The file-manager button previously labelled
   "Download from DovesDataLogger" is now "Download from logger" and opens the new
   logger picker.
+- **Logger picker is now eager.** The picker menu was split out of the lazy
+  Bluetooth chunk into a lightweight host (`LoggerDownload`), so the home-screen
+  "Download from logger" button opens the menu instantly instead of waiting on (and
+  silently failing when) the BLE chunk stalls. The heavy BLE flow still loads lazily
+  — only once the Fledgling is picked.
+- **Device tab is Fledgling-gated.** The drawer's Device tab (settings / tracks /
+  firmware) now shows a "Fledgling only" notice when the connected logger isn't a
+  Fledgling, groundwork for MyChron/Alfano connections that don't expose those
+  surfaces.
 - **Header logo returns to the home screen.** Tapping the LapWing logo (top-left)
   in an open session now closes the session and returns to the landing page.
 - **Purple theme + new logo.** The brand accent moved from teal to **purple**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ src/
 │   ├── RaceLineView.tsx   # Leaflet map: race line, speed heatmap, braking zones
 │   ├── TelemetryChart.tsx # Canvas speed/telemetry chart (simple mode)
 │   ├── VideoPlayer.tsx    # Synced video playback + overlay system (multi-chunk GoPro playlists via lib/videoPlaylist)
-│   └── …                  # FileImport, LoggerPicker (image-based logger chooser), DataloggerDownload (BLE entry, lazy), LapSnapshot*, …
+│   └── …                  # FileImport, LoggerDownload (eager picker host) + LoggerPicker (image chooser) + DataloggerDownload (lazy Fledgling BLE flow), LapSnapshot*, …
 ├── hooks/                 # One concern each; Index.tsx orchestrates.
 │   ├── useSessionData     # Parses imported file → ParsedData
 │   ├── useLapManagement   # Lap calc, selection, visible range
@@ -116,6 +116,7 @@ src/
 │   ├── fileLoadingState.ts # ★ Host pub/sub for the global file-load overlay
 │   ├── *Storage.ts        # IDB/localStorage store modules (file, vehicle, engine, template, note, setup, …)
 │   ├── gps/               # ★ Phone-as-datalogger layer: gpsFix, customGps, sessionGate, realtimeTimer, dovepWriter
+│   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=BLE today; MyChron (Tauri)/Alfano later satisfy the same interface
 │   ├── speedHeatmap.ts / mapMarker.ts / brakingZones / gforceCalculation / …  # racing math
 │   ├── chartUtils / canvas2d / chartAxis / chartColors / videoExport / overlayCanvasRenderer  # charts/video
 │   ├── videoPlaylist.ts   # ★ Pure GoPro chunked-video model: parse/order GH/GX/GP/GOPR chunk names, build a virtual timeline (cumulative offsets) + virtual↔local time mapping + planAudioSegments (export audio stitch). useVideoSync swaps the <video> src per chunk; a single file is a 1-chunk playlist
@@ -433,7 +434,9 @@ re-merges it into the main chunk — watch for this.
 
 **Lazy (off the initial path):** routes (`Login`, `Admin`, `Register`, `Privacy`);
 view tabs (`RaceLineTab`, `GraphViewTab`, `CoachTab`, `ToolsTab`, `SetupsTab`); `FileManagerDrawer`;
-`DataloggerDownload` (keeps `lib/ble/*` out); `CourseSectorEditor` (carries
+`DataloggerDownload` — the Fledgling BLE flow, mounted on demand by the eager
+`LoggerDownload` picker host so `lib/ble/*` stays off the landing payload while the
+menu still opens instantly; `CourseSectorEditor` (carries
 `@dnd-kit/*`). Lazy components must render inside `<Suspense>`; use
 `lazy(() => import('…').then((m) => ({ default: m.Named })))` for named exports.
 

--- a/docs/ble.md
+++ b/docs/ble.md
@@ -5,11 +5,19 @@ transfer, settings, track sync, battery, and the SD-staged firmware OTA. Kept ou
 of `CLAUDE.md` so it loads only when working on device code. Global BLE connection
 state lives in `DeviceContext.tsx` (wraps the app tree in `Index.tsx`). Source:
 `src/lib/ble/` (split per-concern; `bleDatalogger.ts` is the legacy barrel).
-Everything here is lazy-loaded — `DataloggerDownload` is the BLE entry point so
-`lib/ble/*` stays out of the initial bundle. The user reaches it through
-`LoggerPicker` (an image-based chooser of supported loggers); selecting the
-PerchWerks Fledgling tile starts this Bluetooth flow, while the other loggers
-(MyChron, Alfano) open explanatory dialogs and don't touch `lib/ble/*` yet.
+The user reaches the BLE flow through `LoggerDownload` → `LoggerPicker` (an eager,
+lightweight image chooser of supported loggers). Picking the PerchWerks Fledgling
+tile mounts `DataloggerDownload` — the lazy BLE flow — on demand, so `lib/ble/*`
+stays out of the initial bundle while the menu still opens instantly. The other
+loggers (MyChron, Alfano) open explanatory dialogs and don't touch `lib/ble/*` yet.
+
+`DataloggerDownload` talks to the device only through the generic
+`LoggerConnection` interface (`src/lib/loggers/`): `listLogs` / `downloadLog` /
+`disconnect`, with `createFledglingConnection()` adapting a `BleConnection`. New
+transports (MyChron over the native shell, Alfano over BLE) add sibling adapters
+that satisfy the same interface, and `DeviceContext.loggerKind` records which
+logger is connected so Fledgling-only surfaces (settings / tracks / firmware) can
+gate themselves.
 
 ---
 

--- a/src/components/DataloggerDownload.tsx
+++ b/src/components/DataloggerDownload.tsx
@@ -1,17 +1,9 @@
-import { useState, useCallback, useEffect, type ReactNode } from "react";
-import { useTranslation } from "react-i18next";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { Bluetooth, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { LoggerPicker } from "@/components/LoggerPicker";
-import {
-  FileInfo,
-  DownloadProgress,
-  isBleSupported,
-  requestFileList,
-  downloadFile,
-  formatBytes,
-} from "@/lib/bleDatalogger";
+import { formatBytes } from "@/lib/bleDatalogger";
+import { createFledglingConnection, type LoggerConnection, type LoggerFile, type LoggerDownloadProgress } from "@/lib/loggers";
 import { useDeviceContext } from "@/contexts/DeviceContext";
 import { parseDatalogContent } from "@/lib/datalogParser";
 import { ParsedData } from "@/types/racing";
@@ -28,55 +20,29 @@ interface DataloggerDownloadProps {
   onDataLoaded: (data: ParsedData, fileName?: string) => void;
   autoSave?: boolean;
   autoSaveFile?: (name: string, blob: Blob) => Promise<void>;
-  /**
-   * Optional custom trigger (e.g. a big landing-page ActionTile). Receives the
-   * handler that opens the logger picker. When omitted, the default outline
-   * button is rendered.
-   */
-  renderTrigger?: (args: { onOpen: () => void }) => ReactNode;
+  /** Begin connecting as soon as the flow mounts (it's mounted on demand). */
+  autoStart?: boolean;
+  /** Called when the flow finishes or is dismissed so the host can unmount it. */
+  onClose: () => void;
 }
 
-export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTrigger }: DataloggerDownloadProps) {
-  const { t } = useTranslation("logger");
+/**
+ * The PerchWerks Fledgling download flow: connect over Web Bluetooth, list logs,
+ * download + parse the chosen one. Mounted on demand by `LoggerDownload` once the
+ * user picks the Fledgling in the logger picker, so the BLE protocol bundle
+ * (`lib/ble/*`) stays off the initial/landing payload. Talks to the device only
+ * through the generic `LoggerConnection` surface.
+ */
+export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, autoStart, onClose }: DataloggerDownloadProps) {
   const device = useDeviceContext();
   const connection = device.connection;
-  const [pickerOpen, setPickerOpen] = useState(false);
   const [state, setState] = useState<DownloadState>("idle");
-  const [files, setFiles] = useState<FileInfo[]>([]);
-  const [progress, setProgress] = useState<DownloadProgress | null>(null);
+  const [files, setFiles] = useState<LoggerFile[]>([]);
+  const [progress, setProgress] = useState<LoggerDownloadProgress | null>(null);
   const [currentFile, setCurrentFile] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [statusMessage, setStatusMessage] = useState<string>("");
-
-  const bleSupported = isBleSupported();
-
-  const handleConnect = useCallback(async () => {
-    setState("connecting");
-    setError("");
-    setStatusMessage("Scanning for DovesLapTimer...");
-
-    try {
-      // Reuse existing context connection if available; otherwise connect via context.
-      const conn = device.connection ?? (await device.connect(setStatusMessage));
-      if (!conn) {
-        // User cancelled the picker
-        setState("idle");
-        return;
-      }
-
-      setState("fetching-files");
-      setStatusMessage("Fetching file list...");
-
-      const fileList = await requestFileList(conn, setStatusMessage);
-      setFiles(fileList);
-      setState("file-list");
-      setStatusMessage(`Found ${fileList.length} files`);
-    } catch (err) {
-      console.error("Connection/file list error:", err);
-      setError(err instanceof Error ? err.message : "Failed to connect");
-      setState("error");
-    }
-  }, [device]);
+  const loggerRef = useRef<LoggerConnection | null>(null);
 
   const handleClose = useCallback(() => {
     // Do NOT disconnect — connection lifecycle is owned by DeviceContext.
@@ -87,11 +53,54 @@ export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, rende
     setCurrentFile("");
     setError("");
     setStatusMessage("");
-  }, []);
+    loggerRef.current = null;
+    onClose();
+  }, [onClose]);
+
+  const handleConnect = useCallback(async () => {
+    setState("connecting");
+    setError("");
+    setStatusMessage("Scanning for DovesLapTimer...");
+
+    try {
+      // Reuse existing context connection if available; otherwise connect via context.
+      const conn = device.connection ?? (await device.connect(setStatusMessage));
+      if (!conn) {
+        // User cancelled the picker — close the flow.
+        handleClose();
+        return;
+      }
+
+      const logger = createFledglingConnection(conn);
+      loggerRef.current = logger;
+
+      setState("fetching-files");
+      setStatusMessage("Fetching file list...");
+
+      const fileList = await logger.listLogs(setStatusMessage);
+      setFiles(fileList);
+      setState("file-list");
+      setStatusMessage(`Found ${fileList.length} files`);
+    } catch (err) {
+      console.error("Connection/file list error:", err);
+      setError(err instanceof Error ? err.message : "Failed to connect");
+      setState("error");
+    }
+  }, [device, handleClose]);
+
+  // Kick off the connection as soon as the flow is mounted (once).
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (autoStart && !startedRef.current) {
+      startedRef.current = true;
+      void handleConnect();
+    }
+  }, [autoStart, handleConnect]);
 
   const handleFileSelect = useCallback(
-    async (file: FileInfo) => {
-      if (!connection) {
+    async (file: LoggerFile) => {
+      const logger = loggerRef.current;
+      if (!connection || !logger) {
         setError("Device disconnected. Please reconnect.");
         setState("error");
         return;
@@ -109,12 +118,7 @@ export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, rende
       setError("");
 
       try {
-        const fileData = await downloadFile(
-          connection,
-          file.name,
-          setProgress,
-          setStatusMessage
-        );
+        const fileData = await logger.downloadLog(file.name, setProgress, setStatusMessage);
 
         // Always save the raw file first so it's never lost
         if (autoSave && autoSaveFile) {
@@ -157,13 +161,12 @@ export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, rende
 
   const handleRetry = useCallback(() => {
     setError("");
-    setState("idle");
-  }, []);
+    void handleConnect();
+  }, [handleConnect]);
 
   const isModalOpen = state !== "idle";
 
-  // The transfer modal — shared by every trigger variant below.
-  const downloadDialog = (
+  return (
     <Dialog open={isModalOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
@@ -272,46 +275,5 @@ export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, rende
         )}
       </DialogContent>
     </Dialog>
-  );
-
-  // The logger chooser — shown for every trigger variant before any download
-  // starts. Selecting the Fledgling kicks off the Bluetooth flow; the other
-  // loggers open their own explanatory dialogs from inside the picker.
-  const loggerPicker = (
-    <LoggerPicker
-      open={pickerOpen}
-      onOpenChange={setPickerOpen}
-      bleSupported={bleSupported}
-      onSelectFledgling={() => {
-        setPickerOpen(false);
-        void handleConnect();
-      }}
-    />
-  );
-
-  const openPicker = useCallback(() => setPickerOpen(true), []);
-
-  // Custom-trigger mode (e.g. the landing-page ActionTile): caller owns the
-  // presentation; we just wire up the handler that opens the picker.
-  if (renderTrigger) {
-    return (
-      <>
-        {renderTrigger({ onOpen: openPicker })}
-        {loggerPicker}
-        {downloadDialog}
-      </>
-    );
-  }
-
-  return (
-    <>
-      <Button variant="outline" onClick={openPicker}>
-        <Bluetooth className="w-4 h-4 mr-2" />
-        {t("title")}
-      </Button>
-
-      {loggerPicker}
-      {downloadDialog}
-    </>
   );
 }

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -216,6 +216,14 @@ export function FileManagerDrawer({
                   {device.isConnecting ? (<><Loader2 className="w-4 h-4 animate-spin" /> {t("shell.connecting")}</>) : (<><Bluetooth className="w-4 h-4" /> {t("shell.connect")}</>)}
                 </Button>
               </div>
+            ) : device.loggerKind && device.loggerKind !== "fledgling" ? (
+              // Settings/tracks/firmware are Fledgling-only. Other loggers (MyChron,
+              // Alfano) can connect for downloads but have no device-detail surface yet.
+              <div className="flex-1 flex flex-col items-center justify-center p-8 gap-4 text-center">
+                <Cpu className="w-12 h-12 text-muted-foreground" />
+                <h3 className="font-semibold text-foreground">{t("shell.deviceFledglingOnlyTitle")}</h3>
+                <p className="text-sm text-muted-foreground max-w-[260px]">{t("shell.deviceFledglingOnlyDesc")}</p>
+              </div>
             ) : (
               <>
                 <div className="flex gap-1 px-3 py-2 border-b border-border shrink-0">

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, lazy, Suspense } from "react";
+import { Fragment } from "react";
 import {
   Github,
   Heart,
@@ -34,11 +34,10 @@ import { interceptExternal } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { ParsedData } from "@/types/racing";
 
-// Lazy so the BLE module (Web Bluetooth protocol) stays out of the initial
-// bundle — it only loads when this tile mounts on the landing page.
-const DataloggerDownload = lazy(() =>
-  import("./DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
-);
+// Eager: the logger picker is lightweight and must open instantly. The heavy
+// BLE flow it launches stays lazy (loaded only when the Fledgling is picked),
+// so the protocol bundle is still kept off the initial landing payload.
+import { LoggerDownload } from "@/components/LoggerDownload";
 
 interface LandingPageProps {
   onDataLoaded: (data: ParsedData, fileName?: string) => void;
@@ -175,30 +174,19 @@ export function LandingPage({
               onClick={onOpenFileManager}
             />
 
-            <Suspense
-              fallback={
+            <LoggerDownload
+              onDataLoaded={onDataLoaded}
+              autoSave={autoSave}
+              autoSaveFile={autoSaveFile}
+              renderTrigger={({ onOpen }) => (
                 <ActionTile
                   icon={Bluetooth}
                   title={t("landing:tiles.logger.title")}
-                  description={t("common:actions.loading")}
-                  disabled
+                  description={t("landing:tiles.logger.description")}
+                  onClick={onOpen}
                 />
-              }
-            >
-              <DataloggerDownload
-                onDataLoaded={onDataLoaded}
-                autoSave={autoSave}
-                autoSaveFile={autoSaveFile}
-                renderTrigger={({ onOpen }) => (
-                  <ActionTile
-                    icon={Bluetooth}
-                    title={t("landing:tiles.logger.title")}
-                    description={t("landing:tiles.logger.description")}
-                    onClick={onOpen}
-                  />
-                )}
-              />
-            </Suspense>
+              )}
+            />
 
             {/* Track manager — create/draw tracks & courses without a datalog. */}
             <TrackEditor

--- a/src/components/LoggerDownload.tsx
+++ b/src/components/LoggerDownload.tsx
@@ -1,0 +1,77 @@
+import { lazy, Suspense, useCallback, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { Bluetooth } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { LoggerPicker } from "@/components/LoggerPicker";
+import { useDeviceContext } from "@/contexts/DeviceContext";
+import type { ParsedData } from "@/types/racing";
+
+// The Fledgling BLE flow is the only heavy part — lazy-load it so the protocol
+// bundle (`lib/ble/*`) loads only when the user actually picks the Fledgling.
+// The host itself (button + picker) stays eager so the menu opens instantly and
+// never depends on a chunk finishing to load.
+const DataloggerDownload = lazy(() =>
+  import("@/components/DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
+);
+
+interface LoggerDownloadProps {
+  onDataLoaded: (data: ParsedData, fileName?: string) => void;
+  autoSave?: boolean;
+  autoSaveFile?: (name: string, blob: Blob) => Promise<void>;
+  /**
+   * Optional custom trigger (e.g. a big landing-page ActionTile). Receives the
+   * handler that opens the logger picker. When omitted, the default outline
+   * button is rendered.
+   */
+  renderTrigger?: (args: { onOpen: () => void }) => ReactNode;
+}
+
+/**
+ * Entry point for "Download from logger": renders the trigger (button or a
+ * caller-supplied tile) and the image-based `LoggerPicker`. Picking the
+ * Fledgling mounts the lazy Bluetooth download flow; MyChron and Alfano are
+ * handled inside the picker (explanatory dialogs).
+ */
+export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTrigger }: LoggerDownloadProps) {
+  const { t } = useTranslation("logger");
+  const { bleSupported } = useDeviceContext();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [fledglingActive, setFledglingActive] = useState(false);
+
+  const openPicker = useCallback(() => setPickerOpen(true), []);
+
+  return (
+    <>
+      {renderTrigger ? (
+        renderTrigger({ onOpen: openPicker })
+      ) : (
+        <Button variant="outline" onClick={openPicker}>
+          <Bluetooth className="w-4 h-4 mr-2" />
+          {t("title")}
+        </Button>
+      )}
+
+      <LoggerPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        bleSupported={bleSupported}
+        onSelectFledgling={() => {
+          setPickerOpen(false);
+          setFledglingActive(true);
+        }}
+      />
+
+      {fledglingActive && (
+        <Suspense fallback={null}>
+          <DataloggerDownload
+            autoStart
+            onDataLoaded={onDataLoaded}
+            autoSave={autoSave}
+            autoSaveFile={autoSaveFile}
+            onClose={() => setFledglingActive(false)}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/src/components/drawer/FilesTab.tsx
+++ b/src/components/drawer/FilesTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect, useMemo, lazy, Suspense } from "react";
+import { useCallback, useRef, useState, useEffect, useMemo } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { toast } from "sonner";
 import { Trash2, Download, Upload, FolderOpen, Loader2, Video, Cloud, CloudDownload } from "lucide-react";
@@ -14,10 +14,8 @@ import {
 import { SessionBrowser } from "@/components/SessionBrowser";
 import { FileTypeBadge } from "@/components/FileTypeBadge";
 import { useFileSources, type FileSource, type RemoteFile } from "@/plugins/fileSources";
-// Lazy — keeps the BLE module in its own chunk, loaded only on device use.
-const DataloggerDownload = lazy(() =>
-  import("@/components/DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
-);
+// The picker host is light; the BLE flow it launches stays in its own lazy chunk.
+import { LoggerDownload } from "@/components/LoggerDownload";
 import { listSessionVideos, StoredVideoMeta } from "@/lib/videoFileStorage";
 import { PluginMount } from "@/plugins/PluginMount";
 import { MountSlot } from "@/plugins/mounts";
@@ -426,13 +424,11 @@ export function FilesTab({
           {loading ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Upload className="w-4 h-4 mr-2" />}
           {t("files.uploadFiles")}
         </Button>
-        <Suspense fallback={null}>
-          <DataloggerDownload
-            onDataLoaded={handleBleDataLoaded}
-            autoSave={autoSave}
-            autoSaveFile={onSaveFile}
-          />
-        </Suspense>
+        <LoggerDownload
+          onDataLoaded={handleBleDataLoaded}
+          autoSave={autoSave}
+          autoSaveFile={onSaveFile}
+        />
       </div>
     </div>
   );

--- a/src/contexts/DeviceContext.tsx
+++ b/src/contexts/DeviceContext.tsx
@@ -5,10 +5,17 @@ import {
   disconnect,
   isBleSupported,
 } from "@/lib/bleDatalogger";
+import type { LoggerKind } from "@/lib/loggers";
 
 interface DeviceContextValue {
   /** Current BLE connection (null when disconnected) */
   connection: BleConnection | null;
+  /**
+   * Which logger the current connection talks to (null when disconnected). Only
+   * the Fledgling connects today; this lets surfaces like the Device tab gate
+   * logger-specific features as other transports (MyChron, Alfano) land.
+   */
+  loggerKind: LoggerKind | null;
   /** Friendly device name from BluetoothDevice */
   deviceName: string | null;
   /** True while the browser BLE picker is open */
@@ -33,6 +40,7 @@ const DeviceContext = createContext<DeviceContextValue | null>(null);
 
 export function DeviceProvider({ children }: { children: ReactNode }) {
   const [connection, setConnection] = useState<BleConnection | null>(null);
+  const [loggerKind, setLoggerKind] = useState<LoggerKind | null>(null);
   const [deviceName, setDeviceName] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isFlashing, setIsFlashing] = useState(false);
@@ -55,6 +63,7 @@ export function DeviceProvider({ children }: { children: ReactNode }) {
     // drop is expected, so keep the UI mounted instead of tearing it down.
     if (flashingRef.current) return;
     setConnection(null);
+    setLoggerKind(null);
     setDeviceName(null);
   }, []);
 
@@ -67,6 +76,8 @@ export function DeviceProvider({ children }: { children: ReactNode }) {
       // Listen for unexpected disconnects
       conn.device.addEventListener("gattserverdisconnected", handleDisconnect);
       setConnection(conn);
+      // Web Bluetooth only ever reaches the Fledgling today.
+      setLoggerKind("fledgling");
       setDeviceName(conn.device.name ?? "Unknown Device");
       return conn;
     } catch (err) {
@@ -97,7 +108,7 @@ export function DeviceProvider({ children }: { children: ReactNode }) {
 
   return (
     <DeviceContext.Provider
-      value={{ connection, deviceName, isConnecting, bleSupported, connect: connectFn, disconnectDevice, isFlashing, setFlashing }}
+      value={{ connection, loggerKind, deviceName, isConnecting, bleSupported, connect: connectFn, disconnectDevice, isFlashing, setFlashing }}
     >
       {children}
     </DeviceContext.Provider>

--- a/src/lib/loggers/fledglingConnection.test.ts
+++ b/src/lib/loggers/fledglingConnection.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as ble from "@/lib/ble";
+import { createFledglingConnection } from "./fledglingConnection";
+
+vi.mock("@/lib/ble", () => ({
+  requestFileList: vi.fn(),
+  downloadFile: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+function fakeBle(name?: string) {
+  return { device: { name } } as unknown as ble.BleConnection;
+}
+
+describe("createFledglingConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a Fledgling that supports device details", () => {
+    const conn = createFledglingConnection(fakeBle("DovesLapTimer 1"));
+    expect(conn.kind).toBe("fledgling");
+    expect(conn.supportsDeviceDetails).toBe(true);
+    expect(conn.displayName).toBe("DovesLapTimer 1");
+  });
+
+  it("falls back to a brand name when the device is unnamed", () => {
+    const conn = createFledglingConnection(fakeBle(undefined));
+    expect(conn.displayName).toBe("PerchWerks Fledgling");
+  });
+
+  it("delegates listLogs to the BLE file-list request", async () => {
+    const files = [{ name: "RUN1.dove", size: 10 }];
+    vi.mocked(ble.requestFileList).mockResolvedValue(files);
+    const underlying = fakeBle("x");
+    const conn = createFledglingConnection(underlying);
+    const onStatus = vi.fn();
+
+    await expect(conn.listLogs(onStatus)).resolves.toBe(files);
+    expect(ble.requestFileList).toHaveBeenCalledWith(underlying, onStatus);
+  });
+
+  it("delegates downloadLog to the BLE file download", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    vi.mocked(ble.downloadFile).mockResolvedValue(bytes);
+    const underlying = fakeBle("x");
+    const conn = createFledglingConnection(underlying);
+    const onProgress = vi.fn();
+    const onStatus = vi.fn();
+
+    await expect(conn.downloadLog("RUN1.dove", onProgress, onStatus)).resolves.toBe(bytes);
+    expect(ble.downloadFile).toHaveBeenCalledWith(underlying, "RUN1.dove", onProgress, onStatus);
+  });
+
+  it("delegates disconnect to the BLE teardown", () => {
+    const underlying = fakeBle("x");
+    createFledglingConnection(underlying).disconnect();
+    expect(ble.disconnect).toHaveBeenCalledWith(underlying);
+  });
+});

--- a/src/lib/loggers/fledglingConnection.ts
+++ b/src/lib/loggers/fledglingConnection.ts
@@ -1,0 +1,24 @@
+/**
+ * PerchWerks Fledgling adapter — wraps a Web Bluetooth `BleConnection` in the
+ * generic `LoggerConnection` surface. This is the only transport wired today;
+ * MyChron (Wi-Fi via the native shell) and Alfano (BLE) will add sibling
+ * adapters that satisfy the same interface.
+ *
+ * Importing this module pulls the BLE protocol in, so only the lazy Fledgling
+ * download flow should reference it — never the eager picker.
+ */
+
+import { type BleConnection, requestFileList, downloadFile, disconnect } from "@/lib/ble";
+import type { LoggerConnection } from "./types";
+
+/** Adapt a live Fledgling BLE connection to the generic logger interface. */
+export function createFledglingConnection(ble: BleConnection): LoggerConnection {
+  return {
+    kind: "fledgling",
+    displayName: ble.device.name ?? "PerchWerks Fledgling",
+    supportsDeviceDetails: true,
+    listLogs: (onStatus) => requestFileList(ble, onStatus),
+    downloadLog: (name, onProgress, onStatus) => downloadFile(ble, name, onProgress, onStatus),
+    disconnect: () => disconnect(ble),
+  };
+}

--- a/src/lib/loggers/index.ts
+++ b/src/lib/loggers/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Generic logger layer. The app downloads from any logger through
+ * `LoggerConnection`; transport-specific adapters live alongside (BLE today).
+ */
+
+export type { LoggerKind, LoggerFile, LoggerDownloadProgress, LoggerConnection } from "./types";
+export { createFledglingConnection } from "./fledglingConnection";

--- a/src/lib/loggers/types.ts
+++ b/src/lib/loggers/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Generic logger-connection contract.
+ *
+ * The app talks to every logger (PerchWerks Fledgling over BLE today; AiM
+ * MyChron over Wi-Fi via the native shell, Alfano over BLE — both later) through
+ * this one interface, so download UI never has to branch on the transport. Each
+ * logger ships an adapter that fulfils `LoggerConnection`; see
+ * `fledglingConnection.ts` for the BLE implementation.
+ *
+ * Kept free of any transport imports (no Web Bluetooth, no Tauri) so it stays on
+ * the eager graph without pulling a protocol bundle in.
+ */
+
+/** Which physical logger a connection talks to. */
+export type LoggerKind = "fledgling" | "mychron" | "alfano";
+
+/** A downloadable log on the device. */
+export interface LoggerFile {
+  name: string;
+  size: number;
+}
+
+/** Progress for an in-flight download. */
+export interface LoggerDownloadProgress {
+  received: number;
+  total: number;
+  percent: number;
+  speed: string;
+  eta: string;
+}
+
+/**
+ * A live connection to a logger. The download surface (`listLogs` /
+ * `downloadLog`) is uniform across loggers; logger-specific features (the
+ * Fledgling's settings/tracks/firmware tabs) are gated on `supportsDeviceDetails`
+ * and reach for their own transport directly.
+ */
+export interface LoggerConnection {
+  /** Which logger this connection talks to. */
+  readonly kind: LoggerKind;
+  /** Human-friendly device name for headers/toasts. */
+  readonly displayName: string;
+  /**
+   * Whether the in-app Device tab (settings, tracks, firmware OTA) applies to
+   * this logger. Only the Fledgling exposes those today.
+   */
+  readonly supportsDeviceDetails: boolean;
+  /** List the downloadable logs on the device. */
+  listLogs(onStatus?: (status: string) => void): Promise<LoggerFile[]>;
+  /** Download one log by name, returning its raw bytes. */
+  downloadLog(
+    name: string,
+    onProgress?: (progress: LoggerDownloadProgress) => void,
+    onStatus?: (status: string) => void,
+  ): Promise<Uint8Array>;
+  /** Tear down the connection. Safe to call when already disconnected. */
+  disconnect(): void;
+}

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -23,7 +23,9 @@
     "connectTitle": "Mit Logger verbinden",
     "connectDesc": "Verbinde deinen DovesDataLogger, um Geräteeinstellungen und Strecken zu verwalten.",
     "connecting": "Verbinden…",
-    "connect": "Verbinden"
+    "connect": "Verbinden",
+    "deviceFledglingOnlyTitle": "Nur Fledgling",
+    "deviceFledglingOnlyDesc": "Gerätedetails sind nur für den PerchWerks Fledgling verfügbar. Der verbundene Logger bietet hier keine Einstellungen, Strecken oder Firmware."
   },
   "files": {
     "cloudRowTitle": "{{name}} — in der Cloud, zum Herunterladen tippen",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -22,7 +22,9 @@
     "connectTitle": "Connect to Logger",
     "connectDesc": "Connect to your DovesDataLogger to manage device settings and tracks.",
     "connecting": "Connecting…",
-    "connect": "Connect"
+    "connect": "Connect",
+    "deviceFledglingOnlyTitle": "Fledgling only",
+    "deviceFledglingOnlyDesc": "Device details are only available for the PerchWerks Fledgling. The connected logger doesn't expose settings, tracks or firmware here."
   },
   "files": {
     "cloudRowTitle": "{{name}} — in the cloud, tap to download",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -23,7 +23,9 @@
     "connectTitle": "Conectar al registrador",
     "connectDesc": "Conecta tu DovesDataLogger para gestionar los ajustes y los circuitos del dispositivo.",
     "connecting": "Conectando…",
-    "connect": "Conectar"
+    "connect": "Conectar",
+    "deviceFledglingOnlyTitle": "Solo Fledgling",
+    "deviceFledglingOnlyDesc": "Los detalles del dispositivo solo están disponibles para el PerchWerks Fledgling. El registrador conectado no ofrece ajustes, circuitos ni firmware aquí."
   },
   "files": {
     "cloudRowTitle": "{{name}} — en la nube, toca para descargar",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -23,7 +23,9 @@
     "connectTitle": "Connecter l'enregistreur",
     "connectDesc": "Connectez votre DovesDataLogger pour gérer les réglages et les circuits de l'appareil.",
     "connecting": "Connexion…",
-    "connect": "Connecter"
+    "connect": "Connecter",
+    "deviceFledglingOnlyTitle": "Fledgling uniquement",
+    "deviceFledglingOnlyDesc": "Les détails de l'appareil ne sont disponibles que pour le PerchWerks Fledgling. L'enregistreur connecté n'expose ni réglages, ni circuits, ni firmware ici."
   },
   "files": {
     "cloudRowTitle": "{{name}} — dans le cloud, touchez pour télécharger",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -23,7 +23,9 @@
     "connectTitle": "Connetti al logger",
     "connectDesc": "Connetti il tuo DovesDataLogger per gestire le impostazioni e le piste del dispositivo.",
     "connecting": "Connessione…",
-    "connect": "Connetti"
+    "connect": "Connetti",
+    "deviceFledglingOnlyTitle": "Solo Fledgling",
+    "deviceFledglingOnlyDesc": "I dettagli del dispositivo sono disponibili solo per il PerchWerks Fledgling. Il logger connesso non espone impostazioni, circuiti o firmware qui."
   },
   "files": {
     "cloudRowTitle": "{{name}} — nel cloud, tocca per scaricare",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -23,7 +23,9 @@
     "connectTitle": "ロガーに接続",
     "connectDesc": "DovesDataLogger に接続して、デバイスの設定とコースを管理します。",
     "connecting": "接続中…",
-    "connect": "接続"
+    "connect": "接続",
+    "deviceFledglingOnlyTitle": "Fledgling のみ",
+    "deviceFledglingOnlyDesc": "デバイスの詳細は PerchWerks Fledgling でのみ利用できます。接続中のロガーでは設定・コース・ファームウェアは利用できません。"
   },
   "files": {
     "cloudRowTitle": "{{name}} — クラウド上。タップしてダウンロード",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -23,7 +23,9 @@
     "connectTitle": "Conectar ao registrador",
     "connectDesc": "Conecte seu DovesDataLogger para gerenciar as configurações e as pistas do dispositivo.",
     "connecting": "Conectando…",
-    "connect": "Conectar"
+    "connect": "Conectar",
+    "deviceFledglingOnlyTitle": "Apenas Fledgling",
+    "deviceFledglingOnlyDesc": "Os detalhes do dispositivo estão disponíveis apenas para o PerchWerks Fledgling. O registrador conectado não oferece configurações, pistas ou firmware aqui."
   },
   "files": {
     "cloudRowTitle": "{{name}} — na nuvem, toque para baixar",


### PR DESCRIPTION
## What & why

Builds on the logger picker (#268) with three changes.

### 1. Fix the home-screen "Download from logger" button 🐛
You reported the **drawer** button opened the picker but the **home-screen** button did nothing. Root cause: the picker lived *inside* the lazy `DataloggerDownload` (BLE) chunk, and on the landing it was wrapped in a `<Suspense>` whose fallback was a **disabled** tile. When that chunk stalled (e.g. stale service-worker cache), the disabled tile stayed and clicks went nowhere — while the drawer happened to have the chunk loaded.

Fix: split the lightweight menu into an **eager** host (`LoggerDownload`). The menu now opens instantly and never depends on a chunk finishing. The heavy Fledgling BLE flow (`DataloggerDownload`) is mounted **on demand** once the Fledgling is picked, so `lib/ble/*` still stays off the initial/landing payload (verified: file-transfer protocol is in its own lazy chunk, index grew only ~3 kB).

### 2. Generic logger-connection layer 🔌 (Tauri groundwork)
New `src/lib/loggers/`: the download UI now talks to any logger through **one** `LoggerConnection` interface — `listLogs()` / `downloadLog()` / `disconnect()` (+ `kind`, `displayName`, `supportsDeviceDetails`). `createFledglingConnection()` adapts the existing Web Bluetooth transport. This is the seam future loggers plug into without the UI branching on transport: **MyChron** over the native (Tauri) shell, **Alfano** over BLE — each adds a sibling adapter satisfying the same interface. `DeviceContext` now tracks the connected `loggerKind`.

### 3. Device tab is Fledgling-gated
The drawer's Device tab (settings / tracks / firmware) now shows a **"Fledgling only"** notice when the connected logger isn't a Fledgling. Those surfaces are Fledgling-specific; this is groundwork that activates once non-Fledgling (MyChron/Alfano) connections land — today only the Fledgling connects, so the notice isn't reachable yet.

## Notes
- New unit tests for the `LoggerConnection` adapter (delegation + name fallback).
- New i18n keys (`drawer:shell.deviceFledglingOnly*`) across all 7 locales.
- Docs synced: `CLAUDE.md`, `docs/ble.md`, `CHANGELOG.md` (`[2.8.1] - unreleased`).

## Verification
`bun run lint`, `bun run typecheck`, `bun run test:run` (1883 pass), `bun run build` — all green. Confirmed the BLE protocol stays in a separate lazy chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLRuG1p8vhUXFP5V34WVET

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLRuG1p8vhUXFP5V34WVET)_