### PR TITLE
Pin workers.dev + preview URLs on in wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,16 @@
   // command (npm run build) and then `wrangler deploy`, which uploads ./dist.
   "name": "lapwing",
   "compatibility_date": "2026-05-30",
+  // Pin the workers.dev surface ON so it can't drift off. `wrangler deploy` treats
+  // this config as the source of truth, so any value toggled only in the dashboard
+  // gets reset on the next production deploy. Renaming the Worker (dovesdataviewer
+  // → lapwing) created a fresh Worker, and leaving these unset let each deploy
+  // disable the branch + per-version preview URLs (*-lapwing.perchwerks.workers.dev)
+  // that the beta-proxy and ad-hoc checks rely on. `preview_urls` governs those
+  // preview hostnames; `workers_dev` keeps the *.workers.dev subdomain they live on
+  // enabled. Production traffic still uses the custom_domain route below.
+  "workers_dev": true,
+  "preview_urls": true,
   // Attaching a custom_domain route makes Cloudflare provision the DNS record and
   // TLS certificate for lapwingdata.com automatically on deploy. The zone
   // lapwingdata.com must be in this Cloudflare account; do NOT also attach the


### PR DESCRIPTION
## Why

The `*-lapwing.perchwerks.workers.dev` preview URLs — both the `beta-lapwing…` branch alias that `beta-proxy/` forwards `beta.lapwingdata.com` to, **and** the per-version preview URLs — kept getting **disabled** after the `dovesdataviewer → lapwing` Worker rename (`1c9b777` / `89d4ec2`). They'd work, then revert, and re-enabling them in the Cloudflare dashboard never stuck across deploys.

**Root cause:** renaming a Worker creates a *fresh* Worker, and `wrangler deploy` treats `wrangler.jsonc` as the source of truth. With `workers_dev` / `preview_urls` **omitted** from the config, every production deploy (Workers Builds, on each `main` push) reset the dashboard-toggled values back toward default/off — so the preview surface drifted off again and again.

Nothing in the repo *explicitly* disabled them; the bug was the *absence* of the settings letting deploys reset them.

## What

Pin both settings ON in `wrangler.jsonc` so each deploy re-asserts the preview surface instead of drifting:

```jsonc
"workers_dev": true,
"preview_urls": true,
```

- `preview_urls` governs the `*-lapwing.perchwerks.workers.dev` hostnames (branch alias + per-version).
- `workers_dev` keeps the `*.workers.dev` subdomain those preview URLs live on enabled.
- **Production traffic is unaffected** — it uses the `custom_domain` route for `lapwingdata.com`; pinning `workers_dev: true` only matches what was already the default (no new exposure).

## Still to verify (dashboard-only, can't be expressed in config)

The Workers Builds **"build non-production branches"** toggle on the `lapwing` Worker — confirm `BETA` is still in the build branches (your report that builds were happening suggests it is, but worth a glance: Worker → Settings → Builds).

## Note on targeting

This is merged into **BETA** per request. To actually stop the production-deploy drift, it needs to reach **`main`** (that's the branch whose `wrangler deploy` resets the settings) via the usual BETA → main promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPLW2k93jxaxhNoCXVABZ1)_