### PR TITLE
Native (Tauri) BLE downloader for the Fledgling/DovesLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [2.9.2] - unreleased
+
+### Added
+- **Download from a Fledgling over Bluetooth in the native app.** On the native
+  (Tauri) app the PerchWerks Fledgling tile in the logger picker now runs a real
+  Bluetooth download through the native shell (the native webview has no Web
+  Bluetooth). The flow scans for nearby loggers, lets you pick yours from an in-app
+  list, then connects, lists sessions and downloads + imports the chosen one — the
+  same device files (`.dove`/`.dovex`/`.csv`) and parser as the browser path. Built
+  on a new `createDovesloggerConnection()` adapter behind the existing
+  `LoggerConnection` interface, sharing the native IPC client with MyChron. Settings,
+  track sync and firmware update stay on the Web Bluetooth path for now. Web
+  downloads are unchanged.
+
 ## [2.9.1] - unreleased
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ src/
 │   ├── RaceLineView.tsx   # Leaflet map: race line, speed heatmap, braking zones
 │   ├── TelemetryChart.tsx # Canvas speed/telemetry chart (simple mode)
 │   ├── VideoPlayer.tsx    # Synced video playback + overlay system (multi-chunk GoPro playlists via lib/videoPlaylist)
-│   └── …                  # FileImport, LoggerDownload (eager picker host) + LoggerPicker (image chooser) + DataloggerDownload (lazy Fledgling BLE flow), LapSnapshot*, …
+│   └── …                  # FileImport, LoggerDownload (eager picker host) + LoggerPicker (image chooser) + DataloggerDownload (lazy web-BLE Fledgling flow) / DovesloggerDownload (lazy native-BLE Fledgling flow) / MyChronDownload (lazy native Wi-Fi flow), LapSnapshot*, …
 ├── hooks/                 # One concern each; Index.tsx orchestrates.
 │   ├── useSessionData     # Parses imported file → ParsedData
 │   ├── useLapManagement   # Lap calc, selection, visible range
@@ -116,7 +116,7 @@ src/
 │   ├── fileLoadingState.ts # ★ Host pub/sub for the global file-load overlay
 │   ├── *Storage.ts        # IDB/localStorage store modules (file, vehicle, engine, template, note, setup, …)
 │   ├── gps/               # ★ Phone-as-datalogger layer: gpsFix, customGps, sessionGate, realtimeTimer, dovepWriter
-│   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=BLE, mychron/=MyChron over native (Tauri) Wi-Fi IPC (lazy; @tauri-apps/api dynamic-imported, native-only); Alfano later. progress.ts = transport-neutral formatters + computeProgress (→ docs/ble.md)
+│   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=web BLE, mychron/=MyChron over native (Tauri) Wi-Fi IPC, doveslogger/=same Fledgling hardware over native (Tauri) BLE IPC (scan→connect→list→download); native/ipc.ts = shared kind-agnostic native IPC (both lazy; @tauri-apps/api dynamic-imported, native-only); Alfano later. progress.ts = transport-neutral formatters + computeProgress (→ docs/ble.md)
 │   ├── speedHeatmap.ts / mapMarker.ts / brakingZones / gforceCalculation / …  # racing math
 │   ├── chartUtils / canvas2d / chartAxis / chartColors / videoExport / overlayCanvasRenderer  # charts/video
 │   ├── videoPlaylist.ts   # ★ Pure GoPro chunked-video model: parse/order GH/GX/GP/GOPR chunk names, build a virtual timeline (cumulative offsets) + virtual↔local time mapping + planAudioSegments (export audio stitch). useVideoSync swaps the <video> src per chunk; a single file is a 1-chunk playlist

--- a/docs/ble.md
+++ b/docs/ble.md
@@ -15,20 +15,27 @@ state lives in `DeviceContext.tsx` (wraps the app tree in `Index.tsx`). Source:
 `src/lib/ble/` (split per-concern; `bleDatalogger.ts` is the legacy barrel).
 The user reaches the BLE flow through `LoggerDownload` → `LoggerPicker` (an eager,
 lightweight image chooser of supported loggers). Picking the PerchWerks Fledgling
-tile mounts `DataloggerDownload` — the lazy BLE flow — on demand, so `lib/ble/*`
-stays out of the initial bundle while the menu still opens instantly. On the native
-(Tauri) shell the MyChron tile mounts the lazy `MyChronDownload` flow (Wi-Fi over
-native IPC — see `docs/android.md`); on the web it (and Alfano) still open
-explanatory dialogs.
+tile mounts `DataloggerDownload` — the lazy Web Bluetooth flow — on demand, so
+`lib/ble/*` stays out of the initial bundle while the menu still opens instantly.
+On the native (Tauri) shell the webview has no Web Bluetooth, so the Fledgling tile
+instead mounts the lazy `DovesloggerDownload` flow (BLE over native IPC: scan →
+pick device → connect → list → download), and the MyChron tile mounts the lazy
+`MyChronDownload` flow (Wi-Fi over native IPC — see `docs/android.md`); on the web
+the MyChron and Alfano tiles still open explanatory dialogs.
 
 `DataloggerDownload` talks to the device only through the generic
 `LoggerConnection` interface (`src/lib/loggers/`): `listLogs` / `downloadLog` /
 `disconnect`, with `createFledglingConnection()` adapting a `BleConnection`. MyChron
 is the second adapter — `createMychronConnection()` (`src/lib/loggers/mychron/`),
-native-only, over the Tauri shell — and Alfano (BLE) will be a third. All satisfy
-the same interface, and `DeviceContext.loggerKind` records which logger is connected
-so Fledgling-only surfaces (settings / tracks / firmware) can gate themselves
-(`supportsDeviceDetails` is `false` for MyChron). The pure progress formatters
+native-only, over the Tauri shell — and DovesLogger is the third —
+`createDovesloggerConnection()` (`src/lib/loggers/doveslogger/`), the native-BLE
+path for the same Fledgling hardware over the Tauri shell. Both native loggers share
+the kind-agnostic IPC client in `src/lib/loggers/native/ipc.ts` (only their
+`connect` / `scan` differ); Alfano (web BLE) will be a fourth. All satisfy the same
+interface, and `DeviceContext.loggerKind` records which logger is connected so
+Fledgling-only surfaces (settings / tracks / firmware) can gate themselves
+(`supportsDeviceDetails` is `false` for MyChron and for the native DovesLogger path,
+whose settings/tracks/firmware stay on the Web Bluetooth build for now). The pure progress formatters
 (`formatBytes` / `formatSpeed` / `formatTime`) and the `computeProgress()` helper now
 live transport-neutrally in `src/lib/loggers/progress.ts` (re-exported from
 `src/lib/ble/format.ts` for existing BLE callers) so both flows share them without

