### PR TITLE
Fix synced-video stutter during data playback and scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every tab and panel ~30–60×/sec. The per-frame playhead now lives in its own tiny
   context (like the playback cursor already does), so only the video time readout
   re-renders per frame and the rest of the view stays quiet.
+- **A synced video no longer stutters when you play or scrub the data.** Pressing
+  the top play button (or dragging the chart) used to *seek* the video ~20×/sec to
+  chase the telemetry cursor — every seek forces the decoder back to a keyframe, so
+  the picture juddered instead of playing. When the cursor is being played over
+  footage, the video now plays **natively** and is only nudged back into alignment
+  if it drifts more than a couple of frames, so playback is smooth; scrubbing uses a
+  faster approximate seek. The telemetry cursor stays the single clock, and stretches
+  with no footage still let the charts play straight through.
 - **Split-graphs comparison video no longer drifts lap-by-lap.** Two causes are
   fixed. First, the comparison player seeked off the overlay lap's snapped first
   sample (a sub-sample fraction before the true start/finish crossing); it now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the picture juddered instead of playing. The top play button now drives the
   **video itself** when it's locked over footage (the same smooth path as the
   video's own play button), with the cursor derived from the video's playhead.
-- **Scrubbing a synced video now lands on the same frame every time.** Dragging the
-  data cursor and releasing could leave the video on a slightly different frame each
-  time: a fixed seek-throttle silently dropped the final seek, parking the video on a
-  stale frame. Seeks are now coalesced onto the next animation frame, so the cursor's
-  final position always lands (and a fast approximate seek is used where supported).
+- **Scrubbing a synced video is smoother and lands on the same frame every time.**
+  Dragging the data cursor fired a fresh video seek every frame regardless of whether
+  the previous one had finished, so the decoder thrashed (cancel/restart) and the
+  picture juddered; a fixed seek-throttle also dropped the final seek, parking the
+  video on a stale frame. Seeks are now **paced** on the video's own `seeked` event —
+  the next seek is issued only when the last completes, always to the latest cursor
+  position — using a fast approximate seek during the drag and one precise seek once
+  the cursor settles, so the parked frame is exact and repeatable.
 - **Split-graphs comparison video no longer drifts lap-by-lap.** Two causes are
   fixed. First, the comparison player seeked off the overlay lap's snapped first
   sample (a sub-sample fraction before the true start/finish crossing); it now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   video on a stale frame. Seeks are now **paced** on the video's own `seeked` event —
   the next seek is issued only when the last completes, always to the latest cursor
   position — using a fast approximate seek during the drag and one precise seek once
-  the cursor settles, so the parked frame is exact and repeatable.
+  the cursor settles, so the parked frame is exact and repeatable. Scrub cursor
+  updates are also coalesced to one per animation frame, so a high-rate mouse or
+  trackpad no longer floods the main thread with graph redraws while the video seeks.
 - **Split-graphs comparison video no longer drifts lap-by-lap.** Two causes are
   fixed. First, the comparison player seeked off the overlay lap's snapped first
   sample (a sub-sample fraction before the true start/finish crossing); it now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,13 +44,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context (like the playback cursor already does), so only the video time readout
   re-renders per frame and the rest of the view stays quiet.
 - **A synced video no longer stutters when you play or scrub the data.** Pressing
-  the top play button (or dragging the chart) used to *seek* the video ~20×/sec to
-  chase the telemetry cursor — every seek forces the decoder back to a keyframe, so
-  the picture juddered instead of playing. When the cursor is being played over
-  footage, the video now plays **natively** and is only nudged back into alignment
-  if it drifts more than a couple of frames, so playback is smooth; scrubbing uses a
-  faster approximate seek. The telemetry cursor stays the single clock, and stretches
-  with no footage still let the charts play straight through.
+  the top play button used to advance the data cursor on its own clock and *seek*
+  the locked video to chase it — every seek forces the decoder back to a keyframe,
+  so the picture juddered instead of playing. The top play button now drives the
+  **video itself** when it's locked over footage (the same smooth path as the
+  video's own play button), with the cursor derived from the video's playhead.
+- **Scrubbing a synced video now lands on the same frame every time.** Dragging the
+  data cursor and releasing could leave the video on a slightly different frame each
+  time: a fixed seek-throttle silently dropped the final seek, parking the video on a
+  stale frame. Seeks are now coalesced onto the next animation frame, so the cursor's
+  final position always lands (and a fast approximate seek is used where supported).
 - **Split-graphs comparison video no longer drifts lap-by-lap.** Two causes are
   fixed. First, the comparison player seeked off the overlay lap's snapped first
   sample (a sub-sample fraction before the true start/finish crossing); it now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.9.2] - unreleased
 
 ### Added
+- **Frame-by-frame stepping in the header.** Two new buttons flank the play button
+  to step the data cursor one sample back/forward. A synced video follows the step
+  (through the same sync path), landing on the exact frame — so drivers and coaches
+  can compare a lap literally frame by frame. Stepping pauses any running playback.
 - **Split graphs — side-by-side lap comparison (Pro tab).** On tablet and larger,
   a new **Split graphs** button (top-right of the Pro tab, where the Simple tab's
   Overlay toggle sits) splits the graph area into a draggable two-up view. Pick one

--- a/src/hooks/useLapManagement.ts
+++ b/src/hooks/useLapManagement.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { ParsedData, Lap, GpsSample, TrackCourseSelection, Course } from "@/types/racing";
 import { calculateLaps } from "@/lib/lapCalculation";
 import { updateFileMetadata } from "@/lib/fileStorage";
@@ -129,10 +129,27 @@ export function useLapManagement(data: ParsedData | null, currentFileName: strin
     setReferenceLapNumber((prev) => (prev === lapNumber ? null : lapNumber));
   }, []);
 
+  // rAF-coalesce scrub updates: a fast pointer fires far more than 60×/s, and
+  // every cursor change redraws every graph canvas (+ map + overlays) and seeks
+  // the synced video. Doing that per pointer event saturates the main thread and
+  // stutters the video. Cap to one update per frame — the latest index always
+  // lands, so the resting position stays deterministic. (Playback drives the
+  // cursor through setCurrentIndex directly, so it is unaffected.)
+  const scrubRafRef = useRef<number | null>(null);
+  const scrubPendingRef = useRef<number | null>(null);
+  useEffect(() => () => { if (scrubRafRef.current != null) cancelAnimationFrame(scrubRafRef.current); }, []);
+
   const handleScrub = useCallback(
     (index: number) => {
-      const clampedIndex = Math.max(0, Math.min(index, visibleRange[1] - visibleRange[0]));
-      setCurrentIndex(clampedIndex);
+      scrubPendingRef.current = index;
+      if (scrubRafRef.current != null) return;
+      scrubRafRef.current = requestAnimationFrame(() => {
+        scrubRafRef.current = null;
+        const idx = scrubPendingRef.current;
+        if (idx == null) return;
+        const clampedIndex = Math.max(0, Math.min(idx, visibleRange[1] - visibleRange[0]));
+        setCurrentIndex(clampedIndex);
+      });
     },
     [visibleRange]
   );

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -585,53 +585,90 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     return () => { active = false; };
   }, [videoUrl, isLocked, isPlaying, syncOffsetMs, syncRate]);
 
