### PR TITLE
Native mychron downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing Bluetooth download flow; MyChron and Alfano open explanatory dialogs for
   now (MyChron's copy differs between the native app and the web). Placeholder
   artwork lives in `public/loggers/` for easy swap-out. New `logger` i18n namespace.
+- **Download from a MyChron over Wi-Fi (native app).** In the native (Tauri) app,
+  the MyChron tile in the logger picker now runs a real download: it connects to the
+  logger over Wi-Fi (on Android it prompts you to pick the MyChron in the system
+  Wi-Fi dialog), lists the sessions on the device, and downloads + opens the one you
+  choose — mirroring the existing Bluetooth flow. The web app is unchanged (browsers
+  can't reach the logger's Wi-Fi) and still shows the explanatory dialog. Built on a
+  new `createMychronConnection()` adapter behind the existing `LoggerConnection`
+  interface; the native Tauri IPC (`@tauri-apps/api`) is lazy-loaded so it never
+  enters the web bundle.
 - **Safe-area padding on native / installed PWA.** The app shell now respects the
   device's safe-area insets (status bar / notch) via `env(safe-area-inset-*)` and
   `viewport-fit=cover`, so header content no longer sits under the phone's status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ src/
 │   ├── fileLoadingState.ts # ★ Host pub/sub for the global file-load overlay
 │   ├── *Storage.ts        # IDB/localStorage store modules (file, vehicle, engine, template, note, setup, …)
 │   ├── gps/               # ★ Phone-as-datalogger layer: gpsFix, customGps, sessionGate, realtimeTimer, dovepWriter
-│   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=BLE today; MyChron (Tauri)/Alfano later satisfy the same interface
+│   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=BLE, mychron/=MyChron over native (Tauri) Wi-Fi IPC (lazy; @tauri-apps/api dynamic-imported, native-only); Alfano later. progress.ts = transport-neutral formatters + computeProgress (→ docs/ble.md)
 │   ├── speedHeatmap.ts / mapMarker.ts / brakingZones / gforceCalculation / …  # racing math
 │   ├── chartUtils / canvas2d / chartAxis / chartColors / videoExport / overlayCanvasRenderer  # charts/video
 │   ├── videoPlaylist.ts   # ★ Pure GoPro chunked-video model: parse/order GH/GX/GP/GOPR chunk names, build a virtual timeline (cumulative offsets) + virtual↔local time mapping + planAudioSegments (export audio stitch). useVideoSync swaps the <video> src per chunk; a single file is a 1-chunk playlist

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ License notices for libxrk + TrackDataAnalysis ship at
 
 Built on the shoulders of these incredible open-source projects and free services:
 
-- [React](https://react.dev) · [Vite](https://vite.dev) · [TypeScript](https://www.typescriptlang.org)
+- [React](https://react.dev) · [Vite](https://vite.dev) · [TypeScript](https://www.typescriptlang.org) · [Tauri](https://tauri.app) (native shell IPC, native-only)
 - [Tailwind CSS](https://tailwindcss.com) · [shadcn/ui](https://ui.shadcn.com) · [Radix UI](https://www.radix-ui.com) · [Lucide Icons](https://lucide.dev)
 - [Inter](https://rsms.me/inter/) · [JetBrains Mono](https://www.jetbrains.com/lp/mono/) (OFL fonts) · [Fontsource](https://fontsource.org) (self-hosted, offline-ready)
 - [Leaflet](https://leafletjs.com) · [CARTO basemaps](https://carto.com) · [Esri World Imagery & Wayback](https://livingatlas.arcgis.com/wayback/) (satellite + historical imagery dates)

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@supabase/supabase-js": "^2.95.3",
         "@tanstack/react-query": "^5.83.0",
+        "@tauri-apps/api": "^2.9.0",
         "@types/leaflet": "^1.9.21",
         "@types/web-bluetooth": "^0.0.21",
         "class-variance-authority": "^0.7.1",
@@ -606,6 +607,8 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
+
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -55,6 +55,41 @@ window.__HTT_NATIVE__ = {
 If the bridge is absent, `openExternal` falls back to `window.open(..., "_blank")`.
 The TypeScript contract is `NativeBridge` in `src/lib/platform.ts`.
 
+## MyChron Wi-Fi download (native-only)
+
+Browsers can't open raw TCP sockets, so pulling a session off an **AiM MyChron**
+over Wi-Fi is native-only. The MyChron tile in the logger picker
+(`LoggerPicker.tsx`) starts the real flow only when `isNativeApp()`; on the web it
+keeps its explanatory dialog. The flow lives in `MyChronDownload.tsx` (lazy) and
+drives the Tauri backend through app-defined IPC commands (no capabilities to
+configure — allowed by `core:default`). The client is
+`src/lib/loggers/mychron/ipc.ts`, which reaches Tauri via a **dynamic**
+`import("@tauri-apps/api/core")` so `@tauri-apps/api` code-splits into the lazy
+MyChron chunk and never enters the web/eager bundle.
+
+IPC contract (args camelCase; all reject with a plain string whose prefix encodes
+the category — `device unreachable:`, `device hung:`, `protocol error:`,
+`unsupported:`, `Wi-Fi join was declined…`, `no logger connected …`):
+
+| Command | Args | Resolves to |
+|---------|------|-------------|
+| `logger_connect` | `{ kind:"mychron", host?, wifi? }` | device info |
+| `logger_list_files` | – | file entries |
+| `logger_download_file` | `{ name, onProgress: Channel }` | `ArrayBuffer` (already-inflated XRK) |
+| `logger_disconnect` | – | `void` |
+
+On **Android** the flow passes `wifi: { ssidPrefix: MYCHRON_SSID_PREFIX }`; the OS
+shows a system Wi-Fi picker (the backend joins + binds the process to the AP via
+`WifiNetworkSpecifier`), and the UI shows a "waiting for you to pick your MyChron…"
+state while it's up. On **desktop** the `wifi` hint is omitted (the user joins the
+AP via the OS). `MYCHRON_SSID_PREFIX` (in `ipc.ts`) and whether the AP is open or
+WPA2 are **open hardware items** — confirm from a real device. The download returns
+decompressed XRK bytes, which go straight into the existing async importer
+(`parseDatalogFile`, wasm worker) named `<name>.xrk`. The flow **owns its
+connection** and calls `logger_disconnect` on every exit (close/cancel/error/
+unmount). MyChron's `LoggerConnection.supportsDeviceDetails` is `false` — no in-app
+settings/tracks/firmware tab.
+
 ## Account deletion (Google Play requirement)
 
 Play requires a publicly reachable account-deletion URL in addition to the in-app

--- a/docs/ble.md
+++ b/docs/ble.md
@@ -16,16 +16,23 @@ state lives in `DeviceContext.tsx` (wraps the app tree in `Index.tsx`). Source:
 The user reaches the BLE flow through `LoggerDownload` → `LoggerPicker` (an eager,
 lightweight image chooser of supported loggers). Picking the PerchWerks Fledgling
 tile mounts `DataloggerDownload` — the lazy BLE flow — on demand, so `lib/ble/*`
-stays out of the initial bundle while the menu still opens instantly. The other
-loggers (MyChron, Alfano) open explanatory dialogs and don't touch `lib/ble/*` yet.
+stays out of the initial bundle while the menu still opens instantly. On the native
+(Tauri) shell the MyChron tile mounts the lazy `MyChronDownload` flow (Wi-Fi over
+native IPC — see `docs/android.md`); on the web it (and Alfano) still open
+explanatory dialogs.
 
 `DataloggerDownload` talks to the device only through the generic
 `LoggerConnection` interface (`src/lib/loggers/`): `listLogs` / `downloadLog` /
-`disconnect`, with `createFledglingConnection()` adapting a `BleConnection`. New
-transports (MyChron over the native shell, Alfano over BLE) add sibling adapters
-that satisfy the same interface, and `DeviceContext.loggerKind` records which
-logger is connected so Fledgling-only surfaces (settings / tracks / firmware) can
-gate themselves.
+`disconnect`, with `createFledglingConnection()` adapting a `BleConnection`. MyChron
+is the second adapter — `createMychronConnection()` (`src/lib/loggers/mychron/`),
+native-only, over the Tauri shell — and Alfano (BLE) will be a third. All satisfy
+the same interface, and `DeviceContext.loggerKind` records which logger is connected
+so Fledgling-only surfaces (settings / tracks / firmware) can gate themselves
+(`supportsDeviceDetails` is `false` for MyChron). The pure progress formatters
+(`formatBytes` / `formatSpeed` / `formatTime`) and the `computeProgress()` helper now
+live transport-neutrally in `src/lib/loggers/progress.ts` (re-exported from
+`src/lib/ble/format.ts` for existing BLE callers) so both flows share them without
+either pulling the other's protocol bundle.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.95.3",
     "@tanstack/react-query": "^5.83.0",
+    "@tauri-apps/api": "^2.9.0",
     "@types/leaflet": "^1.9.21",
     "@types/web-bluetooth": "^0.0.21",
     "class-variance-authority": "^0.7.1",

--- a/src/components/CreditsDialog.tsx
+++ b/src/components/CreditsDialog.tsx
@@ -9,6 +9,7 @@ import { interceptExternal } from "@/lib/platform";
 const CREDITS: ReadonlyArray<readonly [name: string, url: string]> = [
   ["React", "https://react.dev"],
   ["Vite", "https://vite.dev"],
+  ["Tauri", "https://tauri.app"],
   ["TypeScript", "https://www.typescriptlang.org"],
   ["Tailwind CSS", "https://tailwindcss.com"],
   ["shadcn/ui", "https://ui.shadcn.com"],

--- a/src/components/DataloggerDownload.tsx
+++ b/src/components/DataloggerDownload.tsx
@@ -2,8 +2,8 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { Bluetooth, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { formatBytes } from "@/lib/bleDatalogger";
 import { createFledglingConnection, type LoggerConnection, type LoggerFile, type LoggerDownloadProgress } from "@/lib/loggers";
+import { FileListPanel, ProgressPanel } from "@/components/loggers/DownloadPanels";
 import { useDeviceContext } from "@/contexts/DeviceContext";
 import { parseDatalogContent } from "@/lib/datalogParser";
 import { ParsedData } from "@/types/racing";
@@ -201,64 +201,12 @@ export function DataloggerDownload({ onDataLoaded, autoSave, autoSaveFile, autoS
 
         {/* File List State */}
         {state === "file-list" && (
-          <div className="flex flex-col gap-2">
-            <p className="text-sm text-muted-foreground mb-2">
-              Click a file to download and load it:
-            </p>
-            <div className="max-h-80 overflow-y-auto space-y-1">
-              {files.length === 0 ? (
-                <p className="text-center text-muted-foreground py-4">
-                  No files found on device
-                </p>
-              ) : (
-                files.map((file) => (
-                  <button
-                    key={file.name}
-                    onClick={() => handleFileSelect(file)}
-                    className="w-full text-left px-3 py-2 rounded-md bg-muted/50 hover:bg-muted transition-colors flex justify-between items-center"
-                  >
-                    <span className="font-mono text-sm">{file.name}</span>
-                    <span className="text-xs text-muted-foreground">
-                      {formatBytes(file.size)}
-                    </span>
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
+          <FileListPanel files={files} onSelect={handleFileSelect} />
         )}
 
         {/* Downloading State */}
         {state === "downloading" && progress && (
-          <div className="flex flex-col gap-4 py-4">
-            <p className="font-mono text-sm text-center">{currentFile}</p>
-
-            {/* Progress Bar */}
-            <div className="w-full bg-muted rounded-full h-3 overflow-hidden">
-              <div
-                className="h-full bg-primary transition-all duration-150"
-                style={{ width: `${progress.percent}%` }}
-              />
-            </div>
-
-            {/* Stats */}
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <div className="text-muted-foreground">Received:</div>
-              <div className="text-right font-mono">
-                {formatBytes(progress.received)} / {formatBytes(progress.total)}
-              </div>
-
-              <div className="text-muted-foreground">Speed:</div>
-              <div className="text-right font-mono">{progress.speed}</div>
-
-              <div className="text-muted-foreground">ETA:</div>
-              <div className="text-right font-mono">{progress.eta}</div>
-            </div>
-
-            <p className="text-xs text-center text-muted-foreground">
-              {progress.percent.toFixed(1)}% complete
-            </p>
-          </div>
+          <ProgressPanel currentFile={currentFile} progress={progress} />
         )}
 
         {/* Error State */}

--- a/src/components/LoggerDownload.tsx
+++ b/src/components/LoggerDownload.tsx
@@ -14,6 +14,12 @@ const DataloggerDownload = lazy(() =>
   import("@/components/DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
 );
 
+// The native MyChron Wi-Fi flow is likewise lazy so `@tauri-apps/api` (dynamic
+// import inside it) never enters the web/eager bundle.
+const MyChronDownload = lazy(() =>
+  import("@/components/MyChronDownload").then((m) => ({ default: m.MyChronDownload })),
+);
+
 interface LoggerDownloadProps {
   onDataLoaded: (data: ParsedData, fileName?: string) => void;
   autoSave?: boolean;
@@ -37,6 +43,7 @@ export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTri
   const { bleSupported } = useDeviceContext();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [fledglingActive, setFledglingActive] = useState(false);
+  const [mychronActive, setMychronActive] = useState(false);
 
   const openPicker = useCallback(() => setPickerOpen(true), []);
 
@@ -59,6 +66,10 @@ export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTri
           setPickerOpen(false);
           setFledglingActive(true);
         }}
+        onSelectMychron={() => {
+          setPickerOpen(false);
+          setMychronActive(true);
+        }}
       />
 
       {fledglingActive && (
@@ -69,6 +80,18 @@ export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTri
             autoSave={autoSave}
             autoSaveFile={autoSaveFile}
             onClose={() => setFledglingActive(false)}
+          />
+        </Suspense>
+      )}
+
+      {mychronActive && (
+        <Suspense fallback={null}>
+          <MyChronDownload
+            autoStart
+            onDataLoaded={onDataLoaded}
+            autoSave={autoSave}
+            autoSaveFile={autoSaveFile}
+            onClose={() => setMychronActive(false)}
           />
         </Suspense>
       )}

--- a/src/components/LoggerPicker.tsx
+++ b/src/components/LoggerPicker.tsx
@@ -28,6 +28,11 @@ interface LoggerPickerProps {
   bleSupported: boolean;
   /** Begin the standard Bluetooth download flow (PerchWerks Fledgling). */
   onSelectFledgling: () => void;
+  /**
+   * Begin the native MyChron Wi-Fi flow. Only supplied (and only fired) on the
+   * native shell; on web the MyChron card keeps its explanatory dialog.
+   */
+  onSelectMychron?: () => void;
 }
 
 interface LoggerCardProps {
@@ -72,7 +77,7 @@ function LoggerCard({ image, name, tag, onClick, disabled, badge, hint }: Logger
  * downloadable and open an explanatory dialog instead (MyChron's copy differs
  * between the native shell and the web app — see `isNativeApp`).
  */
-export function LoggerPicker({ open, onOpenChange, bleSupported, onSelectFledgling }: LoggerPickerProps) {
+export function LoggerPicker({ open, onOpenChange, bleSupported, onSelectFledgling, onSelectMychron }: LoggerPickerProps) {
   const { t } = useTranslation("logger");
   const [info, setInfo] = useState<"mychron" | "alfano" | null>(null);
   const native = isNativeApp();
@@ -99,7 +104,7 @@ export function LoggerPicker({ open, onOpenChange, bleSupported, onSelectFledgli
               image={MYCHRON_IMAGE}
               name={MYCHRON_NAME}
               tag={t("tags.mychron")}
-              onClick={() => setInfo("mychron")}
+              onClick={() => (native && onSelectMychron ? onSelectMychron() : setInfo("mychron"))}
             />
             <LoggerCard
               image={ALFANO_IMAGE}

--- a/src/components/MyChronDownload.tsx
+++ b/src/components/MyChronDownload.tsx
@@ -1,0 +1,217 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Wifi, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { FileListPanel, ProgressPanel } from "@/components/loggers/DownloadPanels";
+import { createMychronConnection } from "@/lib/loggers/mychron/mychronConnection";
+import { MYCHRON_SSID_PREFIX, loggerConnect } from "@/lib/loggers/mychron/ipc";
+import type { LoggerConnection, LoggerFile, LoggerDownloadProgress } from "@/lib/loggers";
+import { parseDatalogFile } from "@/lib/datalogParser";
+import { ParsedData } from "@/types/racing";
+
+type DownloadState =
+  | "idle"
+  | "connecting"
+  | "wifi-selecting"
+  | "fetching-files"
+  | "file-list"
+  | "downloading"
+  | "error";
+
+interface MyChronDownloadProps {
+  onDataLoaded: (data: ParsedData, fileName?: string) => void;
+  autoSave?: boolean;
+  autoSaveFile?: (name: string, blob: Blob) => Promise<void>;
+  /** Begin connecting as soon as the flow mounts (it's mounted on demand). */
+  autoStart?: boolean;
+  /** Called when the flow finishes or is dismissed so the host can unmount it. */
+  onClose: () => void;
+}
+
+// Android needs the system Wi-Fi picker (join + bind to the MyChron AP); desktop
+// joins the AP via the OS and sockets just work, so we omit the wifi hint there.
+const isAndroid = () =>
+  typeof navigator !== "undefined" && /Android/i.test(navigator.userAgent);
+
+/**
+ * The native MyChron download flow: connect over Wi-Fi via the Tauri shell, list
+ * sessions, download + import the chosen one. Native-only and mounted on demand
+ * by `LoggerDownload` once the user picks MyChron, so `@tauri-apps/api` stays off
+ * the web/eager bundle. Talks to the device only through the generic
+ * `LoggerConnection` surface, and owns the connection — it disconnects on every
+ * exit (close/cancel/error/unmount).
+ */
+export function MyChronDownload({ onDataLoaded, autoSave, autoSaveFile, autoStart, onClose }: MyChronDownloadProps) {
+  const { t } = useTranslation("logger");
+  const [state, setState] = useState<DownloadState>("idle");
+  const [files, setFiles] = useState<LoggerFile[]>([]);
+  const [progress, setProgress] = useState<LoggerDownloadProgress | null>(null);
+  const [currentFile, setCurrentFile] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const loggerRef = useRef<LoggerConnection | null>(null);
+
+  const handleClose = useCallback(() => {
+    loggerRef.current?.disconnect();
+    loggerRef.current = null;
+    setState("idle");
+    setFiles([]);
+    setProgress(null);
+    setCurrentFile("");
+    setError("");
+    onClose();
+  }, [onClose]);
+
+  const handleConnect = useCallback(async () => {
+    setError("");
+    try {
+      // Connect — on Android this drives the OS Wi-Fi picker (join + bind).
+      const android = isAndroid();
+      setState(android ? "wifi-selecting" : "connecting");
+      const info = await (android
+        ? loggerConnect({ wifi: { ssidPrefix: MYCHRON_SSID_PREFIX } })
+        : loggerConnect());
+
+      const logger = createMychronConnection(info);
+      loggerRef.current = logger;
+
+      setState("fetching-files");
+      const fileList = await logger.listLogs();
+      setFiles(fileList);
+      setState("file-list");
+    } catch (err) {
+      console.error("MyChron connect/list error:", err);
+      setError(err instanceof Error ? err.message : String(err));
+      setState("error");
+    }
+  }, []);
+
+  // Kick off the connection as soon as the flow is mounted (once).
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (autoStart && !startedRef.current) {
+      startedRef.current = true;
+      void handleConnect();
+    }
+  }, [autoStart, handleConnect]);
+
+  // Always release the device + Wi-Fi binding when this flow unmounts.
+  useEffect(() => () => void loggerRef.current?.disconnect(), []);
+
+  const handleFileSelect = useCallback(
+    async (file: LoggerFile) => {
+      const logger = loggerRef.current;
+      if (!logger) {
+        setError(t("mychron.flow.errorTitle"));
+        setState("error");
+        return;
+      }
+
+      setState("downloading");
+      setCurrentFile(file.name);
+      setProgress({ received: 0, total: file.size, percent: 0, speed: "0 B/s", eta: "--" });
+      setError("");
+
+      // Bytes are already-inflated XRK — name accordingly so the importer routes
+      // them to the async wasm path.
+      const fileName = file.name.toLowerCase().endsWith(".xrk") ? file.name : `${file.name}.xrk`;
+
+      try {
+        const bytes = await logger.downloadLog(file.name, setProgress);
+        const blob = new Blob([bytes.buffer as ArrayBuffer]);
+
+        // Save the raw file first so it's never lost.
+        if (autoSave && autoSaveFile) {
+          try {
+            await autoSaveFile(fileName, blob);
+          } catch (e) {
+            console.warn("Auto-save failed:", e);
+          }
+        }
+
+        const data = await parseDatalogFile(new File([blob], fileName));
+        handleClose();
+        onDataLoaded(data, fileName);
+      } catch (err) {
+        console.error("MyChron download/parse error:", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(`${msg}${t("mychron.flow.savedHint")}`);
+        setState("error");
+      }
+    },
+    [autoSave, autoSaveFile, handleClose, onDataLoaded, t],
+  );
+
+  const handleRetry = useCallback(() => {
+    loggerRef.current?.disconnect();
+    loggerRef.current = null;
+    setError("");
+    void handleConnect();
+  }, [handleConnect]);
+
+  const isModalOpen = state !== "idle";
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Wifi className="w-5 h-5" />
+            {state === "connecting" && t("mychron.flow.connecting")}
+            {state === "wifi-selecting" && t("mychron.flow.wifiSelecting")}
+            {state === "fetching-files" && t("mychron.flow.fetching")}
+            {state === "file-list" && t("mychron.flow.selectFile")}
+            {state === "downloading" && t("mychron.flow.downloading")}
+            {state === "error" && t("mychron.flow.errorTitle")}
+          </DialogTitle>
+        </DialogHeader>
+
+        {state === "wifi-selecting" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-12 h-12 animate-spin text-primary" />
+            <p className="text-sm text-center text-muted-foreground">{t("mychron.flow.wifiHint")}</p>
+          </div>
+        )}
+
+        {state === "connecting" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-12 h-12 animate-spin text-primary" />
+            <p className="text-muted-foreground">{t("mychron.flow.connecting")}</p>
+          </div>
+        )}
+
+        {state === "fetching-files" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-12 h-12 animate-spin text-primary" />
+            <p className="text-muted-foreground">{t("mychron.flow.fetching")}</p>
+          </div>
+        )}
+
+        {state === "file-list" && (
+          <FileListPanel
+            files={files}
+            onSelect={handleFileSelect}
+            instructions={t("mychron.flow.instructions")}
+            emptyText={t("mychron.flow.empty")}
+          />
+        )}
+
+        {state === "downloading" && progress && (
+          <ProgressPanel currentFile={currentFile} progress={progress} />
+        )}
+
+        {state === "error" && (
+          <div className="flex flex-col items-center gap-4 py-4">
+            <p className="text-destructive text-center">{error}</p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleClose}>
+                {t("mychron.flow.cancel")}
+              </Button>
+              <Button onClick={handleRetry}>{t("mychron.flow.retry")}</Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/loggers/DownloadPanels.tsx
+++ b/src/components/loggers/DownloadPanels.tsx
@@ -1,0 +1,86 @@
+/**
+ * Shared presentational panels for the logger download flows. The file-list and
+ * progress UI is identical across transports (BLE Fledgling, native MyChron), so
+ * it lives here and both flows compose it. Transport-specific states (connecting,
+ * Wi-Fi selecting, errors) stay in each flow's component.
+ */
+
+import { formatBytes } from "@/lib/loggers/progress";
+import type { LoggerFile, LoggerDownloadProgress } from "@/lib/loggers";
+
+interface FileListPanelProps {
+  files: LoggerFile[];
+  onSelect: (file: LoggerFile) => void;
+  /** Instruction line above the list. */
+  instructions?: string;
+  /** Shown when the device reports no files. */
+  emptyText?: string;
+}
+
+/** Tappable list of downloadable logs on the device. */
+export function FileListPanel({
+  files,
+  onSelect,
+  instructions = "Click a file to download and load it:",
+  emptyText = "No files found on device",
+}: FileListPanelProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-muted-foreground mb-2">{instructions}</p>
+      <div className="max-h-80 overflow-y-auto space-y-1">
+        {files.length === 0 ? (
+          <p className="text-center text-muted-foreground py-4">{emptyText}</p>
+        ) : (
+          files.map((file) => (
+            <button
+              key={file.name}
+              onClick={() => onSelect(file)}
+              className="w-full text-left px-3 py-2 rounded-md bg-muted/50 hover:bg-muted transition-colors flex justify-between items-center"
+            >
+              <span className="font-mono text-sm">{file.name}</span>
+              <span className="text-xs text-muted-foreground">{formatBytes(file.size)}</span>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ProgressPanelProps {
+  currentFile: string;
+  progress: LoggerDownloadProgress;
+}
+
+/** Progress bar + received/speed/eta stats for an in-flight download. */
+export function ProgressPanel({ currentFile, progress }: ProgressPanelProps) {
+  return (
+    <div className="flex flex-col gap-4 py-4">
+      <p className="font-mono text-sm text-center">{currentFile}</p>
+
+      <div className="w-full bg-muted rounded-full h-3 overflow-hidden">
+        <div
+          className="h-full bg-primary transition-all duration-150"
+          style={{ width: `${progress.percent}%` }}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div className="text-muted-foreground">Received:</div>
+        <div className="text-right font-mono">
+          {formatBytes(progress.received)} / {formatBytes(progress.total)}
+        </div>
+
+        <div className="text-muted-foreground">Speed:</div>
+        <div className="text-right font-mono">{progress.speed}</div>
+
+        <div className="text-muted-foreground">ETA:</div>
+        <div className="text-right font-mono">{progress.eta}</div>
+      </div>
+
+      <p className="text-xs text-center text-muted-foreground">
+        {progress.percent.toFixed(1)}% complete
+      </p>
+    </div>
+  );
+}

--- a/src/lib/ble/format.ts
+++ b/src/lib/ble/format.ts
@@ -1,32 +1,9 @@
 /**
  * Display formatters for BLE transfer progress UI.
- * Pure functions — no BLE dependencies.
+ *
+ * These moved to the transport-neutral `@/lib/loggers/progress` so the native
+ * MyChron flow can share them without pulling the BLE protocol bundle in. This
+ * module stays as a re-export for existing BLE callers.
  */
 
-/** Format bytes to human-readable string. */
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return bytes + " B";
-  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " KB";
-  return (bytes / 1048576).toFixed(1) + " MB";
-}
-
-/** Format transfer speed (bytes/sec) to human-readable string. */
-export function formatSpeed(bytesPerSecond: number): string {
-  if (isNaN(bytesPerSecond) || !isFinite(bytesPerSecond)) {
-    return "0 B/s";
-  }
-  if (bytesPerSecond < 1024) return bytesPerSecond.toFixed(0) + " B/s";
-  if (bytesPerSecond < 1048576) return (bytesPerSecond / 1024).toFixed(1) + " KB/s";
-  return (bytesPerSecond / 1048576).toFixed(2) + " MB/s";
-}
-
-/** Format time remaining (seconds) as e.g. "12s" or "1m 30s". */
-export function formatTime(seconds: number): string {
-  if (isNaN(seconds) || !isFinite(seconds)) {
-    return "--";
-  }
-  if (seconds < 60) return Math.ceil(seconds) + "s";
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.ceil(seconds % 60);
-  return `${mins}m ${secs}s`;
-}
+export { formatBytes, formatSpeed, formatTime } from "@/lib/loggers/progress";

--- a/src/lib/loggers/mychron/ipc.test.ts
+++ b/src/lib/loggers/mychron/ipc.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock of the Tauri core API (dynamically imported by ipc.ts).
+const { invoke, ChannelMock } = vi.hoisted(() => {
+  const invoke = vi.fn();
+  class ChannelMock<T> {
+    onmessage: ((m: T) => void) | null = null;
+  }
+  return { invoke, ChannelMock };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke, Channel: ChannelMock }));
+
+import { loggerConnect, loggerListFiles, loggerDownloadFile, loggerDisconnect } from "./ipc";
+
+describe("mychron ipc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("connects with the mychron kind, default host and the wifi hint", async () => {
+    invoke.mockResolvedValue({ kind: "mychron", fields: {} });
+    await loggerConnect({ wifi: { ssidPrefix: "MYCHRON5" } });
+    expect(invoke).toHaveBeenCalledWith("logger_connect", {
+      kind: "mychron",
+      host: "10.0.0.1",
+      wifi: { ssidPrefix: "MYCHRON5" },
+    });
+  });
+
+  it("passes backend error strings through unwrapped (prefix preserved)", async () => {
+    invoke.mockRejectedValueOnce("device unreachable: not joined");
+    await expect(loggerListFiles()).rejects.toBe("device unreachable: not joined");
+  });
+
+  it("wires a progress Channel and returns the bytes as a Uint8Array", async () => {
+    invoke.mockImplementation(async (cmd: string, args: { onProgress: { onmessage?: (m: unknown) => void } }) => {
+      if (cmd === "logger_download_file") {
+        args.onProgress.onmessage?.({ received: 1, total: 2 });
+        return new Uint8Array([9, 8, 7]).buffer;
+      }
+      return undefined;
+    });
+
+    const onProgress = vi.fn();
+    const result = await loggerDownloadFile("a_0217.xrz", onProgress);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result)).toEqual([9, 8, 7]);
+    expect(onProgress).toHaveBeenCalledWith({ received: 1, total: 2 });
+  });
+
+  it("swallows errors on disconnect (safe when already gone)", async () => {
+    invoke.mockRejectedValueOnce("boom");
+    await expect(loggerDisconnect()).resolves.toBeUndefined();
+    expect(invoke).toHaveBeenCalledWith("logger_disconnect");
+  });
+});

--- a/src/lib/loggers/mychron/ipc.ts
+++ b/src/lib/loggers/mychron/ipc.ts
@@ -1,0 +1,112 @@
+/**
+ * Native (Tauri) IPC client for the AiM MyChron Wi-Fi downloader.
+ *
+ * This is the ONLY module that touches `@tauri-apps/api`, and it does so via a
+ * dynamic `import("@tauri-apps/api/core")` so Vite code-splits Tauri into the
+ * lazy MyChron chunk — the web build never fetches it (Golden Rule #1). Only the
+ * lazy native flow may reach this module; never the eager picker.
+ *
+ * Commands are app-defined on the native side; arg keys are camelCase and every
+ * command rejects with a plain string whose prefix encodes the error category
+ * (`device unreachable:`, `device hung:`, `protocol error:`, `unsupported:`,
+ * `Wi-Fi join was declined…`, `no logger connected …`). We pass those strings
+ * through unwrapped so the UI can match on the prefix.
+ */
+
+/**
+ * SSID prefix for the MyChron's Wi-Fi AP, used on Android to drive the system
+ * Wi-Fi picker. OPEN HARDWARE ITEM: confirm the real prefix from a device and
+ * whether the AP is open or WPA2 (+ passphrase). Single source of truth.
+ */
+export const MYCHRON_SSID_PREFIX = "MYCHRON5";
+
+/** Default MyChron gateway host — omit to let the backend use it. */
+const DEFAULT_HOST = "10.0.0.1";
+
+/** Device fields the backend reports after a connect (flattened hw.* / path.* / usr.*). */
+export interface LoggerDeviceInfo {
+  kind: string;
+  name?: string;
+  model?: string;
+  fields: Record<string, string>;
+}
+
+/** A downloadable session on the device. */
+export interface FileEntry {
+  name: string;
+  size: number;
+  date?: string;
+  meta: Record<string, string>;
+}
+
+/** Raw progress payload from the native download channel. */
+export interface DownloadProgress {
+  received: number;
+  total: number;
+}
+
+/** Wi-Fi join hint (Android) — exact SSID or a prefix the OS picker matches. */
+export interface WifiHint {
+  ssid?: string;
+  ssidPrefix?: string;
+  passphrase?: string;
+}
+
+// Memoized loader for the Tauri core API. Dynamic so the import is the
+// code-split boundary that keeps `@tauri-apps/api` off the web/eager graph.
+let apiPromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
+function api() {
+  if (!apiPromise) apiPromise = import("@tauri-apps/api/core");
+  return apiPromise;
+}
+
+/** Connect to the MyChron — joins + binds Wi-Fi on Android when `wifi` is set. */
+export async function loggerConnect(opts: { host?: string; wifi?: WifiHint } = {}): Promise<LoggerDeviceInfo> {
+  const { invoke } = await api();
+  return invoke<LoggerDeviceInfo>("logger_connect", {
+    kind: "mychron",
+    host: opts.host ?? DEFAULT_HOST,
+    wifi: opts.wifi,
+  });
+}
+
+/** Re-read device info from an already-connected logger. */
+export async function loggerDeviceInfo(): Promise<LoggerDeviceInfo> {
+  const { invoke } = await api();
+  return invoke<LoggerDeviceInfo>("logger_device_info");
+}
+
+/** List the downloadable sessions on the connected device. */
+export async function loggerListFiles(): Promise<FileEntry[]> {
+  const { invoke } = await api();
+  return invoke<FileEntry[]>("logger_list_files");
+}
+
+/**
+ * Download one session by name, streaming progress through a `Channel`. Resolves
+ * to the already-inflated XRK bytes (the backend downloads the `.xrz` and unzips
+ * it for us).
+ */
+export async function loggerDownloadFile(
+  name: string,
+  onProgress: (p: DownloadProgress) => void,
+): Promise<Uint8Array> {
+  const { invoke, Channel } = await api();
+  const channel = new Channel<DownloadProgress>();
+  channel.onmessage = onProgress;
+  const buf = await invoke<ArrayBuffer>("logger_download_file", { name, onProgress: channel });
+  return new Uint8Array(buf);
+}
+
+/**
+ * Drop the connection, stop the keepalive and unbind the Wi-Fi. Safe to call
+ * when already disconnected — errors are swallowed.
+ */
+export async function loggerDisconnect(): Promise<void> {
+  try {
+    const { invoke } = await api();
+    await invoke("logger_disconnect");
+  } catch {
+    // Best-effort teardown — ignore (already disconnected / shutting down).
+  }
+}

--- a/src/lib/loggers/mychron/mychronConnection.test.ts
+++ b/src/lib/loggers/mychron/mychronConnection.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as ipc from "./ipc";
+import { createMychronConnection } from "./mychronConnection";
+
+vi.mock("./ipc", () => ({
+  loggerListFiles: vi.fn(),
+  loggerDownloadFile: vi.fn(),
+  loggerDisconnect: vi.fn(),
+}));
+
+function info(overrides: Partial<ipc.LoggerDeviceInfo> = {}): ipc.LoggerDeviceInfo {
+  return { kind: "mychron", fields: {}, ...overrides };
+}
+
+describe("createMychronConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a MyChron without in-app device details", () => {
+    const conn = createMychronConnection(info({ name: "Pilot 7" }));
+    expect(conn.kind).toBe("mychron");
+    expect(conn.supportsDeviceDetails).toBe(false);
+    expect(conn.displayName).toBe("Pilot 7");
+  });
+
+  it("falls back name → model → brand for the display name", () => {
+    expect(createMychronConnection(info({ model: "MyChron 5S" })).displayName).toBe("MyChron 5S");
+    expect(createMychronConnection(info()).displayName).toBe("AiM MyChron");
+  });
+
+  it("maps device file entries down to the generic LoggerFile shape", async () => {
+    vi.mocked(ipc.loggerListFiles).mockResolvedValue([
+      { name: "a_0217.xrz", size: 1234, date: "2026-02-17", meta: { nlap: "12" } },
+    ]);
+    const conn = createMychronConnection(info());
+    await expect(conn.listLogs()).resolves.toEqual([{ name: "a_0217.xrz", size: 1234 }]);
+  });
+
+  it("wraps raw {received,total} progress into a full LoggerDownloadProgress", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    vi.mocked(ipc.loggerDownloadFile).mockImplementation(async (_name, onProgress) => {
+      onProgress({ received: 50, total: 100 });
+      return bytes;
+    });
+    const conn = createMychronConnection(info());
+    const onProgress = vi.fn();
+
+    await expect(conn.downloadLog("a_0217.xrz", onProgress)).resolves.toBe(bytes);
+    expect(ipc.loggerDownloadFile).toHaveBeenCalledWith("a_0217.xrz", expect.any(Function));
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ received: 50, total: 100, percent: 50 }),
+    );
+    const reported = onProgress.mock.calls[0][0];
+    expect(reported).toHaveProperty("speed");
+    expect(reported).toHaveProperty("eta");
+  });
+
+  it("delegates disconnect to the IPC teardown", () => {
+    createMychronConnection(info()).disconnect();
+    expect(ipc.loggerDisconnect).toHaveBeenCalled();
+  });
+});

--- a/src/lib/loggers/mychron/mychronConnection.ts
+++ b/src/lib/loggers/mychron/mychronConnection.ts
@@ -1,0 +1,41 @@
+/**
+ * AiM MyChron adapter — wraps the native (Tauri) Wi-Fi transport in the generic
+ * `LoggerConnection` surface so the download UI never branches on transport.
+ * Mirrors `fledglingConnection.ts` (BLE).
+ *
+ * Importing this module pulls the native IPC client (and, lazily, Tauri) in, so
+ * only the lazy MyChron download flow should reference it — never the eager
+ * picker. Connection establishment (`loggerConnect`) happens in the UI; this
+ * factory adapts an already-connected device, just like `createFledglingConnection`
+ * takes a live BLE handle.
+ */
+
+import type { LoggerConnection } from "../types";
+import { computeProgress } from "../progress";
+import {
+  type LoggerDeviceInfo,
+  loggerListFiles,
+  loggerDownloadFile,
+  loggerDisconnect,
+} from "./ipc";
+
+/** Adapt a connected MyChron (described by `info`) to the generic logger interface. */
+export function createMychronConnection(info: LoggerDeviceInfo): LoggerConnection {
+  return {
+    kind: "mychron",
+    displayName: info.name ?? info.model ?? "AiM MyChron",
+    // No in-app Device tab (settings/tracks/firmware) for MyChron.
+    supportsDeviceDetails: false,
+    listLogs: async () => {
+      const files = await loggerListFiles();
+      return files.map((f) => ({ name: f.name, size: f.size }));
+    },
+    downloadLog: (name, onProgress) => {
+      const start = Date.now();
+      return loggerDownloadFile(name, ({ received, total }) => {
+        onProgress?.(computeProgress(received, total, start));
+      });
+    },
+    disconnect: () => void loggerDisconnect(),
+  };
+}

--- a/src/lib/loggers/progress.test.ts
+++ b/src/lib/loggers/progress.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { formatBytes, formatSpeed, formatTime, computeProgress } from "./progress";
+
+describe("formatBytes", () => {
+  it("formats across unit boundaries", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(5 * 1048576)).toBe("5.0 MB");
+  });
+});
+
+describe("formatSpeed", () => {
+  it("formats and guards against non-finite input", () => {
+    expect(formatSpeed(500)).toBe("500 B/s");
+    expect(formatSpeed(2048)).toBe("2.0 KB/s");
+    expect(formatSpeed(NaN)).toBe("0 B/s");
+    expect(formatSpeed(Infinity)).toBe("0 B/s");
+  });
+});
+
+describe("formatTime", () => {
+  it("formats seconds and minutes, guarding non-finite input", () => {
+    expect(formatTime(12)).toBe("12s");
+    expect(formatTime(90)).toBe("1m 30s");
+    expect(formatTime(Infinity)).toBe("--");
+  });
+});
+
+describe("computeProgress", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 0% and an unknown ETA when total is unknown", () => {
+    const p = computeProgress(0, 0, Date.now());
+    expect(p.percent).toBe(0);
+    expect(p.eta).toBe("--");
+    expect(p.speed).toBe("0 B/s");
+  });
+
+  it("derives percent, speed and ETA from elapsed time", () => {
+    vi.useFakeTimers();
+    const start = 1_000_000;
+    vi.setSystemTime(start);
+    // 5 s later, half of 1000 bytes received → 500 B over 5 s = 100 B/s,
+    // 500 bytes remaining at 100 B/s = 5 s ETA.
+    vi.setSystemTime(start + 5000);
+    const p = computeProgress(500, 1000, start);
+    expect(p.received).toBe(500);
+    expect(p.total).toBe(1000);
+    expect(p.percent).toBe(50);
+    expect(p.speed).toBe("100 B/s");
+    expect(p.eta).toBe("5s");
+  });
+
+  it("reports 100% and no remaining time when complete", () => {
+    vi.useFakeTimers();
+    const start = 2_000_000;
+    vi.setSystemTime(start + 2000);
+    const p = computeProgress(1000, 1000, start);
+    expect(p.percent).toBe(100);
+    expect(p.eta).toBe("0s");
+  });
+});

--- a/src/lib/loggers/progress.ts
+++ b/src/lib/loggers/progress.ts
@@ -1,0 +1,63 @@
+/**
+ * Transport-neutral display formatters + progress math for logger downloads.
+ *
+ * Pure functions, no transport imports — so both the BLE (Fledgling) and native
+ * (MyChron over Tauri) flows can share them without dragging a protocol bundle
+ * into the other's chunk. `src/lib/ble/format.ts` re-exports the formatters for
+ * its existing callers.
+ */
+
+import type { LoggerDownloadProgress } from "./types";
+
+/** Format bytes to human-readable string. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " KB";
+  return (bytes / 1048576).toFixed(1) + " MB";
+}
+
+/** Format transfer speed (bytes/sec) to human-readable string. */
+export function formatSpeed(bytesPerSecond: number): string {
+  if (isNaN(bytesPerSecond) || !isFinite(bytesPerSecond)) {
+    return "0 B/s";
+  }
+  if (bytesPerSecond < 1024) return bytesPerSecond.toFixed(0) + " B/s";
+  if (bytesPerSecond < 1048576) return (bytesPerSecond / 1024).toFixed(1) + " KB/s";
+  return (bytesPerSecond / 1048576).toFixed(2) + " MB/s";
+}
+
+/** Format time remaining (seconds) as e.g. "12s" or "1m 30s". */
+export function formatTime(seconds: number): string {
+  if (isNaN(seconds) || !isFinite(seconds)) {
+    return "--";
+  }
+  if (seconds < 60) return Math.ceil(seconds) + "s";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.ceil(seconds % 60);
+  return `${mins}m ${secs}s`;
+}
+
+/**
+ * Build a full `LoggerDownloadProgress` from raw byte counts. Speed/ETA are
+ * derived from the elapsed time since `startTimeMs` (overall average), mirroring
+ * the BLE transfer math. Used by transports whose progress source reports only
+ * `received`/`total` (e.g. the MyChron native channel).
+ */
+export function computeProgress(
+  received: number,
+  total: number,
+  startTimeMs: number,
+): LoggerDownloadProgress {
+  const percent = total > 0 ? (received / total) * 100 : 0;
+  const elapsedSeconds = (Date.now() - startTimeMs) / 1000;
+  const speed = elapsedSeconds > 0 ? received / elapsedSeconds : 0;
+  // Unknown total → "--"; known total but no speed yet → 0s.
+  const etaSeconds = total <= 0 ? NaN : speed > 0 ? (total - received) / speed : 0;
+  return {
+    received,
+    total,
+    percent,
+    speed: formatSpeed(speed),
+    eta: formatTime(etaSeconds),
+  };
+}

--- a/src/locales/de/logger.json
+++ b/src/locales/de/logger.json
@@ -13,7 +13,21 @@
     "nativeTitle": "MyChron-Download",
     "nativeBody": "Noch offen",
     "webTitle": "Native App erforderlich",
-    "webBody": "MyChron-Logger übertragen per WLAN, worauf Webbrowser nicht direkt zugreifen können. Eine eigene native App zum Herunterladen von MyChron ist in aktiver Entwicklung und soll um Juli 2026 erscheinen."
+    "webBody": "MyChron-Logger übertragen per WLAN, worauf Webbrowser nicht direkt zugreifen können. Eine eigene native App zum Herunterladen von MyChron ist in aktiver Entwicklung und soll um Juli 2026 erscheinen.",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Alfano-Downloads",

--- a/src/locales/de/logger.json
+++ b/src/locales/de/logger.json
@@ -15,18 +15,18 @@
     "webTitle": "Native App erforderlich",
     "webBody": "MyChron-Logger übertragen per WLAN, worauf Webbrowser nicht direkt zugreifen können. Eine eigene native App zum Herunterladen von MyChron ist in aktiver Entwicklung und soll um Juli 2026 erscheinen.",
     "flow": {
-      "connecting": "Connecting to your MyChron…",
-      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
-      "wifiHint": "Approve the connection in the system dialog to continue.",
-      "fetching": "Fetching sessions…",
-      "selectFile": "Select a session to download",
-      "downloading": "Downloading…",
-      "errorTitle": "Connection error",
-      "instructions": "Tap a session to download and load it:",
-      "empty": "No sessions on this device",
-      "savedHint": " — the file was saved and can be found in Browse Files.",
-      "retry": "Try again",
-      "cancel": "Cancel"
+      "connecting": "Verbindung mit deinem MyChron…",
+      "wifiSelecting": "Warten, bis du deinen MyChron in der WLAN-Liste auswählst…",
+      "wifiHint": "Bestätige die Verbindung im Systemdialog, um fortzufahren.",
+      "fetching": "Sitzungen werden abgerufen…",
+      "selectFile": "Wähle eine Sitzung zum Herunterladen",
+      "downloading": "Wird heruntergeladen…",
+      "errorTitle": "Verbindungsfehler",
+      "instructions": "Tippe auf eine Sitzung, um sie herunterzuladen und zu laden:",
+      "empty": "Keine Sitzungen auf diesem Gerät",
+      "savedHint": " — die Datei wurde gespeichert und ist unter „Dateien durchsuchen“ zu finden.",
+      "retry": "Erneut versuchen",
+      "cancel": "Abbrechen"
     }
   },
   "alfano": {

--- a/src/locales/en/logger.json
+++ b/src/locales/en/logger.json
@@ -12,7 +12,21 @@
     "nativeTitle": "MyChron download",
     "nativeBody": "TBD",
     "webTitle": "Native app required",
-    "webBody": "MyChron loggers transfer over Wi-Fi, which web browsers can't access directly. A dedicated native app to download from MyChron is in active development and is slated to launch around July 2026."
+    "webBody": "MyChron loggers transfer over Wi-Fi, which web browsers can't access directly. A dedicated native app to download from MyChron is in active development and is slated to launch around July 2026.",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Alfano downloads",

--- a/src/locales/es/logger.json
+++ b/src/locales/es/logger.json
@@ -13,7 +13,21 @@
     "nativeTitle": "Descarga de MyChron",
     "nativeBody": "Por determinar",
     "webTitle": "Se necesita app nativa",
-    "webBody": "Los registradores MyChron transfieren por Wi-Fi, a lo que los navegadores web no pueden acceder directamente. Hay una app nativa específica para descargar de MyChron en pleno desarrollo, con lanzamiento previsto en torno a julio de 2026."
+    "webBody": "Los registradores MyChron transfieren por Wi-Fi, a lo que los navegadores web no pueden acceder directamente. Hay una app nativa específica para descargar de MyChron en pleno desarrollo, con lanzamiento previsto en torno a julio de 2026.",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Descargas de Alfano",

--- a/src/locales/es/logger.json
+++ b/src/locales/es/logger.json
@@ -15,18 +15,18 @@
     "webTitle": "Se necesita app nativa",
     "webBody": "Los registradores MyChron transfieren por Wi-Fi, a lo que los navegadores web no pueden acceder directamente. Hay una app nativa específica para descargar de MyChron en pleno desarrollo, con lanzamiento previsto en torno a julio de 2026.",
     "flow": {
-      "connecting": "Connecting to your MyChron…",
-      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
-      "wifiHint": "Approve the connection in the system dialog to continue.",
-      "fetching": "Fetching sessions…",
-      "selectFile": "Select a session to download",
-      "downloading": "Downloading…",
-      "errorTitle": "Connection error",
-      "instructions": "Tap a session to download and load it:",
-      "empty": "No sessions on this device",
-      "savedHint": " — the file was saved and can be found in Browse Files.",
-      "retry": "Try again",
-      "cancel": "Cancel"
+      "connecting": "Conectando con tu MyChron…",
+      "wifiSelecting": "Esperando a que elijas tu MyChron en la lista de Wi-Fi…",
+      "wifiHint": "Aprueba la conexión en el cuadro de diálogo del sistema para continuar.",
+      "fetching": "Obteniendo sesiones…",
+      "selectFile": "Selecciona una sesión para descargar",
+      "downloading": "Descargando…",
+      "errorTitle": "Error de conexión",
+      "instructions": "Toca una sesión para descargarla y cargarla:",
+      "empty": "No hay sesiones en este dispositivo",
+      "savedHint": " — el archivo se guardó y puedes encontrarlo en Explorar archivos.",
+      "retry": "Reintentar",
+      "cancel": "Cancelar"
     }
   },
   "alfano": {

--- a/src/locales/fr/logger.json
+++ b/src/locales/fr/logger.json
@@ -13,7 +13,21 @@
     "nativeTitle": "Téléchargement MyChron",
     "nativeBody": "À définir",
     "webTitle": "App native requise",
-    "webBody": "Les enregistreurs MyChron transfèrent en Wi-Fi, auquel les navigateurs web ne peuvent pas accéder directement. Une app native dédiée au téléchargement depuis MyChron est en cours de développement et son lancement est prévu vers juillet 2026."
+    "webBody": "Les enregistreurs MyChron transfèrent en Wi-Fi, auquel les navigateurs web ne peuvent pas accéder directement. Une app native dédiée au téléchargement depuis MyChron est en cours de développement et son lancement est prévu vers juillet 2026.",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Téléchargements Alfano",

--- a/src/locales/fr/logger.json
+++ b/src/locales/fr/logger.json
@@ -15,18 +15,18 @@
     "webTitle": "App native requise",
     "webBody": "Les enregistreurs MyChron transfèrent en Wi-Fi, auquel les navigateurs web ne peuvent pas accéder directement. Une app native dédiée au téléchargement depuis MyChron est en cours de développement et son lancement est prévu vers juillet 2026.",
     "flow": {
-      "connecting": "Connecting to your MyChron…",
-      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
-      "wifiHint": "Approve the connection in the system dialog to continue.",
-      "fetching": "Fetching sessions…",
-      "selectFile": "Select a session to download",
-      "downloading": "Downloading…",
-      "errorTitle": "Connection error",
-      "instructions": "Tap a session to download and load it:",
-      "empty": "No sessions on this device",
-      "savedHint": " — the file was saved and can be found in Browse Files.",
-      "retry": "Try again",
-      "cancel": "Cancel"
+      "connecting": "Connexion à votre MyChron…",
+      "wifiSelecting": "En attente de la sélection de votre MyChron dans la liste Wi-Fi…",
+      "wifiHint": "Approuvez la connexion dans la boîte de dialogue du système pour continuer.",
+      "fetching": "Récupération des sessions…",
+      "selectFile": "Sélectionnez une session à télécharger",
+      "downloading": "Téléchargement…",
+      "errorTitle": "Erreur de connexion",
+      "instructions": "Touchez une session pour la télécharger et la charger :",
+      "empty": "Aucune session sur cet appareil",
+      "savedHint": " — le fichier a été enregistré et se trouve dans Parcourir les fichiers.",
+      "retry": "Réessayer",
+      "cancel": "Annuler"
     }
   },
   "alfano": {

--- a/src/locales/it/logger.json
+++ b/src/locales/it/logger.json
@@ -13,7 +13,21 @@
     "nativeTitle": "Download MyChron",
     "nativeBody": "Da definire",
     "webTitle": "App nativa richiesta",
-    "webBody": "I logger MyChron trasferiscono via Wi-Fi, a cui i browser web non possono accedere direttamente. Un'app nativa dedicata al download da MyChron è in fase di sviluppo e il lancio è previsto intorno a luglio 2026."
+    "webBody": "I logger MyChron trasferiscono via Wi-Fi, a cui i browser web non possono accedere direttamente. Un'app nativa dedicata al download da MyChron è in fase di sviluppo e il lancio è previsto intorno a luglio 2026.",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Download Alfano",

--- a/src/locales/it/logger.json
+++ b/src/locales/it/logger.json
@@ -15,18 +15,18 @@
     "webTitle": "App nativa richiesta",
     "webBody": "I logger MyChron trasferiscono via Wi-Fi, a cui i browser web non possono accedere direttamente. Un'app nativa dedicata al download da MyChron è in fase di sviluppo e il lancio è previsto intorno a luglio 2026.",
     "flow": {
-      "connecting": "Connecting to your MyChron…",
-      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
-      "wifiHint": "Approve the connection in the system dialog to continue.",
-      "fetching": "Fetching sessions…",
-      "selectFile": "Select a session to download",
-      "downloading": "Downloading…",
-      "errorTitle": "Connection error",
-      "instructions": "Tap a session to download and load it:",
-      "empty": "No sessions on this device",
-      "savedHint": " — the file was saved and can be found in Browse Files.",
-      "retry": "Try again",
-      "cancel": "Cancel"
+      "connecting": "Connessione al tuo MyChron…",
+      "wifiSelecting": "In attesa che tu selezioni il tuo MyChron nell'elenco Wi-Fi…",
+      "wifiHint": "Approva la connessione nella finestra di dialogo di sistema per continuare.",
+      "fetching": "Recupero delle sessioni…",
+      "selectFile": "Seleziona una sessione da scaricare",
+      "downloading": "Download in corso…",
+      "errorTitle": "Errore di connessione",
+      "instructions": "Tocca una sessione per scaricarla e caricarla:",
+      "empty": "Nessuna sessione su questo dispositivo",
+      "savedHint": " — il file è stato salvato e si trova in Sfoglia file.",
+      "retry": "Riprova",
+      "cancel": "Annulla"
     }
   },
   "alfano": {

--- a/src/locales/ja/logger.json
+++ b/src/locales/ja/logger.json
@@ -13,7 +13,21 @@
     "nativeTitle": "MyChron のダウンロード",
     "nativeBody": "未定",
     "webTitle": "ネイティブアプリが必要です",
-    "webBody": "MyChron ロガーは Wi-Fi で転送するため、Web ブラウザーから直接アクセスできません。MyChron からダウンロードするための専用ネイティブアプリを開発中で、2026年7月頃のリリースを予定しています。"
+    "webBody": "MyChron ロガーは Wi-Fi で転送するため、Web ブラウザーから直接アクセスできません。MyChron からダウンロードするための専用ネイティブアプリを開発中で、2026年7月頃のリリースを予定しています。",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Alfano のダウンロード",

--- a/src/locales/ja/logger.json
+++ b/src/locales/ja/logger.json
@@ -15,18 +15,18 @@
     "webTitle": "ネイティブアプリが必要です",
     "webBody": "MyChron ロガーは Wi-Fi で転送するため、Web ブラウザーから直接アクセスできません。MyChron からダウンロードするための専用ネイティブアプリを開発中で、2026年7月頃のリリースを予定しています。",
     "flow": {
-      "connecting": "Connecting to your MyChron…",
-      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
-      "wifiHint": "Approve the connection in the system dialog to continue.",
-      "fetching": "Fetching sessions…",
-      "selectFile": "Select a session to download",
-      "downloading": "Downloading…",
-      "errorTitle": "Connection error",
-      "instructions": "Tap a session to download and load it:",
-      "empty": "No sessions on this device",
-      "savedHint": " — the file was saved and can be found in Browse Files.",
-      "retry": "Try again",
-      "cancel": "Cancel"
+      "connecting": "MyChron に接続中…",
+      "wifiSelecting": "Wi-Fi リストで MyChron を選択するのを待っています…",
+      "wifiHint": "続行するには、システムのダイアログで接続を承認してください。",
+      "fetching": "セッションを取得中…",
+      "selectFile": "ダウンロードするセッションを選択",
+      "downloading": "ダウンロード中…",
+      "errorTitle": "接続エラー",
+      "instructions": "セッションをタップしてダウンロードして読み込みます：",
+      "empty": "このデバイスにセッションはありません",
+      "savedHint": " — ファイルは保存され、「ファイルを参照」で見つけられます。",
+      "retry": "再試行",
+      "cancel": "キャンセル"
     }
   },
   "alfano": {

--- a/src/locales/pt-BR/logger.json
+++ b/src/locales/pt-BR/logger.json
@@ -13,7 +13,21 @@
     "nativeTitle": "Download do MyChron",
     "nativeBody": "A definir",
     "webTitle": "App nativo necessário",
-    "webBody": "Os registradores MyChron transferem por Wi-Fi, que os navegadores web não conseguem acessar diretamente. Um app nativo dedicado para baixar do MyChron está em desenvolvimento e tem lançamento previsto para cerca de julho de 2026."
+    "webBody": "Os registradores MyChron transferem por Wi-Fi, que os navegadores web não conseguem acessar diretamente. Um app nativo dedicado para baixar do MyChron está em desenvolvimento e tem lançamento previsto para cerca de julho de 2026.",
+    "flow": {
+      "connecting": "Connecting to your MyChron…",
+      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
+      "wifiHint": "Approve the connection in the system dialog to continue.",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
   },
   "alfano": {
     "title": "Downloads do Alfano",

--- a/src/locales/pt-BR/logger.json
+++ b/src/locales/pt-BR/logger.json
@@ -15,18 +15,18 @@
     "webTitle": "App nativo necessário",
     "webBody": "Os registradores MyChron transferem por Wi-Fi, que os navegadores web não conseguem acessar diretamente. Um app nativo dedicado para baixar do MyChron está em desenvolvimento e tem lançamento previsto para cerca de julho de 2026.",
     "flow": {
-      "connecting": "Connecting to your MyChron…",
-      "wifiSelecting": "Waiting for you to pick your MyChron in the Wi-Fi list…",
-      "wifiHint": "Approve the connection in the system dialog to continue.",
-      "fetching": "Fetching sessions…",
-      "selectFile": "Select a session to download",
-      "downloading": "Downloading…",
-      "errorTitle": "Connection error",
-      "instructions": "Tap a session to download and load it:",
-      "empty": "No sessions on this device",
-      "savedHint": " — the file was saved and can be found in Browse Files.",
-      "retry": "Try again",
-      "cancel": "Cancel"
+      "connecting": "Conectando ao seu MyChron…",
+      "wifiSelecting": "Aguardando você escolher o seu MyChron na lista de Wi-Fi…",
+      "wifiHint": "Aprove a conexão na caixa de diálogo do sistema para continuar.",
+      "fetching": "Buscando sessões…",
+      "selectFile": "Selecione uma sessão para baixar",
+      "downloading": "Baixando…",
+      "errorTitle": "Erro de conexão",
+      "instructions": "Toque em uma sessão para baixá-la e carregá-la:",
+      "empty": "Nenhuma sessão neste dispositivo",
+      "savedHint": " — o arquivo foi salvo e pode ser encontrado em Procurar arquivos.",
+      "retry": "Tentar novamente",
+      "cancel": "Cancelar"
     }
   },
   "alfano": {


### PR DESCRIPTION
## Summary

Replaces the placeholder MyChron dialog (`mychron.nativeBody: "TBD"`) with a real **native-only** "Download from MyChron" flow that pulls a session off an **AiM MyChron** over Wi-Fi via the Tauri shell, mirroring the existing BLE (PerchWerks Fledgling) downloader. Scope is a single-file download; Alfano and multi-select remain out of scope.

The flow slots into the seam BETA already prepared — `LoggerConnection` (`src/lib/loggers/types.ts`) with `"mychron"` already in `LoggerKind` — so the download UI never branches on transport.

## What's included

- **`src/lib/loggers/mychron/ipc.ts`** — typed Tauri IPC client (`logger_connect` / `logger_list_files` / `logger_download_file` / `logger_disconnect`). Reaches `@tauri-apps/api` via a **dynamic** `import("@tauri-apps/api/core")`, wires the progress `Channel`, and passes backend error strings through unwrapped (preserving the `device unreachable:` / `protocol error:` / … prefixes).
- **`src/lib/loggers/mychron/mychronConnection.ts`** — `createMychronConnection()`, the second `LoggerConnection` adapter (mirrors `fledglingConnection.ts`).
- **`src/components/MyChronDownload.tsx`** — lazy native UI. On Android it drives the system Wi-Fi picker (`wifi: { ssidPrefix }`) with a "waiting for you to pick your MyChron…" state; on desktop it omits the hint. Imports via the **async XRK path** (`parseDatalogFile(new File([blob], "<name>.xrk"))`) since the device returns binary XRK that the sync BLE parser rejects. **Owns its connection** — disconnects on close/cancel/error/unmount.
- **`src/lib/loggers/progress.ts`** — transport-neutral `formatBytes`/`formatSpeed`/`formatTime` + a new `computeProgress()`; `ble/format.ts` now re-exports them so neither flow drags in the other's bundle.
- **`src/components/loggers/DownloadPanels.tsx`** — shared file-list/progress panels, now used by both downloaders.
- **Wiring** — `LoggerPicker` gained `onSelectMychron` (fires only when `isNativeApp()`; web keeps the explanatory dialog); `LoggerDownload` mounts the lazy flow.
- **i18n** — new `mychron.flow.*` keys, **fully translated** in all six locales (es/fr/de/it/pt-BR/ja), reusing established terms (Browse Files, Cancel, Retry, Connecting; German uses WLAN).
- **Docs/Credits/Changelog** — `docs/android.md` (IPC contract + Wi-Fi UX + always-disconnect rule), `docs/ble.md`, `CLAUDE.md`, `CreditsDialog` + README (Tauri), `CHANGELOG`.

## Golden Rule #1 (offline-first) — verified

The build chunk map confirms `@tauri-apps/api` and the IPC code land **only** in the lazy `MyChronDownload` chunk (~5 KB) and are **absent from the eager `index` entry** — the web build never fetches Tauri.

## Checks

✅ `bun run typecheck` · ✅ `bun run lint` · ✅ `bun run test:run` (1928 passing, incl. new `progress` / `mychronConnection` / `ipc` suites) · ✅ `bun run build`. Coverage on the new logic: `mychronConnection.ts` 100%, `progress.ts` 94.7%, `ipc.ts` 89.5%.

## Follow-ups

- `MYCHRON_SSID_PREFIX = "MYCHRON5"` and whether the AP is open vs WPA2 are **open hardware items** — confirm from a real device (isolated to one constant in `ipc.ts`).
- A native manual smoke test (real Tauri shell + MyChron) is still worth doing for the Android Wi-Fi-picker path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)