--- a/src/components/DovesloggerDownload.tsx
+++ b/src/components/DovesloggerDownload.tsx
@@ -1,0 +1,231 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Bluetooth, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DeviceListPanel, FileListPanel, ProgressPanel } from "@/components/loggers/DownloadPanels";
+import { createDovesloggerConnection } from "@/lib/loggers/doveslogger/dovesloggerConnection";
+import { loggerScan, loggerConnect, type ScannedDevice } from "@/lib/loggers/doveslogger/ipc";
+import type { LoggerConnection, LoggerFile, LoggerDownloadProgress } from "@/lib/loggers";
+import { parseDatalogFile } from "@/lib/datalogParser";
+import { ParsedData } from "@/types/racing";
+
+type DownloadState =
+  | "idle"
+  | "scanning"
+  | "device-list"
+  | "connecting"
+  | "fetching-files"
+  | "file-list"
+  | "downloading"
+  | "error";
+
+interface DovesloggerDownloadProps {
+  onDataLoaded: (data: ParsedData, fileName?: string) => void;
+  autoSave?: boolean;
+  autoSaveFile?: (name: string, blob: Blob) => Promise<void>;
+  /** Begin scanning as soon as the flow mounts (it's mounted on demand). */
+  autoStart?: boolean;
+  /** Called when the flow finishes or is dismissed so the host can unmount it. */
+  onClose: () => void;
+}
+
+/**
+ * The native (Tauri) PerchWerks Fledgling / DovesLogger download flow: scan over
+ * BLE via the native shell, let the user pick a device (BLE has no OS picker),
+ * connect, list sessions, download + import the chosen one. Native-only and
+ * mounted on demand by `LoggerDownload` once the user picks the Fledgling on the
+ * native app, so `@tauri-apps/api` stays off the web/eager bundle. Talks to the
+ * device only through the generic `LoggerConnection` surface, and owns the
+ * connection — it disconnects on every exit (close/cancel/error/unmount).
+ */
+export function DovesloggerDownload({ onDataLoaded, autoSave, autoSaveFile, autoStart, onClose }: DovesloggerDownloadProps) {
+  const { t } = useTranslation("logger");
+  const [state, setState] = useState<DownloadState>("idle");
+  const [devices, setDevices] = useState<ScannedDevice[]>([]);
+  const [files, setFiles] = useState<LoggerFile[]>([]);
+  const [progress, setProgress] = useState<LoggerDownloadProgress | null>(null);
+  const [currentFile, setCurrentFile] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const loggerRef = useRef<LoggerConnection | null>(null);
+
+  const handleClose = useCallback(() => {
+    loggerRef.current?.disconnect();
+    loggerRef.current = null;
+    setState("idle");
+    setDevices([]);
+    setFiles([]);
+    setProgress(null);
+    setCurrentFile("");
+    setError("");
+    onClose();
+  }, [onClose]);
+
+  const handleScan = useCallback(async () => {
+    setError("");
+    // A fresh scan implies any prior connection is stale — drop it.
+    loggerRef.current?.disconnect();
+    loggerRef.current = null;
+    setState("scanning");
+    try {
+      const found = await loggerScan();
+      setDevices(found);
+      setState("device-list");
+    } catch (err) {
+      console.error("DovesLogger scan error:", err);
+      setError(err instanceof Error ? err.message : String(err));
+      setState("error");
+    }
+  }, []);
+
+  const handleDeviceSelect = useCallback(async (device: ScannedDevice) => {
+    setError("");
+    setState("connecting");
+    try {
+      const info = await loggerConnect({ host: device.id });
+      const logger = createDovesloggerConnection(info);
+      loggerRef.current = logger;
+
+      setState("fetching-files");
+      const fileList = await logger.listLogs();
+      setFiles(fileList);
+      setState("file-list");
+    } catch (err) {
+      console.error("DovesLogger connect/list error:", err);
+      setError(err instanceof Error ? err.message : String(err));
+      setState("error");
+    }
+  }, []);
+
+  // Kick off the scan as soon as the flow is mounted (once).
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (autoStart && !startedRef.current) {
+      startedRef.current = true;
+      void handleScan();
+    }
+  }, [autoStart, handleScan]);
+
+  // Always release the device when this flow unmounts.
+  useEffect(() => () => void loggerRef.current?.disconnect(), []);
+
+  const handleFileSelect = useCallback(
+    async (file: LoggerFile) => {
+      const logger = loggerRef.current;
+      if (!logger) {
+        setError(t("doveslogger.flow.errorTitle"));
+        setState("error");
+        return;
+      }
+
+      setState("downloading");
+      setCurrentFile(file.name);
+      setProgress({ received: 0, total: file.size, percent: 0, speed: "0 B/s", eta: "--" });
+      setError("");
+
+      try {
+        const bytes = await logger.downloadLog(file.name, setProgress);
+        const blob = new Blob([bytes.buffer as ArrayBuffer]);
+
+        // Save the raw file first so it's never lost.
+        if (autoSave && autoSaveFile) {
+          try {
+            await autoSaveFile(file.name, blob);
+          } catch (e) {
+            console.warn("Auto-save failed:", e);
+          }
+        }
+
+        // Raw device bytes (.dove/.dovex/.csv) — route by extension so the binary
+        // .dovex header survives (parseDatalogFile auto-detects; no text decode).
+        const data = await parseDatalogFile(new File([blob], file.name));
+        handleClose();
+        onDataLoaded(data, file.name);
+      } catch (err) {
+        console.error("DovesLogger download/parse error:", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(`${msg}${t("doveslogger.flow.savedHint")}`);
+        setState("error");
+      }
+    },
+    [autoSave, autoSaveFile, handleClose, onDataLoaded, t],
+  );
+
+  const isModalOpen = state !== "idle";
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Bluetooth className="w-5 h-5" />
+            {state === "scanning" && t("doveslogger.flow.scanning")}
+            {state === "device-list" && t("doveslogger.flow.selectDevice")}
+            {state === "connecting" && t("doveslogger.flow.connecting")}
+            {state === "fetching-files" && t("doveslogger.flow.fetching")}
+            {state === "file-list" && t("doveslogger.flow.selectFile")}
+            {state === "downloading" && t("doveslogger.flow.downloading")}
+            {state === "error" && t("doveslogger.flow.errorTitle")}
+          </DialogTitle>
+        </DialogHeader>
+
+        {state === "scanning" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-12 h-12 animate-spin text-primary" />
+            <p className="text-muted-foreground">{t("doveslogger.flow.scanning")}</p>
+          </div>
+        )}
+
+        {state === "device-list" && (
+          <DeviceListPanel
+            devices={devices}
+            onSelect={handleDeviceSelect}
+            onRescan={handleScan}
+            instructions={t("doveslogger.flow.deviceInstructions")}
+            emptyText={t("doveslogger.flow.noDevices")}
+            rescanLabel={t("doveslogger.flow.rescan")}
+          />
+        )}
+
+        {state === "connecting" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-12 h-12 animate-spin text-primary" />
+            <p className="text-muted-foreground">{t("doveslogger.flow.connecting")}</p>
+          </div>
+        )}
+
+        {state === "fetching-files" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-12 h-12 animate-spin text-primary" />
+            <p className="text-muted-foreground">{t("doveslogger.flow.fetching")}</p>
+          </div>
+        )}
+
+        {state === "file-list" && (
+          <FileListPanel
+            files={files}
+            onSelect={handleFileSelect}
+            instructions={t("doveslogger.flow.instructions")}
+            emptyText={t("doveslogger.flow.empty")}
+          />
+        )}
+
+        {state === "downloading" && progress && (
+          <ProgressPanel currentFile={currentFile} progress={progress} />
+        )}
+
+        {state === "error" && (
+          <div className="flex flex-col items-center gap-4 py-4">
+            <p className="text-destructive text-center">{error}</p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleClose}>
+                {t("doveslogger.flow.cancel")}
+              </Button>
+              <Button onClick={handleScan}>{t("doveslogger.flow.retry")}</Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/LoggerDownload.tsx
+++ b/src/components/LoggerDownload.tsx
@@ -4,6 +4,7 @@ import { Bluetooth } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LoggerPicker } from "@/components/LoggerPicker";
 import { useDeviceContext } from "@/contexts/DeviceContext";