-  // Data-drives-video SCRUB (locked + nothing playing): seek the playlist to the
-  // selected sample so the video follows the cursor while you drag or park.
+  // ── Data-drives-video SCRUB (locked + nothing playing) ─────────────────────
+  // Follow the cursor with the video while dragging or parked. Seeks are PACED
+  // on the <video>'s own `seeked` event: we keep only the latest desired
+  // position and issue the next seek when the previous one finishes, rather than
+  // firing a fresh seek every animation frame. Setting `currentTime` faster than
+  // the decoder can service it makes the browser cancel-and-restart in-flight
+  // seeks — that thrash is the scrub stutter. Pacing runs the decoder at its
+  // natural rate and always converges on where the cursor actually ended up.
   //
-  // The seek is COALESCED onto the next animation frame, not gated by a fixed
-  // time-throttle. A throttle (`if (now - last < 50ms) return`) silently DROPS
-  // the trailing seek when you release after a fast drag, so the same cursor
-  // index lands on a different video frame each time (it's parked wherever the
-  // last un-dropped seek left it). rAF coalescing instead guarantees the LAST
-  // cursor position always seeks — deterministic — while still collapsing a
-  // burst of drag updates to one (fast) seek per frame.
+  // During the drag we use the fast (approximate, keyframe) seek for
+  // responsiveness; ~150ms after the cursor settles we land one PRECISE seek so
+  // the parked frame is exact — and deterministic (same cursor → same frame),
+  // which a fixed seek-throttle broke by dropping the trailing seek.
+  const scrubTargetSecRef = useRef<number | null>(null);
+  const scrubInFlightRef = useRef(false);
+  const scrubSettleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const issueScrubSeek = useCallback((virtualSec: number, precise: boolean): boolean => {
+    const video = videoRef.current;
+    if (!video) return false;
+    const pl = playlistRef.current;
+    if (pl) {
+      const { index, localSec } = virtualToLocal(pl, virtualSec);
+      if (index !== currentChunkIndexRef.current) { loadChunk(index, localSec, false); return true; }
+      if (!needsResync(video.currentTime, localSec, 0.5 / fps)) return false;
+      if (precise) video.currentTime = localSec; else seekVideoElement(video, localSec);
+      return true;
+    }
+    if (!needsResync(video.currentTime, virtualSec, 0.5 / fps)) return false;
+    if (precise) video.currentTime = virtualSec; else seekVideoElement(video, virtualSec);
+    return true;
+  }, [loadChunk, fps]);
+
+  const pumpScrubSeek = useCallback(() => {
+    if (scrubInFlightRef.current) return;
+    const target = scrubTargetSecRef.current;
+    if (target == null) return;
+    scrubTargetSecRef.current = null;
+    if (issueScrubSeek(target, false)) scrubInFlightRef.current = true;
+  }, [issueScrubSeek]);
+
+  // Pace the next queued scrub seek off the previous one completing.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const onSeeked = () => { scrubInFlightRef.current = false; pumpScrubSeek(); };
+    video.addEventListener("seeked", onSeeked);
+    return () => video.removeEventListener("seeked", onSeeked);
+  }, [videoUrl, pumpScrubSeek]);
+
+  useEffect(() => () => { if (scrubSettleRef.current) clearTimeout(scrubSettleRef.current); }, []);
+
   useEffect(() => {
     if (!isLocked || isPlaying || dataIsPlaying) return;
     const video = videoRef.current;
     if (!video || !videoUrl || samples.length === 0) return;
     const sample = samples[currentIndex];
     if (!sample) return;
-    const raf = requestAnimationFrame(() => {
-      const pl = playlistRef.current;
-      const total = pl ? pl.totalDuration : video.duration;
-      const virtualSec = sessionMsToVideoSec(sample.t, syncOffsetMs, syncRate);
-      const clampedSec = Math.max(0, virtualSec);
-      const cov = coverageOf(sample.t, syncOffsetMs, total, syncRate);
-      setCoverage(cov);
-      if (cov !== 'covered') {
-        // No footage for this session position — blank it, but the cursor/charts
-        // stay free to scrub or play through the gap.
-        setIsOutOfRange(true);
-        if (!video.paused) video.pause();
-      } else {
-        setIsOutOfRange(false);
-        if (pl) {
-          const { index, localSec } = virtualToLocal(pl, clampedSec);
-          if (index !== currentChunkIndexRef.current) {
-            loadChunk(index, localSec, false);
-          } else if (needsResync(video.currentTime, localSec, 0.5 / fps)) {
-            seekVideoElement(video, localSec);
-          }
-        } else if (needsResync(video.currentTime, clampedSec, 0.5 / fps)) {
-          seekVideoElement(video, clampedSec);
-        }
-      }
-      setVideoCurrentTime(clampedSec);
-    });
-    // A newer cursor value cancels this pending seek and schedules its own, so
-    // only the latest position ever lands — that's what makes it deterministic.
-    return () => cancelAnimationFrame(raf);
-  }, [currentIndex, isLocked, isPlaying, dataIsPlaying, syncOffsetMs, syncRate, samples, videoUrl, fps, loadChunk]);
+    const pl = playlistRef.current;
+    const total = pl ? pl.totalDuration : video.duration;
+    const virtualSec = sessionMsToVideoSec(sample.t, syncOffsetMs, syncRate);
+    const clampedSec = Math.max(0, virtualSec);
+    const cov = coverageOf(sample.t, syncOffsetMs, total, syncRate);
+    setCoverage(cov);
+    setVideoCurrentTime(clampedSec);
+    if (cov !== 'covered') {
+      // No footage here — blank it; the cursor/charts still scrub through the gap.
+      setIsOutOfRange(true);
+      if (!video.paused) video.pause();
+      return;
+    }
+    setIsOutOfRange(false);
+    // Queue the latest position; the pacer issues it when the decoder is ready.
+    scrubTargetSecRef.current = clampedSec;
+    pumpScrubSeek();
+    // Land an exact-frame seek once the drag settles (also self-heals a stuck
+    // in-flight flag if a seek never reported back).
+    if (scrubSettleRef.current) clearTimeout(scrubSettleRef.current);
+    scrubSettleRef.current = setTimeout(() => {
+      scrubInFlightRef.current = false;
+      const v = videoRef.current;
+      if (v && v.paused) issueScrubSeek(clampedSec, true);
+    }, 150);
+  }, [currentIndex, isLocked, isPlaying, dataIsPlaying, syncOffsetMs, syncRate, samples, videoUrl, pumpScrubSeek, issueScrubSeek]);
 
   const togglePlay = useCallback(() => {
     const video = videoRef.current;

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -5,7 +5,7 @@ import { loadSessionVideo, hasSessionVideo, deleteSessionVideo, getSessionVideoM
 import type { OverlaySettings } from "@/components/video-overlays/types";
 import { DEFAULT_OVERLAY_SETTINGS } from "@/components/video-overlays/types";
 import { findNearestIndex } from "@/components/video-overlays/overlayUtils";
-import { coverageOf, sessionMsToVideoSec, videoSecToSessionMs, fitVideoTimeline, type VideoCoverage } from "@/lib/videoTimeline";
+import { coverageOf, sessionMsToVideoSec, videoSecToSessionMs, fitVideoTimeline, videoSlaveAction, resyncThresholdSec, needsResync, type VideoCoverage } from "@/lib/videoTimeline";
 import { buildPlaylist, groupVideoRecordings, virtualToLocal, localToVirtual, type Playlist, type VideoRecording } from "@/lib/videoPlaylist";
 
 interface UseVideoSyncOptions {
@@ -14,6 +14,12 @@ interface UseVideoSyncOptions {
   currentIndex: number;
   onScrub: (index: number) => void;
   sessionFileName: string | null;
+  /**
+   * Whether the telemetry cursor is being PLAYED by the top play button. When
+   * true and the video is locked, the video plays natively as a drift-corrected
+   * slave instead of being seek-scrubbed once per cursor tick (which stutters).
+   */
+  dataIsPlaying: boolean;
 }
 
 export interface VideoSyncState {
@@ -90,6 +96,18 @@ interface ChunkEntry {
   durationSec?: number;
 }
 
+/**
+ * Seek a video element, preferring `fastSeek` (approximate seek, no decode
+ * stall) when the browser supports it — smoother for scrub + drift correction.
+ */
+function seekVideoElement(video: HTMLVideoElement, timeSec: number): void {
+  const fast = (video as HTMLVideoElement & { fastSeek?: (t: number) => void }).fastSeek;
+  try {
+    if (typeof fast === "function") fast.call(video, timeSec);
+    else video.currentTime = timeSec;
+  } catch { /* out-of-range time is clamped by the browser */ }
+}
+
 /** Read a video file's duration via a throwaway metadata-only element. */
 function readVideoDuration(url: string): Promise<number> {
   return new Promise<number>((resolve) => {
@@ -113,7 +131,7 @@ function readVideoDuration(url: string): Promise<number> {
   });
 }
 
-export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessionFileName }: UseVideoSyncOptions) {
+export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessionFileName, dataIsPlaying }: UseVideoSyncOptions) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const preloadVideoRef = useRef<HTMLVideoElement>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -123,6 +141,10 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   onScrubRef.current = onScrub;
   const samplesRef = useRef(samples);
   samplesRef.current = samples;
+  // The cursor index, readable from the rAF slave loop without re-subscribing it
+  // every tick (it advances at playback rate while the loop runs).
+  const currentIndexRef = useRef(currentIndex);
+  currentIndexRef.current = currentIndex;
 
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [preloadUrl, setPreloadUrl] = useState<string | null>(null);
@@ -140,6 +162,11 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const syncAnchorRef = useRef<{ sessionMs: number; videoSec: number } | null>(null);
   const lapAnchorsRef = useRef<Map<number, { sessionMs: number; videoSec: number }>>(new Map());
   const [fps, setFps] = useState(30);
+  // Read by the slave-playback rAF loop without re-subscribing it: fps is
+  // auto-detected ~0.3s into playback, and a dep change there would tear down +
+  // resume the loop (a visible hitch) mid-play.
+  const fpsRef = useRef(30);
+  fpsRef.current = fps;
   const [videoDuration, setVideoDuration] = useState(0);
   const [videoCurrentTime, setVideoCurrentTime] = useState(0);
   const [chunkCount, setChunkCount] = useState(1);
@@ -514,11 +541,13 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     }
   }, [videoUrl]);
 
