### PR TITLE
UI cleanup: landing page split, leaner native shell, footer/login link tidy-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bar. A no-op on browsers and desktops without a safe area.
 - **Privacy / Terms links on the sign-in page.** The login screen now links to the
   Privacy Policy and Terms of Service.
+- **"Back to app" returns you where you were.** The back button on the Privacy and
+  Terms pages now steps back to the page you came from (e.g. the sign-in or register
+  screen) instead of always jumping to the home screen.
 
 ### Changed
 - **"Download from logger" relabel.** The file-manager button previously labelled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   device's safe-area insets (status bar / notch) via `env(safe-area-inset-*)` and
   `viewport-fit=cover`, so header content no longer sits under the phone's status
   bar. A no-op on browsers and desktops without a safe area.
+- **Privacy / Terms links on the sign-in page.** The login screen now links to the
+  Privacy Policy and Terms of Service.
 
 ### Changed
 - **"Download from logger" relabel.** The file-manager button previously labelled
@@ -45,6 +47,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   firmware) now shows a "Fledgling only" notice when the connected logger isn't a
   Fledgling, groundwork for MyChron/Alfano connections that don't expose those
   surfaces.
+- **Landing page upload is now a 50/50 split.** The big drag-and-drop dropzone now
+  shares the top of the home screen with an equal-billing "Download from logger"
+  panel, since most users pull logs straight off a logger rather than dragging files
+  in. The separate "Download from logger" tile was removed (its action moved into the
+  split).
+- **Landing footer / link cleanup.** Privacy Policy and Terms of Service moved out of
+  the mid-page link row: on the stable build they now flank the operated-by / version
+  block in the footer (Privacy left, Terms right). Credits moved up next to the
+  Browser Compatibility button.
+- **Leaner native landing page.** On the native (Android/Tauri) shell the landing
+  page now hides the marketing hero, the feature roadmap, the GitHub repo links and
+  the sponsor button — the user has already installed the app. The "Build your own
+  logger" tile stays.
 - **Header logo returns to the home screen.** Tapping the LapWing logo (top-left)
   in an open session now closes the session and returns to the landing page.
 - **Purple theme + new logo.** The brand accent moved from teal to **purple**

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -1,5 +1,6 @@
 import { BookOpen, ExternalLink } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
@@ -41,10 +42,14 @@ export function CreditsDialog() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <button className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-          <BookOpen className="w-3 h-3" />
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-muted-foreground border-border/50 opacity-60 hover:opacity-100"
+        >
+          <BookOpen className="w-3.5 h-3.5 mr-1.5" />
           {t("credits.trigger")}