+import { isNativeApp } from "@/lib/platform";
 import type { ParsedData } from "@/types/racing";
 
 // The Fledgling BLE flow is the only heavy part — lazy-load it so the protocol
@@ -12,6 +13,13 @@ import type { ParsedData } from "@/types/racing";
 // never depends on a chunk finishing to load.
 const DataloggerDownload = lazy(() =>
   import("@/components/DataloggerDownload").then((m) => ({ default: m.DataloggerDownload })),
+);
+
+// The native Fledgling BLE flow downloads over the Tauri shell instead of Web
+// Bluetooth (which the native webview lacks). Lazy so `@tauri-apps/api` (dynamic
+// import inside it) never enters the web/eager bundle.
+const DovesloggerDownload = lazy(() =>
+  import("@/components/DovesloggerDownload").then((m) => ({ default: m.DovesloggerDownload })),
 );
 
 // The native MyChron Wi-Fi flow is likewise lazy so `@tauri-apps/api` (dynamic
@@ -41,6 +49,9 @@ interface LoggerDownloadProps {
 export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTrigger }: LoggerDownloadProps) {
   const { t } = useTranslation("logger");
   const { bleSupported } = useDeviceContext();
+  // On the native app the webview has no Web Bluetooth, so we route the Fledgling
+  // through native BLE IPC instead — which means the tile must be enabled there.
+  const native = isNativeApp();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [fledglingActive, setFledglingActive] = useState(false);
   const [mychronActive, setMychronActive] = useState(false);
@@ -61,7 +72,9 @@ export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTri
       <LoggerPicker
         open={pickerOpen}
         onOpenChange={setPickerOpen}
-        bleSupported={bleSupported}
+        // Native downloads the Fledgling over BLE IPC, so the tile works there
+        // even though the native webview lacks Web Bluetooth.
+        bleSupported={bleSupported || native}
         onSelectFledgling={() => {
           setPickerOpen(false);
           setFledglingActive(true);
@@ -74,13 +87,23 @@ export function LoggerDownload({ onDataLoaded, autoSave, autoSaveFile, renderTri
 
       {fledglingActive && (
         <Suspense fallback={null}>
-          <DataloggerDownload
-            autoStart
-            onDataLoaded={onDataLoaded}
-            autoSave={autoSave}
-            autoSaveFile={autoSaveFile}
-            onClose={() => setFledglingActive(false)}
-          />
+          {native ? (
+            <DovesloggerDownload
+              autoStart
+              onDataLoaded={onDataLoaded}
+              autoSave={autoSave}
+              autoSaveFile={autoSaveFile}
+              onClose={() => setFledglingActive(false)}
+            />
+          ) : (
+            <DataloggerDownload
+              autoStart
+              onDataLoaded={onDataLoaded}
+              autoSave={autoSave}
+              autoSaveFile={autoSaveFile}
+              onClose={() => setFledglingActive(false)}
+            />
+          )}
         </Suspense>
       )}
 

--- a/src/components/loggers/DownloadPanels.tsx
+++ b/src/components/loggers/DownloadPanels.tsx
@@ -5,8 +5,10 @@
  * Wi-Fi selecting, errors) stay in each flow's component.
  */
 
+import { Button } from "@/components/ui/button";
 import { formatBytes } from "@/lib/loggers/progress";
 import type { LoggerFile, LoggerDownloadProgress } from "@/lib/loggers";
+import type { ScannedDevice } from "@/lib/loggers/doveslogger/ipc";
 
 interface FileListPanelProps {
   files: LoggerFile[];
@@ -43,6 +45,59 @@ export function FileListPanel({
           ))
         )}
       </div>
+    </div>
+  );
+}
+
+interface DeviceListPanelProps {
+  devices: ScannedDevice[];
+  onSelect: (device: ScannedDevice) => void;
+  onRescan: () => void;
+  /** Instruction line above the list. */
+  instructions: string;
+  /** Shown when the scan turns up no devices. */
+  emptyText: string;
+  /** Label for the rescan button (both states). */
+  rescanLabel: string;
+}
+
+/**
+ * Tappable list of nearby loggers found by a BLE scan. BLE has no OS picker, so
+ * the native DovesLogger flow renders this; selection is by `id` (the `name`/
+ * `rssi` are display-only). An empty scan still shows the Rescan affordance.
+ */
+export function DeviceListPanel({
+  devices,
+  onSelect,
+  onRescan,
+  instructions,
+  emptyText,
+  rescanLabel,
+}: DeviceListPanelProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-muted-foreground mb-2">{instructions}</p>
+      <div className="max-h-80 overflow-y-auto space-y-1">
+        {devices.length === 0 ? (
+          <p className="text-center text-muted-foreground py-4">{emptyText}</p>
+        ) : (
+          devices.map((device) => (
+            <button
+              key={device.id}
+              onClick={() => onSelect(device)}
+              className="w-full text-left px-3 py-2 rounded-md bg-muted/50 hover:bg-muted transition-colors flex justify-between items-center"
+            >
+              <span className="font-medium text-sm">{device.name ?? device.id}</span>
+              {typeof device.rssi === "number" && (
+                <span className="text-xs text-muted-foreground">{device.rssi} dBm</span>
+              )}
+            </button>
+          ))
+        )}
+      </div>
+      <Button variant="outline" className="w-full mt-1" onClick={onRescan}>
+        {rescanLabel}
+      </Button>
     </div>
   );
 }