-  // Video-drives-data (locked + playing): map the active chunk's local time to
-  // virtual time, then to telemetry.
+  // Video-drives-data (locked + playing via the VIDEO's own controls): map the
+  // active chunk's local time to virtual time, then to telemetry. When the top
+  // play button is the one driving (dataIsPlaying), the data clock owns the
+  // cursor instead — see the slave-playback effect below — so this yields.
   useEffect(() => {
     const video = videoRef.current;
-    if (!video || !videoUrl || !isLocked || !isPlaying) return;
+    if (!video || !videoUrl || !isLocked || !isPlaying || dataIsPlaying) return;
     let active = true;
     const tick = () => {
       const v = videoRef.current;
@@ -561,11 +590,73 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
       requestAnimationFrame(loop);
     }
     return () => { active = false; };
-  }, [videoUrl, isLocked, isPlaying, syncOffsetMs, syncRate]);
+  }, [videoUrl, isLocked, isPlaying, dataIsPlaying, syncOffsetMs, syncRate]);
 
-  // Data-drives-video (locked + paused): seek the playlist to the selected sample.
+  // Data-drives-video SLAVE (locked + the top play button is playing): keep the
+  // video playing NATIVELY and only nudge it back into alignment when it drifts
+  // past a couple of frames — never seek per cursor tick. The telemetry cursor
+  // stays the single authority (usePlayback's rAF advances it); the video is a
+  // drift-corrected follower. This is what kills the seek-scrub stutter.
+  //
+  // The loop is rAF (not requestVideoFrameCallback) so it keeps ticking while
+  // the cursor crosses an uncovered gap with the video paused — rVFC would stop
+  // firing there and never notice the cursor re-entering footage.
   useEffect(() => {
-    if (!isLocked || isPlaying) return;
+    if (!isLocked || !dataIsPlaying) return;
+    const video = videoRef.current;
+    if (!video || !videoUrl) return;
+    let active = true;
+    const tick = () => {
+      if (!active) return;
+      const v = videoRef.current;
+      if (!v) { return; }
+      const pl = playlistRef.current;
+      const total = pl ? pl.totalDuration : v.duration;
+      const s = samplesRef.current;
+      const sample = s[currentIndexRef.current];
+      if (sample) {
+        const cov = coverageOf(sample.t, syncOffsetMs, total, syncRate);
+        setCoverage(cov);
+        const action = videoSlaveAction({ isLocked: true, dataIsPlaying: true, hasVideo: true, coverage: cov });
+        if (action === 'play') {
+          setIsOutOfRange(false);
+          const targetVirtual = Math.max(0, sessionMsToVideoSec(sample.t, syncOffsetMs, syncRate));
+          const { index, localSec } = pl ? virtualToLocal(pl, targetVirtual) : { index: 0, localSec: targetVirtual };
+          if (pl && index !== currentChunkIndexRef.current) {
+            // Crossed a chunk boundary (or jumped chunks): swap + resume there.
+            loadChunk(index, localSec, true);
+          } else if (v.paused) {
+            // Entering footage (start of play, or after a gap): align once, then
+            // let it play natively from here.
+            try { v.currentTime = localSec; } catch { /* clamped by browser */ }
+            v.play().catch(() => {});
+          } else if (needsResync(v.currentTime, localSec, resyncThresholdSec(fpsRef.current))) {
+            // Playing: correct drift only past the threshold (a couple frames).
+            seekVideoElement(v, localSec);
+          }
+          if (!v.paused) setVideoCurrentTime(pl ? localToVirtual(pl, currentChunkIndexRef.current, v.currentTime) : v.currentTime);
+        } else {
+          // 'hold' — no footage here: blank + pause, cursor plays on through.
+          setIsOutOfRange(true);
+          if (!v.paused) v.pause();
+        }
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+    return () => {
+      active = false;
+      // Stop the slave when the cursor stops playing (top pause / end of window).
+      if (!video.paused) video.pause();
+    };
+  }, [isLocked, dataIsPlaying, videoUrl, syncOffsetMs, syncRate, loadChunk]);
+
+  // Data-drives-video SCRUB (locked + everything paused): seek the playlist to
+  // the selected sample. Runs only when neither the video nor the data cursor is
+  // playing — i.e. the user is scrubbing or parked. Uses fastSeek where it
+  // exists; the 50ms gate coalesces a fast drag into a sane seek rate.
+  useEffect(() => {
+    if (!isLocked || isPlaying || dataIsPlaying) return;
     const video = videoRef.current;
     if (!video || !videoUrl || samples.length === 0) return;
     const pl = playlistRef.current;
@@ -590,15 +681,15 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
         const { index, localSec } = virtualToLocal(pl, clampedSec);
         if (index !== currentChunkIndexRef.current) {
           loadChunk(index, localSec, false);
-        } else if (Math.abs(video.currentTime - localSec) > 0.5 / fps) {
-          video.currentTime = localSec;
+        } else if (needsResync(video.currentTime, localSec, 0.5 / fps)) {
+          seekVideoElement(video, localSec);
         }
-      } else if (Math.abs(video.currentTime - clampedSec) > 0.5 / fps) {
-        video.currentTime = clampedSec;
+      } else if (needsResync(video.currentTime, clampedSec, 0.5 / fps)) {
+        seekVideoElement(video, clampedSec);
       }
     }
     setVideoCurrentTime(clampedSec);
-  }, [currentIndex, isLocked, isPlaying, syncOffsetMs, syncRate, samples, videoUrl, fps, loadChunk]);
+  }, [currentIndex, isLocked, isPlaying, dataIsPlaying, syncOffsetMs, syncRate, samples, videoUrl, fps, loadChunk]);
 
   const togglePlay = useCallback(() => {
     const video = videoRef.current;

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -5,7 +5,7 @@ import { loadSessionVideo, hasSessionVideo, deleteSessionVideo, getSessionVideoM
 import type { OverlaySettings } from "@/components/video-overlays/types";
 import { DEFAULT_OVERLAY_SETTINGS } from "@/components/video-overlays/types";
 import { findNearestIndex } from "@/components/video-overlays/overlayUtils";
-import { coverageOf, sessionMsToVideoSec, videoSecToSessionMs, fitVideoTimeline, videoSlaveAction, resyncThresholdSec, needsResync, type VideoCoverage } from "@/lib/videoTimeline";
+import { coverageOf, sessionMsToVideoSec, videoSecToSessionMs, fitVideoTimeline, needsResync, type VideoCoverage } from "@/lib/videoTimeline";
 import { buildPlaylist, groupVideoRecordings, virtualToLocal, localToVirtual, type Playlist, type VideoRecording } from "@/lib/videoPlaylist";
 
 interface UseVideoSyncOptions {
@@ -135,16 +135,11 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const videoRef = useRef<HTMLVideoElement>(null);
   const preloadVideoRef = useRef<HTMLVideoElement>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const lastSeekTimeRef = useRef(0);
 
   const onScrubRef = useRef(onScrub);
   onScrubRef.current = onScrub;
   const samplesRef = useRef(samples);
   samplesRef.current = samples;
-  // The cursor index, readable from the rAF slave loop without re-subscribing it
-  // every tick (it advances at playback rate while the loop runs).
-  const currentIndexRef = useRef(currentIndex);
-  currentIndexRef.current = currentIndex;
 
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [preloadUrl, setPreloadUrl] = useState<string | null>(null);
@@ -162,11 +157,6 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const syncAnchorRef = useRef<{ sessionMs: number; videoSec: number } | null>(null);
   const lapAnchorsRef = useRef<Map<number, { sessionMs: number; videoSec: number }>>(new Map());
   const [fps, setFps] = useState(30);
-  // Read by the slave-playback rAF loop without re-subscribing it: fps is
-  // auto-detected ~0.3s into playback, and a dep change there would tear down +
-  // resume the loop (a visible hitch) mid-play.
-  const fpsRef = useRef(30);
-  fpsRef.current = fps;
   const [videoDuration, setVideoDuration] = useState(0);
   const [videoCurrentTime, setVideoCurrentTime] = useState(0);
   const [chunkCount, setChunkCount] = useState(1);
@@ -541,13 +531,16 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     }
   }, [videoUrl]);
 
-  // Video-drives-data (locked + playing via the VIDEO's own controls): map the
-  // active chunk's local time to virtual time, then to telemetry. When the top
-  // play button is the one driving (dataIsPlaying), the data clock owns the
-  // cursor instead — see the slave-playback effect below — so this yields.
+  // Video-drives-data (locked + playing): the VIDEO is the master clock — it
+  // plays natively (smooth decode, never seeked) and the telemetry cursor is
+  // DERIVED from its playhead each frame. Reached both from the video's own play
+  // button and from the top play button (which, when locked + over footage,
+  // routes to video.play() instead of running the rAF data clock — see
+  // Index.tsx). Playing the video natively is the only way to get smooth video;
+  // any approach that seeks the video to chase a separate clock stutters.
   useEffect(() => {
     const video = videoRef.current;
-    if (!video || !videoUrl || !isLocked || !isPlaying || dataIsPlaying) return;
+    if (!video || !videoUrl || !isLocked || !isPlaying) return;
     let active = true;
     const tick = () => {
       const v = videoRef.current;
@@ -590,105 +583,54 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
       requestAnimationFrame(loop);
     }
     return () => { active = false; };
-  }, [videoUrl, isLocked, isPlaying, dataIsPlaying, syncOffsetMs, syncRate]);
+  }, [videoUrl, isLocked, isPlaying, syncOffsetMs, syncRate]);
 
