### PR TITLE
Release prep v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [2.9.2] - unreleased
+## [2.9.2] - 2026-06-25
 
 ### Added
 - **Frame-by-frame stepping in the header.** Two new buttons flank the play button
@@ -129,7 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   track sync and firmware update stay on the Web Bluetooth path for now. Web
   downloads are unchanged.
 
-## [2.9.1] - unreleased
+## [2.9.1] - 2026-06-22
 
 ### Changed
 - **Landing hero wording.** Dropped "Online" from the main heading (it's an

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",


### PR DESCRIPTION
Release-prep for **v2.9.2**.

### What this does
- **Version bump** — `package.json` `2.9.1` → `2.9.2` (matches the topmost CHANGELOG heading; the footer/build stamp is baked from here).
- **Dated the changelog** — `## [2.9.2]` → `2026-06-25`. Also dated the stale `## [2.9.1]` heading to its tag date **2026-06-22** (tag `v2.9.1`), resolving the two stacked `- unreleased` headings flagged as REL-02 in the [release review](https://github.com/TheAngryRaven/DovesDataViewer/pull/287#issuecomment-4795930852).
- **Coach plugin** — already on the production npm package `@perchwerks/eye-in-the-sky@0.5.0` in both `package.json` and `vite.config.ts` (matching `main`). **No flip needed; `bun.lock` unchanged.**

### Green before merge
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run test:run` ✅ (142 files / 1990 tests)
- `bun run build` ✅ (production coach package resolves & bundles)

Diff is just `package.json` + `CHANGELOG.md` (3 lines). No tag was created — the maintainer tags `v2.9.2` on `main` manually after the BETA → main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ngbxg8AZFuaHrWn39mKnrg)_