--- a/src/lib/loggers/doveslogger/dovesloggerConnection.test.ts
+++ b/src/lib/loggers/doveslogger/dovesloggerConnection.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as ipc from "./ipc";
+import { createDovesloggerConnection } from "./dovesloggerConnection";
+
+vi.mock("./ipc", () => ({
+  loggerListFiles: vi.fn(),
+  loggerDownloadFile: vi.fn(),
+  loggerDisconnect: vi.fn(),
+}));
+
+function info(overrides: Partial<ipc.LoggerDeviceInfo> = {}): ipc.LoggerDeviceInfo {
+  return { kind: "doveslogger", fields: {}, ...overrides };
+}
+
+describe("createDovesloggerConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a fledgling without in-app device details (native BLE)", () => {
+    const conn = createDovesloggerConnection(info({ name: "BirdsEye-sense" }));
+    expect(conn.kind).toBe("fledgling");
+    expect(conn.supportsDeviceDetails).toBe(false);
+    expect(conn.displayName).toBe("BirdsEye-sense");
+  });
+
+  it("falls back name → model → brand for the display name", () => {
+    expect(createDovesloggerConnection(info({ model: "BirdsEye-sense" })).displayName).toBe("BirdsEye-sense");
+    expect(createDovesloggerConnection(info()).displayName).toBe("PerchWerks Fledgling");
+  });
+
+  it("maps device file entries down to the generic LoggerFile shape", async () => {
+    vi.mocked(ipc.loggerListFiles).mockResolvedValue([
+      { name: "a_0217.dove", size: 1234, date: "2026-02-17", meta: { nlap: "12" } },
+    ]);
+    const conn = createDovesloggerConnection(info());
+    await expect(conn.listLogs()).resolves.toEqual([{ name: "a_0217.dove", size: 1234 }]);
+  });
+
+  it("wraps raw {received,total} progress into a full LoggerDownloadProgress", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    vi.mocked(ipc.loggerDownloadFile).mockImplementation(async (_name, onProgress) => {
+      onProgress({ received: 50, total: 100 });
+      return bytes;
+    });
+    const conn = createDovesloggerConnection(info());
+    const onProgress = vi.fn();
+
+    await expect(conn.downloadLog("a_0217.dove", onProgress)).resolves.toBe(bytes);
+    expect(ipc.loggerDownloadFile).toHaveBeenCalledWith("a_0217.dove", expect.any(Function));
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ received: 50, total: 100, percent: 50 }),
+    );
+    const reported = onProgress.mock.calls[0][0];
+    expect(reported).toHaveProperty("speed");
+    expect(reported).toHaveProperty("eta");
+  });
+
+  it("delegates disconnect to the IPC teardown", () => {
+    createDovesloggerConnection(info()).disconnect();
+    expect(ipc.loggerDisconnect).toHaveBeenCalled();
+  });
+});

--- a/src/lib/loggers/doveslogger/dovesloggerConnection.ts
+++ b/src/lib/loggers/doveslogger/dovesloggerConnection.ts
@@ -1,0 +1,43 @@
+/**
+ * PerchWerks DovesLogger (Fledgling) native-BLE adapter — wraps the native
+ * (Tauri) BLE transport in the generic `LoggerConnection` surface so the download
+ * UI never branches on transport. Mirrors `mychron/mychronConnection.ts`.
+ *
+ * Importing this module pulls the native IPC client (and, lazily, Tauri) in, so
+ * only the lazy native DovesLogger flow should reference it — never the eager
+ * picker. Connection establishment (`loggerScan` / `loggerConnect`) happens in the
+ * UI; this factory adapts an already-connected device, just like
+ * `createMychronConnection` takes a connected device's `info`.
+ */
+
+import type { LoggerConnection } from "../types";
+import { computeProgress } from "../progress";
+import {
+  type LoggerDeviceInfo,
+  loggerListFiles,
+  loggerDownloadFile,
+  loggerDisconnect,
+} from "./ipc";
+
+/** Adapt a connected DovesLogger (described by `info`) to the generic logger interface. */
+export function createDovesloggerConnection(info: LoggerDeviceInfo): LoggerConnection {
+  return {
+    // Same physical logger family as the Web Bluetooth Fledgling.
+    kind: "fledgling",
+    displayName: info.name ?? info.model ?? "PerchWerks Fledgling",
+    // Settings / tracks / firmware OTA stay on the Web Bluetooth path for now, so
+    // the native BLE connection exposes only the download surface.
+    supportsDeviceDetails: false,
+    listLogs: async () => {
+      const files = await loggerListFiles();
+      return files.map((f) => ({ name: f.name, size: f.size }));
+    },
+    downloadLog: (name, onProgress) => {
+      const start = Date.now();
+      return loggerDownloadFile(name, ({ received, total }) => {
+        onProgress?.(computeProgress(received, total, start));
+      });
+    },
+    disconnect: () => void loggerDisconnect(),
+  };
+}

--- a/src/lib/loggers/doveslogger/ipc.test.ts
+++ b/src/lib/loggers/doveslogger/ipc.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock of the Tauri core API (dynamically imported by ../native/ipc).
+const { invoke, ChannelMock } = vi.hoisted(() => {
+  const invoke = vi.fn();
+  class ChannelMock<T> {
+    onmessage: ((m: T) => void) | null = null;
+  }
+  return { invoke, ChannelMock };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke, Channel: ChannelMock }));
+
+import { loggerScan, loggerConnect } from "./ipc";
+
+// The kind-agnostic commands (list / download / disconnect) are covered by
+// ../native/ipc.test.ts; this suite asserts the DovesLogger-specific scan/connect.
+describe("doveslogger ipc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scans with the doveslogger kind and returns the device list", async () => {
+    const devices = [{ id: "AA:BB", name: "BirdsEye", rssi: -52 }];
+    invoke.mockResolvedValue(devices);
+    await expect(loggerScan()).resolves.toEqual(devices);
+    expect(invoke).toHaveBeenCalledWith("logger_scan", { kind: "doveslogger" });
+  });
+
+  it("connects to the chosen device by id (host)", async () => {
+    invoke.mockResolvedValue({ kind: "doveslogger", fields: {} });
+    await loggerConnect({ host: "AA:BB" });
+    expect(invoke).toHaveBeenCalledWith("logger_connect", {
+      kind: "doveslogger",
+      host: "AA:BB",
+    });
+  });
+
+  it("connects to the first logger found when no host is given", async () => {
+    invoke.mockResolvedValue({ kind: "doveslogger", fields: {} });
+    await loggerConnect();
+    expect(invoke).toHaveBeenCalledWith("logger_connect", {
+      kind: "doveslogger",
+      host: undefined,
+    });
+  });
+
+  it("passes backend error strings through unwrapped (prefix preserved)", async () => {
+    invoke.mockRejectedValueOnce("device unreachable: permission denied");
+    await expect(loggerScan()).rejects.toBe("device unreachable: permission denied");
+  });
+});

