### PR TITLE
Picker name tidy, delete-account header, drop landing tagline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   screen) instead of always jumping to the home screen.
 
 ### Changed
+- **Picker/landing polish.** Logger names shortened to "AiM MyChron 5+" and
+  "Alfano 6+" (single-line, and future-proof for newer models); the account-
+  deletion page picked up the shared sticky brand header; and the landing
+  "Telemetry Data Viewer" tagline was removed for now.
 - **Open-source links moved into About.** The GitHub repository links left the
   landing page and now live in the About dialog under "Free & Open Source", above
   the feature list. The About feature list was also refreshed with the headline

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -99,10 +99,7 @@ export function LandingPage({
         <div className="mx-auto flex w-full max-w-4xl items-center justify-between gap-3 px-6 py-4">
           <div className="flex items-center gap-3">
             <BrandLogo className="w-8 h-8" />
-            <div>
-              <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
-              <p className="text-sm text-muted-foreground">{t("landing:tagline")}</p>
-            </div>
+            <h1 className="text-xl font-semibold text-foreground">LapWing</h1>
           </div>
           <div className="flex items-center gap-2">
             <SupportedFilesDialog />

--- a/src/components/LoggerPicker.tsx
+++ b/src/components/LoggerPicker.tsx
@@ -19,8 +19,8 @@ const ALFANO_IMAGE = "/loggers/alfano.png";
 
 // Brand display names are proper nouns — intentionally not translated.
 const FLEDGLING_NAME = "PerchWerks Fledgling";
-const MYCHRON_NAME = "AiM MyChron 5 / 5S / 2T";
-const ALFANO_NAME = "Alfano 6 / 7";
+const MYCHRON_NAME = "AiM MyChron 5+";
+const ALFANO_NAME = "Alfano 6+";
 
 interface LoggerPickerProps {
   open: boolean;

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
+import { BrandHeader } from "@/components/BrandHeader";
 import {
   cancelAccountDeletion,
   getPendingDeletion,
@@ -34,7 +35,9 @@ export default function DeleteAccount() {
   });
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 md:p-12 max-w-2xl mx-auto safe-area-inset">
+    <div className="min-h-screen bg-background text-foreground flex flex-col safe-area-x">
+      <BrandHeader />
+      <div className="w-full max-w-2xl mx-auto p-6 md:p-12">
       <Link
         to="/"
         className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-8"
@@ -66,6 +69,7 @@ export default function DeleteAccount() {
         </p>
 
         {enableCloud ? <DeletionFlow /> : <CloudDisabledNote />}
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Three minor UI tweaks.

1. **Shorter logger names.** "AiM MyChron 5 / 5S / 2T" → **"AiM MyChron 5+"** and "Alfano 6 / 7" → **"Alfano 6+"** — fits on one line and doesn't pin to specific models (the protocol may well cover newer ones; no new artwork yet).
2. **Sticky header on the account-deletion page.** `/delete-account` now uses the shared `BrandHeader` (sticky, clickable → home) + the safe-area layout, matching privacy/terms.
3. **Dropped the landing tagline.** Removed "Telemetry Data Viewer" from the landing header for now. The `landing:tagline` locale strings are kept in place so a future tagline can drop straight back in.

## Checks

✅ `bun run typecheck` · ✅ `bun run lint` · ✅ `bun run test:run` (1928 passing) · ✅ `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbxsCSt8grPs75vfJyt8wP)_