### PR TITLE
Materialize approved track/course submissions into the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.9.2] - unreleased
 
+### Fixed
+- **Approving a track/course submission now adds it to the database.** In the admin
+  **Submissions** tab, approving a submission previously only flipped its status —
+  it never created the track or course, so an approved new track/course silently
+  never appeared in the live tables. Approval now materializes the submission:
+  it upserts the track (creating it for a new track), upserts the course from the
+  submitted geometry/sectors, sets a new track's default course, and attaches any
+  drawn outline — covering new tracks, new courses, and course modifications. A bad
+  payload now errors and leaves the submission pending instead of being marked
+  approved while landing nothing.
+
 ### Changed
 - **Support contact email.** The Terms of Service and Privacy Policy now point to
   **support@perchwerks.com** for questions and requests (replacing the interim

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -363,10 +363,18 @@ The review dialog sends all selected courses in **one** `submit-track` call
 batch size, rate-limits by rows/hour/IP, and inserts one `submissions` row per
 course sharing a generated **`batch_id`** (migration
 `20260603120000_submissions_batch_id.sql`). The admin **Submissions** tab groups a
-batch together with **Approve all / Deny all**; each row is still reviewed/approved
-individually (approval is still manual — it flips status; the admin then
-builds/imports `tracks.json` as before). The single-submission body shape stays
-supported for back-compat.
+batch together with **Approve all / Deny all**; each row is reviewed/approved
+individually. **Approving materializes the submission into the live
+`tracks`/`courses` tables** — `db.applySubmission` upserts the track (creating it
+for a `new_track`), upserts the course by (track, name) from the validated
+`course_data`/`sectors_data` (covering `new_track`/`new_course`/`course_modification`
+alike), sets a new track's `default_course_id`, and attaches any submitted
+`layout_data`. The pure column builder lives in `lib/db/submissionMaterialize.ts`
+(unit-tested); the DB orchestration is in `supabaseAdapter.applySubmission`.
+Materializing runs *before* the status flip, so a bad payload errors and the row
+stays pending instead of being marked approved while never landing. (The Tools-tab
+`tracks.json` export still publishes the approved rows to the offline app as
+before.) The single-submission body shape stays supported for back-compat.
 
 **Submissions table** has `has_layout` (bool) and `layout_data` (jsonb) columns to
 carry drawing data through the workflow. The client sends a course's `layout` as

--- a/src/components/admin/SubmissionsTab.tsx
+++ b/src/components/admin/SubmissionsTab.tsx
@@ -90,9 +90,18 @@ export function SubmissionsTab() {
 
   const groups = useMemo(() => groupSubmissions(submissions), [submissions]);
 
-  const handleAction = async (id: string, status: 'approved' | 'denied') => {
+  // Approve = materialize the submission into the live tracks/courses tables,
+  // THEN flag it approved. Materializing first means a bad payload surfaces an
+  // error and the submission stays pending rather than being marked approved
+  // while the track/course silently never landed.
+  const reviewSubmission = async (sub: DbSubmission, status: 'approved' | 'denied') => {
+    if (status === 'approved') await db.applySubmission(sub);
+    await db.updateSubmission(sub.id, status, reviewNotes[sub.id]);
+  };
+
+  const handleAction = async (sub: DbSubmission, status: 'approved' | 'denied') => {
     try {
-      await db.updateSubmission(id, status, reviewNotes[id]);
+      await reviewSubmission(sub, status);
       toast({ title: status === 'approved' ? t('submissions.toastApproved') : t('submissions.toastDenied') });
       load();
     } catch (e: unknown) {
@@ -103,7 +112,7 @@ export function SubmissionsTab() {
   const handleBatchAction = async (items: DbSubmission[], status: 'approved' | 'denied') => {
     const pending = items.filter(s => s.status === 'pending');
     try {
-      await Promise.all(pending.map(s => db.updateSubmission(s.id, status, reviewNotes[s.id])));
+      await Promise.all(pending.map(s => reviewSubmission(s, status)));
       toast({ title: t(status === 'approved' ? 'submissions.batchApproved' : 'submissions.batchDenied', { count: pending.length }) });
       load();
     } catch (e: unknown) {
@@ -190,10 +199,10 @@ export function SubmissionsTab() {
               onChange={e => setReviewNotes(prev => ({ ...prev, [sub.id]: e.target.value }))}
               className="flex-1 text-sm"
             />
-            <Button size="sm" onClick={() => handleAction(sub.id, 'approved')} className="gap-1">
+            <Button size="sm" onClick={() => handleAction(sub, 'approved')} className="gap-1">
               <Check className="w-3 h-3" /> {t('submissions.approve')}
             </Button>
-            <Button size="sm" variant="destructive" onClick={() => handleAction(sub.id, 'denied')} className="gap-1">
+            <Button size="sm" variant="destructive" onClick={() => handleAction(sub, 'denied')} className="gap-1">
               <X className="w-3 h-3" /> {t('submissions.deny')}
             </Button>
           </div>

--- a/src/lib/db/submissionMaterialize.test.ts
+++ b/src/lib/db/submissionMaterialize.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { buildCourseColumnsFromSubmission } from './submissionMaterialize';
+import type { DbSubmission } from './types';
+
+function makeSubmission(overrides: Partial<DbSubmission> = {}): DbSubmission {
+  return {
+    id: 'sub-1',
+    type: 'new_track',
+    track_name: 'Test Raceway',
+    track_short_name: 'TSTRW',
+    course_name: 'Main',
+    course_data: {
+      start_a_lat: 40.1,
+      start_a_lng: -80.1,
+      start_b_lat: 40.2,
+      start_b_lng: -80.2,
+    },
+    status: 'pending',
+    submitted_by_ip: null,
+    submitted_by_user_id: null,
+    batch_id: null,
+    created_at: '2026-06-01T00:00:00Z',
+    reviewed_at: null,
+    reviewed_by: null,
+    review_notes: null,
+    ...overrides,
+  };
+}
+
+describe('buildCourseColumnsFromSubmission', () => {
+  it('builds the start/finish columns from course_data', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission());
+    expect(cols.name).toBe('Main');
+    expect(cols.enabled).toBe(true);
+    expect(cols.start_a_lat).toBe(40.1);
+    expect(cols.start_a_lng).toBe(-80.1);
+    expect(cols.start_b_lat).toBe(40.2);
+    expect(cols.start_b_lng).toBe(-80.2);
+    expect(cols.superseded_by).toBeNull();
+    expect(cols.sectors_data).toBeNull();
+    expect(cols.length_ft_override).toBeNull();
+  });
+
+  it('trims the course name', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({ course_name: '  Outer  ' }));
+    expect(cols.name).toBe('Outer');
+  });
+
+  it('carries the legacy two-major sector columns', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: {
+        start_a_lat: 1, start_a_lng: 2, start_b_lat: 3, start_b_lng: 4,
+        sector_2_a_lat: 5, sector_2_a_lng: 6, sector_2_b_lat: 7, sector_2_b_lng: 8,
+        sector_3_a_lat: 9, sector_3_a_lng: 10, sector_3_b_lat: 11, sector_3_b_lng: 12,
+      },
+    }));
+    expect(cols.sector_2_a_lat).toBe(5);
+    expect(cols.sector_3_b_lng).toBe(12);
+  });
+
+  it('leaves omitted sector columns null', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission());
+    expect(cols.sector_2_a_lat).toBeNull();
+    expect(cols.sector_3_b_lng).toBeNull();
+  });
+
+  it('prefers the dedicated sectors_data column', () => {
+    const sectors = [
+      { a_lat: 1, a_lng: 2, b_lat: 3, b_lng: 4, major: true },
+      { a_lat: 5, a_lng: 6, b_lat: 7, b_lng: 8, major: false },
+    ];
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({ sectors_data: sectors }));
+    expect(cols.sectors_data).toEqual(sectors);
+  });
+
+  it('falls back to course_data.sectors when no dedicated column', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: {
+        start_a_lat: 1, start_a_lng: 2, start_b_lat: 3, start_b_lng: 4,
+        sectors: [{ a_lat: 1, a_lng: 2, b_lat: 3, b_lng: 4, major: true }],
+      },
+    }));
+    expect(cols.sectors_data).toEqual([{ a_lat: 1, a_lng: 2, b_lat: 3, b_lng: 4, major: true }]);
+  });
+
+  it('coerces the major flag to a boolean', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally loose input
+      sectors_data: [{ a_lat: 1, a_lng: 2, b_lat: 3, b_lng: 4, major: 1 as any }],
+    }));
+    expect(cols.sectors_data?.[0].major).toBe(true);
+  });
+
+  it('rounds lengthFt into length_ft_override', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: { start_a_lat: 1, start_a_lng: 2, start_b_lat: 3, start_b_lng: 4, lengthFt: 1234.6 },
+    }));
+    expect(cols.length_ft_override).toBe(1235);
+  });
+
+  it('ignores a non-positive lengthFt', () => {
+    const cols = buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: { start_a_lat: 1, start_a_lng: 2, start_b_lat: 3, start_b_lng: 4, lengthFt: 0 },
+    }));
+    expect(cols.length_ft_override).toBeNull();
+  });
+
+  it('throws on an out-of-range latitude', () => {
+    expect(() => buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: { start_a_lat: 200, start_a_lng: 2, start_b_lat: 3, start_b_lng: 4 },
+    }))).toThrow(/latitude/i);
+  });
+
+  it('throws on an out-of-range longitude', () => {
+    expect(() => buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: { start_a_lat: 1, start_a_lng: 999, start_b_lat: 3, start_b_lng: 4 },
+    }))).toThrow(/longitude/i);
+  });
+
+  it('throws on a non-finite coordinate', () => {
+    expect(() => buildCourseColumnsFromSubmission(makeSubmission({
+      course_data: { start_a_lat: 'abc', start_a_lng: 2, start_b_lat: 3, start_b_lng: 4 },
+    }))).toThrow();
+  });
+
+  it('throws on a blank course name', () => {
+    expect(() => buildCourseColumnsFromSubmission(makeSubmission({ course_name: '   ' }))).toThrow(/course name/i);
+  });
+
+  it('validates sector coordinates too', () => {
+    expect(() => buildCourseColumnsFromSubmission(makeSubmission({
+      sectors_data: [{ a_lat: 91, a_lng: 2, b_lat: 3, b_lng: 4, major: true }],
+    }))).toThrow(/latitude/i);
+  });
+});