--- a/src/lib/loggers/doveslogger/ipc.ts
+++ b/src/lib/loggers/doveslogger/ipc.ts
@@ -1,0 +1,60 @@
+/**
+ * Native (Tauri) IPC client for the PerchWerks DovesLogger / Fledgling BLE
+ * downloader.
+ *
+ * The kind-agnostic commands (list / download / device info / disconnect) and the
+ * memoized `@tauri-apps/api` loader live in `../native/ipc` and are shared with the
+ * other native loggers; this module adds only the BLE-specific `logger_scan`
+ * (there's no OS picker for BLE — we render the device list in-app) and
+ * `logger_connect`, and re-exports the shared surface so `dovesloggerConnection.ts`
+ * imports everything from here.
+ *
+ * Arg keys are camelCase and every command rejects with a plain string whose
+ * prefix encodes the error category (`device unreachable:` — off / out of range /
+ * Android BLE permission denied, `device hung:`, `protocol error:`, `no logger
+ * connected …`). We pass those strings through unwrapped so the UI can match on
+ * the prefix.
+ */
+
+import { api, type LoggerDeviceInfo } from "../native/ipc";
+
+// Re-export the shared native surface so DovesLogger callers import it all from here.
+export {
+  loggerDeviceInfo,
+  loggerListFiles,
+  loggerDownloadFile,
+  loggerDisconnect,
+} from "../native/ipc";
+export type { LoggerDeviceInfo, FileEntry, DownloadProgress } from "../native/ipc";
+
+/**
+ * A logger found during a BLE scan. The backend matches on the advertised GATT
+ * service (`0x1820`), not the name, so renamed devices still appear; `name`/`rssi`
+ * are DISPLAY ONLY (so the user recognizes their device). Selection is by `id`.
+ */
+export interface ScannedDevice {
+  /** Transport address — pass back as `host` to `loggerConnect`. */
+  id: string;
+  /** Advertised name — display only (user-renamable). */
+  name?: string;
+  /** Signal strength, for sorting / display. */
+  rssi?: number;
+}
+
+/** Scan (~5 s) for nearby DovesLoggers advertising the logger service. */
+export async function loggerScan(): Promise<ScannedDevice[]> {
+  const { invoke } = await api();
+  return invoke<ScannedDevice[]>("logger_scan", { kind: "doveslogger" });
+}
+
+/**
+ * Connect to a DovesLogger over BLE. `host` is the chosen `ScannedDevice.id`;
+ * omitting it connects to the first logger found (the picker is the intended UX).
+ */
+export async function loggerConnect(opts: { host?: string } = {}): Promise<LoggerDeviceInfo> {
+  const { invoke } = await api();
+  return invoke<LoggerDeviceInfo>("logger_connect", {
+    kind: "doveslogger",
+    host: opts.host,
+  });
+}

