### PR TITLE
Add deploy-version check independent of the service worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.8.1] - unreleased
 
 ### Added
+- **"Update available" check that doesn't rely on the service worker.** The app
+  now also compares the running build against a build-emitted `version.json`
+  fetched fresh from the server, so a stale tab reliably surfaces the "Update
+  ready" prompt even when the service worker's own update detection stalls behind
+  HTTP/CDN caching. The Refresh button hard-reboots onto the new build.
 - **Separate cloud + local storage bars in the profile.** When signed in, the
   profile now shows two storage meters — one for cloud quota and one for on-device
   (local) storage — instead of just the cloud one. The local bar carries an (i)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ src/
 │   ├── weatherService.ts  # Historical weather (online-only): NWS/IEM METAR → Open-Meteo fallback
 │   ├── weatherCacheStorage.ts # Per-session historical-weather cache (IndexedDB, local-only/never cloud-synced): a session's date is fixed so its weather is immutable — cache it once, stop re-pinging the station/API on reopen
 │   ├── buildInfo.ts       # Build version/hash/branch stamp + isPreviewBuild()
+│   ├── versionCheck.ts    # ★ "Update available" signal: compares buildInfo vs the build-emitted, uncached /version.json (independent of the SW's own update detection) → main.tsx update toast
 │   ├── debugConsole.ts    # ★ On-screen debug console (`?dbg=true`) — mobile/PWA has no dev tools
 │   ├── units.ts           # ★ Pure unit conversions for the 3 imperial/metric toggles
 │   ├── i18n/              # ★ i18next config/init/format (→ docs/i18n.md)