-  // Data-drives-video SLAVE (locked + the top play button is playing): keep the
-  // video playing NATIVELY and only nudge it back into alignment when it drifts
-  // past a couple of frames — never seek per cursor tick. The telemetry cursor
-  // stays the single authority (usePlayback's rAF advances it); the video is a
-  // drift-corrected follower. This is what kills the seek-scrub stutter.
+  // Data-drives-video SCRUB (locked + nothing playing): seek the playlist to the
+  // selected sample so the video follows the cursor while you drag or park.
   //
-  // The loop is rAF (not requestVideoFrameCallback) so it keeps ticking while
-  // the cursor crosses an uncovered gap with the video paused — rVFC would stop
-  // firing there and never notice the cursor re-entering footage.
-  useEffect(() => {
-    if (!isLocked || !dataIsPlaying) return;
-    const video = videoRef.current;
-    if (!video || !videoUrl) return;
-    let active = true;
-    const tick = () => {
-      if (!active) return;
-      const v = videoRef.current;
-      if (!v) { return; }
-      const pl = playlistRef.current;
-      const total = pl ? pl.totalDuration : v.duration;
-      const s = samplesRef.current;
-      const sample = s[currentIndexRef.current];
-      if (sample) {
-        const cov = coverageOf(sample.t, syncOffsetMs, total, syncRate);
-        setCoverage(cov);
-        const action = videoSlaveAction({ isLocked: true, dataIsPlaying: true, hasVideo: true, coverage: cov });
-        if (action === 'play') {
-          setIsOutOfRange(false);
-          const targetVirtual = Math.max(0, sessionMsToVideoSec(sample.t, syncOffsetMs, syncRate));
-          const { index, localSec } = pl ? virtualToLocal(pl, targetVirtual) : { index: 0, localSec: targetVirtual };
-          if (pl && index !== currentChunkIndexRef.current) {
-            // Crossed a chunk boundary (or jumped chunks): swap + resume there.
-            loadChunk(index, localSec, true);
-          } else if (v.paused) {
-            // Entering footage (start of play, or after a gap): align once, then
-            // let it play natively from here.
-            try { v.currentTime = localSec; } catch { /* clamped by browser */ }
-            v.play().catch(() => {});
-          } else if (needsResync(v.currentTime, localSec, resyncThresholdSec(fpsRef.current))) {
-            // Playing: correct drift only past the threshold (a couple frames).
-            seekVideoElement(v, localSec);
-          }
-          if (!v.paused) setVideoCurrentTime(pl ? localToVirtual(pl, currentChunkIndexRef.current, v.currentTime) : v.currentTime);
-        } else {
-          // 'hold' — no footage here: blank + pause, cursor plays on through.
-          setIsOutOfRange(true);
-          if (!v.paused) v.pause();
-        }
-      }
-      requestAnimationFrame(tick);
-    };
-    requestAnimationFrame(tick);
-    return () => {
-      active = false;
-      // Stop the slave when the cursor stops playing (top pause / end of window).
-      if (!video.paused) video.pause();
-    };
-  }, [isLocked, dataIsPlaying, videoUrl, syncOffsetMs, syncRate, loadChunk]);
-
-  // Data-drives-video SCRUB (locked + everything paused): seek the playlist to
-  // the selected sample. Runs only when neither the video nor the data cursor is
-  // playing — i.e. the user is scrubbing or parked. Uses fastSeek where it
-  // exists; the 50ms gate coalesces a fast drag into a sane seek rate.
+  // The seek is COALESCED onto the next animation frame, not gated by a fixed
+  // time-throttle. A throttle (`if (now - last < 50ms) return`) silently DROPS
+  // the trailing seek when you release after a fast drag, so the same cursor
+  // index lands on a different video frame each time (it's parked wherever the
+  // last un-dropped seek left it). rAF coalescing instead guarantees the LAST
+  // cursor position always seeks — deterministic — while still collapsing a
+  // burst of drag updates to one (fast) seek per frame.
   useEffect(() => {
     if (!isLocked || isPlaying || dataIsPlaying) return;
     const video = videoRef.current;
     if (!video || !videoUrl || samples.length === 0) return;
-    const pl = playlistRef.current;
-    const total = pl ? pl.totalDuration : video.duration;
-    const now = performance.now();
-    if (now - lastSeekTimeRef.current < 50) return;
-    lastSeekTimeRef.current = now;
     const sample = samples[currentIndex];
     if (!sample) return;
-    const virtualSec = sessionMsToVideoSec(sample.t, syncOffsetMs, syncRate);
-    const clampedSec = Math.max(0, virtualSec);
-    const cov = coverageOf(sample.t, syncOffsetMs, total, syncRate);
-    setCoverage(cov);
-    if (cov !== 'covered') {
-      // No footage for this session position — blank it, but the cursor/charts
-      // stay free to scrub or play through the gap.
-      setIsOutOfRange(true);
-      if (!video.paused) video.pause();
-    } else {
-      setIsOutOfRange(false);
-      if (pl) {
-        const { index, localSec } = virtualToLocal(pl, clampedSec);
-        if (index !== currentChunkIndexRef.current) {
-          loadChunk(index, localSec, false);
-        } else if (needsResync(video.currentTime, localSec, 0.5 / fps)) {
-          seekVideoElement(video, localSec);
+    const raf = requestAnimationFrame(() => {
+      const pl = playlistRef.current;
+      const total = pl ? pl.totalDuration : video.duration;
+      const virtualSec = sessionMsToVideoSec(sample.t, syncOffsetMs, syncRate);
+      const clampedSec = Math.max(0, virtualSec);
+      const cov = coverageOf(sample.t, syncOffsetMs, total, syncRate);
+      setCoverage(cov);
+      if (cov !== 'covered') {
+        // No footage for this session position — blank it, but the cursor/charts
+        // stay free to scrub or play through the gap.
+        setIsOutOfRange(true);
+        if (!video.paused) video.pause();
+      } else {
+        setIsOutOfRange(false);
+        if (pl) {
+          const { index, localSec } = virtualToLocal(pl, clampedSec);
+          if (index !== currentChunkIndexRef.current) {
+            loadChunk(index, localSec, false);
+          } else if (needsResync(video.currentTime, localSec, 0.5 / fps)) {
+            seekVideoElement(video, localSec);
+          }
+        } else if (needsResync(video.currentTime, clampedSec, 0.5 / fps)) {
+          seekVideoElement(video, clampedSec);
         }
-      } else if (needsResync(video.currentTime, clampedSec, 0.5 / fps)) {
-        seekVideoElement(video, clampedSec);
       }
-    }
-    setVideoCurrentTime(clampedSec);
+      setVideoCurrentTime(clampedSec);
+    });
+    // A newer cursor value cancels this pending seek and schedules its own, so
+    // only the latest position ever lands — that's what makes it deterministic.
+    return () => cancelAnimationFrame(raf);
   }, [currentIndex, isLocked, isPlaying, dataIsPlaying, syncOffsetMs, syncRate, samples, videoUrl, fps, loadChunk]);
 
   const togglePlay = useCallback(() => {

--- a/src/lib/videoTimeline.test.ts
+++ b/src/lib/videoTimeline.test.ts
@@ -6,6 +6,9 @@ import {
   coverageOf,
   lapCoverage,
   fitVideoTimeline,
+  videoSlaveAction,
+  resyncThresholdSec,
+  needsResync,
 } from "./videoTimeline";
 
 // The video sync anchor is absolute session time: one syncOffsetMs maps the
@@ -164,5 +167,60 @@ describe("fitVideoTimeline", () => {
     expect(fitVideoTimeline(primary, [{ sessionMs: 5000, videoSec: 9 }]).syncRate).toBe(1);
     // Wildly inconsistent anchor would imply a >2× rate → clamped back to 1.
     expect(fitVideoTimeline(primary, [{ sessionMs: 6000, videoSec: 100 }]).syncRate).toBe(1);
+  });
+});
+
+// ─── playback coordination policy ────────────────────────────────────────────
+
+describe("videoSlaveAction", () => {
+  const base = { isLocked: true, dataIsPlaying: true, hasVideo: true, coverage: "covered" as const };
+
+  it("plays the video natively when locked, playing, and over footage", () => {
+    expect(videoSlaveAction(base)).toBe("play");
+  });
+
+  it("holds (blanks) the video when the cursor is in an uncovered gap", () => {
+    expect(videoSlaveAction({ ...base, coverage: "before" })).toBe("hold");
+    expect(videoSlaveAction({ ...base, coverage: "after" })).toBe("hold");
+  });
+
+  it("is idle when not coordinating (unlocked, not playing, or no video)", () => {
+    expect(videoSlaveAction({ ...base, isLocked: false })).toBe("idle");
+    expect(videoSlaveAction({ ...base, dataIsPlaying: false })).toBe("idle");
+    expect(videoSlaveAction({ ...base, hasVideo: false })).toBe("idle");
+  });
+
+  it("idle wins even over a covered cursor (no coordination at all)", () => {
+    expect(videoSlaveAction({ isLocked: false, dataIsPlaying: true, hasVideo: true, coverage: "covered" })).toBe("idle");
+  });
+});
+
+describe("resyncThresholdSec", () => {
+  it("is a couple of frames at the given fps", () => {
+    expect(resyncThresholdSec(30)).toBeCloseTo(2 / 30, 9);
+    expect(resyncThresholdSec(60)).toBeCloseTo(2 / 60, 9);
+    expect(resyncThresholdSec(60, 1)).toBeCloseTo(1 / 60, 9);
+  });
+
+  it("falls back to 30fps for a garbage fps", () => {
+    expect(resyncThresholdSec(0)).toBeCloseTo(2 / 30, 9);
+    expect(resyncThresholdSec(Number.NaN)).toBeCloseTo(2 / 30, 9);
+    expect(resyncThresholdSec(-5)).toBeCloseTo(2 / 30, 9);
+  });
+});
+
+describe("needsResync", () => {
+  it("ignores sub-threshold jitter", () => {
+    expect(needsResync(10.0, 10.02, resyncThresholdSec(30))).toBe(false); // 20ms < ~66ms
+  });
+
+  it("triggers once drift exceeds the threshold", () => {
+    expect(needsResync(10.0, 10.2, resyncThresholdSec(30))).toBe(true); // 200ms > ~66ms
+  });
+
+  it("is symmetric (video ahead or behind)", () => {
+    const th = resyncThresholdSec(30);
+    expect(needsResync(10.2, 10.0, th)).toBe(true);
+    expect(needsResync(9.8, 10.0, th)).toBe(true);
   });
 });

--- a/src/lib/videoTimeline.test.ts
+++ b/src/lib/videoTimeline.test.ts
@@ -6,8 +6,6 @@ import {
   coverageOf,
   lapCoverage,
   fitVideoTimeline,
-  videoSlaveAction,
-  resyncThresholdSec,
   needsResync,
 } from "./videoTimeline";
 
@@ -170,57 +168,25 @@ describe("fitVideoTimeline", () => {
   });
 });
 