--- a/src/lib/loggers/mychron/ipc.test.ts
+++ b/src/lib/loggers/mychron/ipc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Hoisted mock of the Tauri core API (dynamically imported by ipc.ts).
+// Hoisted mock of the Tauri core API (dynamically imported by ../native/ipc).
 const { invoke, ChannelMock } = vi.hoisted(() => {
   const invoke = vi.fn();
   class ChannelMock<T> {
@@ -11,8 +11,10 @@ const { invoke, ChannelMock } = vi.hoisted(() => {
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke, Channel: ChannelMock }));
 
-import { loggerConnect, loggerListFiles, loggerDownloadFile, loggerDisconnect } from "./ipc";
+import { loggerConnect } from "./ipc";
 
+// The kind-agnostic commands (list / download / disconnect) are covered by
+// ../native/ipc.test.ts; this suite only asserts the MyChron-specific connect.
 describe("mychron ipc", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,29 +32,6 @@ describe("mychron ipc", () => {
 
   it("passes backend error strings through unwrapped (prefix preserved)", async () => {
     invoke.mockRejectedValueOnce("device unreachable: not joined");
-    await expect(loggerListFiles()).rejects.toBe("device unreachable: not joined");
-  });
-
-  it("wires a progress Channel and returns the bytes as a Uint8Array", async () => {
-    invoke.mockImplementation(async (cmd: string, args: { onProgress: { onmessage?: (m: unknown) => void } }) => {
-      if (cmd === "logger_download_file") {
-        args.onProgress.onmessage?.({ received: 1, total: 2 });
-        return new Uint8Array([9, 8, 7]).buffer;
-      }
-      return undefined;
-    });
-
-    const onProgress = vi.fn();
-    const result = await loggerDownloadFile("a_0217.xrz", onProgress);
-
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(Array.from(result)).toEqual([9, 8, 7]);
-    expect(onProgress).toHaveBeenCalledWith({ received: 1, total: 2 });
-  });
-
-  it("swallows errors on disconnect (safe when already gone)", async () => {
-    invoke.mockRejectedValueOnce("boom");
-    await expect(loggerDisconnect()).resolves.toBeUndefined();
-    expect(invoke).toHaveBeenCalledWith("logger_disconnect");
+    await expect(loggerConnect()).rejects.toBe("device unreachable: not joined");
   });
 });

--- a/src/lib/loggers/mychron/ipc.ts
+++ b/src/lib/loggers/mychron/ipc.ts
@@ -1,17 +1,29 @@
 /**
  * Native (Tauri) IPC client for the AiM MyChron Wi-Fi downloader.
  *
- * This is the ONLY module that touches `@tauri-apps/api`, and it does so via a
- * dynamic `import("@tauri-apps/api/core")` so Vite code-splits Tauri into the
- * lazy MyChron chunk — the web build never fetches it (Golden Rule #1). Only the
- * lazy native flow may reach this module; never the eager picker.
+ * The kind-agnostic commands (list / download / device info / disconnect) and the
+ * memoized `@tauri-apps/api` loader live in `../native/ipc` and are shared with the
+ * other native loggers; this module adds only the MyChron-specific `logger_connect`
+ * (Wi-Fi join hint) and re-exports the shared surface so existing callers
+ * (`mychronConnection.ts`) keep importing everything from here.
  *
- * Commands are app-defined on the native side; arg keys are camelCase and every
- * command rejects with a plain string whose prefix encodes the error category
- * (`device unreachable:`, `device hung:`, `protocol error:`, `unsupported:`,
- * `Wi-Fi join was declined…`, `no logger connected …`). We pass those strings
- * through unwrapped so the UI can match on the prefix.
+ * Arg keys are camelCase and every command rejects with a plain string whose
+ * prefix encodes the error category (`device unreachable:`, `device hung:`,
+ * `protocol error:`, `unsupported:`, `Wi-Fi join was declined…`, `no logger
+ * connected …`). We pass those strings through unwrapped so the UI can match on
+ * the prefix.
  */
+
+import { api, type LoggerDeviceInfo } from "../native/ipc";
+
+// Re-export the shared native surface so MyChron callers import it all from here.
+export {
+  loggerDeviceInfo,
+  loggerListFiles,
+  loggerDownloadFile,
+  loggerDisconnect,
+} from "../native/ipc";
+export type { LoggerDeviceInfo, FileEntry, DownloadProgress } from "../native/ipc";
 
 /**
  * SSID prefix for the MyChron's Wi-Fi AP, used on Android to drive the system
@@ -23,41 +35,11 @@ export const MYCHRON_SSID_PREFIX = "MYCHRON5";
 /** Default MyChron gateway host — omit to let the backend use it. */
 const DEFAULT_HOST = "10.0.0.1";
 
-/** Device fields the backend reports after a connect (flattened hw.* / path.* / usr.*). */
-export interface LoggerDeviceInfo {
-  kind: string;
-  name?: string;
-  model?: string;
-  fields: Record<string, string>;
-}
-
-/** A downloadable session on the device. */
-export interface FileEntry {
-  name: string;
-  size: number;
-  date?: string;
-  meta: Record<string, string>;
-}
-
-/** Raw progress payload from the native download channel. */
-export interface DownloadProgress {
-  received: number;
-  total: number;
-}
-
 /** Wi-Fi join hint (Android) — exact SSID or a prefix the OS picker matches. */
 export interface WifiHint {
   ssid?: string;
   ssidPrefix?: string;
   passphrase?: string;
-}
-
-// Memoized loader for the Tauri core API. Dynamic so the import is the
-// code-split boundary that keeps `@tauri-apps/api` off the web/eager graph.
-let apiPromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
-function api() {
-  if (!apiPromise) apiPromise = import("@tauri-apps/api/core");
-  return apiPromise;
 }
 
 /** Connect to the MyChron — joins + binds Wi-Fi on Android when `wifi` is set. */
@@ -68,45 +50,4 @@ export async function loggerConnect(opts: { host?: string; wifi?: WifiHint } = {
     host: opts.host ?? DEFAULT_HOST,
     wifi: opts.wifi,
   });
-}
-
-/** Re-read device info from an already-connected logger. */
-export async function loggerDeviceInfo(): Promise<LoggerDeviceInfo> {
-  const { invoke } = await api();
-  return invoke<LoggerDeviceInfo>("logger_device_info");
-}
-
-/** List the downloadable sessions on the connected device. */
-export async function loggerListFiles(): Promise<FileEntry[]> {
-  const { invoke } = await api();
-  return invoke<FileEntry[]>("logger_list_files");
-}
-
-/**
- * Download one session by name, streaming progress through a `Channel`. Resolves
- * to the already-inflated XRK bytes (the backend downloads the `.xrz` and unzips
- * it for us).
- */
-export async function loggerDownloadFile(
-  name: string,
-  onProgress: (p: DownloadProgress) => void,
-): Promise<Uint8Array> {
-  const { invoke, Channel } = await api();
-  const channel = new Channel<DownloadProgress>();
-  channel.onmessage = onProgress;
-  const buf = await invoke<ArrayBuffer>("logger_download_file", { name, onProgress: channel });
-  return new Uint8Array(buf);
-}
-
-/**
- * Drop the connection, stop the keepalive and unbind the Wi-Fi. Safe to call
- * when already disconnected — errors are swallowed.
- */
-export async function loggerDisconnect(): Promise<void> {
-  try {
-    const { invoke } = await api();
-    await invoke("logger_disconnect");
-  } catch {
-    // Best-effort teardown — ignore (already disconnected / shutting down).
-  }
 }

--- a/src/lib/loggers/native/ipc.test.ts
+++ b/src/lib/loggers/native/ipc.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock of the Tauri core API (dynamically imported by ipc.ts).
+const { invoke, ChannelMock } = vi.hoisted(() => {
+  const invoke = vi.fn();
+  class ChannelMock<T> {
+    onmessage: ((m: T) => void) | null = null;
+  }
+  return { invoke, ChannelMock };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke, Channel: ChannelMock }));
+
+import { loggerDeviceInfo, loggerListFiles, loggerDownloadFile, loggerDisconnect } from "./ipc";
+
+describe("native ipc (shared, kind-agnostic commands)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-reads device info without a kind arg", async () => {
+    invoke.mockResolvedValue({ kind: "doveslogger", fields: {} });
+    await loggerDeviceInfo();
+    expect(invoke).toHaveBeenCalledWith("logger_device_info");
+  });
+
+  it("lists files without a kind arg", async () => {
+    invoke.mockResolvedValue([]);
+    await loggerListFiles();
+    expect(invoke).toHaveBeenCalledWith("logger_list_files");
+  });
+
+  it("passes backend error strings through unwrapped (prefix preserved)", async () => {
+    invoke.mockRejectedValueOnce("device unreachable: not joined");
+    await expect(loggerListFiles()).rejects.toBe("device unreachable: not joined");
+  });
+
+  it("wires a progress Channel and returns the bytes as a Uint8Array", async () => {
+    invoke.mockImplementation(async (cmd: string, args: { onProgress: { onmessage?: (m: unknown) => void } }) => {
+      if (cmd === "logger_download_file") {
+        args.onProgress.onmessage?.({ received: 1, total: 2 });
+        return new Uint8Array([9, 8, 7]).buffer;
+      }
+      return undefined;
+    });
+
+    const onProgress = vi.fn();
+    const result = await loggerDownloadFile("a_0217.dove", onProgress);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result)).toEqual([9, 8, 7]);
+    expect(onProgress).toHaveBeenCalledWith({ received: 1, total: 2 });
+  });
+
+  it("swallows errors on disconnect (safe when already gone)", async () => {
+    invoke.mockRejectedValueOnce("boom");
+    await expect(loggerDisconnect()).resolves.toBeUndefined();
+    expect(invoke).toHaveBeenCalledWith("logger_disconnect");
+  });
+});