@@ -381,7 +382,9 @@ and the seeder: **→ `docs/i18n.md`**.
 | `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` / `VITE_GIT_BRANCH` / `VITE_GIT_COMMIT_DATE` | Build (auto) | Footer version stamp — **not hand-set**; baked from `package.json` + git in `vite.config.ts`. |
 
 **PWA/deploy detail:** the active offline worker is `/service-worker.js` (registered
-outside preview/iframe contexts); `public/sw.js` is a legacy kill-switch. Static
+outside preview/iframe contexts); `public/sw.js` is a legacy kill-switch. `vite.config.ts`
+also emits `/version.json` per build (the freshness signal for `versionCheck.ts`); it's
+excluded from the Workbox precache (`globIgnores`) and fetched uncached. Static
 hosting is Cloudflare Workers (static-assets-only, `wrangler.jsonc`,
 `bun run build` then `wrangler deploy`). Production `lapwingdata.com` attaches via
 a `custom_domain` route in `wrangler.jsonc` (auto DNS+TLS — don't also attach it in

--- a/src/lib/versionCheck.test.ts
+++ b/src/lib/versionCheck.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { isUpdateAvailable, type RemoteVersion } from "@/lib/versionCheck";
+import type { BuildInfo } from "@/lib/buildInfo";
+
+const local: BuildInfo = {
+  version: "2.8.1",
+  commit: "aaaaaaa",
+  buildDate: "2026-06-20T12:00:00.000Z",
+  branch: "main",
+  commitDate: "2026-06-20T11:59:00.000Z",
+};
+
+const remote = (over: Partial<RemoteVersion>): RemoteVersion => ({
+  version: "2.8.1",
+  commit: "bbbbbbb",
+  buildDate: "2026-06-21T12:00:00.000Z",
+  branch: "main",
+  commitDate: "2026-06-21T11:59:00.000Z",
+  ...over,
+});
+
+describe("isUpdateAvailable", () => {
+  it("true when remote has a different commit and a newer build date", () => {
+    expect(isUpdateAvailable(remote({}), local)).toBe(true);
+  });
+
+  it("false when commits match (same build)", () => {
+    expect(isUpdateAvailable(remote({ commit: local.commit }), local)).toBe(false);
+  });
+
+  it("false when remote build date is older (rollback / local ahead)", () => {
+    expect(
+      isUpdateAvailable(remote({ buildDate: "2026-06-19T12:00:00.000Z" }), local),
+    ).toBe(false);
+  });
+
+  it("false when remote build date equals local build date", () => {
+    expect(isUpdateAvailable(remote({ buildDate: local.buildDate }), local)).toBe(false);
+  });
+
+  it("false when either commit is 'unknown'", () => {
+    expect(isUpdateAvailable(remote({ commit: "unknown" }), local)).toBe(false);
+    expect(isUpdateAvailable(remote({}), { ...local, commit: "unknown" })).toBe(false);
+  });
+
+  it("false when build dates are missing", () => {
+    expect(isUpdateAvailable(remote({ buildDate: "" }), local)).toBe(false);
+    expect(isUpdateAvailable(remote({}), { ...local, buildDate: "" })).toBe(false);
+  });
+
+  it("false for null / undefined remote (offline or fetch failure)", () => {
+    expect(isUpdateAvailable(null, local)).toBe(false);
+    expect(isUpdateAvailable(undefined, local)).toBe(false);
+  });
+});

--- a/src/lib/versionCheck.ts
+++ b/src/lib/versionCheck.ts
@@ -1,0 +1,103 @@
+// Independent "a newer build is deployed" signal.
+//
+// The PWA already tries to update itself by polling the service worker
+// (`registration.update()` in main.tsx). That relies on the browser noticing a
+// byte-diff in `service-worker.js`, which can silently fail behind aggressive
+// HTTP / CDN caching — leaving a tab pinned to a stale build. This module is the
+// belt to that suspenders: a tiny `version.json` is emitted next to the bundle at
+// build time (see vite.config.ts), and the running tab fetches it fresh and
+// compares it against the build constants compiled into its own bundle
+// (`buildInfo`). The deployed copy is, by definition, "latest".
+
+import { buildInfo, type BuildInfo } from "@/lib/buildInfo";
+
+/** Shape of the build-emitted `/version.json`. Mirrors {@link BuildInfo}. */
+export interface RemoteVersion {
+  version: string;
+  commit: string;
+  buildDate: string;
+  branch: string;
+  commitDate: string;
+}
+
+/** Default poll interval — frequent enough to catch a deploy mid-session,
+ *  infrequent enough to be invisible. Also re-checked on focus / reconnect. */
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Pure update check. True only when the remote build is genuinely newer than the
+ * running one:
+ *  - commit hashes differ (something actually shipped), AND
+ *  - the remote build is strictly newer by build timestamp.
+ *
+ * The timestamp guard keeps us from prompting when the running tab is actually
+ * ahead (a rollback, or a local/preview build), and a missing/`"unknown"` hash
+ * on either side is never treated as an update.
+ */
+export function isUpdateAvailable(
+  remote: RemoteVersion | null | undefined,
+  local: BuildInfo = buildInfo,
+): boolean {
+  if (!remote) return false;
+  if (!remote.commit || remote.commit === "unknown") return false;
+  if (!local.commit || local.commit === "unknown") return false;
+  if (remote.commit === local.commit) return false;
+  if (!remote.buildDate || !local.buildDate) return false;
+  return remote.buildDate > local.buildDate;
+}
+
+/**
+ * Fetch `/version.json` bypassing every cache layer (cache-busting query +
+ * `no-store`). Returns `null` on any failure (offline, 404, malformed) so the
+ * caller can stay silent rather than surfacing an error.
+ */
+export async function fetchRemoteVersion(): Promise<RemoteVersion | null> {
+  try {
+    const res = await fetch(`/version.json?t=${Date.now()}`, { cache: "no-store" });
+    if (!res.ok) return null;
+    const json = (await res.json()) as Partial<RemoteVersion>;
+    if (!json || typeof json.commit !== "string" || typeof json.buildDate !== "string") {
+      return null;
+    }
+    return json as RemoteVersion;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start watching for a newer deployed build. Checks immediately, then on an
+ * interval and whenever the tab regains focus or the network reconnects.
+ * `onUpdate` fires at most once per newly-seen remote commit. Returns a cleanup
+ * function that stops all timers/listeners.
+ */
+export function startVersionPolling(onUpdate: () => void): () => void {
+  let notifiedCommit: string | null = null;
+  let stopped = false;
+
+  const check = async () => {
+    if (stopped || (typeof navigator !== "undefined" && navigator.onLine === false)) return;
+    const remote = await fetchRemoteVersion();
+    if (stopped || !remote || !isUpdateAvailable(remote)) return;
+    if (notifiedCommit === remote.commit) return;
+    notifiedCommit = remote.commit;
+    onUpdate();
+  };
+
+  const onOnline = () => void check();
+  const onVisible = () => {
+    if (document.visibilityState === "visible") void check();
+  };
+
+  void check();
+  const interval = window.setInterval(() => void check(), POLL_INTERVAL_MS);
+  window.addEventListener("online", onOnline);
+  document.addEventListener("visibilitychange", onVisible);
+
+  return () => {
+    stopped = true;
+    window.clearInterval(interval);
+    window.removeEventListener("online", onOnline);
+    document.removeEventListener("visibilitychange", onVisible);
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { registerSW } from "virtual:pwa-register";
 import { initPlugins } from "@/plugins";
 import { initDebugConsole } from "@/lib/debugConsole";
 import { isNativeApp } from "@/lib/platform";
+import { startVersionPolling } from "@/lib/versionCheck";
 // Initialize i18next before render so the chosen language is active on first
 // paint (no English flash). The default export is the configured instance.
 import i18n from "@/lib/i18n";
@@ -54,6 +55,43 @@ const cleanupPreviewServiceWorkers = async () => {
   await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
 };
 
+type UpdateSW = (reloadPage?: boolean) => Promise<void>;
+
+/**
+ * Reboot onto the freshly-deployed build. The happy path hands off to the PWA's
+ * own `updateSW(true)` (activate the waiting worker, then reload). If that does
+ * nothing — e.g. the service worker itself was served stale, which is the very
+ * failure this guards against — fall back after a short grace period to a hard
+ * reset: unregister the worker, drop caches, reload.
+ */
+const rebootToLatest = (updateSW: UpdateSW) => {
+  void updateSW(true);
+  window.setTimeout(async () => {
+    await cleanupPreviewServiceWorkers();
+    window.location.reload();
+  }, 2000);
+};
+
+/**
+ * Persistent "Update ready" toast. A fixed id de-dupes it, so the SW's
+ * `onNeedRefresh` and the version poller can both ask for it without stacking.
+ */
+const showUpdateToast = (updateSW: UpdateSW) => {
+  toast(i18n.t("common:updateToast.title"), {
+    id: "app-update",
+    description: i18n.t("common:updateToast.description"),
+    duration: PERSISTENT_TOAST_DURATION_MS,
+    action: {
+      label: i18n.t("common:updateToast.refresh"),
+      onClick: () => rebootToLatest(updateSW),
+    },
+    cancel: {
+      label: i18n.t("common:updateToast.later"),
+      onClick: () => undefined,
+    },
+  });
+};
+
 // The native (Tauri/Android) shell is a top-level window — not an iframe — so it
 // slips past the checks above. It serves its own packaged assets, so a service
 // worker has nothing useful to do and would only fight the shell's caching;
@@ -64,20 +102,7 @@ if (isInIframe || isPreviewHost || isNativeApp()) {
   const updateSW = registerSW({
     immediate: true,
     onNeedRefresh() {
-      toast(i18n.t("common:updateToast.title"), {
-        description: i18n.t("common:updateToast.description"),
-        duration: PERSISTENT_TOAST_DURATION_MS,
-        action: {
-          label: i18n.t("common:updateToast.refresh"),
-          onClick: async () => {
-            await updateSW(true);
-          },
-        },
-        cancel: {
-          label: i18n.t("common:updateToast.later"),
-          onClick: () => undefined,
-        },
-      });
+      showUpdateToast(updateSW);
     },
     onRegisteredSW(_swUrl: string, registration: ServiceWorkerRegistration | undefined) {
       if (!registration) return;
@@ -85,6 +110,15 @@ if (isInIframe || isPreviewHost || isNativeApp()) {
       window.setInterval(() => {
         void registration.update();
       }, 60_000);
+
+      // Independent of the service worker's own diff-detection (which can stall
+      // behind HTTP/CDN caching): poll a build-emitted version.json and prompt
+      // when a genuinely newer build is live. Nudge the SW first so the reboot
+      // lands on the new assets.
+      startVersionPolling(() => {
+        void registration.update();
+        showUpdateToast(updateSW);
+      });
     },
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -195,6 +195,24 @@ export default defineConfig(({ mode }) => {
       react(),
       externalPluginsLoader(pluginPackages),
       mode === "development" && componentTagger(),
+      // Emit a tiny version.json next to the bundle so a running tab can detect a
+      // newer deploy without depending on the service worker's own diff-detection
+      // (see src/lib/versionCheck.ts). It carries the same build constants baked
+      // into buildInfo, so the deployed copy is by definition "latest".
+      {
+        name: "emit-version-json",
+        generateBundle() {
+          this.emitFile({
+            type: "asset",
+            fileName: "version.json",
+            source: JSON.stringify(
+              { version: appVersion, commit: gitHash, buildDate, branch, commitDate },
+              null,
+              2,
+            ),
+          });
+        },
+      } satisfies Plugin,
       VitePWA({
         filename: "service-worker.js",
         registerType: "autoUpdate",
@@ -236,7 +254,9 @@ export default defineConfig(({ mode }) => {
           // woff2 only: every SW-capable browser supports it, so the legacy
           // .woff fallbacks @fontsource emits would just be dead precache weight.
           globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2,json,nmea,wasm}"],
-          globIgnores: ["**/tracks.zip"],
+          // version.json must never be precached — it's the freshness signal the
+          // running tab fetches uncached to detect a newer deploy (see versionCheck.ts).
+          globIgnores: ["**/tracks.zip", "version.json"],
           navigateFallbackDenylist: [/^\/~oauth/],
           runtimeCaching: [
             {


### PR DESCRIPTION
## Why

A user opened the app on a laptop and was served a **very old version**. The PWA's only update path was the service worker noticing a byte-diff in its own file (`registration.update()` every 60s → `onNeedRefresh` toast in `main.tsx`). Behind browser HTTP / Cloudflare edge caching, that polling can keep re-fetching the *same* stale `service-worker.js`, so a new deploy is never detected and the "Update ready" toast never fires.

## What

An **independent freshness signal** that doesn't depend on the SW's own diff-detection:

- **`vite.config.ts`** emits a tiny `version.json` next to the bundle (`generateBundle` hook) from the same build constants already baked into `buildInfo` — so the deployed copy is, by definition, "latest". It's added to Workbox `globIgnores` so it's **never precached**.
- **`src/lib/versionCheck.ts`** (new) fetches `/version.json` uncached (cache-busting query + `no-store`) on start, on a ~5 min interval, and on focus/reconnect, then compares it against the running build. `isUpdateAvailable()` is pure (newer commit **and** strictly newer build date — guards against rollbacks / preview builds / `unknown` hashes) and unit-tested.
- **`src/main.tsx`** shares the existing "Update ready" Sonner toast between the SW `onNeedRefresh` callback and the new poller (fixed toast `id` de-dupes). Refresh now hard-reboots: `updateSW(true)` with an unregister-SW + reload fallback for the stale-SW case — the actual fix for "old app served from a stuck worker".

Reuses the existing `common:updateToast.*` strings (already translated in all locales) — no new i18n keys.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run test:run`, `bun run build` all green.
- After `bun run build`: `dist/version.json` is emitted with the correct commit/buildDate and is **not** in the precache manifest (`grep -c version.json dist/service-worker.js` → 0).
- New tests in `src/lib/versionCheck.test.ts` cover the comparison edge cases (newer/same/older/equal dates, `unknown` hashes, missing fields, null remote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2ErrGGyzGeQDyq6hwdRYU)_