-// ─── playback coordination policy ────────────────────────────────────────────
-
-describe("videoSlaveAction", () => {
-  const base = { isLocked: true, dataIsPlaying: true, hasVideo: true, coverage: "covered" as const };
-
-  it("plays the video natively when locked, playing, and over footage", () => {
-    expect(videoSlaveAction(base)).toBe("play");
-  });
-
-  it("holds (blanks) the video when the cursor is in an uncovered gap", () => {
-    expect(videoSlaveAction({ ...base, coverage: "before" })).toBe("hold");
-    expect(videoSlaveAction({ ...base, coverage: "after" })).toBe("hold");
-  });
-
-  it("is idle when not coordinating (unlocked, not playing, or no video)", () => {
-    expect(videoSlaveAction({ ...base, isLocked: false })).toBe("idle");
-    expect(videoSlaveAction({ ...base, dataIsPlaying: false })).toBe("idle");
-    expect(videoSlaveAction({ ...base, hasVideo: false })).toBe("idle");
-  });
-
-  it("idle wins even over a covered cursor (no coordination at all)", () => {
-    expect(videoSlaveAction({ isLocked: false, dataIsPlaying: true, hasVideo: true, coverage: "covered" })).toBe("idle");
-  });
-});
-
-describe("resyncThresholdSec", () => {
-  it("is a couple of frames at the given fps", () => {
-    expect(resyncThresholdSec(30)).toBeCloseTo(2 / 30, 9);
-    expect(resyncThresholdSec(60)).toBeCloseTo(2 / 60, 9);
-    expect(resyncThresholdSec(60, 1)).toBeCloseTo(1 / 60, 9);
-  });
-
-  it("falls back to 30fps for a garbage fps", () => {
-    expect(resyncThresholdSec(0)).toBeCloseTo(2 / 30, 9);
-    expect(resyncThresholdSec(Number.NaN)).toBeCloseTo(2 / 30, 9);
-    expect(resyncThresholdSec(-5)).toBeCloseTo(2 / 30, 9);
-  });
-});
+// ─── needsResync ─────────────────────────────────────────────────────────────
 
 describe("needsResync", () => {
   it("ignores sub-threshold jitter", () => {
-    expect(needsResync(10.0, 10.02, resyncThresholdSec(30))).toBe(false); // 20ms < ~66ms
+    expect(needsResync(10.0, 10.005, 0.5 / 30)).toBe(false); // 5ms < ~16.7ms
   });
 
   it("triggers once drift exceeds the threshold", () => {
-    expect(needsResync(10.0, 10.2, resyncThresholdSec(30))).toBe(true); // 200ms > ~66ms
+    expect(needsResync(10.0, 10.2, 0.5 / 30)).toBe(true); // 200ms > ~16.7ms
   });
 
-  it("is symmetric (video ahead or behind)", () => {
-    const th = resyncThresholdSec(30);
+  it("is symmetric (video ahead or behind the target)", () => {
+    const th = 0.5 / 30;
     expect(needsResync(10.2, 10.0, th)).toBe(true);
     expect(needsResync(9.8, 10.0, th)).toBe(true);
+  });
+
+  it("treats exactly-at-threshold as no seek (strict greater-than)", () => {
+    expect(needsResync(10.0, 10.1, 0.1)).toBe(false);
+    expect(needsResync(10.0, 10.1000001, 0.1)).toBe(true);
   });
 });

--- a/src/lib/videoTimeline.ts
+++ b/src/lib/videoTimeline.ts
@@ -120,3 +120,48 @@ export function fitVideoTimeline(
   return { syncOffsetMs, syncRate: rate };
 }
 
+// ─── playback coordination policy ────────────────────────────────────────────
+//
+// When the telemetry cursor is being PLAYED (the top play button) and a video is
+// locked, the video must NOT be seek-scrubbed once per cursor tick — assigning
+// `video.currentTime` ~20×/s forces a keyframe seek every time and stutters
+// badly. Instead the data clock stays the single cursor authority and the video
+// is a *slave* that plays natively (smooth decode), nudged back into alignment
+// only when it drifts past a threshold. These pure helpers encode that policy so
+// the hook is a thin executor and the decision is unit-testable.
+
+/**
+ * What a locked video should do while the telemetry cursor is playing.
+ * - `play` — the cursor is over footage: the video plays natively as a slave.
+ * - `hold` — the cursor is in a gap with no footage: pause + blank the video,
+ *   but the cursor/charts keep playing through the gap.
+ * - `idle` — no coordination (unlocked, no video, or the cursor isn't playing);
+ *   the video is driven by its own controls / the paused-scrub path instead.
+ */
+export type VideoSlaveAction = 'play' | 'hold' | 'idle';
+
+export function videoSlaveAction(args: {
+  isLocked: boolean;
+  dataIsPlaying: boolean;
+  hasVideo: boolean;
+  coverage: VideoCoverage;
+}): VideoSlaveAction {
+  if (!args.isLocked || !args.dataIsPlaying || !args.hasVideo) return 'idle';
+  return args.coverage === 'covered' ? 'play' : 'hold';
+}
+
+/**
+ * Drift tolerance (seconds) before a playing slave video is hard-seeked back
+ * into alignment. A couple of frames keeps A/V tight without seeking on the
+ * sub-frame jitter that native playback always has; `fps` falls back sanely.
+ */
+export function resyncThresholdSec(fps: number, frames = 2): number {
+  const safeFps = Number.isFinite(fps) && fps > 0 ? fps : 30;
+  return frames / safeFps;
+}
+
+/** True when a playing slave video has drifted far enough to warrant a seek. */
+export function needsResync(actualVideoSec: number, targetVideoSec: number, thresholdSec: number): boolean {
+  return Math.abs(actualVideoSec - targetVideoSec) > thresholdSec;
+}
+

--- a/src/lib/videoTimeline.ts
+++ b/src/lib/videoTimeline.ts
@@ -120,47 +120,11 @@ export function fitVideoTimeline(
   return { syncOffsetMs, syncRate: rate };
 }
 
-// ─── playback coordination policy ────────────────────────────────────────────
-//
-// When the telemetry cursor is being PLAYED (the top play button) and a video is
-// locked, the video must NOT be seek-scrubbed once per cursor tick — assigning
-// `video.currentTime` ~20×/s forces a keyframe seek every time and stutters
-// badly. Instead the data clock stays the single cursor authority and the video
-// is a *slave* that plays natively (smooth decode), nudged back into alignment
-// only when it drifts past a threshold. These pure helpers encode that policy so
-// the hook is a thin executor and the decision is unit-testable.
-
 /**
- * What a locked video should do while the telemetry cursor is playing.
- * - `play` — the cursor is over footage: the video plays natively as a slave.
- * - `hold` — the cursor is in a gap with no footage: pause + blank the video,
- *   but the cursor/charts keep playing through the gap.
- * - `idle` — no coordination (unlocked, no video, or the cursor isn't playing);
- *   the video is driven by its own controls / the paused-scrub path instead.
+ * True when the video playhead has drifted far enough from a target time to be
+ * worth a seek. Used to suppress redundant scrub seeks when the video is already
+ * within sub-frame distance of the cursor's position.
  */
-export type VideoSlaveAction = 'play' | 'hold' | 'idle';
-
-export function videoSlaveAction(args: {
-  isLocked: boolean;
-  dataIsPlaying: boolean;
-  hasVideo: boolean;
-  coverage: VideoCoverage;
-}): VideoSlaveAction {
-  if (!args.isLocked || !args.dataIsPlaying || !args.hasVideo) return 'idle';
-  return args.coverage === 'covered' ? 'play' : 'hold';
-}
-
-/**
- * Drift tolerance (seconds) before a playing slave video is hard-seeked back
- * into alignment. A couple of frames keeps A/V tight without seeking on the
- * sub-frame jitter that native playback always has; `fps` falls back sanely.
- */
-export function resyncThresholdSec(fps: number, frames = 2): number {
-  const safeFps = Number.isFinite(fps) && fps > 0 ? fps : 30;
-  return frames / safeFps;
-}
-
-/** True when a playing slave video has drifted far enough to warrant a seek. */
 export function needsResync(actualVideoSec: number, targetVideoSec: number, thresholdSec: number): boolean {
   return Math.abs(actualVideoSec - targetVideoSec) > thresholdSec;
 }

--- a/src/locales/de/session.json
+++ b/src/locales/de/session.json
@@ -14,6 +14,8 @@
     "home": "Startseite",
     "play": "Abspielen",
     "pause": "Pause",
+    "prevFrame": "Vorheriges Bild",
+    "nextFrame": "Nächstes Bild",
     "allLaps": "Alle Runden",
     "lap": "Runde {{number}}",
     "garage": "Garage",

--- a/src/locales/en/session.json
+++ b/src/locales/en/session.json
@@ -13,6 +13,8 @@
     "home": "Home",
     "play": "Play",
     "pause": "Pause",
+    "prevFrame": "Previous frame",
+    "nextFrame": "Next frame",
     "allLaps": "All Laps",
     "lap": "Lap {{number}}",
     "garage": "Garage",

--- a/src/locales/es/session.json
+++ b/src/locales/es/session.json
@@ -14,6 +14,8 @@
     "home": "Inicio",
     "play": "Reproducir",
     "pause": "Pausar",
+    "prevFrame": "Fotograma anterior",
+    "nextFrame": "Fotograma siguiente",
     "allLaps": "Todas las vueltas",
     "lap": "Vuelta {{number}}",
     "garage": "Garaje",

--- a/src/locales/fr/session.json
+++ b/src/locales/fr/session.json
@@ -14,6 +14,8 @@
     "home": "Accueil",
     "play": "Lecture",
     "pause": "Pause",
+    "prevFrame": "Image précédente",
+    "nextFrame": "Image suivante",
     "allLaps": "Tous les tours",
     "lap": "Tour {{number}}",
     "garage": "Garage",

--- a/src/locales/it/session.json
+++ b/src/locales/it/session.json
@@ -14,6 +14,8 @@
     "home": "Home",
     "play": "Riproduci",
     "pause": "Pausa",
+    "prevFrame": "Fotogramma precedente",
+    "nextFrame": "Fotogramma successivo",
     "allLaps": "Tutti i giri",
     "lap": "Giro {{number}}",
     "garage": "Garage",

--- a/src/locales/ja/session.json
+++ b/src/locales/ja/session.json
@@ -14,6 +14,8 @@
     "home": "ホーム",
     "play": "再生",
     "pause": "一時停止",
+    "prevFrame": "前のフレーム",
+    "nextFrame": "次のフレーム",
     "allLaps": "すべてのラップ",
     "lap": "ラップ {{number}}",
     "garage": "ガレージ",

--- a/src/locales/pt-BR/session.json
+++ b/src/locales/pt-BR/session.json
@@ -14,6 +14,8 @@
     "home": "Início",
     "play": "Reproduzir",
     "pause": "Pausar",
+    "prevFrame": "Quadro anterior",
+    "nextFrame": "Próximo quadro",
     "allLaps": "Todas as voltas",
     "lap": "Volta {{number}}",
     "garage": "Garagem",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -211,6 +211,9 @@ export default function Index() {
     currentIndex,
     onScrub: handleScrub,
     sessionFileName: currentFileName,
+    // When the top play button drives the cursor, the video plays natively as a
+    // drift-corrected slave instead of being seek-scrubbed per tick (stutter).
+    dataIsPlaying: isPlaying,
   });
   const currentSample = visibleSamples[currentIndex] ?? null;
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
-import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, Eye, EyeOff, AlertCircle, Wrench, NotebookPen, SlidersHorizontal, Columns2 } from "lucide-react";
+import { Gauge, Map, ListOrdered, BarChart3, FolderOpen, Play, Pause, StepBack, StepForward, Eye, EyeOff, AlertCircle, Wrench, NotebookPen, SlidersHorizontal, Columns2 } from "lucide-react";
 import { BrandLogo } from "@/components/BrandLogo";
 import { LandingPage } from "@/components/LandingPage";
 import { TrackEditor } from "@/components/TrackEditor"; // still used in compact header
