### PR TITLE
Fix login rate limiter locking out valid sign-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   component). Pairs with the refreshed app icons and favicon. Data-viz colors
   (speed/telemetry scales) are unchanged.
 
+### Fixed
+- **Login rate limiter locked out valid sign-ins.** The limiter counted *every*
+  sign-in attempt — successes included — as a failure on a pre-login check, so
+  after five tries an IP was locked for an hour even with the correct password.
+  It now only counts genuine failures, clears the counter on a successful login,
+  and ages failures out over a 15-minute sliding window.
+
 ## [2.8.0] - 2026-06-20
 
 ### Added

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -35,7 +35,9 @@ export default function Login() {
     e.preventDefault();
     setIsLoading(true);
     try {
-      const { data: rateCheck } = await supabase.functions.invoke('check-login-rate', { body: {} });
+      // Pre-check only reports whether this IP is locked — it never counts an
+      // attempt. The failure/success is recorded after the login resolves below.
+      const { data: rateCheck } = await supabase.functions.invoke('check-login-rate', { body: { action: 'check' } });
       if (rateCheck && !rateCheck.allowed) {
         toast({ title: t('login.tooManyAttempts'), description: rateCheck.message || t('login.tooManyAttemptsDesc'), variant: 'destructive' });
         setIsLoading(false);
@@ -43,8 +45,12 @@ export default function Login() {
       }
       const { error } = await login(email, password);
       if (error) {
+        // Record the failed attempt (best-effort) so brute force still trips the lock.
+        void supabase.functions.invoke('check-login-rate', { body: { action: 'fail' } });
         toast({ title: t('login.failed'), description: error.message, variant: 'destructive' });
       } else {
+        // Success clears this IP's failure counter.
+        void supabase.functions.invoke('check-login-rate', { body: { action: 'reset' } });
         toast({ title: t('login.signedIn') });
         navigate(next);
       }

--- a/supabase/functions/check-login-rate/index.ts
+++ b/supabase/functions/check-login-rate/index.ts
@@ -1,9 +1,21 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { DEFAULT_CONFIG, isLocked, recordFailure, type AttemptRow } from "./rateLimit.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
 };
+
+// What the caller is telling us happened:
+//   • check — about to attempt a login; only report whether the IP is locked.
+//   • fail  — a login just failed; record it (and lock once the threshold trips).
+//   • reset — a login just succeeded; clear this IP's failure counter.
+type Action = "check" | "fail" | "reset";
+
+const json = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
@@ -11,14 +23,17 @@ Deno.serve(async (req) => {
   }
 
   try {
-    // Derive IP server-side — never trust client-provided IP
+    // Derive IP server-side — never trust a client-provided IP.
     const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
                req.headers.get('cf-connecting-ip') || 'unknown';
 
+    const body = await req.json().catch(() => ({}));
+    const action: Action =
+      body?.action === 'fail' || body?.action === 'reset' ? body.action : 'check';
+
+    // No usable IP — we can't track this client, so never block it.
     if (ip === 'unknown') {
-      return new Response(JSON.stringify({ allowed: true }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      return json({ allowed: true });
     }
 
     const supabase = createClient(
@@ -26,69 +41,62 @@ Deno.serve(async (req) => {
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
     );
 
-    // Clean up expired lockouts (TTL-based reset: entries older than 1 hour)
+    const now = Date.now();
+
+    // Drop expired lockouts so they don't linger (TTL-style reset).
     await supabase
       .from('login_attempts')
       .delete()
-      .lt('locked_until', new Date().toISOString());
+      .lt('locked_until', new Date(now).toISOString());
 
-    // Check current attempts
+    // A successful login wipes the slate for this IP.
+    if (action === 'reset') {
+      await supabase.from('login_attempts').delete().eq('ip_address', ip);
+      return json({ allowed: true });
+    }
+
     const { data: existing } = await supabase
       .from('login_attempts')
       .select('*')
       .eq('ip_address', ip)
       .maybeSingle();
+    const row = existing as AttemptRow | null;
 
-    if (existing) {
-      // Check if locked
-      if (existing.locked_until && new Date(existing.locked_until) > new Date()) {
-        return new Response(JSON.stringify({ 
-          allowed: false, 
-          locked_until: existing.locked_until,
-          message: 'Too many failed attempts. Try again later.' 
-        }), {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
-      }
-
-      // If lock expired, we already cleaned it above, but handle edge case
-      if (existing.locked_until) {
-        // Lock expired — reset and allow
-        await supabase.from('login_attempts').delete().eq('ip_address', ip);
-        return new Response(JSON.stringify({ allowed: true }), {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        });
-      }
-
-      const newAttempts = (existing.attempts || 0) + 1;
-      const updates: Record<string, unknown> = { attempts: newAttempts };
-      
-      if (newAttempts >= 5) {
-        const lockUntil = new Date(Date.now() + 60 * 60 * 1000).toISOString();
-        updates.locked_until = lockUntil;
-        updates.attempts = 0;
-      }
-
-      await supabase.from('login_attempts').update(updates).eq('ip_address', ip);
-
-      return new Response(JSON.stringify({ 
-        allowed: newAttempts < 5,
-        ...(newAttempts >= 5 ? { locked_until: updates.locked_until, message: 'Too many failed attempts. Try again in 1 hour.' } : {}),
-      }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
-    } else {
-      // First attempt
-      await supabase.from('login_attempts').insert({ ip_address: ip, attempts: 1 });
-      return new Response(JSON.stringify({ allowed: true }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    // Currently locked out? Block regardless of action.
+    if (isLocked(row, now)) {
+      return json({
+        allowed: false,
+        locked_until: row!.locked_until,
+        message: 'Too many failed attempts. Try again later.',
       });
     }
+
+    // The pre-login check NEVER mutates state — it only reports lock status. This
+    // is the core fix: previously every attempt (success included) was counted
+    // as a failure here, locking out users who could actually sign in.
+    if (action === 'check') {
+      return json({ allowed: true });
+    }
+
+    // action === 'fail' — record the failed attempt within the sliding window.
+    const decision = recordFailure(row, now, DEFAULT_CONFIG);
+    if (decision.op.kind === 'insert') {
+      await supabase.from('login_attempts').insert({ ip_address: ip, attempts: decision.op.attempts });
+    } else {
+      await supabase
+        .from('login_attempts')
+        .update({ attempts: decision.op.attempts, locked_until: decision.op.lockedUntil })
+        .eq('ip_address', ip);
+    }
+
+    return json(
+      decision.allowed
+        ? { allowed: true }
+        : { allowed: false, locked_until: decision.lockedUntil, message: 'Too many failed attempts. Try again in 1 hour.' },
+    );
   } catch (e) {
     console.error('check-login-rate error:', e);
-    // Fail open — don't block login if rate limiter errors
-    return new Response(JSON.stringify({ allowed: true }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    // Fail open — never block login because the limiter itself errored.
+    return json({ allowed: true });
   }
 });

--- a/supabase/functions/check-login-rate/rateLimit.test.ts
+++ b/supabase/functions/check-login-rate/rateLimit.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_CONFIG,
+  isLocked,
+  recordFailure,
+  type AttemptRow,
+  type RateConfig,
+} from "./rateLimit";
+
+const NOW = Date.UTC(2026, 5, 21, 12, 0, 0); // fixed clock
+const cfg: RateConfig = { maxFailures: 5, lockMs: 60 * 60 * 1000, windowMs: 15 * 60 * 1000 };
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+describe("isLocked", () => {
+  it("is false for no row", () => {
+    expect(isLocked(null, NOW)).toBe(false);
+    expect(isLocked(undefined, NOW)).toBe(false);
+  });
+
+  it("is false when there is no lock", () => {
+    expect(isLocked({ attempts: 3, locked_until: null }, NOW)).toBe(false);
+  });
+
+  it("is true only while the lock is in the future", () => {
+    expect(isLocked({ attempts: 0, locked_until: iso(NOW + 1000) }, NOW)).toBe(true);
+    expect(isLocked({ attempts: 0, locked_until: iso(NOW - 1000) }, NOW)).toBe(false);
+  });
+});
+
+describe("recordFailure", () => {
+  it("inserts the first failure for a new IP", () => {
+    const d = recordFailure(null, NOW, cfg);
+    expect(d.allowed).toBe(true);
+    expect(d.op).toEqual({ kind: "insert", attempts: 1 });
+  });
+
+  it("increments within the sliding window", () => {
+    const row: AttemptRow = { attempts: 2, locked_until: null, updated_at: iso(NOW - 60 * 1000) };
+    const d = recordFailure(row, NOW, cfg);
+    expect(d.allowed).toBe(true);
+    expect(d.op).toEqual({ kind: "update", attempts: 3, lockedUntil: null });
+  });
+
+  it("restarts the count when the last failure is older than the window", () => {
+    const row: AttemptRow = { attempts: 4, locked_until: null, updated_at: iso(NOW - 20 * 60 * 1000) };
+    const d = recordFailure(row, NOW, cfg);
+    expect(d.allowed).toBe(true);
+    expect(d.op).toEqual({ kind: "update", attempts: 1, lockedUntil: null });
+  });
+
+  it("locks out on the Nth failure and resets the counter under the lock", () => {
+    const row: AttemptRow = { attempts: 4, locked_until: null, updated_at: iso(NOW - 60 * 1000) };
+    const d = recordFailure(row, NOW, cfg);
+    expect(d.allowed).toBe(false);
+    expect(d.lockedUntil).toBe(iso(NOW + cfg.lockMs));
+    expect(d.op).toEqual({ kind: "update", attempts: 0, lockedUntil: iso(NOW + cfg.lockMs) });
+  });
+
+  it("treats a missing updated_at as stale (counts from 1)", () => {
+    const row: AttemptRow = { attempts: 3, locked_until: null };
+    const d = recordFailure(row, NOW, cfg);
+    expect(d.op).toEqual({ kind: "update", attempts: 1, lockedUntil: null });
+  });
+
+  it("uses sane defaults", () => {
+    expect(DEFAULT_CONFIG.maxFailures).toBe(5);
+    expect(DEFAULT_CONFIG.lockMs).toBe(60 * 60 * 1000);
+    expect(DEFAULT_CONFIG.windowMs).toBe(15 * 60 * 1000);
+  });
+});

--- a/supabase/functions/check-login-rate/rateLimit.ts
+++ b/supabase/functions/check-login-rate/rateLimit.ts
@@ -1,0 +1,79 @@
+// Pure failed-login rate-limit decisions — no I/O, so the edge function and its
+// tests share the exact same logic. The function (index.ts) does the Supabase
+// reads/writes and translates the returned `op` into table mutations.
+//
+// The original limiter counted EVERY login attempt (successes included) as a
+// failure on a pre-login check, locking out users who could actually sign in.
+// The model here separates the three things that happen:
+//   • a pre-login "check" only reads lock state (never mutates),
+//   • a failure is recorded only when the password is actually wrong, and
+//   • a success clears the counter.
+// Failures are also counted in a sliding window so a stray wrong password days
+// ago doesn't combine with today's to trigger a surprise lockout.
+
+export interface AttemptRow {
+  attempts: number | null;
+  locked_until: string | null;
+  /** Last time this row was written — the trigger maintains it. */
+  updated_at?: string | null;
+}
+
+export interface RateConfig {
+  /** Failures within the window before the IP is locked out. */
+  maxFailures: number;
+  /** Lockout duration once tripped (ms). */
+  lockMs: number;
+  /** Sliding window over which failures accumulate (ms). */
+  windowMs: number;
+}
+
+export const DEFAULT_CONFIG: RateConfig = {
+  maxFailures: 5,
+  lockMs: 60 * 60 * 1000, // 1 hour
+  windowMs: 15 * 60 * 1000, // 15 minutes
+};
+
+/** The table mutation a decision wants persisted (the function performs it). */
+export type AttemptOp =
+  | { kind: "insert"; attempts: number }
+  | { kind: "update"; attempts: number; lockedUntil: string | null };
+
+export interface FailureDecision {
+  /** False once the lockout has just been tripped. */
+  allowed: boolean;
+  /** Set when a lockout is now in effect. */
+  lockedUntil?: string;
+  op: AttemptOp;
+}
+
+/** Whether `row` is under an active lockout at time `now` (ms epoch). */
+export function isLocked(row: AttemptRow | null | undefined, now: number): boolean {
+  return !!row?.locked_until && new Date(row.locked_until).getTime() > now;
+}
+
+/**
+ * Decide what recording one failed login does. Assumes the caller has already
+ * confirmed the IP is not currently locked (see `isLocked`).
+ */
+export function recordFailure(
+  row: AttemptRow | null | undefined,
+  now: number,
+  cfg: RateConfig = DEFAULT_CONFIG,
+): FailureDecision {
+  if (!row) {
+    return { allowed: true, op: { kind: "insert", attempts: 1 } };
+  }
+
+  // Failures older than the window don't count toward the current streak.
+  const lastSeen = row.updated_at ? new Date(row.updated_at).getTime() : 0;
+  const withinWindow = now - lastSeen <= cfg.windowMs;
+  const attempts = (withinWindow ? row.attempts ?? 0 : 0) + 1;
+
+  if (attempts >= cfg.maxFailures) {
+    const lockedUntil = new Date(now + cfg.lockMs).toISOString();
+    // Reset the counter under the lock so it starts clean when the lock expires.
+    return { allowed: false, lockedUntil, op: { kind: "update", attempts: 0, lockedUntil } };
+  }
+
+  return { allowed: true, op: { kind: "update", attempts, lockedUntil: null } };
+}

--- a/supabase/migrations/20260621000000_login_attempts_sliding_window.sql
+++ b/supabase/migrations/20260621000000_login_attempts_sliding_window.sql
@@ -1,0 +1,14 @@
+-- Failed-login rate limiting now counts failures in a sliding time window
+-- instead of forever. Add a last-activity timestamp (maintained by the shared
+-- update_updated_at_column() trigger) so the check-login-rate edge function can
+-- age out stale, sub-threshold failures. Additive + idempotent.
+
+ALTER TABLE public.login_attempts
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS set_login_attempts_updated_at ON public.login_attempts;
+CREATE TRIGGER set_login_attempts_updated_at
+  BEFORE UPDATE ON public.login_attempts
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+NOTIFY pgrst, 'reload schema';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    // App tests live under src/; also pick up pure logic extracted from Supabase
+    // edge functions (Deno) so it can be unit-tested here (coverage stays src/-only).
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "supabase/functions/**/*.{test,spec}.ts"],
     exclude: ["node_modules", "dist", ".lovable"],
     setupFiles: ["./vitest.setup.ts"],
     coverage: {


### PR DESCRIPTION
## The bug

`Login.tsx` called the `check-login-rate` edge function **before** attempting the login, and that function **incremented the IP's attempt counter on every call** — successes included. After 5 attempts within the hour the IP was locked for an hour, **even with the correct password**. It also never reset on a successful login, and sub-threshold failures (counter > 0, not locked) never aged out — so stray failures across sessions could pile up into a surprise lockout. (This is what was blocking the beta login earlier; it cleared once the hour elapsed.)

## The fix

Reworked the limiter around what actually happened, via a small action on the edge function:
- **`check`** (pre-login) — only reports whether the IP is locked; **never mutates state**.
- **`fail`** — recorded only when the password was genuinely wrong; locks once the threshold trips.
- **`reset`** — a successful login clears the IP's counter.
- Failures accumulate over a **15-minute sliding window**, so an old wrong password doesn't combine with a fresh one to trigger a lockout.

`Login.tsx` now calls `check` first, then fires `fail`/`reset` (best-effort) based on the real outcome.

## Changes
- `supabase/functions/check-login-rate/index.ts` — action-based, no-mutation pre-check, reset-on-success.
- `supabase/functions/check-login-rate/rateLimit.ts` — **pure** decision logic (`isLocked`, `recordFailure`), so it's unit-testable.
- `supabase/functions/check-login-rate/rateLimit.test.ts` — 9 regression tests (window increment, stale reset, lockout-on-Nth, etc.).
- `supabase/migrations/20260621000000_login_attempts_sliding_window.sql` — adds an `updated_at` column + the shared `update_updated_at_column()` trigger to power the sliding window (additive + idempotent).
- `src/pages/Login.tsx` — check → login → record outcome.
- `vitest.config.ts` — also runs `supabase/functions/**` pure-logic tests (coverage scope unchanged, still `src/**`).

## Notes
- Thresholds unchanged: **5 failures → 1-hour lock**.
- The migration must be applied to the beta (and prod) Supabase project for the sliding window; the function tolerates a missing `updated_at` (treats it as stale).

## Checks
`bun run lint`, `bun run typecheck`, `bun run test:run` (1897 pass, incl. 9 new), `bun run test:coverage`, and `bun run build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcQYR6dBauo2iSyqt8VkyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcQYR6dBauo2iSyqt8VkyU)_