### PR TITLE
Extend safe-area insets to drawer + full-page routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing Bluetooth download flow; MyChron and Alfano open explanatory dialogs for
   now (MyChron's copy differs between the native app and the web). Placeholder
   artwork lives in `public/loggers/` for easy swap-out. New `logger` i18n namespace.
-- **Safe-area padding on native / installed PWA.** The app shell now respects the
-  device's safe-area insets (status bar / notch) via `env(safe-area-inset-*)` and
-  `viewport-fit=cover`, so header content no longer sits under the phone's status
-  bar. A no-op on browsers and desktops without a safe area.
+- **Safe-area padding on native / installed PWA.** Every full-screen surface now
+  respects the device's safe-area insets (status bar / notch) via
+  `env(safe-area-inset-*)` and `viewport-fit=cover`, so chrome no longer sits under
+  the phone's status bar — the app shell + landing, the full-page routes
+  (login/register/admin/legal), and the file-manager drawer (its garage/profile/
+  device header). A no-op on browsers and desktops without a safe area.
 - **Privacy / Terms links on the sign-in page.** The login screen now links to the
   Privacy Policy and Terms of Service.
 - **"Back to app" returns you where you were.** The back button on the Privacy and

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -122,7 +122,7 @@ export function FileManagerDrawer({
   return (
     <>
       <div className="fixed inset-0 z-[10000] bg-black/40" onClick={onClose} />
-      <div className="fixed inset-y-0 right-0 z-[10001] w-full sm:w-1/2 min-w-[320px] bg-background border-l border-border flex flex-col shadow-2xl animate-in slide-in-from-right duration-200">
+      <div className="fixed inset-y-0 right-0 z-[10001] w-full sm:w-1/2 min-w-[320px] bg-background border-l border-border flex flex-col shadow-2xl animate-in slide-in-from-right duration-200 safe-area-inset">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
           <div className="flex items-center gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -220,9 +220,11 @@
      WebView / iOS) and installed PWAs, which draw edge-to-edge. Requires
      `viewport-fit=cover` (set in index.html). Insets resolve to 0 on browsers
      and desktops without a safe area, so this is a no-op everywhere else.
-     Applied to the app-shell containers, whose `border-box` sizing keeps the
-     padding inside `h-screen`/`min-h-screen` (no overflow) while the shell's
-     background fills the inset region behind the status bar. */
+     Applied to every full-screen surface — the app shell + landing, full-page
+     routes (login/register/admin/legal), and portal overlays like the file-
+     manager drawer — whose `border-box` sizing keeps the padding inside
+     `h-screen`/`min-h-screen` (no overflow) while the surface's background
+     fills the inset region behind the status bar. */
   .safe-area-inset {
     padding-top: env(safe-area-inset-top);
     padding-left: env(safe-area-inset-left);

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -29,13 +29,13 @@ export default function Admin() {
   }, [user, isAdmin, loading, navigate]);
 
   if (loading) {
-    return <div className="min-h-screen bg-background flex items-center justify-center text-muted-foreground">{t('loading')}</div>;
+    return <div className="min-h-screen bg-background flex items-center justify-center text-muted-foreground safe-area-inset">{t('loading')}</div>;
   }
 
   if (!user || !isAdmin) return null;
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-background flex flex-col safe-area-inset">
       <header className="border-b border-border px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -34,7 +34,7 @@ export default function DeleteAccount() {
   });
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-2xl mx-auto">
+    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-2xl mx-auto safe-area-inset">
       <Link
         to="/"
         className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -71,7 +71,7 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8">
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8 safe-area-inset">
       <div className="w-full max-w-sm space-y-6">
         <div className="flex items-center gap-3 justify-center">
           <BrandLogo className="w-8 h-8" />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,7 +12,7 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted">
+    <div className="flex min-h-screen items-center justify-center bg-muted safe-area-inset">
       <div className="text-center">
         <h1 className="mb-4 text-4xl font-bold">404</h1>
         <p className="mb-4 text-xl text-muted-foreground">Oops! Page not found</p>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -23,7 +23,7 @@ const Privacy = () => {
     canonical: "https://lapwingdata.com/privacy",
   });
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
+    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto safe-area-inset">
       <button
         type="button"
         onClick={() => goBackOrHome(navigate)}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -109,7 +109,7 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center p-8 gap-12">
+    <div className="min-h-screen bg-background flex flex-col items-center p-8 gap-12 safe-area-inset">
       <div className="flex items-center gap-3 justify-center mt-4">
         <BrandLogo className="w-8 h-8" />
         <h1 className="text-xl font-semibold text-foreground">LapWing</h1>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -19,7 +19,7 @@ const Terms = () => {
     canonical: "https://lapwingdata.com/terms",
   });
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto">
+    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-3xl mx-auto safe-area-inset">
       <button
         type="button"
         onClick={() => goBackOrHome(navigate)}


### PR DESCRIPTION
## Why

On native / installed-PWA the app draws edge-to-edge (`viewport-fit=cover`). The `.safe-area-inset` utility already kept the **main app shell** and **landing page** clear of the device status bar / notch, but several other full-screen surfaces were left drawing under it — so their top chrome (vital info) was hidden beneath the phone's status bar.

## What

Apply the existing reusable `.safe-area-inset` utility (top/left/right via `env(safe-area-inset-*)`) to the remaining full-screen surfaces:

- **File-manager drawer** — its garage / profile / device header (title, battery, disconnect, close button) is a portal overlay (`fixed inset-y-0 right-0`) rendered *outside* the padded app shell, so its header sat under the status bar.
- **Full-page routes** — `Login`, `Register`, `Admin` (+ loading state), `Privacy`, `Terms`, `DeleteAccount`, and `NotFound`, each of which owns its own `min-h-screen` root.

No new CSS class was needed — the utility already existed; this just broadens where it's applied. The comment in `index.css` and the `CHANGELOG.md` entry are updated to match.

A **no-op on browsers and desktops** without a safe area (insets resolve to 0).

## Verification

- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run test:run` ✅ (134 files, 1913 tests)
- `bun run build` ✅

View-layer / className-only change, so no new unit tests (these surfaces are outside the coverage scope by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FojvNNtPyxoixHn2mR5Txu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FojvNNtPyxoixHn2mR5Txu)_