@@ -237,6 +237,17 @@ export default function Index() {
       togglePlayback();
     }
   }, [isPlaying, videoSync.state, videoSync.actions, togglePlayback]);
+
+  // Frame-by-frame stepping: nudge the data cursor one sample, pausing any
+  // playback first. A synced video follows through the same scrub path (the
+  // transposer), so drivers/coaches can step a lap one frame at a time. Disabled
+  // with no data or at the respective end of the window.
+  const lastIndex = Math.max(0, visibleRange[1] - visibleRange[0]);
+  const stepDataFrame = useCallback((dir: 1 | -1) => {
+    if (isPlaying) togglePlayback();
+    if (videoSync.state.isPlaying) videoSync.actions.togglePlay();
+    setCurrentIndex((i) => Math.max(0, Math.min(lastIndex, i + dir)));
+  }, [isPlaying, togglePlayback, videoSync.state.isPlaying, videoSync.actions, setCurrentIndex, lastIndex]);
 
   // Data loading orchestration — owns the track-prompt UI state and the
   // sample-loader. Returns the three callbacks Index.tsx wires up to imports.
@@ -695,12 +706,32 @@ export default function Index() {
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
+                <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => stepDataFrame(-1)} disabled={visibleSamples.length === 0 || currentIndex <= 0} aria-label={t("header.prevFrame")}>
+                  <StepBack className="w-4 h-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{t("header.prevFrame")}</p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
                 <Button variant="outline" size="icon" className="h-8 w-8" onClick={handlePlaybackToggle}>
                   {anyPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
                 <p>{anyPlaying ? t("header.pause") : t("header.play")} ({averageFrameRate ? `${averageFrameRate.toFixed(0)} Hz` : "–"})</p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => stepDataFrame(1)} disabled={visibleSamples.length === 0 || currentIndex >= lastIndex} aria-label={t("header.nextFrame")}>