-        </button>
+        </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[80vh] overflow-y-auto">
         <DialogHeader>

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -11,10 +11,11 @@ interface FileImportProps {
 }
 
 /**
- * The landing page's primary action: a large drag-and-drop / click-to-browse
- * zone. The whole card is the upload target — secondary actions (browse saved
- * files, download from the logger, sample data, track manager) live as their
- * own tiles in LandingPage rather than bundled inside this dropzone.
+ * The drag-and-drop / click-to-browse half of the landing page's primary
+ * action. The whole card is the upload target; LandingPage pairs it 50/50 with
+ * a "Download from logger" panel (`h-full` so the two halves match height).
+ * Other entry points (browse saved files, sample data, track manager) live as
+ * their own tiles below.
  */
 export function FileImport({ onDataLoaded, autoSave, autoSaveFile }: FileImportProps) {
   const { t } = useTranslation("landing");
@@ -83,13 +84,13 @@ export function FileImport({ onDataLoaded, autoSave, autoSaveFile }: FileImportP
   }, []);
 
   return (
-    <div className="space-y-3">
+    <div className="flex h-full flex-col gap-3">
       <label
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         className={[
-          "flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-10 text-center transition-colors",
+          "flex h-full flex-1 cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-10 text-center transition-colors",
           isDragging ? "border-primary bg-primary/10" : "border-border bg-card/50 hover:border-primary/50 hover:bg-card",
         ].join(" ")}
       >

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -30,7 +30,7 @@ import { PluginMount } from "@/plugins/PluginMount";
 import { MountSlot } from "@/plugins/mounts";
 import { useAuth } from "@/contexts/AuthContext";
 import { buildInfo, formatBuildLabel, commitUrl, isPreviewBuild } from "@/lib/buildInfo";
-import { interceptExternal } from "@/lib/platform";
+import { interceptExternal, isNativeApp } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { ParsedData } from "@/types/racing";
 
@@ -86,6 +86,11 @@ export function LandingPage({
   const { user, logout, isAdmin } = useAuth();
   const { t } = useTranslation(["landing", "common"]);
 
+  // On the native (Tauri/Android) shell the user has already installed the app,
+  // so the marketing surfaces (hero pitch, roadmap, GitHub/sponsor links) just
+  // add noise — hide them. The DIY-logger tile stays (it's genuinely useful).
+  const native = isNativeApp();
+
   const roadmapItems = t("landing:roadmap.items", { returnObjects: true }) as string[];
 
   // Group roadmap items by their trailing month/quarter parenthetical (works
@@ -123,35 +128,65 @@ export function LandingPage({
                 </Button>
               )
             )}
-            <a
-              href="https://github.com/sponsors/TheAngryRaven"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => interceptExternal(e, "https://github.com/sponsors/TheAngryRaven")}
-            >
-              <Button variant="outline" size="sm" className="gap-2">
-                <Heart className="w-4 h-4 text-pink-500" />
-                <span className="hidden sm:inline">{t("common:actions.sponsor")}</span>
-              </Button>
-            </a>
+            {!native && (
+              <a
+                href="https://github.com/sponsors/TheAngryRaven"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => interceptExternal(e, "https://github.com/sponsors/TheAngryRaven")}
+              >
+                <Button variant="outline" size="sm" className="gap-2">
+                  <Heart className="w-4 h-4 text-pink-500" />
+                  <span className="hidden sm:inline">{t("common:actions.sponsor")}</span>
+                </Button>
+              </a>
+            )}
           </div>
         </div>
       </header>
 
       <main className="flex-1 px-6 py-10">
         <div className="mx-auto w-full max-w-4xl space-y-10">
-          {/* Hero */}
-          <div className="text-center space-y-3">
-            <h2 className="text-2xl sm:text-3xl font-bold text-foreground">
-              {t("landing:hero.title")}
-            </h2>
-            <p className="mx-auto max-w-xl text-sm text-muted-foreground">
-              {t("landing:hero.subtitle")}
-            </p>
-          </div>
+          {/* Hero — pure marketing, so it's dropped on the native shell where
+              the user has already chosen to install the app. */}
+          {!native && (
+            <div className="text-center space-y-3">
+              <h2 className="text-2xl sm:text-3xl font-bold text-foreground">
+                {t("landing:hero.title")}
+              </h2>
+              <p className="mx-auto max-w-xl text-sm text-muted-foreground">
+                {t("landing:hero.subtitle")}
+              </p>
+            </div>
+          )}
 