--- a/src/lib/db/submissionMaterialize.ts
+++ b/src/lib/db/submissionMaterialize.ts
@@ -1,0 +1,98 @@
+/**
+ * Materialize an approved community submission into concrete track/course rows.
+ *
+ * Approving a submission used to only flip `submissions.status` to `approved` —
+ * a moderation flag that left the `tracks`/`courses` tables untouched, so an
+ * approved track/course never actually appeared in the live database. This
+ * module builds the validated course payload from a submission so the adapter
+ * can upsert it; the pure builder is unit-tested, the DB orchestration lives in
+ * the adapter (`applySubmission`).
+ */
+
+import type { DbSubmission, DbCourse } from './types';
+
+/** A course's column values minus the keys the DB/adapter fills in. */
+export type SubmissionCourseColumns = Omit<
+  DbCourse,
+  'id' | 'track_id' | 'created_at' | 'updated_at'
+>;
+
+function validateLat(v: unknown, label: string, courseName: string): number {
+  const n = Number(v);
+  if (isNaN(n) || !isFinite(n) || n < -90 || n > 90) {
+    throw new Error(`Invalid latitude ${label} in course "${courseName}": must be between -90 and 90`);
+  }
+  return n;
+}
+
+function validateLng(v: unknown, label: string, courseName: string): number {
+  const n = Number(v);
+  if (isNaN(n) || !isFinite(n) || n < -180 || n > 180) {
+    throw new Error(`Invalid longitude ${label} in course "${courseName}": must be between -180 and 180`);
+  }
+  return n;
+}
+
+/**
+ * Build the validated course columns for an approved submission. Throws on any
+ * out-of-range / non-finite coordinate so a bad submission never lands as a
+ * malformed course row. Sectors come from the dedicated `sectors_data` column
+ * (preferred), falling back to the `sectors` key inside `course_data`.
+ */
+export function buildCourseColumnsFromSubmission(sub: DbSubmission): SubmissionCourseColumns {
+  const courseName = sub.course_name.trim();
+  if (!courseName || courseName.length > 100) {
+    throw new Error(`Invalid course name in submission: "${sub.course_name}"`);
+  }
+  const cd = (sub.course_data ?? {}) as Record<string, unknown>;
+
+  const optLat = (v: unknown, label: string): number | null =>
+    v === undefined || v === null ? null : validateLat(v, label, courseName);
+  const optLng = (v: unknown, label: string): number | null =>
+    v === undefined || v === null ? null : validateLng(v, label, courseName);
+
+  const columns: SubmissionCourseColumns = {
+    name: courseName,
+    enabled: true,
+    start_a_lat: validateLat(cd.start_a_lat, 'start_a_lat', courseName),
+    start_a_lng: validateLng(cd.start_a_lng, 'start_a_lng', courseName),
+    start_b_lat: validateLat(cd.start_b_lat, 'start_b_lat', courseName),
+    start_b_lng: validateLng(cd.start_b_lng, 'start_b_lng', courseName),
+    sector_2_a_lat: optLat(cd.sector_2_a_lat, 'sector_2_a_lat'),
+    sector_2_a_lng: optLng(cd.sector_2_a_lng, 'sector_2_a_lng'),
+    sector_2_b_lat: optLat(cd.sector_2_b_lat, 'sector_2_b_lat'),
+    sector_2_b_lng: optLng(cd.sector_2_b_lng, 'sector_2_b_lng'),
+    sector_3_a_lat: optLat(cd.sector_3_a_lat, 'sector_3_a_lat'),
+    sector_3_a_lng: optLng(cd.sector_3_a_lng, 'sector_3_a_lng'),
+    sector_3_b_lat: optLat(cd.sector_3_b_lat, 'sector_3_b_lat'),
+    sector_3_b_lng: optLng(cd.sector_3_b_lng, 'sector_3_b_lng'),
+    sectors_data: null,
+    superseded_by: null,
+    length_ft_override: null,
+  };
+
+  // Canonical ordered sector list: prefer the dedicated column, fall back to the
+  // `sectors` key folded into course_data by the submit edge function.
+  const rawSectors = Array.isArray(sub.sectors_data)
+    ? sub.sectors_data
+    : Array.isArray(cd.sectors)
+      ? (cd.sectors as Array<Record<string, unknown>>)
+      : null;
+  if (rawSectors && rawSectors.length > 0) {
+    columns.sectors_data = rawSectors.map((s) => ({
+      a_lat: validateLat(s.a_lat, 'sector a_lat', courseName),
+      a_lng: validateLng(s.a_lng, 'sector a_lng', courseName),
+      b_lat: validateLat(s.b_lat, 'sector b_lat', courseName),
+      b_lng: validateLng(s.b_lng, 'sector b_lng', courseName),
+      major: Boolean(s.major),
+    }));
+  }
+
+  // lengthFt (if the submitter sent one) becomes the length override.
+  const lengthFt = Number(cd.lengthFt);
+  if (cd.lengthFt !== undefined && cd.lengthFt !== null && !isNaN(lengthFt) && lengthFt > 0) {
+    columns.length_ft_override = Math.round(lengthFt);
+  }
+
+  return columns;
+}