--- a/src/lib/loggers/native/ipc.ts
+++ b/src/lib/loggers/native/ipc.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared native (Tauri) IPC client for the logger downloaders.
+ *
+ * This is the ONLY module that touches `@tauri-apps/api`, and it does so via a
+ * dynamic `import("@tauri-apps/api/core")` so Vite code-splits Tauri into the
+ * lazy native chunks — the web build never fetches it (Golden Rule #1). Only the
+ * lazy native flows may reach this module; never the eager picker.
+ *
+ * The commands here are **kind-agnostic** — `logger_list_files`,
+ * `logger_download_file`, `logger_device_info` and `logger_disconnect` operate on
+ * whichever logger the last `logger_connect` bound, so every native logger
+ * (MyChron over Wi-Fi, DovesLogger over BLE) shares them. The per-logger
+ * `logger_connect` / `logger_scan` wrappers live in each logger's own `ipc.ts`
+ * and call `api()` from here.
+ *
+ * Arg keys are camelCase and every command rejects with a plain string whose
+ * prefix encodes the error category (`device unreachable:`, `device hung:`,
+ * `protocol error:`, `unsupported:`, `no logger connected …`). We pass those
+ * strings through unwrapped so the UI can match on the prefix.
+ */
+
+/** Device fields the backend reports after a connect (flattened hw.* / path.* / usr.*). */
+export interface LoggerDeviceInfo {
+  kind: string;
+  name?: string;
+  model?: string;
+  fields: Record<string, string>;
+}
+
+/** A downloadable session on the device. */
+export interface FileEntry {
+  name: string;
+  size: number;
+  date?: string;
+  meta: Record<string, string>;
+}
+
+/** Raw progress payload from the native download channel. */
+export interface DownloadProgress {
+  received: number;
+  total: number;
+}
+
+// Memoized loader for the Tauri core API. Dynamic so the import is the
+// code-split boundary that keeps `@tauri-apps/api` off the web/eager graph.
+let apiPromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
+
+/** Lazily load (and memoize) the Tauri core API. Per-logger connect/scan reuse this. */
+export function api() {
+  if (!apiPromise) apiPromise = import("@tauri-apps/api/core");
+  return apiPromise;
+}
+
+/** Re-read device info from an already-connected logger. */
+export async function loggerDeviceInfo(): Promise<LoggerDeviceInfo> {
+  const { invoke } = await api();
+  return invoke<LoggerDeviceInfo>("logger_device_info");
+}
+
+/** List the downloadable sessions on the connected device. */
+export async function loggerListFiles(): Promise<FileEntry[]> {
+  const { invoke } = await api();
+  return invoke<FileEntry[]>("logger_list_files");
+}
+
+/**
+ * Download one session by name, streaming progress through a `Channel`. Resolves
+ * to the raw device-file bytes the backend hands back (MyChron inflates its XRK
+ * server-side; DovesLogger returns its `.dove`/`.dovex`/`.csv` verbatim).
+ */
+export async function loggerDownloadFile(
+  name: string,
+  onProgress: (p: DownloadProgress) => void,
+): Promise<Uint8Array> {
+  const { invoke, Channel } = await api();
+  const channel = new Channel<DownloadProgress>();
+  channel.onmessage = onProgress;
+  const buf = await invoke<ArrayBuffer>("logger_download_file", { name, onProgress: channel });
+  return new Uint8Array(buf);
+}
+
+/**
+ * Drop the connection and release any transport resources (Wi-Fi binding, BLE
+ * link). Safe to call when already disconnected — errors are swallowed.
+ */
+export async function loggerDisconnect(): Promise<void> {
+  try {
+    const { invoke } = await api();
+    await invoke("logger_disconnect");
+  } catch {
+    // Best-effort teardown — ignore (already disconnected / shutting down).
+  }
+}

--- a/src/locales/de/logger.json
+++ b/src/locales/de/logger.json
@@ -31,6 +31,25 @@
       "cancel": "Abbrechen"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "Suche nach Loggern…",
+      "selectDevice": "Wähle deinen Logger",
+      "deviceInstructions": "Tippe auf deinen Logger, um zu verbinden:",
+      "noDevices": "Keine Logger gefunden. Stelle sicher, dass deiner eingeschaltet und Bluetooth aktiviert ist, und suche dann erneut.",
+      "rescan": "Erneut suchen",
+      "connecting": "Verbindung…",
+      "fetching": "Sitzungen werden abgerufen…",
+      "selectFile": "Wähle eine Sitzung zum Herunterladen",
+      "downloading": "Wird heruntergeladen…",
+      "errorTitle": "Verbindungsfehler",
+      "instructions": "Tippe auf eine Sitzung, um sie herunterzuladen und zu laden:",
+      "empty": "Keine Sitzungen auf diesem Gerät",
+      "savedHint": " — die Datei wurde gespeichert und ist unter „Dateien durchsuchen“ zu finden.",
+      "retry": "Erneut versuchen",
+      "cancel": "Abbrechen"
+    }
+  },
   "alfano": {
     "title": "Alfano-Downloads",
     "body": "Alfano-Downloads werden dank der Bluetooth-Konnektivität des Loggers ohne native App verfügbar sein. Es geht voran – bleib dran (voraussichtlich Anfang Juli 2026)."

--- a/src/locales/en/logger.json
+++ b/src/locales/en/logger.json
@@ -30,6 +30,25 @@
       "cancel": "Cancel"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "Scanning for loggers…",
+      "selectDevice": "Select your logger",
+      "deviceInstructions": "Tap your logger to connect:",
+      "noDevices": "No loggers found. Make sure yours is powered on, Bluetooth is enabled, then rescan.",
+      "rescan": "Rescan",
+      "connecting": "Connecting…",
+      "fetching": "Fetching sessions…",
+      "selectFile": "Select a session to download",
+      "downloading": "Downloading…",
+      "errorTitle": "Connection error",
+      "instructions": "Tap a session to download and load it:",
+      "empty": "No sessions on this device",
+      "savedHint": " — the file was saved and can be found in Browse Files.",
+      "retry": "Try again",
+      "cancel": "Cancel"
+    }
+  },
   "alfano": {
     "title": "Alfano downloads",
     "body": "Alfano downloads will be available without a native app thanks to the logger's Bluetooth connectivity. Progress is being made — stay tuned for updates (estimated early July '26)."

--- a/src/locales/es/logger.json
+++ b/src/locales/es/logger.json
@@ -31,6 +31,25 @@
       "cancel": "Cancelar"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "Buscando registradores…",
+      "selectDevice": "Selecciona tu registrador",
+      "deviceInstructions": "Toca tu registrador para conectar:",
+      "noDevices": "No se encontraron registradores. Asegúrate de que el tuyo esté encendido y el Bluetooth activado, luego vuelve a buscar.",
+      "rescan": "Buscar de nuevo",
+      "connecting": "Conectando…",
+      "fetching": "Obteniendo sesiones…",
+      "selectFile": "Selecciona una sesión para descargar",
+      "downloading": "Descargando…",
+      "errorTitle": "Error de conexión",
+      "instructions": "Toca una sesión para descargarla y cargarla:",
+      "empty": "No hay sesiones en este dispositivo",
+      "savedHint": " — el archivo se guardó y puedes encontrarlo en Explorar archivos.",
+      "retry": "Reintentar",
+      "cancel": "Cancelar"
+    }
+  },
   "alfano": {
     "title": "Descargas de Alfano",
     "body": "Las descargas de Alfano estarán disponibles sin una app nativa gracias a la conectividad Bluetooth del registrador. Se está avanzando; mantente atento a las novedades (estimado para principios de julio de 2026)."

--- a/src/locales/fr/logger.json
+++ b/src/locales/fr/logger.json
@@ -31,6 +31,25 @@
       "cancel": "Annuler"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "Recherche d'enregistreurs…",
+      "selectDevice": "Sélectionnez votre enregistreur",
+      "deviceInstructions": "Touchez votre enregistreur pour vous connecter :",
+      "noDevices": "Aucun enregistreur trouvé. Assurez-vous que le vôtre est allumé et que le Bluetooth est activé, puis relancez la recherche.",
+      "rescan": "Relancer la recherche",
+      "connecting": "Connexion…",
+      "fetching": "Récupération des sessions…",
+      "selectFile": "Sélectionnez une session à télécharger",
+      "downloading": "Téléchargement…",
+      "errorTitle": "Erreur de connexion",
+      "instructions": "Touchez une session pour la télécharger et la charger :",
+      "empty": "Aucune session sur cet appareil",
+      "savedHint": " — le fichier a été enregistré et se trouve dans Parcourir les fichiers.",
+      "retry": "Réessayer",
+      "cancel": "Annuler"
+    }
+  },
   "alfano": {
     "title": "Téléchargements Alfano",
     "body": "Les téléchargements Alfano seront disponibles sans app native grâce à la connectivité Bluetooth de l'enregistreur. Des progrès sont en cours — restez à l'écoute (estimé début juillet 2026)."

--- a/src/locales/it/logger.json
+++ b/src/locales/it/logger.json
@@ -31,6 +31,25 @@
       "cancel": "Annulla"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "Ricerca dei logger…",
+      "selectDevice": "Seleziona il tuo logger",
+      "deviceInstructions": "Tocca il tuo logger per connetterti:",
+      "noDevices": "Nessun logger trovato. Assicurati che il tuo sia acceso e che il Bluetooth sia attivo, poi riavvia la ricerca.",
+      "rescan": "Cerca di nuovo",
+      "connecting": "Connessione…",
+      "fetching": "Recupero delle sessioni…",
+      "selectFile": "Seleziona una sessione da scaricare",
+      "downloading": "Download in corso…",
+      "errorTitle": "Errore di connessione",
+      "instructions": "Tocca una sessione per scaricarla e caricarla:",
+      "empty": "Nessuna sessione su questo dispositivo",
+      "savedHint": " — il file è stato salvato e si trova in Sfoglia file.",
+      "retry": "Riprova",
+      "cancel": "Annulla"
+    }
+  },
   "alfano": {
     "title": "Download Alfano",
     "body": "I download Alfano saranno disponibili senza un'app nativa grazie alla connettività Bluetooth del logger. Stiamo facendo progressi: resta sintonizzato per gli aggiornamenti (stimato inizio luglio 2026)."

--- a/src/locales/ja/logger.json
+++ b/src/locales/ja/logger.json
@@ -31,6 +31,25 @@
       "cancel": "キャンセル"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "ロガーを検索中…",
+      "selectDevice": "ロガーを選択",
+      "deviceInstructions": "接続するロガーをタップしてください：",
+      "noDevices": "ロガーが見つかりません。電源が入っていて Bluetooth が有効になっていることを確認し、再検索してください。",
+      "rescan": "再検索",
+      "connecting": "接続中…",
+      "fetching": "セッションを取得中…",
+      "selectFile": "ダウンロードするセッションを選択",
+      "downloading": "ダウンロード中…",
+      "errorTitle": "接続エラー",
+      "instructions": "セッションをタップしてダウンロードして読み込みます：",
+      "empty": "このデバイスにセッションはありません",
+      "savedHint": " — ファイルは保存され、「ファイルを参照」で見つけられます。",
+      "retry": "再試行",
+      "cancel": "キャンセル"
+    }
+  },
   "alfano": {
     "title": "Alfano のダウンロード",
     "body": "Alfano のダウンロードは、ロガーの Bluetooth 接続によりネイティブアプリなしで利用できるようになります。開発は進行中です。最新情報にご注目ください（2026年7月初旬予定）。"

--- a/src/locales/pt-BR/logger.json
+++ b/src/locales/pt-BR/logger.json
@@ -31,6 +31,25 @@
       "cancel": "Cancelar"
     }
   },