-          {/* Primary action: drag & drop / click to browse */}
-          <FileImport onDataLoaded={onDataLoaded} autoSave={autoSave} autoSaveFile={autoSaveFile} />
+          {/* Primary action: a 50/50 split — most users download straight off a
+              logger, so it gets equal billing with drag & drop / click-to-browse. */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:items-stretch">
+            <LoggerDownload
+              onDataLoaded={onDataLoaded}
+              autoSave={autoSave}
+              autoSaveFile={autoSaveFile}
+              renderTrigger={({ onOpen }) => (
+                <button
+                  type="button"
+                  onClick={onOpen}
+                  className="flex h-full cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-border bg-card/50 p-10 text-center transition-colors hover:border-primary/50 hover:bg-card"
+                >
+                  <span className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <Bluetooth className="h-7 w-7" />
+                  </span>
+                  <span className="text-xl font-semibold text-foreground">
+                    {t("landing:tiles.logger.title")}
+                  </span>
+                  <span className="max-w-md text-sm text-muted-foreground">
+                    {t("landing:tiles.logger.description")}
+                  </span>
+                </button>
+              )}
+            />
+            <FileImport onDataLoaded={onDataLoaded} autoSave={autoSave} autoSaveFile={autoSaveFile} />
+          </div>
 
           {/* Secondary actions — big, single-purpose tiles */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -172,20 +207,6 @@ export function LandingPage({
               title={t("landing:tiles.browse.title")}
               description={t("landing:tiles.browse.description")}
               onClick={onOpenFileManager}
-            />
-
-            <LoggerDownload
-              onDataLoaded={onDataLoaded}
-              autoSave={autoSave}
-              autoSaveFile={autoSaveFile}
-              renderTrigger={({ onOpen }) => (
-                <ActionTile
-                  icon={Bluetooth}
-                  title={t("landing:tiles.logger.title")}
-                  description={t("landing:tiles.logger.description")}
-                  onClick={onOpen}
-                />
-              )}
             />
 
             {/* Track manager — create/draw tracks & courses without a datalog. */}
@@ -213,7 +234,9 @@ export function LandingPage({
             <PluginMount slot={MountSlot.Landing} ctx={{}} />
           </div>
 
-          {/* Roadmap — what's still coming, with rough timing estimates. */}
+          {/* Roadmap — what's still coming, with rough timing estimates.
+              Hidden on native: it's a sales surface for a user who's already in. */}
+          {!native && (
           <div className="rounded-xl border border-border bg-card/50 p-5">
             <div className="flex items-center gap-2">
               <Route className="h-5 w-5 text-primary" />
@@ -248,9 +271,11 @@ export function LandingPage({
               {t("landing:roadmap.contact")}
             </p>
           </div>
+          )}
 
-          {/* Reference dialogs */}
+          {/* Reference dialogs — Credits sits to the left of Browser Compatibility. */}
           <div className="flex flex-wrap items-center justify-center gap-3">
+            <CreditsDialog />
             <BrowserCompatDialog />
             <span className="inline-flex">
               <LocalWeatherDialog />
@@ -258,34 +283,27 @@ export function LandingPage({
             <ContactDialog variant="header" />
           </div>
 
-          {/* Open-source repos */}
-          <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-3">
-            {GITHUB_LINKS.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => interceptExternal(e, link.href)}
-                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <Github className="w-4 h-4" />
-                <span className="text-sm">{link.label}</span>
-              </a>
-            ))}
-          </div>
+          {/* Open-source repos — web only; the native shell drops outbound GitHub links. */}
+          {!native && (
+            <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-3">
+              {GITHUB_LINKS.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => interceptExternal(e, link.href)}
+                  className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <Github className="w-4 h-4" />
+                  <span className="text-sm">{link.label}</span>
+                </a>
+              ))}
+            </div>
+          )}
 
-          <div className="flex items-center justify-center gap-6 flex-wrap">
-            <Link to="/privacy" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-              <Shield className="w-3 h-3" />
-              {t("landing:links.privacy")}
-            </Link>
-            <Link to="/terms" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-              <FileText className="w-3 h-3" />
-              {t("landing:links.terms")}
-            </Link>
-            <CreditsDialog />
-            {enableAdmin && isAdmin && (
+          {enableAdmin && isAdmin && (
+            <div className="flex items-center justify-center gap-6 flex-wrap">
               <button
                 onClick={() => navigate('/admin')}
                 className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
@@ -293,8 +311,8 @@ export function LandingPage({
                 <Shield className="w-3 h-3" />
                 {t("landing:links.admin")}
               </button>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </main>
 
@@ -304,42 +322,69 @@ export function LandingPage({
           isPreviewBuild() ? "border-warning/60 bg-warning/10" : "border-border",
         )}
       >
-        <p className="text-center text-xs text-muted-foreground">
-          {t("landing:footer.operatedBy")}{" "}
-          <a
-            href="https://PerchWerks.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => interceptExternal(e, "https://PerchWerks.com")}
-            className="font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
-          >
-            PerchWerks LLC
-          </a>
-        </p>
-        <p
-          className={cn(
-            "mt-1 text-center text-[11px]",
-            isPreviewBuild() ? "font-semibold text-warning" : "text-muted-foreground/60",
-          )}
-          title={buildInfo.buildDate ? `Built ${new Date(buildInfo.buildDate).toLocaleString()}` : undefined}
-        >
-          {commitUrl() ? (
-            <a
-              href={commitUrl()!}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => interceptExternal(e, commitUrl()!)}
-              className={cn(
-                "underline-offset-4 transition-colors hover:underline",
-                isPreviewBuild() ? "hover:text-warning/80" : "hover:text-muted-foreground",
-              )}
+        {/* Operated-by + build stamp read as one solid block. On the stable
+            (non-preview) build, Privacy flanks it on the left and Terms on the
+            right; the preview build keeps the block centered + the warning. */}
+        <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1">
+          {!isPreviewBuild() && (
+            <Link
+              to="/privacy"
+              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/60 transition-colors hover:text-muted-foreground"
             >
-              {formatBuildLabel()}
-            </a>
-          ) : (
-            formatBuildLabel()
+              <Shield className="w-3 h-3" />
+              {t("landing:links.privacy")}
+            </Link>
           )}
-        </p>
+
+          <div>
+            <p className="text-center text-xs text-muted-foreground">
+              {t("landing:footer.operatedBy")}{" "}
+              <a
+                href="https://PerchWerks.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => interceptExternal(e, "https://PerchWerks.com")}
+                className="font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+              >
+                PerchWerks LLC
+              </a>
+            </p>
+            <p
+              className={cn(
+                "mt-1 text-center text-[11px]",
+                isPreviewBuild() ? "font-semibold text-warning" : "text-muted-foreground/60",
+              )}
+              title={buildInfo.buildDate ? `Built ${new Date(buildInfo.buildDate).toLocaleString()}` : undefined}
+            >
+              {commitUrl() ? (
+                <a
+                  href={commitUrl()!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => interceptExternal(e, commitUrl()!)}
+                  className={cn(
+                    "underline-offset-4 transition-colors hover:underline",
+                    isPreviewBuild() ? "hover:text-warning/80" : "hover:text-muted-foreground",
+                  )}
+                >
+                  {formatBuildLabel()}
+                </a>
+              ) : (
+                formatBuildLabel()
+              )}
+            </p>
+          </div>
+
+          {!isPreviewBuild() && (
+            <Link
+              to="/terms"
+              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+            >
+              <FileText className="w-3 h-3" />
+              {t("landing:links.terms")}
+            </Link>
+          )}
+        </div>
         {isPreviewBuild() && (
           <p className="mx-auto mt-2 max-w-2xl text-center text-[11px] leading-relaxed text-warning">
             <Trans ns="landing" i18nKey="footer.previewWarning" components={{ strong: <strong /> }} />

--- a/src/lib/navBack.test.ts
+++ b/src/lib/navBack.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { goBackOrHome } from "./navBack";
+
+describe("goBackOrHome", () => {
+  it("steps back one entry when there is in-app history (idx > 0)", () => {
+    const navigate = vi.fn();
+    goBackOrHome(navigate, { state: { idx: 3 } });
+    expect(navigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("falls back to home when the page was opened directly (idx === 0)", () => {
+    const navigate = vi.fn();
+    goBackOrHome(navigate, { state: { idx: 0 } });
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("falls back to home when there is no history state at all", () => {
+    const navigate = vi.fn();
+    goBackOrHome(navigate, {});
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("falls back to home when history state lacks an idx", () => {
+    const navigate = vi.fn();
+    goBackOrHome(navigate, { state: { foo: "bar" } });
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/src/lib/navBack.ts
+++ b/src/lib/navBack.ts
@@ -1,0 +1,22 @@
+import type { NavigateFunction } from "react-router-dom";
+
+/**
+ * "Back to app" navigation that returns the user to wherever they came from.
+ *
+ * React Router stamps an incrementing `idx` onto `history.state` for every
+ * in-app navigation. When `idx > 0` there's a prior in-app entry to return to,
+ * so we step back one (preserving its scroll/form state). When it's 0 the page
+ * was reached directly — a fresh tab, a bookmark, or an external link — and
+ * there's nothing in-app to go back to, so we fall back to the home route.
+ */
+export function goBackOrHome(
+  navigate: NavigateFunction,
+  history: { state?: unknown } = typeof window !== "undefined" ? window.history : {},
+): void {
+  const idx = (history.state as { idx?: number } | null | undefined)?.idx ?? 0;
+  if (idx > 0) {
+    navigate(-1);
+  } else {
+    navigate("/");
+  }
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Shield, FileText } from 'lucide-react';
 import { BrandLogo } from "@/components/BrandLogo";
 import { useDocumentHead } from '@/hooks/useDocumentHead';
 
@@ -17,7 +17,7 @@ const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === 'true';
 const enableGoogleAuth = import.meta.env.VITE_ENABLE_GOOGLE_AUTH === 'true';
 
 export default function Login() {
-  const { t } = useTranslation('auth');
+  const { t } = useTranslation(['auth', 'landing']);
   useDocumentHead({
     title: t('login.metaTitle'),
     description: t('login.metaDescription'),
@@ -119,6 +119,17 @@ export default function Login() {
         <Button variant="ghost" className="w-full gap-2" onClick={() => navigate('/')}>
           <ArrowLeft className="w-4 h-4" /> {t('backToHome')}
         </Button>
+
+        <div className="flex items-center justify-center gap-6">
+          <Link to="/privacy" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+            <Shield className="w-3 h-3" />
+            {t('landing:links.privacy')}
+          </Link>
+          <Link to="/terms" className="inline-flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+            <FileText className="w-3 h-3" />
+            {t('landing:links.terms')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,7 +1,8 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
 import { interceptExternal } from "@/lib/platform";
+import { goBackOrHome } from "@/lib/navBack";
 
 const enableAdmin = import.meta.env.VITE_ENABLE_ADMIN === "true";
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
@@ -14,6 +15,7 @@ const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 // advice — have it reviewed for your jurisdiction.
 
 const Privacy = () => {
+  const navigate = useNavigate();
   useDocumentHead({
     title: "Privacy Policy — LapWing",
     description:
@@ -22,13 +24,14 @@ const Privacy = () => {
   });
   return (
     <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
-      <Link
-        to="/"
+      <button
+        type="button"
+        onClick={() => goBackOrHome(navigate)}
         className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"
       >
         <ArrowLeft className="w-4 h-4" />
         <span className="text-sm">Back to app</span>
-      </Link>
+      </button>
 
       <h1 className="text-2xl font-bold mb-6">Privacy Policy</h1>
 

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,6 +1,7 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
+import { goBackOrHome } from "@/lib/navBack";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -10,6 +11,7 @@ const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 // champagne@perchwerks.com (interim) until dedicated support addresses exist.
 
 const Terms = () => {
+  const navigate = useNavigate();
   useDocumentHead({
     title: "Terms of Service — LapWing",
     description:
@@ -18,13 +20,14 @@ const Terms = () => {
   });
   return (
     <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
-      <Link
-        to="/"
+      <button
+        type="button"
+        onClick={() => goBackOrHome(navigate)}
         className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"
       >
         <ArrowLeft className="w-4 h-4" />
         <span className="text-sm">Back to app</span>
-      </Link>
+      </button>
 
       <h1 className="text-2xl font-bold mb-6">Terms of Service</h1>
 


### PR DESCRIPTION
## Summary

A round of landing-page / UI cleanup, split into focused commits so individual pieces can be cherry-picked out if needed.

### Everyone
- **Upload is now a 50/50 split.** The big drag-and-drop dropzone shares the top of the home screen with an equal-billing **"Download from logger"** panel — most users pull logs straight off a logger rather than dragging files in. The separate "Download from logger" tile in the grid below is removed (its action moved into the split).
- **Privacy / Terms links on the sign-in page.** The login screen now links to the Privacy Policy and Terms of Service.
- **Footer / mid-page link cleanup.** Privacy & Terms move out of the mid-page link row: on the **stable (non-preview)** build they now **flank the operated-by / version block** in the footer — Privacy on the left, Terms on the right. The preview build keeps its centered block + warning unchanged.
- **Credits moves up** next to the Browser Compatibility button (and is restyled as a matching button).

### Native shell only (Tauri / Android)
The user has already installed the app, so the marketing surfaces are dropped:
- Hero pitch ("Free Online … Viewer"), feature **roadmap**, **GitHub** repo links, and the **sponsor** button are all hidden.
- The **"Build your own logger"** (DIY) tile stays.

## Notes
- No new i18n keys — reuses existing `landing:links.*` and `landing:tiles.logger.*`, so locale parity stays green.
- `CHANGELOG.md` updated under `[2.8.1] - unreleased`.

## Checks
`bun run lint`, `bun run typecheck`, `bun run test:run` (1883 pass), and `bun run build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcQYR6dBauo2iSyqt8VkyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcQYR6dBauo2iSyqt8VkyU)_