--- a/src/lib/db/supabaseAdapter.ts
+++ b/src/lib/db/supabaseAdapter.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { ITrackDatabase, DbTrack, DbCourse, DbSubmission, DbBannedIp, DbCourseLayout, DbProfile } from './types';
+import { buildCourseColumnsFromSubmission } from './submissionMaterialize';
 import { calculatePolylineLength } from '@/lib/trackUtils';
 import { METERS_TO_FEET } from '@/lib/parserUtils';
 
@@ -115,6 +116,58 @@ export class SupabaseTrackDatabase implements ITrackDatabase {
       reviewed_by: user?.id ?? null,
     }).eq('id', id);
     if (error) throw error;
+  }
+
+  // Materialize an approved submission into the live tracks/courses tables.
+  // Upserts the track (creating it for a new_track submission), then upserts the
+  // course by (track, name) — covering new_track / new_course / course_modification
+  // alike — and attaches any submitted drawn outline. Updating the submission's
+  // status is the caller's job; this is the step that was previously missing, so
+  // an approved track/course never reached the live tables.
+  async applySubmission(sub: DbSubmission): Promise<void> {
+    const columns = buildCourseColumnsFromSubmission(sub);
+    const trackName = sub.track_name.trim();
+    const shortName = (sub.track_short_name?.trim() || trackName.split(/\s+/).map(w => w[0]).join('').slice(0, 8).toUpperCase()).slice(0, 8);
+
+    // Upsert the track, matched by name first, then short name.
+    let track: DbTrack;
+    const { data: byName } = await supabase.from('tracks').select('*').eq('name', trackName).maybeSingle();
+    const existingTrack = byName
+      ?? (sub.track_short_name
+        ? (await supabase.from('tracks').select('*').eq('short_name', sub.track_short_name).maybeSingle()).data
+        : null);
+    if (existingTrack) {
+      track = existingTrack as DbTrack;
+      await supabase.from('tracks').update({ enabled: true }).eq('id', track.id);
+    } else {
+      track = await this.createTrack({ name: trackName, short_name: shortName, enabled: true });
+    }
+
+    // Upsert the course by (track, name).
+    const { data: existingCourse } = await supabase.from('courses')
+      .select('id').eq('track_id', track.id).eq('name', columns.name).maybeSingle();
+    let courseId: string;
+    if (existingCourse) {
+      courseId = (existingCourse as { id: string }).id;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Supabase types lag schema; remove on next type regen
+      const { error } = await supabase.from('courses').update(columns as any).eq('id', courseId);
+      if (error) throw error;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Supabase types lag schema; remove on next type regen
+      const { data, error } = await supabase.from('courses').insert({ ...columns, track_id: track.id } as any).select('id').single();
+      if (error) throw error;
+      courseId = (data as { id: string }).id;
+    }
+
+    // A brand-new track with no default course points at this first course.
+    if (!track.default_course_id) {
+      await supabase.from('tracks').update({ default_course_id: courseId }).eq('id', track.id);
+    }
+
+    // Attach the submitted drawn outline, when present.
+    if (Array.isArray(sub.layout_data) && sub.layout_data.length >= 2) {
+      await this.saveLayout(courseId, sub.layout_data);
+    }
   }
 
   // Profiles — resolve user ids to display names (e.g. submission attribution).

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -109,6 +109,8 @@ export interface ITrackDatabase {
   // Submissions
   getSubmissions(status?: string): Promise<DbSubmission[]>;
   updateSubmission(id: string, status: string, reviewNotes?: string): Promise<void>;
+  /** Materialize an approved submission into the live tracks/courses tables. */
+  applySubmission(sub: DbSubmission): Promise<void>;
 
   // Profiles (display-name lookup, e.g. to show who submitted a track)
   getProfiles(userIds: string[]): Promise<DbProfile[]>;


### PR DESCRIPTION
## Why

You approved a new course on a new track in the admin **Submissions** tab, but it never showed up in the `tracks`/`courses` tables. Here's why:

**Approving a submission only flipped `submissions.status` to `approved`.** That field is a moderation flag — nothing (no edge function, no DB trigger, no client code) ever read an approved submission and wrote it into the `tracks`/`courses` tables. The submission queue was effectively a review log. The only way to get the data live was to re-create the track/course by hand or rebuild `tracks.json`. The existing **Apply to course layout** button only attaches a drawing to a course that *already exists*.

## What this changes

Approval now **materializes** the submission into the live tables via a new `db.applySubmission(sub)`:

- Upserts the **track** — matched by name, then short name; created (with auto short name + `default_course_id`) for a `new_track`.
- Upserts the **course** by `(track, name)` from the validated `course_data` / `sectors_data` — one path that covers `new_track`, `new_course`, and `course_modification`.
- Attaches any submitted **drawn outline** (`layout_data`).

Materialization runs **before** the status flip, so a malformed payload surfaces an error and the submission stays *pending* rather than being marked approved while landing nothing. Batch **Approve all** materializes each row the same way.

The pure, validated column builder lives in `lib/db/submissionMaterialize.ts` (14 new unit tests cover coordinate validation, the legacy two-major columns, sector sourcing/precedence, `lengthFt` → override, and error cases). The DB orchestration is in `supabaseAdapter.applySubmission`.

## Notes

- No schema change — uses existing tables/columns.
- The Tools-tab `tracks.json` export still publishes approved rows to the offline app as before; this just makes the rows actually exist to be exported.
- Docs (`docs/subsystems.md`) and `CHANGELOG.md` updated.

## Checks

`bun run lint`, `bun run typecheck`, `bun run test:run` (1954 passing), and `bun run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dXSh5euMWN9s5D9SrEbjm

---
_Generated by [Claude Code](https://claude.ai/code/session_015dXSh5euMWN9s5D9SrEbjm)_