### PR TITLE
CI: auto-deploy the beta-proxy Worker

### DIFF
--- a/.github/workflows/deploy-beta-proxy.yml
+++ b/.github/workflows/deploy-beta-proxy.yml
@@ -1,0 +1,66 @@
+name: Deploy beta-proxy
+
+# beta-proxy/ is the reverse-proxy Worker that serves beta.lapwingdata.com (it
+# forwards to the lapwing `beta` branch preview). It is a SEPARATE Worker from
+# the main app — Cloudflare's connected-repo CI builds the app but nothing
+# deploys this proxy. This workflow does:
+#   • validate it on PRs that touch it (dry-run, no secrets — runs on forks too)
+#   • deploy it on BETA pushes that change it, or on demand (workflow_dispatch)
+#
+# Required repo secrets for the deploy job:
+#   • CLOUDFLARE_API_TOKEN   — token with "Edit Cloudflare Workers" on the account
+#   • CLOUDFLARE_ACCOUNT_ID  — the account that owns the lapwingdata.com zone
+
+on:
+  push:
+    branches: [BETA]
+    paths:
+      - "beta-proxy/**"
+      - ".github/workflows/deploy-beta-proxy.yml"
+  pull_request:
+    paths:
+      - "beta-proxy/**"
+      - ".github/workflows/deploy-beta-proxy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Pin the wrangler version used to both validate and deploy so runs are
+# reproducible (beta-proxy has no committed lockfile).
+env:
+  WRANGLER_VERSION: "4.103.0"
+
+# Never let two deploys of the same ref overlap; queue rather than cancel so an
+# in-flight deploy always finishes.
+concurrency:
+  group: deploy-beta-proxy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Bundle + config check for PRs. Needs no Cloudflare secrets, so it catches a
+  # broken wrangler.toml before it can reach BETA (and works for fork PRs).
+  validate:
+    if: github.event_name == 'pull_request'
+    name: Dry-run
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: beta-proxy
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx --yes wrangler@${{ env.WRANGLER_VERSION }} deploy --dry-run --config ./wrangler.toml
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    name: Deploy Worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: beta-proxy
+          wranglerVersion: ${{ env.WRANGLER_VERSION }}
+          command: deploy --config ./wrangler.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,8 +387,9 @@ hosting is Cloudflare Workers (static-assets-only, `wrangler.jsonc`,
 a `custom_domain` route in `wrangler.jsonc` (auto DNS+TLS — don't also attach it in
 the dashboard). The beta domain `beta.lapwingdata.com` can't bind to a Branch
 Preview URL, so a separate thin reverse-proxy Worker in `beta-proxy/` owns it and
-forwards to `beta-lapwing.perchwerks.workers.dev` (deployed on its own; see
-`beta-proxy/README.md`). Per-branch preview backend: `vite.config.ts` `pick()`
+forwards to `beta-lapwing.perchwerks.workers.dev` (auto-deployed by the
+`deploy-beta-proxy.yml` workflow on `BETA` pushes that touch `beta-proxy/**`;
+see `beta-proxy/README.md`). Per-branch preview backend: `vite.config.ts` `pick()`
 prefers `*_PREVIEW` Supabase creds on any non-`main` branch
 (`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`), so beta deployments bake in a preview DB.
 `main` and local dev never read `_PREVIEW`. See README "Deployment".

--- a/beta-proxy/README.md
+++ b/beta-proxy/README.md
@@ -31,6 +31,23 @@ doesn't change.)
 
 ## Deploy
 
+### Automatic (CI)
+
+The `.github/workflows/deploy-beta-proxy.yml` workflow deploys this Worker
+automatically on every push to **`BETA`** that touches `beta-proxy/**` (and can
+be run on demand via *workflow_dispatch*). PRs that touch it get a `wrangler
+deploy --dry-run` validation instead. The deploy job needs two repo secrets:
+
+| Secret | What |
+|--------|------|
+| `CLOUDFLARE_API_TOKEN` | A token with **Edit Cloudflare Workers** on the account |
+| `CLOUDFLARE_ACCOUNT_ID` | The account that owns the `lapwingdata.com` zone |
+
+The wrangler version is pinned in the workflow (`WRANGLER_VERSION`) so CI runs
+are reproducible — there is no committed lockfile here.
+
+### Manual
+
 ```bash
 cd beta-proxy
 npm install


### PR DESCRIPTION
## Summary

The `beta-proxy/` reverse-proxy Worker (serves **beta.lapwingdata.com** → `beta-lapwing.perchwerks.workers.dev`) is a *separate* Worker from the main app. Cloudflare's connected-repo CI builds the app, but **nothing deployed the proxy** — it had to be pushed by hand. This adds a GitHub Actions workflow so it deploys automatically.

I verified the worker is already correct and deployable: `wrangler deploy --dry-run` passes (bundles clean, valid `custom_domain` config). The only gap was automation.

## What this adds
`.github/workflows/deploy-beta-proxy.yml`:
- **Deploy** on pushes to **`BETA`** that touch `beta-proxy/**` (and on demand via `workflow_dispatch`), via `cloudflare/wrangler-action@v3` running `deploy --config ./wrangler.toml` in `beta-proxy/`.
- **Validate** on PRs that touch `beta-proxy/**` with `wrangler deploy --dry-run` — needs no secrets, so it works on fork PRs and catches a broken `wrangler.toml` before it reaches BETA.
- Wrangler version pinned (`WRANGLER_VERSION`) for reproducible runs (beta-proxy has no committed lockfile); `concurrency` queues deploys so two never overlap.

## ⚠️ Action required before the deploy job can run
Add two repo secrets:
| Secret | What |
|--------|------|
| `CLOUDFLARE_API_TOKEN` | Token with **Edit Cloudflare Workers** on the account |
| `CLOUDFLARE_ACCOUNT_ID` | The account that owns the `lapwingdata.com` zone |

And the operational prerequisites from `beta-proxy/README.md` still apply: **Cloudflare Access OFF** on the upstream preview URL, branch previews enabled on `lapwing`, and don't hand-create the DNS record (the `custom_domain` route provisions it).

## Docs
Updated `beta-proxy/README.md` (CI section + secrets table) and the deploy note in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcQYR6dBauo2iSyqt8VkyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcQYR6dBauo2iSyqt8VkyU)_