+                  <StepForward className="w-4 h-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{t("header.nextFrame")}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -217,6 +217,27 @@ export default function Index() {
   });
   const currentSample = visibleSamples[currentIndex] ?? null;
 
+  // The top play button. When a video is locked AND the cursor sits over footage,
+  // drive the VIDEO natively (it plays smoothly and video-drives-data derives the
+  // cursor from it) instead of running the rAF data clock — a separate clock that
+  // seeks the video to keep up is what stutters. Otherwise (no video / unlocked /
+  // cursor in an uncovered gap) the data clock drives the cursor and the video
+  // stays put. The icon reflects whichever clock is running.
+  const anyPlaying = isPlaying || videoSync.state.isPlaying;
+  const handlePlaybackToggle = useCallback(() => {
+    const { isLocked, videoUrl, coverage, isPlaying: videoPlaying } = videoSync.state;
+    if (isPlaying || videoPlaying) {
+      if (videoPlaying) videoSync.actions.togglePlay();
+      if (isPlaying) togglePlayback();
+      return;
+    }
+    if (isLocked && videoUrl && coverage === "covered") {
+      videoSync.actions.togglePlay();
+    } else {
+      togglePlayback();
+    }
+  }, [isPlaying, videoSync.state, videoSync.actions, togglePlayback]);
+
   // Data loading orchestration — owns the track-prompt UI state and the
   // sample-loader. Returns the three callbacks Index.tsx wires up to imports.
   const dataLoader = useDataLoader({ sessionData, lapMgmt, sessionMeta });