+  "doveslogger": {
+    "flow": {
+      "scanning": "Procurando registradores…",
+      "selectDevice": "Selecione seu registrador",
+      "deviceInstructions": "Toque no seu registrador para conectar:",
+      "noDevices": "Nenhum registrador encontrado. Verifique se o seu está ligado e o Bluetooth ativado e procure novamente.",
+      "rescan": "Procurar novamente",
+      "connecting": "Conectando…",
+      "fetching": "Buscando sessões…",
+      "selectFile": "Selecione uma sessão para baixar",
+      "downloading": "Baixando…",
+      "errorTitle": "Erro de conexão",
+      "instructions": "Toque em uma sessão para baixá-la e carregá-la:",
+      "empty": "Nenhuma sessão neste dispositivo",
+      "savedHint": " — o arquivo foi salvo e pode ser encontrado em Procurar arquivos.",
+      "retry": "Tentar novamente",
+      "cancel": "Cancelar"
+    }
+  },
   "alfano": {
     "title": "Downloads do Alfano",
     "body": "Os downloads do Alfano estarão disponíveis sem um app nativo graças à conectividade Bluetooth do registrador. Estamos progredindo — fique de olho nas novidades (estimado para início de julho de 2026)."


### PR DESCRIPTION
## Why

On the **native (Tauri) app** the PerchWerks Fledgling tile in the logger picker was dead: the native webview has no Web Bluetooth, so `navigator.bluetooth` is always `false` and the tile stays disabled. You couldn't download from a Fledgling on the phone.

This wires the **native BLE download path** through the backend's already-prepped `logger_*` Tauri IPC (plus a new `logger_scan`, since BLE has no OS device picker), so the same Fledgling hardware downloads natively — mirroring the proven MyChron Wi-Fi flow. Per the integration spec: **gate on native → scan → pick device → connect → list → download → existing parser → disconnect.**

> Scope: native-only, **not** released with web features (targets the next beta, version TBD — landed under `## [2.9.2] - unreleased`). Settings, track sync and firmware update stay on the Web Bluetooth path for now (spec §9). **Web downloads are unchanged.**

## What

- **Shared native IPC** — extracted the kind-agnostic commands (`logger_list_files` / `logger_download_file` / `logger_device_info` / `logger_disconnect`) and the memoized `@tauri-apps/api` loader into `src/lib/loggers/native/ipc.ts`. MyChron now re-exports it and keeps only its Wi-Fi `logger_connect`; DovesLogger reuses it and adds `loggerScan` + `loggerConnect`.
- **Adapter** — `createDovesloggerConnection()` (`loggers/doveslogger/`) satisfies the generic `LoggerConnection` interface; `kind: "fledgling"`, `supportsDeviceDetails: false`.
- **Flow** — new lazy `DovesloggerDownload.tsx`: `scanning → device-list → connecting → fetching-files → file-list → downloading → error`. Owns its connection; disconnects on close/cancel/error/unmount. Parses via `parseDatalogFile(new File(...))` (extension-routed, binary-safe for `.dovex`).
- **UI** — shared `DeviceListPanel` for the in-app BLE picker (name/rssi + Rescan); `LoggerDownload` routes the Fledgling tile to the native flow when `isNativeApp()` and enables the tile there.
- **i18n / docs** — `doveslogger` keys across all 7 locales; `CLAUDE.md`, `docs/ble.md`, and `CHANGELOG.md` updated.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run test:run` (1940 tests), `bun run build` — all green.
- New unit tests cover scan/connect arg shapes, error-prefix passthrough, the shared download Channel wiring → `Uint8Array`, best-effort disconnect, and connection delegation + progress wrapping.
- **Bundle check:** `@tauri-apps/api` stays in its own lazy `core-*.js` chunk; `logger_scan` appears only in the `DovesloggerDownload` chunk; the web `DataloggerDownload` chunk has zero references — the eager/landing graph is untouched.
- Manual (native shell, hardware-dependent — open items in the spec): scan finds a powered-on (incl. renamed) logger advertising `0x1820`, connect → list → download imports; cancel/close disconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPLW2k93jxaxhNoCXVABZ1)_