### PR TITLE
Add password rules + realtime strength checker to sign-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.8.1] - unreleased
 
 ### Added
+- **Password strength rules + a realtime checker on sign-up.** The registration
+  form now enforces stronger passwords (at least 8 characters, with a lowercase
+  letter, an uppercase letter, a number, and a symbol) and shows a live strength
+  meter with a per-rule checklist that updates as you type. The check is fully
+  offline (`lib/passwordStrength.ts`).
 - **"Update available" check that doesn't rely on the service worker.** The app
   now also compares the running build against a build-emitted `version.json`
   fetched fresh from the server, so a stale tab reliably surfaces the "Update

--- a/src/components/PasswordStrengthMeter.tsx
+++ b/src/components/PasswordStrengthMeter.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next';
+import { Check, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  evaluatePassword,
+  type PasswordRuleId,
+  type PasswordStrengthLevel,
+} from '@/lib/passwordStrength';
+
+interface PasswordStrengthMeterProps {
+  password: string;
+  className?: string;
+}
+
+// Bar colour + how many of the four segments fill, per strength level.
+const LEVEL_STYLE: Record<PasswordStrengthLevel, { bar: string; segments: number; text: string }> = {
+  weak: { bar: 'bg-destructive', segments: 1, text: 'text-destructive' },
+  fair: { bar: 'bg-warning', segments: 2, text: 'text-warning' },
+  good: { bar: 'bg-warning', segments: 3, text: 'text-warning' },
+  strong: { bar: 'bg-success', segments: 4, text: 'text-success' },
+};
+
+const RULE_LABEL_KEY = {
+  length: 'register.passwordRules.length',
+  lowercase: 'register.passwordRules.lowercase',
+  uppercase: 'register.passwordRules.uppercase',
+  number: 'register.passwordRules.number',
+  symbol: 'register.passwordRules.symbol',
+} as const satisfies Record<PasswordRuleId, string>;
+
+const STRENGTH_LABEL_KEY = {
+  weak: 'register.strengthLevel.weak',
+  fair: 'register.strengthLevel.fair',
+  good: 'register.strengthLevel.good',
+  strong: 'register.strengthLevel.strong',
+} as const satisfies Record<PasswordStrengthLevel, string>;
+
+/**
+ * Realtime password feedback for sign-up: a four-segment strength bar plus a
+ * per-rule checklist. Pure presentation — all logic lives in
+ * `lib/passwordStrength` so it stays unit-tested and reusable.
+ */
+export function PasswordStrengthMeter({ password, className }: PasswordStrengthMeterProps) {
+  const { t } = useTranslation('auth');
+  const { rules, level } = evaluatePassword(password);
+  const style = LEVEL_STYLE[level];
+  const hasInput = password.length > 0;
+
+  return (
+    <div className={cn('space-y-2', className)} aria-live="polite">
+      <div className="flex gap-1" role="presentation">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={cn(
+              'h-1 flex-1 rounded-full transition-colors',
+              hasInput && i < style.segments ? style.bar : 'bg-muted',
+            )}
+          />
+        ))}
+      </div>
+      {hasInput && (
+        <p className={cn('text-xs font-medium', style.text)}>
+          {t('register.passwordStrength')}: {t(STRENGTH_LABEL_KEY[level])}
+        </p>
+      )}
+      <ul className="space-y-1">
+        {rules.map((rule) => (
+          <li
+            key={rule.id}
+            className={cn(
+              'flex items-center gap-1.5 text-xs',
+              rule.passed ? 'text-success' : 'text-muted-foreground',
+            )}
+          >
+            {rule.passed ? (
+              <Check className="h-3 w-3 shrink-0" aria-hidden />
+            ) : (
+              <X className="h-3 w-3 shrink-0" aria-hidden />
+            )}
+            <span>{t(RULE_LABEL_KEY[rule.id])}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/passwordStrength.test.ts
+++ b/src/lib/passwordStrength.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluatePassword,
+  MIN_PASSWORD_LENGTH,
+  PASSWORD_RULE_IDS,
+  type PasswordRuleId,
+} from "./passwordStrength";
+
+function ruleMap(password: string): Record<PasswordRuleId, boolean> {
+  const { rules } = evaluatePassword(password);
+  return Object.fromEntries(rules.map((r) => [r.id, r.passed])) as Record<
+    PasswordRuleId,
+    boolean
+  >;
+}
+
+describe("evaluatePassword rules", () => {
+  it("exposes every rule in a stable order, even for an empty password", () => {
+    const { rules } = evaluatePassword("");
+    expect(rules.map((r) => r.id)).toEqual(PASSWORD_RULE_IDS);
+    expect(rules.every((r) => !r.passed)).toBe(true);
+  });
+
+  it("flags each character-class rule independently", () => {
+    expect(ruleMap("password")).toMatchObject({
+      length: true,
+      lowercase: true,
+      uppercase: false,
+      number: false,
+      symbol: false,
+    });
+    expect(ruleMap("Aa1!")).toMatchObject({
+      length: false,
+      lowercase: true,
+      uppercase: true,
+      number: true,
+      symbol: true,
+    });
+  });
+
+  it("requires at least the minimum length", () => {
+    const short = "Aa1!".padEnd(MIN_PASSWORD_LENGTH - 1, "x");
+    expect(evaluatePassword(short).rules.find((r) => r.id === "length")?.passed).toBe(false);
+    const ok = "Aa1!".padEnd(MIN_PASSWORD_LENGTH, "x");
+    expect(evaluatePassword(ok).rules.find((r) => r.id === "length")?.passed).toBe(true);
+  });
+
+  it("treats unicode/space-free symbols as a symbol but not whitespace", () => {
+    expect(ruleMap("abc def").symbol).toBe(false);
+    expect(ruleMap("abc-def").symbol).toBe(true);
+  });
+});
+
+describe("evaluatePassword scoring", () => {
+  it("scores an empty password as zero and weak", () => {
+    const result = evaluatePassword("");
+    expect(result.score).toBe(0);
+    expect(result.level).toBe("weak");
+    expect(result.meetsRequirements).toBe(false);
+  });
+
+  it("never rates a too-short password above fair", () => {
+    const result = evaluatePassword("Aa1!");
+    expect(result.score).toBeLessThanOrEqual(2);
+    expect(["weak", "fair"]).toContain(result.level);
+  });
+
+  it("does not let raw length carry a low-variety password", () => {
+    const result = evaluatePassword("aaaaaaaaaaaa");
+    expect(result.level).not.toBe("strong");
+  });
+
+  it("rates a long, varied password as strong and meeting requirements", () => {
+    const result = evaluatePassword("Str0ng!Pass99");
+    expect(result.score).toBe(4);
+    expect(result.level).toBe("strong");
+    expect(result.meetsRequirements).toBe(true);
+  });
+
+  it("only meets requirements when every rule passes", () => {
+    expect(evaluatePassword("alllowercase1!").meetsRequirements).toBe(false);
+    expect(evaluatePassword("GoodPass1!").meetsRequirements).toBe(true);
+  });
+});

--- a/src/lib/passwordStrength.ts
+++ b/src/lib/passwordStrength.ts
@@ -1,0 +1,90 @@
+// Offline-first password-strength evaluation for account sign-up. Pure and
+// dependency-free (no zxcvbn — it would balloon the bundle and break the
+// offline-first rule), so it runs client-side for the realtime visual checker
+// and doubles as the gate before we hand the password to Supabase auth.
+
+/** Minimum length we accept for a new password. */
+export const MIN_PASSWORD_LENGTH = 8;
+
+/** A length at which we stop rewarding extra characters in the score. */
+const STRONG_LENGTH = 12;
+
+/** Identifier for each rule the UI renders as a realtime checklist item. */
+export type PasswordRuleId =
+  | "length"
+  | "lowercase"
+  | "uppercase"
+  | "number"
+  | "symbol";
+
+/** Coarse strength bucket used to colour/label the meter. */
+export type PasswordStrengthLevel = "weak" | "fair" | "good" | "strong";
+
+export interface PasswordRuleResult {
+  id: PasswordRuleId;
+  passed: boolean;
+}
+
+export interface PasswordStrength {
+  /** Per-rule pass/fail, in a stable display order. */
+  rules: PasswordRuleResult[];
+  /** Normalised 0–4 score for the strength meter. */
+  score: number;
+  /** Bucketed label derived from the score. */
+  level: PasswordStrengthLevel;
+  /** True only when every rule passes — the sign-up gate. */
+  meetsRequirements: boolean;
+}
+
+const RULE_TESTS: { id: PasswordRuleId; test: (pw: string) => boolean }[] = [
+  { id: "length", test: (pw) => pw.length >= MIN_PASSWORD_LENGTH },
+  { id: "lowercase", test: (pw) => /[a-z]/.test(pw) },
+  { id: "uppercase", test: (pw) => /[A-Z]/.test(pw) },
+  { id: "number", test: (pw) => /[0-9]/.test(pw) },
+  // Anything that isn't a letter, digit, or whitespace counts as a symbol.
+  { id: "symbol", test: (pw) => /[^A-Za-z0-9\s]/.test(pw) },
+];
+
+/** The rule ids in display order — handy for rendering before any input. */
+export const PASSWORD_RULE_IDS: PasswordRuleId[] = RULE_TESTS.map((r) => r.id);
+
+function levelForScore(score: number): PasswordStrengthLevel {
+  if (score <= 1) return "weak";
+  if (score === 2) return "fair";
+  if (score === 3) return "good";
+  return "strong";
+}
+
+/**
+ * Evaluate a password against the sign-up rules and produce a 0–4 strength
+ * score. The score blends how many character-class rules pass with a small
+ * length bonus, so "aaaaaaaa" (long but trivial) never reads as strong while a
+ * varied 12+ character password tops out.
+ */
+export function evaluatePassword(password: string): PasswordStrength {
+  const rules: PasswordRuleResult[] = RULE_TESTS.map(({ id, test }) => ({
+    id,
+    passed: test(password),
+  }));
+
+  const meetsRequirements = rules.every((r) => r.passed);
+
+  if (password.length === 0) {
+    return { rules, score: 0, level: "weak", meetsRequirements };
+  }
+
+  // Character-class variety (excluding the pure length rule) is the backbone of
+  // the score; length only nudges it up so it can't carry a weak password.
+  const classRules = rules.filter((r) => r.id !== "length");
+  const classesPassed = classRules.filter((r) => r.passed).length;
+
+  let score = classesPassed; // 0–4
+  if (password.length >= MIN_PASSWORD_LENGTH) score += 1;
+  if (password.length >= STRONG_LENGTH) score += 1;
+  // A password that fails the basic length rule can never read above "fair".
+  if (password.length < MIN_PASSWORD_LENGTH) score = Math.min(score, 2);
+
+  score = Math.max(0, Math.min(4, score));
+
+  return { rules, score, level: levelForScore(score), meetsRequirements };
+}

--- a/src/locales/de/auth.json
+++ b/src/locales/de/auth.json
@@ -33,7 +33,22 @@
     "disposableEmail": "Bitte verwende eine dauerhafte E-Mail-Adresse",
     "disposableEmailDesc": "Wegwerf- oder temporäre Postfächer sind nicht zulässig.",
     "passwordsNoMatch": "Die Passwörter stimmen nicht überein",
-    "passwordTooShort": "Das Passwort muss mindestens 6 Zeichen lang sein",
+    "passwordTooWeak": "Das Passwort ist zu schwach",
+    "passwordTooWeakDesc": "Bitte erfülle alle unten stehenden Passwortanforderungen.",
+    "passwordStrength": "Stärke",
+    "strengthLevel": {
+      "weak": "Schwach",
+      "fair": "Mäßig",
+      "good": "Gut",
+      "strong": "Stark"
+    },
+    "passwordRules": {
+      "length": "Mindestens 8 Zeichen",
+      "lowercase": "Ein Kleinbuchstabe",
+      "uppercase": "Ein Großbuchstabe",
+      "number": "Eine Zahl",
+      "symbol": "Ein Sonderzeichen"
+    },
     "completeCaptcha": "Bitte schließe das Captcha ab",
     "confirmAgeRequired": "Bitte bestätige, dass du 16 Jahre oder älter bist",
     "failed": "Registrierung fehlgeschlagen",

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -114,7 +114,22 @@
     "disposableEmail": "Please use a permanent email address",
     "disposableEmailDesc": "Disposable / temporary mailboxes are not allowed.",
     "passwordsNoMatch": "Passwords do not match",
-    "passwordTooShort": "Password must be at least 6 characters",
+    "passwordTooWeak": "Password is too weak",
+    "passwordTooWeakDesc": "Please meet all the password requirements below.",
+    "passwordStrength": "Strength",
+    "strengthLevel": {
+      "weak": "Weak",
+      "fair": "Fair",
+      "good": "Good",
+      "strong": "Strong"
+    },
+    "passwordRules": {
+      "length": "At least 8 characters",
+      "lowercase": "One lowercase letter",
+      "uppercase": "One uppercase letter",
+      "number": "One number",
+      "symbol": "One symbol"
+    },
     "completeCaptcha": "Please complete the captcha",
     "confirmAgeRequired": "Please confirm you are 16 or older",
     "failed": "Registration failed",

--- a/src/locales/es/auth.json
+++ b/src/locales/es/auth.json
@@ -33,7 +33,22 @@
     "disposableEmail": "Usa una dirección de correo permanente",
     "disposableEmailDesc": "No se permiten buzones desechables o temporales.",
     "passwordsNoMatch": "Las contraseñas no coinciden",
-    "passwordTooShort": "La contraseña debe tener al menos 6 caracteres",
+    "passwordTooWeak": "La contraseña es demasiado débil",
+    "passwordTooWeakDesc": "Cumple todos los requisitos de contraseña que se indican abajo.",
+    "passwordStrength": "Seguridad",
+    "strengthLevel": {
+      "weak": "Débil",
+      "fair": "Aceptable",
+      "good": "Buena",
+      "strong": "Fuerte"
+    },
+    "passwordRules": {
+      "length": "Al menos 8 caracteres",
+      "lowercase": "Una letra minúscula",
+      "uppercase": "Una letra mayúscula",
+      "number": "Un número",
+      "symbol": "Un símbolo"
+    },
     "completeCaptcha": "Completa el captcha",
     "confirmAgeRequired": "Confirma que tienes 16 años o más",
     "failed": "Error al registrarse",

--- a/src/locales/fr/auth.json
+++ b/src/locales/fr/auth.json
@@ -33,7 +33,22 @@
     "disposableEmail": "Utilisez une adresse e-mail permanente",
     "disposableEmailDesc": "Les boîtes jetables ou temporaires ne sont pas autorisées.",
     "passwordsNoMatch": "Les mots de passe ne correspondent pas",
-    "passwordTooShort": "Le mot de passe doit comporter au moins 6 caractères",
+    "passwordTooWeak": "Le mot de passe est trop faible",
+    "passwordTooWeakDesc": "Veuillez respecter toutes les exigences ci-dessous.",
+    "passwordStrength": "Robustesse",
+    "strengthLevel": {
+      "weak": "Faible",
+      "fair": "Moyen",
+      "good": "Bon",
+      "strong": "Fort"
+    },
+    "passwordRules": {
+      "length": "Au moins 8 caractères",
+      "lowercase": "Une lettre minuscule",
+      "uppercase": "Une lettre majuscule",
+      "number": "Un chiffre",
+      "symbol": "Un symbole"
+    },
     "completeCaptcha": "Veuillez compléter le captcha",
     "confirmAgeRequired": "Veuillez confirmer que vous avez 16 ans ou plus",
     "failed": "Échec de l'inscription",

--- a/src/locales/it/auth.json
+++ b/src/locales/it/auth.json
@@ -33,7 +33,22 @@
     "disposableEmail": "Usa un indirizzo email permanente",
     "disposableEmailDesc": "Le caselle usa e getta o temporanee non sono consentite.",
     "passwordsNoMatch": "Le password non corrispondono",
-    "passwordTooShort": "La password deve contenere almeno 6 caratteri",
+    "passwordTooWeak": "La password è troppo debole",
+    "passwordTooWeakDesc": "Soddisfa tutti i requisiti della password qui sotto.",
+    "passwordStrength": "Sicurezza",
+    "strengthLevel": {
+      "weak": "Debole",
+      "fair": "Discreta",
+      "good": "Buona",
+      "strong": "Forte"
+    },
+    "passwordRules": {
+      "length": "Almeno 8 caratteri",
+      "lowercase": "Una lettera minuscola",
+      "uppercase": "Una lettera maiuscola",
+      "number": "Un numero",
+      "symbol": "Un simbolo"
+    },
     "completeCaptcha": "Completa il captcha",
     "confirmAgeRequired": "Conferma di avere 16 anni o più",
     "failed": "Registrazione non riuscita",

--- a/src/locales/ja/auth.json
+++ b/src/locales/ja/auth.json
@@ -33,7 +33,22 @@
     "disposableEmail": "永続的なメールアドレスを使用してください",
     "disposableEmailDesc": "使い捨て・一時的なメールボックスは使用できません。",
     "passwordsNoMatch": "パスワードが一致しません",
-    "passwordTooShort": "パスワードは6文字以上にしてください",
+    "passwordTooWeak": "パスワードが弱すぎます",
+    "passwordTooWeakDesc": "以下のパスワード要件をすべて満たしてください。",
+    "passwordStrength": "強度",
+    "strengthLevel": {
+      "weak": "弱い",
+      "fair": "普通",
+      "good": "良い",
+      "strong": "強い"
+    },
+    "passwordRules": {
+      "length": "8文字以上",
+      "lowercase": "小文字を1つ",
+      "uppercase": "大文字を1つ",
+      "number": "数字を1つ",
+      "symbol": "記号を1つ"
+    },
     "completeCaptcha": "キャプチャを完了してください",
     "confirmAgeRequired": "16歳以上であることを確認してください",
     "failed": "登録に失敗しました",

--- a/src/locales/pt-BR/auth.json
+++ b/src/locales/pt-BR/auth.json
@@ -33,7 +33,22 @@
     "disposableEmail": "Use um endereço de e-mail permanente",
     "disposableEmailDesc": "Caixas de e-mail descartáveis ou temporárias não são permitidas.",
     "passwordsNoMatch": "As senhas não coincidem",
-    "passwordTooShort": "A senha deve ter pelo menos 6 caracteres",
+    "passwordTooWeak": "A senha é muito fraca",
+    "passwordTooWeakDesc": "Atenda a todos os requisitos de senha abaixo.",
+    "passwordStrength": "Força",
+    "strengthLevel": {
+      "weak": "Fraca",
+      "fair": "Razoável",
+      "good": "Boa",
+      "strong": "Forte"
+    },
+    "passwordRules": {
+      "length": "Pelo menos 8 caracteres",
+      "lowercase": "Uma letra minúscula",
+      "uppercase": "Uma letra maiúscula",
+      "number": "Um número",
+      "symbol": "Um símbolo"
+    },
     "completeCaptcha": "Complete o captcha",
     "confirmAgeRequired": "Confirme que você tem 16 anos ou mais",
     "failed": "Falha no cadastro",

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -14,6 +14,8 @@ import { PricingCards } from '@/components/PricingCards';
 import { PlanCheckout, PlanCheckoutSummary, type PlanSelection } from '@/components/PlanCheckout';
 import { useStripePrices } from '@/hooks/useStripePrices';
 import { isDisposableEmail, looksLikeEmail } from '@/lib/emailValidation';
+import { evaluatePassword } from '@/lib/passwordStrength';
+import { PasswordStrengthMeter } from '@/components/PasswordStrengthMeter';
 import { isPaidTier } from '@/lib/billing';
 import { setPendingCheckout } from '@/lib/pendingCheckout';
 import { isNativeApp } from '@/lib/platform';
@@ -57,8 +59,8 @@ export default function Register() {
       toast({ title: t('register.passwordsNoMatch'), variant: 'destructive' });
       return;
     }
-    if (password.length < 6) {
-      toast({ title: t('register.passwordTooShort'), variant: 'destructive' });
+    if (!evaluatePassword(password).meetsRequirements) {
+      toast({ title: t('register.passwordTooWeak'), description: t('register.passwordTooWeakDesc'), variant: 'destructive' });
       return;
     }
     if (turnstileEnabled && !captchaToken) {
@@ -127,6 +129,7 @@ export default function Register() {
             <div className="space-y-2">
               <Label htmlFor="password">{t('password')}</Label>
               <Input id="password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+              <PasswordStrengthMeter password={password} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">{t('register.confirmPassword')}</Label>


### PR DESCRIPTION
## Why

The registration form accepted any 6+ character password and gave no feedback on quality. This modernizes sign-up with real password rules and a live visual strength checker.

## What changed

- **`src/lib/passwordStrength.ts`** — pure, offline-first password evaluator (no zxcvbn, keeps the bundle small and respects the offline-first rule). Enforces:
  - at least 8 characters
  - a lowercase letter
  - an uppercase letter
  - a number
  - a symbol

  Returns a per-rule pass/fail list plus a normalized 0–4 score / `weak|fair|good|strong` level. Length alone can't carry a low-variety password, and a too-short password never reads above "fair".
- **`src/components/PasswordStrengthMeter.tsx`** — realtime visual checker: a four-segment colored strength bar (destructive → warning → success tokens) and a per-rule checklist with check/✗ icons that updates as you type. Pure presentation; all logic lives in the lib.
- **`src/pages/Register.tsx`** — renders the meter under the password field and blocks sign-up until every rule passes (replaces the old bare `length < 6` check).
- **i18n** — new `register.*` strings added to `en` and translated across all shipped locales (`es`, `fr`, `de`, `it`, `pt-BR`, `ja`) so the parity test stays green.
- **Tests** — full Vitest coverage for `passwordStrength` (rules, scoring, edge cases).
- **CHANGELOG** — entry under `[2.8.1] - unreleased`.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test:run` (1913 passed), `bun run build`, and `bun run test:coverage` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rs8GJ1Wsy1izavKFUDvFSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs8GJ1Wsy1izavKFUDvFSM)_