### PR TITLE
Point contact email to support@perchwerks.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.9.2] - unreleased
 
+### Changed
+- **Support contact email.** The Terms of Service and Privacy Policy now point to
+  **support@perchwerks.com** for questions and requests (replacing the interim
+  address), and the Code of Conduct's enforcement contact was updated to match.
+
 ### Added
 - **Download from a Fledgling over Bluetooth in the native app.** On the native
   (Tauri) app the PerchWerks Fledgling tile in the logger picker now runs a real

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-hackthetrackfoss@gmail.com.
+support@perchwerks.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -12,7 +12,7 @@ const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 // features off it describes the offline-only app; with VITE_ENABLE_CLOUD on it
 // also covers accounts, payments and AI. The official hosted service is operated
 // by PERCHWERKS LLC (Windermere, Florida, USA); AI coaching uses Anthropic;
-// interim contact champagne@perchwerks.com. This is a drafted policy, not legal
+// contact support@perchwerks.com. This is a drafted policy, not legal
 // advice — have it reviewed for your jurisdiction.
 
 const Privacy = () => {
@@ -419,7 +419,7 @@ const Privacy = () => {
             Florida, USA). We may update this policy as the app evolves; material
             changes will be reflected by the “Last updated” date below. Questions
             or requests can be sent through the in-app contact form or to
-            champagne@perchwerks.com.
+            support@perchwerks.com.
           </p>
         </section>
       </div>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -9,7 +9,7 @@ const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 // NOTE FOR THE OPERATOR: drafted Terms, not legal advice — have them reviewed by
 // a lawyer for your jurisdiction. The official hosted service is operated by
 // PERCHWERKS LLC, based in Windermere, Florida, USA; contact
-// champagne@perchwerks.com (interim) until dedicated support addresses exist.
+// support@perchwerks.com.
 
 const Terms = () => {
   const navigate = useNavigate();
@@ -248,7 +248,7 @@ const Terms = () => {
             Windermere, Florida, USA. These Terms are governed by the laws of the
             State of Florida, United States, without regard to conflict-of-laws
             rules. Questions about these Terms can be sent through the in-app
-            contact form or to champagne@perchwerks.com.
+            contact form or to support@perchwerks.com.
           </p>
         </section>
       </div>


### PR DESCRIPTION
## Why

Consolidate every contact email on the site to the new dedicated address **support@perchwerks.com**, replacing the interim `champagne@perchwerks.com` reference.

## What

- **Terms of Service** (`src/pages/Terms.tsx`) — the in-page contact line + the operator comment now point to `support@perchwerks.com` (dropped the "interim, until dedicated support addresses exist" wording since the address now exists).
- **Privacy Policy** (`src/pages/Privacy.tsx`) — same: in-page contact line + operator comment.
- **Code of Conduct** (`CODE_OF_CONDUCT.md`) — updated the stale enforcement contact (old `hackthetrackfoss@gmail.com`, from the former project name) to `support@perchwerks.com` so all contact references are consistent.
- **CHANGELOG.md** — noted under `[2.9.2] - unreleased`.

No other hardcoded contact emails exist in the app (verified — the only other `@` hits are input placeholders like `your@email.com` and test fixtures, which are intentionally left alone). Legal pages are English-only by design, so there are no locale files to update.

## Verification

- `bun run lint` and `bun run typecheck` pass. Changes are string/comment-only (no logic or locale changes), so tests/build are unaffected — CI confirms.
- `git grep` shows zero remaining `champagne@`/`hackthetrackfoss` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPLW2k93jxaxhNoCXVABZ1)_