@@ -674,12 +695,12 @@ export default function Index() {
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="outline" size="icon" className="h-8 w-8" onClick={togglePlayback}>
-                  {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+                <Button variant="outline" size="icon" className="h-8 w-8" onClick={handlePlaybackToggle}>
+                  {anyPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>{isPlaying ? t("header.pause") : t("header.play")} ({averageFrameRate ? `${averageFrameRate.toFixed(0)} Hz` : "–"})</p>
+                <p>{anyPlaying ? t("header.pause") : t("header.play")} ({averageFrameRate ? `${averageFrameRate.toFixed(0)} Hz` : "–"})</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>


### PR DESCRIPTION
## Problem

A synced video plays smoothly via the **video's own** play button, but the picture **judders** when you press the **top "play data"** button, and **scrubbing** lands the video on a slightly different frame each time you return to the same cursor position.

### Root cause

The app has two clocks: `usePlayback` (the top button's rAF cursor) and the `<video>` element. The smooth case (video's own play button) makes the **video the master** — it plays natively (never seeked) and the cursor is derived from its playhead. The top button instead ran the rAF cursor clock and **seeked the locked video to chase it**. Seeking forces the decoder back to a keyframe, so the video judders. The scrub path additionally used a **50 ms seek-throttle that silently dropped the trailing seek**, parking the video on a stale frame (→ "different frame every time").

## Fix

1. **Playback — video as master.** The top play button now drives the **video itself** when it's locked and over footage (the exact same native-playback path as the video's own play button); the cursor is derived from the video's playhead. No second clock seeks the video. When there's no video / it's unlocked / the cursor is in an uncovered gap, the rAF data clock drives the cursor as before. The play/pause icon reflects whichever clock is running.

2. **Scrub determinism.** The fixed seek-throttle is replaced with **rAF coalescing**: a burst of drag updates collapses to one fast seek per frame, and the **last cursor position always lands** — same cursor index → same video frame, every time. Uses `fastSeek` where supported.

> Supersedes the first attempt in this PR (a "data-master + drift-corrected slave" approach), which still seeked the video to chase a separate clock and therefore still stuttered. That effect and its `videoSlaveAction`/`resyncThresholdSec` helpers were removed; the pure `needsResync` guard is kept.

## Changes

- **`src/hooks/useVideoSync.ts`** — video-drives-data is the single playback path (video master); the data-driven seek path is **scrub-only** and rAF-coalesced (no time-throttle); `fastSeek` via a shared `seekVideoElement` helper.
- **`src/pages/Index.tsx`** — the top play button routes to native video playback when locked + over footage, else the data clock; icon reflects combined state.
- **`src/lib/videoTimeline.ts`** — adds the pure `needsResync` helper (the abandoned slave-policy helpers were removed).
- **`src/lib/videoTimeline.test.ts`** — `needsResync` coverage.
- **`CHANGELOG.md`** — two user-facing entries under `[2.9.2] - unreleased`.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run test:run` (1990 passed), `bun run build` — all green.
- Manual (recommended): with a **locked** synced video over footage, press the top play button (should play **smoothly**, cursor tracks); scrub and return to the same spot repeatedly (video lands on the **same frame**); test a multi-chunk GoPro and a partial video (footage that starts after / ends before the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)