### PR TITLE
plan 0006: public driver profiles with avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.10.0] - unreleased
 
 ### Added
+- **Public driver profiles (plan 0006).** A new public `/driver/{name}` page (shareable,
+  viewable signed-out) shows a driver's **profile picture**, display name, their **opt-in
+  vehicles** (name/type/engine only — never weights or setups), and their uploaded
+  **leaderboard snapshots** grouped by course and weight. URLs are case-insensitive.
+- **Profile pictures.** Tap your profile picture on the Profile tab to upload one; it's
+  cropped to a centred square and downscaled to ≤256px on-device, then stored in the
+  cloud. Avatar thumbnails now appear next to names on the Leaderboards.
+- **Copy profile link.** A button under Sign out on the Profile tab copies your public
+  driver-profile link.
+- **Show a vehicle on your profile.** Each vehicle in the garage now has a *Show on
+  profile* toggle that publishes a public-safe projection (no weight, no setup).
+- A **← Back to home** button on the Leaderboards and driver-profile pages.
+
+### Changed
+- **Display names are now unique case-insensitively** so a name can't be impersonated by
+  changing case (existing case-duplicates are auto-suffixed by the migration).
+
 - **Leaderboards (plan 0005).** A new public **Leaderboards** page (linked from the
   landing page) where anyone — signed in or not — can browse fastest community laps
   by **track → course → engine class**, with an optional **Group by weight** toggle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ telemetry viewer.
 src/
 ├── pages/
 │   ├── Index.tsx          # ★ Main SPA — file import, tab views, all state orchestration. Also hosts the read-only Leaderboards viewer (plan 0005): consumes a leaderboardHandoff bundle on mount, injects its prebuilt laps/selection, flips a `readOnly` flag that alert-colours the header + hides Coach/Tools/Setups + video/weather/snapshots and labels laps by submitter.
-│   ├── Leaderboards.tsx   # ★ Public /leaderboards page (cloud-gated): Track→Course→engine/weight accordion (Group-by-weight + Show-top), opens a group into Index's read-only viewer via leaderboardHandoff
+│   ├── Leaderboards.tsx   # ★ Public /leaderboards page (cloud-gated): Track→Course→engine/weight accordion (Group-by-weight + Show-top), opens a group into Index's read-only viewer via leaderboardHandoff; shows uploader avatar thumbnails
+│   ├── DriverProfile.tsx  # ★ Public /driver/:username page (plan 0006, anon, case-insensitive via .ilike): avatar + name + opt-in vehicles (no weights/setups) + the driver's approved leaderboard snapshots grouped by course/weight
 │   ├── Admin.tsx          # Admin panel (behind VITE_ENABLE_ADMIN)
 │   └── …                  # Login / Register / Privacy / Terms / NotFound
 ├── components/
@@ -118,6 +119,8 @@ src/
 │   ├── lapOverlays.ts / lapAlignment.ts  # ★ Multi-lap overlay logic + Kabsch drift-align (→ docs/subsystems.md)
 │   ├── lapSnapshot*.ts    # ★ Snapshot types/buffer + IndexedDB CRUD (→ docs/subsystems.md)
 │   ├── leaderboard*.ts    # ★ Leaderboards (plan 0005): leaderboardTypes (shared), leaderboardBrowse (Track→Course→engine/weight tree), leaderboardSession (transpose entries → one read-only synthetic session, fastest=lap 1), leaderboardHandoff (one-shot page→Index handoff). Submission + Supabase access live in plugins/cloud-sync (leaderboardSubmission/leaderboardClient). → docs/backend.md
+│   ├── imageCrop.ts       # ★ Pure on-device avatar crop (1:1 centre + downscale ≤256, webp/jpeg) — no Supabase (plan 0006)
+│   ├── driverProfileGroups.ts # ★ Pure: one driver's leaderboard entries → Course→weight buckets (plan 0006, DriverProfile)
 │   ├── setupRevision*.ts  # ★ Content-addressed setup history + IndexedDB CRUD (→ docs/subsystems.md)
 │   ├── setupHistory.ts    # ★ Pure setup-history view-model (diff + fastest-lap aggregation) → drawer/SetupHistoryPanel (→ docs/subsystems.md)
 │   ├── vehicleHistory.ts  # ★ Pure vehicle-history view-model (per-vehicle setup revisions, fastest-lap first, course filter) → drawer/VehicleHistoryPanel; reuses setupHistory primitives; shared card chrome in drawer/HistoryCard.tsx

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -59,8 +59,11 @@ Backend (migrations `..._cloud_sync.sql`, `..._storage_quotas.sql`,
 | `enforce_sync_quota` | trigger | BEFORE INSERT/UPDATE on `sync_records`: rejects a write that pushes the caller's **pooled total** (this table + all `lap_snapshots`, minus the upserted row) over `tier_total_limit()` (`quota_exceeded`). |
 | `enforce_snapshot_quota` | trigger | BEFORE INSERT/UPDATE on `lap_snapshots`: same pooled check keyed off the snapshot's serialized size (`quota_exceeded`). |
 | `sync_storage_usage()` | RPC | Single row `(documents_bytes, logs_bytes, snapshots_bytes, total_limit_bytes)` for the caller — the limit reflects the caller's tier. |
-| `profiles` | table | `(user_id PK→auth.users, display_name unique, …)`. RLS: authenticated read-all, update/insert own. Display name is unique but **not** a key — user-editable. |
-| `handle_new_user` | trigger | On `auth.users` insert: creates a profile, using the sign-up `display_name` or a generated silly name (`SpeedyRac3r-546`). `unique_display_name()` auto-suffixes a taken name at creation; user edits get an explicit "taken" error instead. |
+| `profiles` | table | `(user_id PK→auth.users, display_name, avatar_path, avatar_updated_at, …)`. RLS: authenticated read-all, update/insert own. Display name is **unique case-insensitively** (`unique index on lower(display_name)`, plan 0006) but **not** a key — user-editable. |
+| `public_profiles` | view | Plan 0006. Anon-readable, column-limited (`user_id, display_name, avatar_path, avatar_updated_at`) — backs the public `/driver/:username` page + Leaderboards avatar thumbnails without exposing the base table to anon. |
+| `public_vehicles` | table | Plan 0006. Opt-in public projection of a user's vehicles `(user_id, vehicle_id PK, name, type_name, engine, number)` — **never weight/setup**. RLS: anon read, owner write. Synced off the garage-change path (`publicVehicleSync`); cascades on account delete. |
+| `user-avatars` | Storage bucket | Plan 0006. **Public**. Avatar at `{user_id}/avatar.{webp\|jpg}` (cropped ≤256px client-side). Public read; owner-folder write. Not FK-cascaded — the deletion worker empties the folder. |
+| `handle_new_user` | trigger | On `auth.users` insert: creates a profile, using the sign-up `display_name` or a generated silly name (`SpeedyRac3r-546`). `unique_display_name()` auto-suffixes a taken name at creation (case-insensitively); user edits get an explicit "taken" error instead. |
 
 Synced stores (`syncStores.ts` — pure, unit-tested): `metadata`, `karts`,
 `setups`, `notes`, `graph-prefs`, `vehicle-types`, `setup-templates`, `engines`,
@@ -300,9 +303,10 @@ JWT manually):
 - `request-account-deletion` — auth user → inserts an `account_deletions` row
   `scheduled_for = now()+7d` (idempotent; never shortens an in-flight request).
 - `process-account-deletions` — **cron-only** (`x-cron-secret` must equal
-  `DELETION_CRON_SECRET`). For each due user: removes their `user-files` Storage
-  objects, then `auth.admin.deleteUser` (cascades profiles/sync_records/
-  subscription/roles/account_deletions via FKs).
+  `DELETION_CRON_SECRET`). For each due user: `auth.admin.deleteUser` (cascades
+  profiles/sync_records/public_vehicles/subscription/roles/account_deletions via
+  FKs), then removes their `user-files` **and** `user-avatars` Storage objects
+  (buckets aren't FK-cascaded).
 
 Scheduling: the migration always schedules the IP purge (pure SQL). The deletion
 worker is auto-wired via `pg_cron` + `pg_net` **only if** a Vault secret

--- a/docs/plans/0006-user-profiles.md
+++ b/docs/plans/0006-user-profiles.md
@@ -1,0 +1,81 @@
+# Plan 0006 — User Profiles
+
+Status: implemented on branch `claude/user-profiles-images-fheq7s`.
+
+## Why
+
+Leaderboards (plan 0005) gave the app its first public, anonymous-readable cloud
+surface, but user identity was just a `display_name` on a `profiles` table that
+was authenticated-read only, case-sensitively unique, and had no avatar. This plan
+rounds out the web app with **public driver profiles**: a face (avatar), a name you
+can't impersonate by changing case, a sharable page showing a driver's vehicles and
+uploaded leaderboard snapshots, and avatar thumbnails on the Leaderboards.
+
+## What shipped
+
+1. **Avatars.** Tap the profile picture on the Profile tab → on-device 1:1 centre-crop +
+   downscale to ≤256px (`src/lib/imageCrop.ts`, pure + tested) → upload to a new **public**
+   `user-avatars` bucket. The fixed object path + an `avatar_updated_at` `?v=` cache-buster
+   make replacements repaint.
+2. **Case-insensitive unique display names.** A destructive pre-flight de-dups any
+   case-collisions (acceptable at ~5 users), then a `unique index on lower(display_name)`
+   replaces the case-sensitive constraint. The `random_display_name`/`unique_display_name`
+   SQL functions now compare case-insensitively. `/driver/:username` resolves via `.ilike`.
+3. **Public `/driver/:username` page** (`src/pages/DriverProfile.tsx`, lazy, anon): avatar +
+   name, the driver's **opt-in vehicles** (name/type/engine/number — never weight/setup), and
+   approved leaderboard entries grouped by **course → weight** (`src/lib/driverProfileGroups.ts`,
+   pure + tested). Unknown name → a "not found" state that keeps the header + back button.
+4. **Opt-in vehicle publishing.** `Vehicle.publicProfile` flag (a *Show on profile* toggle in
+   `VehiclesTab`) drives a public-safe projection into a new `public_vehicles` table, synced off
+   the existing garage-change path (`autoSync.pushOne` → `publicVehicleSync.ts`). Unflag/delete
+   removes the public row. Best-effort (self-heals on the next edit); the private `sync_records`
+   backup is unchanged.
+5. **Copy profile link** button under Sign out; **avatar thumbnails** left of names on
+   Leaderboards rows; **← Back to home** on both off-session pages (`BackToHome.tsx`).
+
+## Backend (two migrations)
+
+- `20260627120000_profiles_ci_avatars.sql` — de-dup, `lower(display_name)` unique index,
+  `avatar_path` + `avatar_updated_at` columns, CI name-resolution functions, and a
+  column-limited anon-readable `public_profiles` **view** (RLS can't restrict columns, so a
+  view is the right tool — exposes only `user_id, display_name, avatar_*`).
+- `20260627120100_public_vehicles_and_avatar_bucket.sql` — `public_vehicles` table (anon read,
+  owner write; FK-cascades on account delete), the public `user-avatars` bucket + owner-folder
+  write policies.
+- `process-account-deletions` now also empties the `user-avatars/{uid}/` folder (Storage objects
+  aren't FK-cascaded).
+
+## Key constraint honoured
+
+`vendor-supabase` stays off the eager Index/Landing graph: all new Supabase access lives in
+lazy `src/plugins/cloud-sync/*` (`publicProfile.ts`, `publicVehicleSync.ts`, avatar helpers in
+`profile.ts`) or the lazy `DriverProfile` page, reached only via dynamic import. Build confirms
+`DriverProfile`/`publicProfile` are their own chunks. `imageCrop.ts` is Supabase-free.
+
+## Files
+
+- Migrations: `supabase/migrations/20260627120000_*.sql`, `..._120100_*.sql`;
+  `supabase/functions/process-account-deletions/index.ts`.
+- New: `src/lib/imageCrop.ts`, `src/lib/driverProfileGroups.ts`, `src/pages/DriverProfile.tsx`,
+  `src/components/BackToHome.tsx`, `src/components/ProfileAvatar.tsx`,
+  `src/plugins/cloud-sync/publicProfile.ts`, `src/plugins/cloud-sync/publicVehicleSync.ts`,
+  `src/locales/*/driver.json` (+ tests for the pure utils).
+- Edited: `cloudClient.ts`, `profile.ts`, `leaderboardClient.ts`, `leaderboardBrowse.ts`
+  (`GroupEntry.userId`), `autoSync.ts`, `vehicleStorage.ts`, `VehiclesTab.tsx`, `StoragePanel.tsx`,
+  `Leaderboards.tsx`, `App.tsx`, i18n config/typing + `common`/`plugins`/`drawer` locales.
+
+## Verification
+
+`bun run lint`, `bun run typecheck`, `bun run test:run` (2051 pass), `bun run build` all green.
+Manual end-to-end (staging Supabase needed): apply both migrations; upload/replace an avatar;
+toggle a vehicle public on/off and confirm the `public_vehicles` row appears/disappears with no
+weight column; open `/driver/<Name>` signed-out incognito (and a different-case URL); copy the
+profile link; confirm the Leaderboards thumbnail and back-to-home button.
+
+## Follow-ups
+
+- Other languages were stop-gap seeded with the English strings (no API key in this
+  environment); run `bun run i18n:seed` to machine-translate the new `driver` namespace + the
+  added `common`/`plugins`/`drawer` keys (they carry no `_sourceHashes`, so they'll be picked up).
+- Confirm the `public_profiles` view's definer-vs-`security_invoker` semantics on the target
+  Postgres before relying on anon reads.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const Login = lazy(() => import("./pages/Login"));
 const Admin = lazy(() => import("./pages/Admin"));
 const Register = lazy(() => import("./pages/Register"));
 const Leaderboards = lazy(() => import("./pages/Leaderboards"));
+const DriverProfile = lazy(() => import("./pages/DriverProfile"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const Terms = lazy(() => import("./pages/Terms"));
 // Public, no-login account-deletion request page. Mounted un-gated (below) so the
@@ -81,6 +82,7 @@ const App = () => {
               {enableAdmin && <Route path="/admin" element={<Admin />} />}
               {enableCloud && <Route path="/register" element={<Register />} />}
               {enableCloud && <Route path="/leaderboards" element={<Leaderboards />} />}
+              {enableCloud && <Route path="/driver/:username" element={<DriverProfile />} />}
               {enableCloud && <Route path="/forgot-password" element={<ForgotPassword />} />}
               {enableCloud && <Route path="/reset-password" element={<ResetPassword />} />}
               {enableCloud && <Route path="/auth/callback" element={<AuthCallback />} />}

--- a/src/components/BackToHome.tsx
+++ b/src/components/BackToHome.tsx
@@ -1,0 +1,21 @@
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+
+/** Shared "← back to home" link for the off-session pages (Leaderboards, driver profiles). */
+export function BackToHome({ className }: { className?: string }) {
+  const navigate = useNavigate();
+  const { t } = useTranslation("common");
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`gap-1.5 px-2 text-muted-foreground ${className ?? ""}`}
+      onClick={() => navigate("/")}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      {t("actions.backToHome")}
+    </Button>
+  );
+}

--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -1,0 +1,34 @@
+import { User as UserIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ProfileAvatarProps {
+  /** Public avatar URL (with cache-buster), or null for the placeholder. */
+  url: string | null | undefined;
+  alt?: string;
+  /** Tailwind size classes for the circle (e.g. "h-12 w-12"). */
+  sizeClassName?: string;
+  className?: string;
+}
+
+/**
+ * Round avatar with a UserIcon fallback. Presentational only — shared by the
+ * profile panel, the driver page, and the leaderboard rows so they stay visually
+ * identical. The icon scales to roughly half the circle.
+ */
+export function ProfileAvatar({ url, alt = "", sizeClassName = "h-12 w-12", className }: ProfileAvatarProps) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-muted-foreground",
+        sizeClassName,
+        className,
+      )}
+    >
+      {url ? (
+        <img src={url} alt={alt} className="h-full w-full object-cover" loading="lazy" />
+      ) : (
+        <UserIcon className="h-1/2 w-1/2" />
+      )}
+    </div>
+  );
+}

--- a/src/components/drawer/VehiclesTab.tsx
+++ b/src/components/drawer/VehiclesTab.tsx
@@ -31,6 +31,7 @@ const emptyForm = (defaultTypeId: string): Omit<Vehicle, "id"> => ({
   number: 0,
   weight: 0,
   weightUnit: "lb",
+  publicProfile: false,
 });
 
 export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove, onOpenFile, onCreateVehicleType }: VehiclesTabProps) {
@@ -73,6 +74,7 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove,
       number: vehicle.number,
       weight: vehicle.weight,
       weightUnit: vehicle.weightUnit,
+      publicProfile: vehicle.publicProfile ?? false,
     });
   };
 
@@ -208,6 +210,17 @@ export function VehiclesTab({ vehicles, vehicleTypes, onAdd, onUpdate, onRemove,
               </div>
             </div>
           </div>
+        </div>
+        <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 px-3 py-2">
+          <div className="min-w-0">
+            <Label className="text-xs">{t("vehicles.showOnProfile")}</Label>
+            <p className="text-[11px] text-muted-foreground">{t("vehicles.showOnProfileHint")}</p>
+          </div>
+          <Switch
+            checked={!!form.publicProfile}
+            onCheckedChange={checked => setForm(f => ({ ...f, publicProfile: checked }))}
+            className="shrink-0"
+          />
         </div>
         {form.name.trim() && !form.engine.trim() && (
           <p className="text-xs text-destructive">{t("vehicles.engineRequired")}</p>

--- a/src/lib/driverProfileGroups.test.ts
+++ b/src/lib/driverProfileGroups.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { groupEntriesByCourseWeight } from "./driverProfileGroups";
+import type { EngineClass, LeaderboardEntry } from "./leaderboardTypes";
+
+function entry(over: Partial<LeaderboardEntry>): LeaderboardEntry {
+  return {
+    id: "e",
+    userId: "u",
+    displayName: "Racer",
+    trackName: "Track A",
+    courseName: "Course 1",
+    courseKey: "ck1",
+    engine: "X30",
+    engineKey: "x30",
+    engineClassId: null,
+    listedWeight: 165,
+    listedWeightUnit: "lb",
+    lapTimeMs: 60000,
+    contentHash: "h",
+    engineTelemetryPublic: false,
+    status: "approved",
+    createdAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+const classes: EngineClass[] = [{ id: "c1", name: "Senior", keywords: [], sortOrder: 0 }];
+
+describe("groupEntriesByCourseWeight", () => {
+  it("returns nothing for no entries", () => {
+    expect(groupEntriesByCourseWeight([], classes)).toEqual([]);
+  });
+
+  it("groups by course then by exact weight, fastest-first", () => {
+    const groups = groupEntriesByCourseWeight(
+      [
+        entry({ id: "a", lapTimeMs: 61000, listedWeight: 165 }),
+        entry({ id: "b", lapTimeMs: 59000, listedWeight: 165 }),
+        entry({ id: "c", lapTimeMs: 58000, listedWeight: 180 }),
+      ],
+      classes,
+    );
+    expect(groups).toHaveLength(1);
+    const course = groups[0];
+    expect(course.courseKey).toBe("ck1");
+    expect(course.recordCount).toBe(3);
+    // Two weight buckets; the 180 lb bucket is faster so it sorts first.
+    expect(course.weightGroups.map((w) => w.weightLabel)).toEqual(["180 lb", "165 lb"]);
+    // Laps within the 165 bucket are ranked fastest-first.
+    const w165 = course.weightGroups.find((w) => w.weightLabel === "165 lb")!;
+    expect(w165.laps.map((l) => l.id)).toEqual(["b", "a"]);
+  });
+
+  it("orders courses by fastest lap and labels engine via class", () => {
+    const groups = groupEntriesByCourseWeight(
+      [
+        entry({ id: "slow", courseKey: "ckSlow", courseName: "Slow", lapTimeMs: 90000 }),
+        entry({ id: "fast", courseKey: "ckFast", courseName: "Fast", lapTimeMs: 50000, engineClassId: "c1" }),
+      ],
+      classes,
+    );
+    expect(groups.map((g) => g.courseKey)).toEqual(["ckFast", "ckSlow"]);
+    expect(groups[0].weightGroups[0].laps[0].engineLabel).toBe("Senior");
+  });
+
+  it("buckets entries with no listed weight under a null label", () => {
+    const groups = groupEntriesByCourseWeight(
+      [entry({ id: "x", listedWeight: null, listedWeightUnit: null })],
+      classes,
+    );
+    expect(groups[0].weightGroups[0].weightLabel).toBeNull();
+    expect(groups[0].weightGroups[0].key).toBe("none");
+  });
+});

--- a/src/lib/driverProfileGroups.ts
+++ b/src/lib/driverProfileGroups.ts
@@ -1,0 +1,104 @@
+// Pure grouping for the driver profile page (plan 0006): one user's approved
+// leaderboard entries → Course → weight buckets → ranked laps. Simpler than the
+// full Leaderboards browse tree (no track level, weight always split, no top-N) —
+// the profile just answers "what has this driver posted, by course and weight".
+// No React / network so it stays unit-testable.
+
+import type { EngineClass, LeaderboardEntry } from "./leaderboardTypes";
+import { engineLabelFor } from "./leaderboardBrowse";
+
+export interface DriverLap {
+  id: string;
+  engineLabel: string;
+  lapTimeMs: number;
+}
+
+export interface DriverWeightGroup {
+  /** Stable key within the course (weight+unit, or "none"). */
+  key: string;
+  /** "165 lb" etc., or null when the entry carried no listed weight. */
+  weightLabel: string | null;
+  /** Laps fastest-first. */
+  laps: DriverLap[];
+  fastestMs: number;
+}
+
+export interface DriverCourseGroup {
+  courseKey: string;
+  courseName: string;
+  trackName: string;
+  fastestMs: number;
+  recordCount: number;
+  weightGroups: DriverWeightGroup[];
+}
+
+function weightKey(e: LeaderboardEntry): string {
+  return e.listedWeight == null ? "none" : `${e.listedWeight}|${e.listedWeightUnit ?? "lb"}`;
+}
+
+function weightLabel(e: LeaderboardEntry): string | null {
+  if (e.listedWeight == null) return null;
+  return `${e.listedWeight} ${e.listedWeightUnit ?? "lb"}`;
+}
+
+const fastestOf = (es: { lapTimeMs: number }[]) =>
+  es.reduce((m, e) => Math.min(m, e.lapTimeMs), Infinity);
+
+/** Group a driver's entries by course, then by exact listed weight, each fastest-first. */
+export function groupEntriesByCourseWeight(
+  entries: LeaderboardEntry[],
+  classes: EngineClass[],
+): DriverCourseGroup[] {
+  const classesById = new Map(classes.map((c) => [c.id, c]));
+
+  interface Bucket {
+    courseName: string;
+    trackName: string;
+    weights: Map<string, LeaderboardEntry[]>;
+  }
+  const courses = new Map<string, Bucket>();
+  for (const e of entries) {
+    const bucket = courses.get(e.courseKey) ?? {
+      courseName: e.courseName,
+      trackName: e.trackName,
+      weights: new Map<string, LeaderboardEntry[]>(),
+    };
+    courses.set(e.courseKey, bucket);
+    const wk = weightKey(e);
+    const list = bucket.weights.get(wk) ?? [];
+    bucket.weights.set(wk, list);
+    list.push(e);
+  }
+
+  const result: DriverCourseGroup[] = [];
+  for (const [courseKey, bucket] of courses) {
+    const weightGroups: DriverWeightGroup[] = [];
+    let recordCount = 0;
+    for (const [wk, es] of bucket.weights) {
+      recordCount += es.length;
+      const ranked = [...es].sort((a, b) => a.lapTimeMs - b.lapTimeMs);
+      weightGroups.push({
+        key: wk,
+        weightLabel: weightLabel(es[0]),
+        laps: ranked.map((e) => ({
+          id: e.id,
+          engineLabel: engineLabelFor(e, classesById),
+          lapTimeMs: e.lapTimeMs,
+        })),
+        fastestMs: fastestOf(es),
+      });
+    }
+    weightGroups.sort((a, b) => a.fastestMs - b.fastestMs);
+    result.push({
+      courseKey,
+      courseName: bucket.courseName,
+      trackName: bucket.trackName,
+      fastestMs: weightGroups.reduce((m, w) => Math.min(m, w.fastestMs), Infinity),
+      recordCount,
+      weightGroups,
+    });
+  }
+
+  result.sort((a, b) => a.fastestMs - b.fastestMs);
+  return result;
+}

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -35,7 +35,7 @@ export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
  * migrated (see docs/plans/0004-i18n-translation-system.md). `common` is always
  * loaded; the rest load on demand for their surface.
  */
-export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin", "logger", "leaderboard"] as const;
+export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin", "logger", "leaderboard", "driver"] as const;
 export type Namespace = (typeof NAMESPACES)[number];
 
 export const DEFAULT_NAMESPACE: Namespace = "common";

--- a/src/lib/imageCrop.test.ts
+++ b/src/lib/imageCrop.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { computeSquareCrop } from "./imageCrop";
+
+describe("computeSquareCrop", () => {
+  it("centers the crop on a landscape image and caps the output", () => {
+    // 800x400 → 400 square, offset 200 on x, downscaled to 256.
+    expect(computeSquareCrop(800, 400, 256)).toEqual({ sx: 200, sy: 0, side: 400, target: 256 });
+  });
+
+  it("centers the crop on a portrait image", () => {
+    expect(computeSquareCrop(400, 800, 256)).toEqual({ sx: 0, sy: 200, side: 400, target: 256 });
+  });
+
+  it("keeps a square image unchanged except for the cap", () => {
+    expect(computeSquareCrop(500, 500, 256)).toEqual({ sx: 0, sy: 0, side: 500, target: 256 });
+  });
+
+  it("never upscales below the cap", () => {
+    // A 120x90 image: square side 90, target stays 90 (not 256).
+    expect(computeSquareCrop(120, 90, 256)).toEqual({ sx: 15, sy: 0, side: 90, target: 90 });
+  });
+
+  it("floors odd offsets so the crop stays inside the source", () => {
+    // 401x400 → side 400, (401-400)/2 = 0.5 → floored to 0.
+    expect(computeSquareCrop(401, 400, 256)).toEqual({ sx: 0, sy: 0, side: 400, target: 256 });
+  });
+});

--- a/src/lib/imageCrop.ts
+++ b/src/lib/imageCrop.ts
@@ -1,0 +1,123 @@
+// Client-side avatar cropping: take any uploaded image, crop a centered square,
+// downscale so neither side exceeds a cap (256 px), and re-encode small. Pure
+// browser work — no upload, no Supabase — so profile pictures never need a
+// server-side image pipeline (Golden Rule 1: don't do on the server what the
+// client can do). The geometry is split into `computeSquareCrop` so it can be
+// unit-tested without a real canvas.
+
+export interface SquareCrop {
+  /** Source-x of the centered square crop. */
+  sx: number;
+  /** Source-y of the centered square crop. */
+  sy: number;
+  /** Side length of the square crop in source pixels. */
+  side: number;
+  /** Output side length (<= side, capped at `max`). */
+  target: number;
+}
+
+/**
+ * Geometry for a centered 1:1 crop downscaled to at most `max` px per side.
+ * Never upscales: `target` is the smaller of the crop side and `max`.
+ */
+export function computeSquareCrop(width: number, height: number, max: number): SquareCrop {
+  const side = Math.max(0, Math.min(width, height));
+  const sx = Math.floor((width - side) / 2);
+  const sy = Math.floor((height - side) / 2);
+  const target = Math.max(1, Math.min(side, max));
+  return { sx, sy, side, target };
+}
+
+export interface CroppedImage {
+  blob: Blob;
+  width: number;
+  height: number;
+  type: string;
+}
+
+export interface CropOptions {
+  /** Max output side in px (default 256). */
+  max?: number;
+  /** Encoder quality 0..1 (default 0.85). */
+  quality?: number;
+  /** Preferred output type; falls back to JPEG if unsupported (default webp). */
+  type?: "image/webp" | "image/jpeg";
+}
+
+interface LoadedImage {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  close: () => void;
+}
+
+/** Decode a Blob to a drawable image, preferring createImageBitmap. */
+async function loadImage(file: Blob): Promise<LoadedImage> {
+  if (typeof createImageBitmap === "function") {
+    const bitmap = await createImageBitmap(file);
+    return {
+      source: bitmap,
+      width: bitmap.width,
+      height: bitmap.height,
+      close: () => bitmap.close(),
+    };
+  }
+  // Fallback for older webviews without createImageBitmap.
+  const url = URL.createObjectURL(file);
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error("Failed to decode image"));
+      el.src = url;
+    });
+    return {
+      source: img,
+      width: img.naturalWidth || img.width,
+      height: img.naturalHeight || img.height,
+      close: () => undefined,
+    };
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, quality));
+}
+
+/**
+ * Crop `file` to a centered square, downscale to at most `max` px (default 256),
+ * and re-encode (webp when supported, else jpeg). Throws on an undecodable image.
+ */
+export async function cropToSquareAvatar(file: Blob, opts: CropOptions = {}): Promise<CroppedImage> {
+  const max = opts.max ?? 256;
+  const quality = opts.quality ?? 0.85;
+  const preferred = opts.type ?? "image/webp";
+
+  const img = await loadImage(file);
+  try {
+    if (!img.width || !img.height) throw new Error("Image has no dimensions");
+    const { sx, sy, side, target } = computeSquareCrop(img.width, img.height, max);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = target;
+    canvas.height = target;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable");
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = "high";
+    ctx.drawImage(img.source, sx, sy, side, side, 0, 0, target, target);
+
+    // Prefer webp; if the platform can't encode it, toBlob yields null → jpeg.
+    let blob = await canvasToBlob(canvas, preferred, quality);
+    if (!blob || (preferred === "image/webp" && !blob.type.includes("webp"))) {
+      blob = await canvasToBlob(canvas, "image/jpeg", quality);
+    }
+    if (!blob) throw new Error("Failed to encode cropped image");
+
+    return { blob, width: target, height: target, type: blob.type || "image/jpeg" };
+  } finally {
+    img.close();
+  }
+}

--- a/src/lib/leaderboardBrowse.ts
+++ b/src/lib/leaderboardBrowse.ts
@@ -9,6 +9,7 @@ import type { EngineClass, LeaderboardEntry } from "./leaderboardTypes";
 /** One ranked entry within a group (for the leaderboard list level). */
 export interface GroupEntry {
   id: string;
+  userId: string;
   displayName: string;
   lapTimeMs: number;
 }
@@ -125,7 +126,7 @@ export function buildBrowseTree(
           engineLabel: eng,
           weightLabel: wl,
           entryIds: ranked.map((e) => e.id),
-          entries: ranked.map((e) => ({ id: e.id, displayName: e.displayName, lapTimeMs: e.lapTimeMs })),
+          entries: ranked.map((e) => ({ id: e.id, userId: e.userId, displayName: e.displayName, lapTimeMs: e.lapTimeMs })),
           recordCount: es.length,
           fastestMs: f,
         });

--- a/src/lib/vehicleStorage.ts
+++ b/src/lib/vehicleStorage.ts
@@ -14,6 +14,11 @@ export interface Vehicle {
   number: number;
   weight: number;
   weightUnit: "lb" | "kg";
+  /**
+   * Opt-in: when true, a public-safe projection (name/type/engine/number — never
+   * weight/setup) is published to the user's public driver profile. See plan 0006.
+   */
+  publicProfile?: boolean;
   /** Last local edit time (ms) — set by saveVehicle; used for sync merge. */
   updatedAt?: number;
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -9,7 +9,8 @@
     "loading": "Wird geladen…",
     "reset": "Auf Standard zurücksetzen",
     "update": "Aktualisieren",
-    "updating": "Wird aktualisiert…"
+    "updating": "Wird aktualisiert…",
+    "backToHome": "Back to home"
   },
   "language": {
     "heading": "Sprache",

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -74,7 +74,9 @@
     "update": "Fahrzeug aktualisieren",
     "add": "Fahrzeug hinzufügen",
     "engineRequired": "Ein Motor ist erforderlich.",
-    "needsEngine": "Dieses Fahrzeug benötigt einen Motor – bearbeite es, um einen hinzuzufügen."
+    "needsEngine": "Dieses Fahrzeug benötigt einen Motor – bearbeite es, um einen hinzuzufügen.",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "Motor",

--- a/src/locales/de/driver.json
+++ b/src/locales/de/driver.json
@@ -1,0 +1,13 @@
+{
+  "_machine": true,
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -26,7 +26,13 @@
     "nameEmpty": "Der Anzeigename darf nicht leer sein.",
     "nameProfanity": "Bitte wähle einen saubereren Anzeigenamen.",
     "nameUpdateFailed": "Anzeigename konnte nicht aktualisiert werden.",
-    "loadUsageFailed": "Speichernutzung konnte nicht geladen werden"
+    "loadUsageFailed": "Speichernutzung konnte nicht geladen werden",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "Tarif",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -4,6 +4,7 @@
     "signIn": "Sign in",
     "signOut": "Sign out",
     "profile": "Profile",
+    "backToHome": "Back to home",
     "sponsor": "Sponsor",
     "loading": "Loading…",
     "reset": "Reset to Defaults",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -73,7 +73,9 @@
     "update": "Update Vehicle",
     "add": "Add Vehicle",
     "engineRequired": "An engine is required.",
-    "needsEngine": "This vehicle needs an engine — edit to add one."
+    "needsEngine": "This vehicle needs an engine — edit to add one.",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "Engine",

--- a/src/locales/en/driver.json
+++ b/src/locales/en/driver.json
@@ -1,0 +1,12 @@
+{
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -47,7 +47,13 @@
     "nameEmpty": "Display name can't be empty.",
     "nameProfanity": "Please choose a cleaner display name.",
     "nameUpdateFailed": "Couldn't update display name.",
-    "loadUsageFailed": "Failed to load storage usage"
+    "loadUsageFailed": "Failed to load storage usage",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "Plan",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -9,7 +9,8 @@
     "loading": "Cargando…",
     "reset": "Restablecer valores predeterminados",
     "update": "Actualizar",
-    "updating": "Actualizando…"
+    "updating": "Actualizando…",
+    "backToHome": "Back to home"
   },
   "language": {
     "heading": "Idioma",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -74,7 +74,9 @@
     "update": "Actualizar vehículo",
     "add": "Añadir vehículo",
     "engineRequired": "Se requiere un motor.",
-    "needsEngine": "Este vehículo necesita un motor; edítalo para añadir uno."
+    "needsEngine": "Este vehículo necesita un motor; edítalo para añadir uno.",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "Motor",

--- a/src/locales/es/driver.json
+++ b/src/locales/es/driver.json
@@ -1,0 +1,13 @@
+{
+  "_machine": true,
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -26,7 +26,13 @@
     "nameEmpty": "El nombre para mostrar no puede estar vacío.",
     "nameProfanity": "Elige un nombre para mostrar más limpio, por favor.",
     "nameUpdateFailed": "No se pudo actualizar el nombre para mostrar.",
-    "loadUsageFailed": "No se pudo cargar el uso de almacenamiento"
+    "loadUsageFailed": "No se pudo cargar el uso de almacenamiento",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "Plan",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -9,7 +9,8 @@
     "loading": "Chargement…",
     "reset": "Réinitialiser les valeurs par défaut",
     "update": "Mettre à jour",
-    "updating": "Mise à jour…"
+    "updating": "Mise à jour…",
+    "backToHome": "Back to home"
   },
   "language": {
     "heading": "Langue",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -74,7 +74,9 @@
     "update": "Mettre à jour le véhicule",
     "add": "Ajouter un véhicule",
     "engineRequired": "Un moteur est requis.",
-    "needsEngine": "Ce véhicule a besoin d'un moteur — modifiez-le pour en ajouter un."
+    "needsEngine": "Ce véhicule a besoin d'un moteur — modifiez-le pour en ajouter un.",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "Moteur",

--- a/src/locales/fr/driver.json
+++ b/src/locales/fr/driver.json
@@ -1,0 +1,13 @@
+{
+  "_machine": true,
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/fr/plugins.json
+++ b/src/locales/fr/plugins.json
@@ -26,7 +26,13 @@
     "nameEmpty": "Le nom d'affichage ne peut pas être vide.",
     "nameProfanity": "Veuillez choisir un nom d'affichage plus correct.",
     "nameUpdateFailed": "Impossible de mettre à jour le nom d'affichage.",
-    "loadUsageFailed": "Impossible de charger l'utilisation du stockage"
+    "loadUsageFailed": "Impossible de charger l'utilisation du stockage",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "Forfait",

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -9,7 +9,8 @@
     "loading": "Caricamento…",
     "reset": "Ripristina valori predefiniti",
     "update": "Aggiorna",
-    "updating": "Aggiornamento…"
+    "updating": "Aggiornamento…",
+    "backToHome": "Back to home"
   },
   "language": {
     "heading": "Lingua",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -74,7 +74,9 @@
     "update": "Aggiorna veicolo",
     "add": "Aggiungi veicolo",
     "engineRequired": "È richiesto un motore.",
-    "needsEngine": "Questo veicolo ha bisogno di un motore — modificalo per aggiungerne uno."
+    "needsEngine": "Questo veicolo ha bisogno di un motore — modificalo per aggiungerne uno.",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "Motore",

--- a/src/locales/it/driver.json
+++ b/src/locales/it/driver.json
@@ -1,0 +1,13 @@
+{
+  "_machine": true,
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/it/plugins.json
+++ b/src/locales/it/plugins.json
@@ -26,7 +26,13 @@
     "nameEmpty": "Il nome visualizzato non può essere vuoto.",
     "nameProfanity": "Scegli un nome visualizzato più appropriato.",
     "nameUpdateFailed": "Impossibile aggiornare il nome visualizzato.",
-    "loadUsageFailed": "Impossibile caricare l'utilizzo dello spazio"
+    "loadUsageFailed": "Impossibile caricare l'utilizzo dello spazio",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "Piano",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -9,7 +9,8 @@
     "loading": "読み込み中…",
     "reset": "デフォルトに戻す",
     "update": "更新",
-    "updating": "更新中…"
+    "updating": "更新中…",
+    "backToHome": "Back to home"
   },
   "language": {
     "heading": "言語",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -74,7 +74,9 @@
     "update": "車両を更新",
     "add": "車両を追加",
     "engineRequired": "エンジンは必須です。",
-    "needsEngine": "この車両にはエンジンが必要です。編集して追加してください。"
+    "needsEngine": "この車両にはエンジンが必要です。編集して追加してください。",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "エンジン",

--- a/src/locales/ja/driver.json
+++ b/src/locales/ja/driver.json
@@ -1,0 +1,13 @@
+{
+  "_machine": true,
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/ja/plugins.json
+++ b/src/locales/ja/plugins.json
@@ -26,7 +26,13 @@
     "nameEmpty": "表示名を空にすることはできません。",
     "nameProfanity": "もっと適切な表示名を選んでください。",
     "nameUpdateFailed": "表示名を更新できませんでした。",
-    "loadUsageFailed": "ストレージ使用量を読み込めませんでした"
+    "loadUsageFailed": "ストレージ使用量を読み込めませんでした",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "プラン",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -9,7 +9,8 @@
     "loading": "Carregando…",
     "reset": "Restaurar padrões",
     "update": "Atualizar",
-    "updating": "Atualizando…"
+    "updating": "Atualizando…",
+    "backToHome": "Back to home"
   },
   "language": {
     "heading": "Idioma",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -74,7 +74,9 @@
     "update": "Atualizar veículo",
     "add": "Adicionar veículo",
     "engineRequired": "Um motor é obrigatório.",
-    "needsEngine": "Este veículo precisa de um motor — edite para adicionar um."
+    "needsEngine": "Este veículo precisa de um motor — edite para adicionar um.",
+    "showOnProfile": "Show on profile",
+    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup)."
   },
   "engine": {
     "label": "Motor",

--- a/src/locales/pt-BR/driver.json
+++ b/src/locales/pt-BR/driver.json
@@ -1,0 +1,13 @@
+{
+  "_machine": true,
+  "loading": "Loading profile…",
+  "loadFailed": "Couldn't load this profile.",
+  "notFoundTitle": "Driver not found",
+  "notFoundBody": "No driver named “{{name}}” exists.",
+  "vehiclesTitle": "Vehicles",
+  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
+  "unknownType": "Unknown type",
+  "snapshotsTitle": "Leaderboard snapshots",
+  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
+  "noWeight": "No listed weight"
+}

--- a/src/locales/pt-BR/plugins.json
+++ b/src/locales/pt-BR/plugins.json
@@ -26,7 +26,13 @@
     "nameEmpty": "O nome de exibição não pode ficar vazio.",
     "nameProfanity": "Escolha um nome de exibição mais adequado.",
     "nameUpdateFailed": "Não foi possível atualizar o nome de exibição.",
-    "loadUsageFailed": "Não foi possível carregar o uso de armazenamento"
+    "loadUsageFailed": "Não foi possível carregar o uso de armazenamento",
+    "changeAvatar": "Change profile picture",
+    "avatarUpdated": "Profile picture updated.",
+    "avatarFailed": "Couldn't update profile picture.",
+    "copyProfileLink": "Copy profile link",
+    "linkCopied": "Profile link copied.",
+    "linkCopyFailed": "Couldn't copy profile link."
   },
   "plan": {
     "title": "Plano",

--- a/src/pages/DriverProfile.tsx
+++ b/src/pages/DriverProfile.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Car, Trophy, UserX } from "lucide-react";
+import { SiteHeader } from "@/components/SiteHeader";
+import { SettingsModal } from "@/components/SettingsModal";
+import { BackToHome } from "@/components/BackToHome";
+import { ProfileAvatar } from "@/components/ProfileAvatar";
+import { useSettings } from "@/hooks/useSettings";
+import { formatLapTime } from "@/lib/lapCalculation";
+import { groupEntriesByCourseWeight, type DriverCourseGroup } from "@/lib/driverProfileGroups";
+import type { PublicProfile, PublicVehicle } from "@/plugins/cloud-sync/publicProfile";
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+interface LoadedData {
+  profile: PublicProfile;
+  vehicles: PublicVehicle[];
+  courses: DriverCourseGroup[];
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "notfound" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: LoadedData };
+
+export default function DriverProfile() {
+  const navigate = useNavigate();
+  const { username } = useParams<{ username: string }>();
+  const name = decodeURIComponent(username ?? "");
+  const { t } = useTranslation(["driver", "common"]);
+  const { settings, setSettings, toggleFieldDefault } = useSettings();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    (async () => {
+      try {
+        const { fetchPublicProfileByName, fetchPublicVehicles } = await import(
+          "@/plugins/cloud-sync/publicProfile"
+        );
+        const profile = await fetchPublicProfileByName(name);
+        if (cancelled) return;
+        if (!profile) {
+          setState({ status: "notfound" });
+          return;
+        }
+        const { fetchApprovedLightByUser, fetchEngineClasses } = await import(
+          "@/plugins/cloud-sync/leaderboardClient"
+        );
+        const [entries, classes, vehicles] = await Promise.all([
+          fetchApprovedLightByUser(profile.userId),
+          fetchEngineClasses(),
+          fetchPublicVehicles(profile.userId),
+        ]);
+        if (cancelled) return;
+        setState({
+          status: "ready",
+          data: { profile, vehicles, courses: groupEntriesByCourseWeight(entries, classes) },
+        });
+      } catch (e) {
+        if (!cancelled) {
+          setState({ status: "error", message: e instanceof Error ? e.message : t("loadFailed") });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [name, t]);
+
+  const settingsButton = (
+    <SettingsModal
+      settings={settings}
+      onSettingsChange={setSettings}
+      onToggleFieldDefault={toggleFieldDefault}
+      canHideSampleFiles
+      triggerLabelBreakpoint="sm"
+    />
+  );
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col safe-area-x">
+      <SiteHeader
+        settingsButton={settingsButton}
+        enableCloud={enableCloud}
+        onOpenProfile={() => navigate("/", { state: { openProfile: true } })}
+        showSupportedFiles={false}
+        showAbout={false}
+      />
+
+      <main className="flex-1 px-6 py-6">
+        <div className="mx-auto w-full max-w-4xl space-y-6">
+          <BackToHome />
+
+          {state.status === "loading" && (
+            <p className="text-sm text-muted-foreground">{t("loading")}</p>
+          )}
+          {state.status === "error" && <p className="text-sm text-destructive">{state.message}</p>}
+          {state.status === "notfound" && (
+            <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border p-10 text-center text-muted-foreground">
+              <UserX className="h-10 w-10 opacity-40" />
+              <p className="text-base font-medium text-foreground">{t("notFoundTitle")}</p>
+              <p className="text-sm">{t("notFoundBody", { name })}</p>
+            </div>
+          )}
+
+          {state.status === "ready" && <DriverBody data={state.data} />}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function DriverBody({ data }: { data: LoadedData }) {
+  const { t } = useTranslation("driver");
+  const { profile, vehicles, courses } = data;
+
+  return (
+    <div className="space-y-8">
+      {/* Header: avatar + name */}
+      <div className="flex items-center gap-4">
+        <ProfileAvatar url={profile.avatarUrl} alt={profile.displayName} sizeClassName="h-16 w-16" />
+        <h2 className="text-2xl font-bold text-foreground">{profile.displayName}</h2>
+      </div>
+
+      {/* Vehicles (no weights, no setups) */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Car className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold text-foreground">{t("vehiclesTitle")}</h3>
+        </div>
+        {vehicles.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+            {t("vehiclesEmpty")}
+          </p>
+        ) : (
+          <div className="grid gap-2 sm:grid-cols-2">
+            {vehicles.map((v) => (
+              <div key={v.vehicleId} className="rounded-lg border border-border px-3 py-2">
+                <div className="text-sm font-medium text-foreground">
+                  {v.number ? `#${v.number} — ` : ""}
+                  {v.name}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {v.typeName ?? t("unknownType")}
+                  {v.engine ? ` · ${v.engine}` : ""}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Uploaded leaderboard snapshots, by course + weight */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Trophy className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold text-foreground">{t("snapshotsTitle")}</h3>
+        </div>
+        {courses.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+            {t("snapshotsEmpty")}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {courses.map((course) => (
+              <div key={course.courseKey} className="rounded-lg border border-border">
+                <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2.5">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-foreground">{course.courseName}</p>
+                    <p className="truncate text-xs text-muted-foreground">{course.trackName}</p>
+                  </div>
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                    {formatLapTime(course.fastestMs)}
+                  </span>
+                </div>
+                <div className="space-y-2 px-2 py-2">
+                  {course.weightGroups.map((wg) => (
+                    <div key={wg.key} className="rounded-md border border-border/60">
+                      <div className="border-b border-border/60 px-3 py-1.5 text-xs font-medium text-muted-foreground">
+                        {wg.weightLabel ?? t("noWeight")}
+                      </div>
+                      <div className="px-2 py-1.5 space-y-1">
+                        {wg.laps.map((lap, i) => (
+                          <div
+                            key={lap.id}
+                            className="flex items-center gap-2 rounded px-2 py-1 text-sm"
+                          >
+                            <span className="w-5 shrink-0 text-center font-mono text-xs text-muted-foreground">
+                              {i + 1}
+                            </span>
+                            <span className="flex-1 truncate text-foreground">{lap.engineLabel}</span>
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {formatLapTime(lap.lapTimeMs)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Leaderboards.tsx
+++ b/src/pages/Leaderboards.tsx
@@ -5,6 +5,8 @@ import { ChevronRight, Trophy, Cpu, Hash, Layers } from "lucide-react";
 import { toast } from "sonner";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SettingsModal } from "@/components/SettingsModal";
+import { BackToHome } from "@/components/BackToHome";
+import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -40,6 +42,7 @@ export default function Leaderboards() {
 
   const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
   const [classes, setClasses] = useState<EngineClass[]>([]);
+  const [avatars, setAvatars] = useState<Map<string, string | null>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [groupByWeight, setGroupByWeight] = useState(false);
   const [top, setTop] = useState<number | "all">(DEFAULT_TOP);
@@ -53,10 +56,16 @@ export default function Leaderboards() {
     (async () => {
       try {
         const { fetchApprovedLight, fetchEngineClasses } = await import("@/plugins/cloud-sync/leaderboardClient");
-        const [light, cls] = await Promise.all([fetchApprovedLight(), fetchEngineClasses()]);
+        const { fetchAllPublicProfiles } = await import("@/plugins/cloud-sync/publicProfile");
+        const [light, cls, profiles] = await Promise.all([
+          fetchApprovedLight(),
+          fetchEngineClasses(),
+          fetchAllPublicProfiles().catch(() => new Map()),
+        ]);
         if (cancelled) return;
         setEntries(light);
         setClasses(cls);
+        setAvatars(new Map([...profiles].map(([id, p]) => [id, p.avatarUrl])));
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : t("loadFailed"));
       }
@@ -137,6 +146,7 @@ export default function Leaderboards() {
 
       <main className="flex-1 px-6 py-8">
         <div className="mx-auto w-full max-w-4xl space-y-5">
+          <BackToHome />
           <div className="flex items-center gap-3">
             <Trophy className="h-6 w-6 text-primary" />
             <div>
@@ -187,6 +197,7 @@ export default function Leaderboards() {
                 onOpenSingle={openSingle}
                 top={top}
                 loadingKey={loadingKey}
+                avatars={avatars}
               />
             ))}
           </div>
@@ -198,7 +209,7 @@ export default function Leaderboards() {
 
 function TrackRow({
   track, open, onToggle, openCourses, onToggleCourse, openGroups, onToggleGroup,
-  onOpenTopSession, onOpenSingle, top, loadingKey,
+  onOpenTopSession, onOpenSingle, top, loadingKey, avatars,
 }: {
   track: TrackNode;
   open: boolean;
@@ -211,6 +222,7 @@ function TrackRow({
   onOpenSingle: (course: CourseNode, group: GroupNode, entryId: string) => void;
   top: number | "all";
   loadingKey: string | null;
+  avatars: Map<string, string | null>;
 }) {
   const { t } = useTranslation("leaderboard");
   return (
@@ -295,6 +307,7 @@ function TrackRow({
                                   className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-primary/10 disabled:opacity-60"
                                 >
                                   <span className="w-6 shrink-0 text-center font-mono text-xs text-muted-foreground">{i + 1}</span>
+                                  <ProfileAvatar url={avatars.get(entry.userId)} alt={entry.displayName} sizeClassName="h-5 w-5" />
                                   <span className="flex-1 truncate text-foreground">{entry.displayName}</span>
                                   <span className="font-mono text-xs text-muted-foreground">{formatLapTime(entry.lapTimeMs)}</span>
                                 </button>

--- a/src/plugins/cloud-sync/StoragePanel.tsx
+++ b/src/plugins/cloud-sync/StoragePanel.tsx
@@ -1,14 +1,15 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import {
-  Check, CloudOff, CreditCard, Info, Loader2, LogOut, Pencil, RefreshCw,
-  User as UserIcon, WifiOff, X,
+  Camera, Check, CloudOff, CreditCard, Info, Link2, Loader2, LogOut, Pencil, RefreshCw,
+  WifiOff, X,
 } from "lucide-react";
 import { toast } from "sonner";
 import type { PluginPanelProps } from "@/plugins/panels";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
@@ -17,9 +18,10 @@ import { isPaidTier, isComped, hasCompGrant, daysUntilTrim } from "@/lib/billing
 import { createPortal } from "@/lib/billingClient";
 import { isNativeApp } from "@/lib/platform";
 import { onGarageChange } from "@/lib/garageEvents";
+import { cropToSquareAvatar } from "@/lib/imageCrop";
 import { getStorageUsage } from "./syncEngine";
 import { getLocalStorageUsage } from "./localUsage";
-import { getMyProfile, updateDisplayName } from "./profile";
+import { avatarPublicUrl, getMyProfile, updateDisplayName, uploadAvatar } from "./profile";
 import { pendingCount } from "./pendingSync";
 import {
   formatBytes, segmentFractions, totalUsed, usageFraction,
@@ -163,23 +165,58 @@ function SignInPrompt() {
 function DisplayName({ userId, email, action }: { userId: string; email: string; action?: ReactNode }) {
   const { t } = useTranslation("plugins");
   const [name, setName] = useState<string | null>(null);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     let cancelled = false;
     void getMyProfile(userId)
       .then((p) => {
-        if (!cancelled) setName(p?.display_name ?? null);
+        if (cancelled) return;
+        setName(p?.display_name ?? null);
+        setAvatarUrl(avatarPublicUrl(p));
       })
       .catch(() => {
-        if (!cancelled) setName(null);
+        if (!cancelled) {
+          setName(null);
+          setAvatarUrl(null);
+        }
       });
     return () => {
       cancelled = true;
     };
   }, [userId]);
+
+  // Crop to a centered ≤256px square on-device, then upload to the public bucket.
+  const onPickAvatar = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-picking the same file
+    if (!file) return;
+    setUploading(true);
+    try {
+      const { blob } = await cropToSquareAvatar(file);
+      const saved = await uploadAvatar(userId, blob);
+      setAvatarUrl(avatarPublicUrl(saved));
+      toast.success(t("account.avatarUpdated"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("account.avatarFailed"));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const copyProfileLink = () => {
+    if (!name) return;
+    const url = `${window.location.origin}/driver/${encodeURIComponent(name)}`;
+    void navigator.clipboard
+      ?.writeText(url)
+      .then(() => toast.success(t("account.linkCopied")))
+      .catch(() => toast.error(t("account.linkCopyFailed")));
+  };
 
   const startEdit = () => {
     setDraft(name ?? "");
@@ -207,9 +244,25 @@ function DisplayName({ userId, email, action }: { userId: string; email: string;
 
   return (
     <div className="flex items-center gap-3">
-      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        <UserIcon className="h-6 w-6" />
-      </div>
+      <button
+        type="button"
+        onClick={() => fileRef.current?.click()}
+        disabled={uploading}
+        aria-label={t("account.changeAvatar")}
+        className="group relative shrink-0 rounded-full ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <ProfileAvatar url={avatarUrl} alt={name ?? ""} sizeClassName="h-12 w-12" />
+        <span className="absolute inset-0 flex items-center justify-center rounded-full bg-black/45 text-white opacity-0 transition-opacity group-hover:opacity-100">
+          {uploading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Camera className="h-5 w-5" />}
+        </span>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => void onPickAvatar(e)}
+        />
+      </button>
       <div className="min-w-0 flex-1">
         {editing ? (
           <div className="flex items-center gap-1.5">
@@ -242,7 +295,18 @@ function DisplayName({ userId, email, action }: { userId: string; email: string;
         )}
         <p className="truncate text-xs text-muted-foreground">{email}</p>
       </div>
-      {action}
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        {action}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground"
+          disabled={!name}
+          onClick={copyProfileLink}
+        >
+          <Link2 className="mr-1.5 h-4 w-4" /> {t("account.copyProfileLink")}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/plugins/cloud-sync/autoSync.ts
+++ b/src/plugins/cloud-sync/autoSync.ts
@@ -22,6 +22,7 @@ import { unselectFile } from "./fileSync";
 import { setActiveUserId } from "./activeUser";
 import { pendingId } from "./merge";
 import { FILE_STORE } from "./syncStores";
+import { syncPublicVehicle } from "./publicVehicleSync";
 
 const DEBOUNCE_MS = 800;
 
@@ -72,6 +73,9 @@ async function pushOne(userId: string, change: GarageChange): Promise<void> {
   }
   if (change.type === "delete") await deleteRecord(userId, change.store, change.key);
   else await pushRecord(userId, change.store, change.key);
+
+  // Vehicles carry an opt-in public projection alongside their private backup.
+  if (change.store === STORE_NAMES.KARTS) await syncPublicVehicle(userId, change);
 }
 
 async function flush(change: GarageChange): Promise<void> {

--- a/src/plugins/cloud-sync/cloudClient.ts
+++ b/src/plugins/cloud-sync/cloudClient.ts
@@ -12,6 +12,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
 export const SYNC_BUCKET = "user-files";
+export const AVATAR_BUCKET = "user-avatars";
 
 /** A row in public.sync_records — one client record stored as a jsonb document. */
 export interface SyncRecordRow {
@@ -50,6 +51,11 @@ export function userFiles() {
   return untyped.storage.from(SYNC_BUCKET);
 }
 
+/** Storage API for the public per-user avatar bucket. */
+export function userAvatars() {
+  return untyped.storage.from(AVATAR_BUCKET);
+}
+
 /** The single-row pooled-usage shape returned by the server's sync_storage_usage() RPC. */
 export interface StorageUsageRow {
   documents_bytes: number;
@@ -73,15 +79,48 @@ export function isQuotaError(err: unknown): boolean {
   return err instanceof Error && /quota_exceeded/i.test(err.message);
 }
 
-/** A row in public.profiles — the user's unique, editable display name. */
+/** A row in public.profiles — the user's unique, editable display name + avatar. */
 export interface ProfileRow {
   user_id: string;
   display_name: string;
+  /** Object path in the user-avatars bucket, or null when no avatar is set. */
+  avatar_path?: string | null;
+  /** Last avatar change — used as a ?v= cache-buster on the public URL. */
+  avatar_updated_at?: string | null;
 }
 
-/** Query builder for the profiles table. */
+/** Query builder for the profiles table (owner reads/writes). */
 export function profiles() {
   return untyped.from("profiles");
+}
+
+/** A row in public.public_profiles — the anon-readable, column-limited view. */
+export interface PublicProfileRow {
+  user_id: string;
+  display_name: string;
+  avatar_path: string | null;
+  avatar_updated_at: string | null;
+}
+
+/** Query builder for the anon-readable public_profiles view. */
+export function publicProfilesView() {
+  return untyped.from("public_profiles");
+}
+
+/** A row in public.public_vehicles — a user's opt-in, public-safe vehicle. */
+export interface PublicVehicleRow {
+  user_id: string;
+  vehicle_id: string;
+  name: string;
+  type_name: string | null;
+  engine: string;
+  number: number;
+  updated_at?: string;
+}
+
+/** Query builder for the public_vehicles projection table. */
+export function publicVehicles() {
+  return untyped.from("public_vehicles");
 }
 
 /** True when a Postgres error is a unique-constraint violation (e.g. taken name). */

--- a/src/plugins/cloud-sync/leaderboardClient.ts
+++ b/src/plugins/cloud-sync/leaderboardClient.ts
@@ -107,6 +107,16 @@ export async function fetchApprovedLight(): Promise<LeaderboardEntry[]> {
   return ((data ?? []) as EntryRow[]).map(mapEntryRow);
 }
 
+/** Lightweight approved rows for one user — the public driver profile page (anon). */
+export async function fetchApprovedLightByUser(userId: string): Promise<LeaderboardEntry[]> {
+  const { data, error } = await leaderboardEntriesTable()
+    .select(LIGHT_COLUMNS)
+    .eq("status", "approved")
+    .eq("user_id", userId);
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as EntryRow[]).map(mapEntryRow);
+}
+
 /**
  * Full rows (with `data`) for one engine[/weight] group, fastest first. `limit`
  * null loads all. Grouping is resolved client-side, so callers pass the already

--- a/src/plugins/cloud-sync/profile.test.ts
+++ b/src/plugins/cloud-sync/profile.test.ts
@@ -26,12 +26,17 @@ vi.mock("./cloudClient", () => {
   };
   return {
     profiles: () => builder,
+    userAvatars: () => ({
+      getPublicUrl: (path: string) => ({
+        data: { publicUrl: `https://cdn.test/user-avatars/${path}` },
+      }),
+    }),
     isUniqueViolation: (err: unknown) =>
       typeof err === "object" && err !== null && (err as { code?: string }).code === "23505",
   };
 });
 
-import { getMyProfile, updateDisplayName } from "./profile";
+import { avatarPublicUrl, getMyProfile, updateDisplayName } from "./profile";
 
 beforeEach(() => {
   state.read = { data: null, error: null };
@@ -53,6 +58,29 @@ describe("getMyProfile", () => {
   it("throws on a query error", async () => {
     state.read = { data: null, error: { message: "db down" } };
     await expect(getMyProfile("u1")).rejects.toThrow(/db down/);
+  });
+});
+
+describe("avatarPublicUrl", () => {
+  it("returns null when no avatar path is set", () => {
+    expect(avatarPublicUrl(null)).toBeNull();
+    expect(avatarPublicUrl({ avatar_path: null, avatar_updated_at: null })).toBeNull();
+  });
+
+  it("builds a public URL with a ?v= cache-buster from avatar_updated_at", () => {
+    const url = avatarPublicUrl({
+      avatar_path: "u1/avatar.webp",
+      avatar_updated_at: "2026-06-27T00:00:00.000Z",
+    });
+    expect(url).toBe(
+      `https://cdn.test/user-avatars/u1/avatar.webp?v=${Date.parse("2026-06-27T00:00:00.000Z")}`,
+    );
+  });
+
+  it("omits the cache-buster when there is no timestamp", () => {
+    expect(avatarPublicUrl({ avatar_path: "u1/avatar.jpg", avatar_updated_at: null })).toBe(
+      "https://cdn.test/user-avatars/u1/avatar.jpg",
+    );
   });
 });
 

--- a/src/plugins/cloud-sync/profile.ts
+++ b/src/plugins/cloud-sync/profile.ts
@@ -3,16 +3,60 @@
 // while an explicit edit surfaces a "taken" result so the user can pick another.
 
 import { containsProfanity } from "@/lib/profanity";
-import { isUniqueViolation, profiles, type ProfileRow } from "./cloudClient";
+import { isUniqueViolation, profiles, userAvatars, type ProfileRow } from "./cloudClient";
 
 /** The signed-in user's profile, or null if it doesn't exist yet. */
 export async function getMyProfile(userId: string): Promise<ProfileRow | null> {
   const { data, error } = await profiles()
-    .select("user_id,display_name")
+    .select("user_id,display_name,avatar_path,avatar_updated_at")
     .eq("user_id", userId)
     .maybeSingle();
   if (error) throw new Error(error.message);
   return (data as ProfileRow | null) ?? null;
+}
+
+/**
+ * Public URL for a profile's avatar, with a ?v= cache-buster derived from
+ * avatar_updated_at (the object path is fixed, so a replaced avatar would
+ * otherwise serve the stale cached image). Null when no avatar is set.
+ */
+export function avatarPublicUrl(
+  p: Pick<ProfileRow, "avatar_path" | "avatar_updated_at"> | null | undefined,
+): string | null {
+  if (!p?.avatar_path) return null;
+  const { data } = userAvatars().getPublicUrl(p.avatar_path);
+  if (!data?.publicUrl) return null;
+  const v = p.avatar_updated_at ? Date.parse(p.avatar_updated_at) : 0;
+  return v ? `${data.publicUrl}?v=${v}` : data.publicUrl;
+}
+
+/** Extension for the stored avatar object, derived from the (already-cropped) blob type. */
+function avatarExt(type: string): string {
+  return type.includes("webp") ? "webp" : "jpg";
+}
+
+/**
+ * Upload a cropped avatar blob to the public bucket at a fixed per-user path and
+ * record the new path + timestamp on the profile. Returns the stored fields so
+ * the caller can repaint immediately via the cache-buster.
+ */
+export async function uploadAvatar(
+  userId: string,
+  blob: Blob,
+): Promise<{ avatar_path: string; avatar_updated_at: string }> {
+  const path = `${userId}/avatar.${avatarExt(blob.type)}`;
+  const up = await userAvatars().upload(path, blob, {
+    upsert: true,
+    contentType: blob.type || "image/jpeg",
+  });
+  if (up.error) throw new Error(up.error.message);
+
+  const now = new Date().toISOString();
+  const { error } = await profiles()
+    .update({ avatar_path: path, avatar_updated_at: now })
+    .eq("user_id", userId);
+  if (error) throw new Error(error.message);
+  return { avatar_path: path, avatar_updated_at: now };
 }
 
 export type UpdateNameResult =

--- a/src/plugins/cloud-sync/publicProfile.ts
+++ b/src/plugins/cloud-sync/publicProfile.ts
@@ -1,0 +1,82 @@
+// Anonymous, public reads for the driver profile page (/driver/:username) and
+// the Leaderboards avatar thumbnails. Kept separate from profile.ts (owner-only
+// reads/writes): everything here goes through the column-limited public_profiles
+// view and the public_vehicles projection, both anon-readable by RLS. Names are
+// matched case-insensitively so a profile resolves regardless of URL casing.
+
+import {
+  avatarPublicUrl,
+} from "./profile";
+import {
+  publicProfilesView,
+  publicVehicles,
+  type PublicProfileRow,
+  type PublicVehicleRow,
+} from "./cloudClient";
+
+export interface PublicProfile {
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+export interface PublicVehicle {
+  vehicleId: string;
+  name: string;
+  typeName: string | null;
+  engine: string;
+  number: number;
+}
+
+/** Escape PostgREST ilike wildcards so a name is matched literally (not as a pattern). */
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+function toPublicProfile(row: PublicProfileRow): PublicProfile {
+  return {
+    userId: row.user_id,
+    displayName: row.display_name,
+    avatarUrl: avatarPublicUrl(row),
+  };
+}
+
+/** Resolve a display name (case-insensitive, exact) to its public profile, or null. */
+export async function fetchPublicProfileByName(name: string): Promise<PublicProfile | null> {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  const { data, error } = await publicProfilesView()
+    .select("user_id,display_name,avatar_path,avatar_updated_at")
+    .ilike("display_name", escapeLike(trimmed))
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return data ? toPublicProfile(data as PublicProfileRow) : null;
+}
+
+/** The user's opt-in, public-safe vehicles (no weight, no setup), number-ordered. */
+export async function fetchPublicVehicles(userId: string): Promise<PublicVehicle[]> {
+  const { data, error } = await publicVehicles()
+    .select("vehicle_id,name,type_name,engine,number")
+    .eq("user_id", userId)
+    .order("number", { ascending: true });
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as PublicVehicleRow[]).map((r) => ({
+    vehicleId: r.vehicle_id,
+    name: r.name,
+    typeName: r.type_name,
+    engine: r.engine,
+    number: r.number,
+  }));
+}
+
+/** All public profiles keyed by user id — one query, used for leaderboard avatar thumbnails. */
+export async function fetchAllPublicProfiles(): Promise<Map<string, PublicProfile>> {
+  const { data, error } = await publicProfilesView()
+    .select("user_id,display_name,avatar_path,avatar_updated_at");
+  if (error) throw new Error(error.message);
+  const map = new Map<string, PublicProfile>();
+  for (const row of (data ?? []) as PublicProfileRow[]) {
+    map.set(row.user_id, toPublicProfile(row));
+  }
+  return map;
+}

--- a/src/plugins/cloud-sync/publicVehicleSync.test.ts
+++ b/src/plugins/cloud-sync/publicVehicleSync.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Vehicle } from "@/lib/vehicleStorage";
+
+// Capture the calls the projection makes against the public_vehicles builder.
+const { state } = vi.hoisted(() => ({
+  state: {
+    vehicle: null as Vehicle | null,
+    typeName: "Shifter Kart" as string | null,
+    upsertArg: undefined as Record<string, unknown> | undefined,
+    deleted: [] as Array<Record<string, string>>,
+  },
+}));
+
+vi.mock("@/lib/vehicleStorage", () => ({
+  getVehicle: async () => state.vehicle,
+}));
+vi.mock("@/lib/templateStorage", () => ({
+  getVehicleType: async () => (state.typeName === null ? null : { id: "vt1", name: state.typeName }),
+}));
+vi.mock("./cloudClient", () => {
+  const deleteBuilder = {
+    _eqs: {} as Record<string, string>,
+    eq(col: string, val: string) {
+      this._eqs[col] = val;
+      return this;
+    },
+    then(onFulfilled: (v: unknown) => unknown) {
+      state.deleted.push({ ...this._eqs });
+      return onFulfilled({ error: null });
+    },
+  };
+  return {
+    publicVehicles: () => ({
+      upsert: (arg: Record<string, unknown>) => {
+        state.upsertArg = arg;
+        return Promise.resolve({ error: null });
+      },
+      delete: () => {
+        deleteBuilder._eqs = {};
+        return deleteBuilder;
+      },
+    }),
+  };
+});
+
+import { syncPublicVehicle } from "./publicVehicleSync";
+
+const baseVehicle: Vehicle = {
+  id: "v1",
+  name: "Kart 7",
+  vehicleTypeId: "vt1",
+  engine: "IAME X30",
+  number: 7,
+  weight: 165,
+  weightUnit: "lb",
+  publicProfile: true,
+};
+
+beforeEach(() => {
+  state.vehicle = { ...baseVehicle };
+  state.typeName = "Shifter Kart";
+  state.upsertArg = undefined;
+  state.deleted = [];
+});
+
+describe("syncPublicVehicle", () => {
+  it("upserts only public-safe columns for a flagged vehicle (never weight)", async () => {
+    await syncPublicVehicle("u1", { store: "karts", key: "v1", type: "put" });
+    expect(state.upsertArg).toMatchObject({
+      user_id: "u1",
+      vehicle_id: "v1",
+      name: "Kart 7",
+      type_name: "Shifter Kart",
+      engine: "IAME X30",
+      number: 7,
+    });
+    expect(state.upsertArg).not.toHaveProperty("weight");
+    expect(state.upsertArg).not.toHaveProperty("weightUnit");
+    expect(state.deleted).toHaveLength(0);
+  });
+
+  it("deletes the public row when the vehicle is not flagged", async () => {
+    state.vehicle = { ...baseVehicle, publicProfile: false };
+    await syncPublicVehicle("u1", { store: "karts", key: "v1", type: "put" });
+    expect(state.upsertArg).toBeUndefined();
+    expect(state.deleted).toEqual([{ user_id: "u1", vehicle_id: "v1" }]);
+  });
+
+  it("deletes the public row when the vehicle no longer exists", async () => {
+    state.vehicle = null;
+    await syncPublicVehicle("u1", { store: "karts", key: "v1", type: "put" });
+    expect(state.upsertArg).toBeUndefined();
+    expect(state.deleted).toEqual([{ user_id: "u1", vehicle_id: "v1" }]);
+  });
+
+  it("deletes the public row on a vehicle delete", async () => {
+    await syncPublicVehicle("u1", { store: "karts", key: "v1", type: "delete" });
+    expect(state.upsertArg).toBeUndefined();
+    expect(state.deleted).toEqual([{ user_id: "u1", vehicle_id: "v1" }]);
+  });
+
+  it("tolerates a missing vehicle type (null type_name)", async () => {
+    state.typeName = null;
+    await syncPublicVehicle("u1", { store: "karts", key: "v1", type: "put" });
+    expect(state.upsertArg).toMatchObject({ type_name: null });
+  });
+});

--- a/src/plugins/cloud-sync/publicVehicleSync.ts
+++ b/src/plugins/cloud-sync/publicVehicleSync.ts
@@ -1,0 +1,51 @@
+// Projects a user's opt-in vehicles to the public_vehicles table (plan 0006).
+//
+// Vehicles back up privately to sync_records like every garage record; this is a
+// SECOND, public-safe projection driven off the same garage-change event. Only
+// vehicles flagged `publicProfile` are published, and only public-safe columns
+// (name/type/engine/number) — never weight or any setup. Unflagging or deleting
+// a vehicle removes its public row. Best-effort: a failed projection is logged,
+// not retried (it self-heals on the next vehicle edit), so it never blocks the
+// authoritative private backup.
+
+import type { GarageChange } from "@/lib/garageEvents";
+import { getVehicle } from "@/lib/vehicleStorage";
+import { getVehicleType } from "@/lib/templateStorage";
+import { publicVehicles } from "./cloudClient";
+
+async function removePublicVehicle(userId: string, vehicleId: string): Promise<void> {
+  const { error } = await publicVehicles()
+    .delete()
+    .eq("user_id", userId)
+    .eq("vehicle_id", vehicleId);
+  if (error) throw new Error(error.message);
+}
+
+/** Mirror one garage vehicle change into the public projection (best-effort). */
+export async function syncPublicVehicle(userId: string, change: GarageChange): Promise<void> {
+  try {
+    if (change.type === "delete") {
+      await removePublicVehicle(userId, change.key);
+      return;
+    }
+    const vehicle = await getVehicle(change.key);
+    // Gone, or opted out → ensure no public row lingers.
+    if (!vehicle || !vehicle.publicProfile) {
+      await removePublicVehicle(userId, change.key);
+      return;
+    }
+    const type = vehicle.vehicleTypeId ? await getVehicleType(vehicle.vehicleTypeId) : null;
+    const { error } = await publicVehicles().upsert({
+      user_id: userId,
+      vehicle_id: vehicle.id,
+      name: vehicle.name,
+      type_name: type?.name ?? null,
+      engine: vehicle.engine,
+      number: vehicle.number,
+      updated_at: new Date().toISOString(),
+    });
+    if (error) throw new Error(error.message);
+  } catch (err) {
+    console.error("public vehicle projection failed", err);
+  }
+}

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -19,6 +19,7 @@ import type auth from "@/locales/en/auth.json";
 import type admin from "@/locales/en/admin.json";
 import type logger from "@/locales/en/logger.json";
 import type leaderboard from "@/locales/en/leaderboard.json";
+import type driver from "@/locales/en/driver.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -37,6 +38,7 @@ declare module "i18next" {
       admin: typeof admin;
       logger: typeof logger;
       leaderboard: typeof leaderboard;
+      driver: typeof driver;
     };
   }
 }

--- a/supabase/functions/process-account-deletions/index.ts
+++ b/supabase/functions/process-account-deletions/index.ts
@@ -11,15 +11,20 @@ const corsHeaders = {
 };
 
 const SYNC_BUCKET = 'user-files';
+const AVATAR_BUCKET = 'user-avatars';
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
 
-/** Remove every object under `${userId}/` in the private user-files bucket. */
-async function removeUserFiles(admin: ReturnType<typeof createClient>, userId: string): Promise<void> {
-  const bucket = admin.storage.from(SYNC_BUCKET);
+/** Remove every object under `${userId}/` in a flat ({userId}/{name}) bucket. */
+async function removeUserObjects(
+  admin: ReturnType<typeof createClient>,
+  bucketId: string,
+  userId: string,
+): Promise<void> {
+  const bucket = admin.storage.from(bucketId);
   // List in pages; the folder is flat ({userId}/{filename}), so one level is enough.
   for (;;) {
     const { data: objects, error } = await bucket.list(userId, { limit: 1000 });
@@ -70,8 +75,11 @@ Deno.serve(async (req) => {
         // harmful than losing files before the account is confirmed deleted. The
         // user is no longer in due_account_deletions, so log loudly for manual
         // sweeping rather than failing the (successful) deletion.
+        // Avatars live in a separate public bucket; public_vehicles rows cascade
+        // via FK, but Storage objects are never FK-cascaded, so wipe both folders.
         try {
-          await removeUserFiles(admin, userId);
+          await removeUserObjects(admin, SYNC_BUCKET, userId);
+          await removeUserObjects(admin, AVATAR_BUCKET, userId);
         } catch (fileErr) {
           console.error('process-account-deletions: blob cleanup failed after delete for', userId, fileErr);
         }

--- a/supabase/migrations/20260627120000_profiles_ci_avatars.sql
+++ b/supabase/migrations/20260627120000_profiles_ci_avatars.sql
@@ -1,0 +1,108 @@
+-- Plan 0006 — User profiles, part 1: case-insensitive-unique display names,
+-- avatar columns, and a column-limited anon-readable view.
+--
+-- Display names were previously unique only case-sensitively, so "aetter" and
+-- "Aetter" could coexist and one could impersonate the other by changing case.
+-- We collapse any case-insensitive duplicates (destructive — acceptable at the
+-- current ~5-user scale) and replace the unique constraint with a functional
+-- unique index on lower(display_name). Avatars live in the user-avatars bucket;
+-- the path + an updated-at cache-buster are stored here. A public_profiles view
+-- exposes ONLY the four public columns to anonymous visitors (the driver page).
+
+-- ── Pre-flight: collapse case-insensitive duplicate names ────────────────────
+-- Keep the earliest row per lower(name); suffix later collisions so the new
+-- unique index can build. Destructive by design (a renamed account keeps its id).
+do $$
+declare r record;
+begin
+  for r in
+    select user_id, display_name,
+      row_number() over (partition by lower(display_name) order by created_at, user_id) as rn
+    from public.profiles
+  loop
+    if r.rn > 1 then
+      update public.profiles
+        set display_name = r.display_name || '-' || r.rn::text,
+            updated_at = now()
+        where user_id = r.user_id;
+    end if;
+  end loop;
+end $$;
+
+-- ── Swap the case-sensitive unique constraint for a case-insensitive index ────
+alter table public.profiles drop constraint if exists profiles_display_name_key;
+drop index if exists profiles_display_name_lower_idx;
+create unique index profiles_display_name_lower_idx
+  on public.profiles (lower(display_name));
+
+-- ── Avatar columns ───────────────────────────────────────────────────────────
+-- avatar_path: stable object path in the user-avatars bucket ({user_id}/avatar.<ext>).
+-- avatar_updated_at: appended to the public URL as ?v= so a replaced avatar (same
+-- path, upsert) repaints instead of serving the cached image.
+alter table public.profiles add column if not exists avatar_path text;
+alter table public.profiles add column if not exists avatar_updated_at timestamptz;
+
+-- ── Make server-side name resolution case-insensitive ────────────────────────
+-- These compared with `=`; switch to lower(...) so auto-generated / suffixed
+-- names never collide case-insensitively with the new unique index.
+create or replace function public.random_display_name()
+returns text language plpgsql as $$
+declare
+  adjs text[] := array[
+    'Speedy','Turbo','Drifty','Nitro','Reckless','Smooth','Apex','Sideways',
+    'Greasy','Loose','Sketchy','Mighty','Sneaky','Wobbly','Blazing','Rowdy',
+    'Janky','Cosmic','Feral','Zippy'];
+  nouns text[] := array[
+    'Racer','Driver','Pilot','Hooligan','Throttle','Slider','Charger','Rocket',
+    'Gremlin','Goblin','Wrench','Piston','Sender','Drifter','Maniac','Comet',
+    'Bandit','Cheetah','Noodle','Menace'];
+  candidate text;
+begin
+  loop
+    candidate :=
+      adjs[1 + floor(random() * array_length(adjs, 1))::int]
+      || replace(nouns[1 + floor(random() * array_length(nouns, 1))::int], 'e', '3')
+      || '-' || (100 + floor(random() * 900))::int::text;
+    exit when not exists (
+      select 1 from public.profiles where lower(display_name) = lower(candidate)
+    );
+  end loop;
+  return candidate;
+end;
+$$;
+
+create or replace function public.unique_display_name(desired text)
+returns text language plpgsql as $$
+declare
+  d text := nullif(btrim(coalesce(desired, '')), '');
+  candidate text;
+  tries int := 0;
+begin
+  if d is null then
+    return public.random_display_name();
+  end if;
+  candidate := d;
+  while exists (
+    select 1 from public.profiles where lower(display_name) = lower(candidate)
+  ) loop
+    tries := tries + 1;
+    candidate := d || '-' || (100 + floor(random() * 9900))::int::text;
+    if tries > 50 then
+      candidate := d || '-' || replace(gen_random_uuid()::text, '-', '');
+      exit;
+    end if;
+  end loop;
+  return candidate;
+end;
+$$;
+
+-- ── Anon-readable, column-limited public view ────────────────────────────────
+-- RLS can restrict rows but not columns, so a view is the right tool: anonymous
+-- visitors of /driver/:username may read only these four columns. The view runs
+-- with the (definer) migration role's rights; base-table RLS still gates writes.
+create or replace view public.public_profiles as
+  select user_id, display_name, avatar_path, avatar_updated_at
+  from public.profiles;
+grant select on public.public_profiles to anon, authenticated;
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20260627120100_public_vehicles_and_avatar_bucket.sql
+++ b/supabase/migrations/20260627120100_public_vehicles_and_avatar_bucket.sql
@@ -1,0 +1,75 @@
+-- Plan 0006 — User profiles, part 2: the opt-in public vehicle projection and
+-- the public avatar bucket.
+--
+-- A user's garage lives privately in sync_records (owner-only RLS, weights and
+-- setups attached). The driver profile page must show vehicles publicly, so
+-- vehicles the user flags "show on profile" are projected into public_vehicles
+-- with ONLY public-safe columns — never weight/weightUnit or any setup. Avatars
+-- go in a public bucket so the page can render them with a plain public URL.
+
+-- ── Opt-in public vehicle projection ─────────────────────────────────────────
+create table if not exists public.public_vehicles (
+  user_id    uuid not null references auth.users (id) on delete cascade,
+  vehicle_id text not null,                 -- the client Vehicle.id
+  name       text not null,
+  type_name  text,                          -- resolved vehicle-type label (denormalized)
+  engine     text not null,
+  number     integer not null default 0,
+  updated_at timestamptz not null default now(),
+  primary key (user_id, vehicle_id)
+);
+-- NEVER add weight / weightUnit / setup columns here — that is the whole point.
+
+alter table public.public_vehicles enable row level security;
+
+drop policy if exists "Anyone reads public vehicles" on public.public_vehicles;
+create policy "Anyone reads public vehicles"
+  on public.public_vehicles for select to anon, authenticated using (true);
+
+drop policy if exists "Users insert own public vehicles" on public.public_vehicles;
+create policy "Users insert own public vehicles"
+  on public.public_vehicles for insert to authenticated
+  with check (auth.uid() = user_id);
+
+drop policy if exists "Users update own public vehicles" on public.public_vehicles;
+create policy "Users update own public vehicles"
+  on public.public_vehicles for update to authenticated
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+drop policy if exists "Users delete own public vehicles" on public.public_vehicles;
+create policy "Users delete own public vehicles"
+  on public.public_vehicles for delete to authenticated
+  using (auth.uid() = user_id);
+
+-- ── Public avatar bucket ─────────────────────────────────────────────────────
+-- Public read (it's a public bucket); writes stay scoped to the owner's folder,
+-- mirroring the user-files policies.
+insert into storage.buckets (id, name, public)
+values ('user-avatars', 'user-avatars', true)
+on conflict (id) do nothing;
+
+drop policy if exists "Users upload own avatar" on storage.objects;
+create policy "Users upload own avatar"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'user-avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "Users update own avatar" on storage.objects;
+create policy "Users update own avatar"
+  on storage.objects for update to authenticated
+  using (
+    bucket_id = 'user-avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "Users delete own avatar" on storage.objects;
+create policy "Users delete own avatar"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'user-avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Rounds out the web app with **public driver profiles** (plan 0006):

- **Avatars** — tap your profile picture on the Profile tab to upload one; it's cropped to a centred 1:1 square and downscaled to ≤256px **on-device** (`lib/imageCrop.ts`, pure + tested), then stored in a new **public** `user-avatars` bucket. A `?v=` cache-buster repaints on replace.
- **Case-insensitive unique display names** — replaces the case-sensitive unique constraint with a `lower(display_name)` unique index (+ CI name-resolution functions), so a name can't be impersonated by changing case. `/driver/:username` resolves regardless of casing via `.ilike`. A destructive pre-flight de-dups existing case-collisions (~5 users).
- **Public `/driver/:username` page** (lazy, fully anonymous): avatar + display name, the driver's **opt-in vehicles** (name/type/engine/number — never weights or setups), and their **uploaded leaderboard snapshots** grouped by course + weight (`lib/driverProfileGroups.ts`, pure + tested). Unknown name → a "not found" state that keeps the header + back button.
- **Opt-in vehicle publishing** — a *Show on profile* toggle per vehicle publishes a public-safe projection to a new `public_vehicles` table, synced off the existing garage-change path (`autoSync.pushOne` → `publicVehicleSync`); unflag/delete removes the public row. The private `sync_records` backup is unchanged.
- **Copy profile link** button under Sign out; **avatar thumbnails** left of names on the Leaderboards; a shared **← Back to home** button on both off-session pages.

Backend: two migrations (CI names + avatar cols + anon-readable column-limited `public_profiles` view; `public_vehicles` table + public `user-avatars` bucket). The account-deletion worker now also empties the avatar folder (Storage objects aren't FK-cascaded). `vendor-supabase` stays off the eager graph — `DriverProfile` and `publicProfile` build as their own lazy chunks; `imageCrop.ts` is Supabase-free.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (2051 tests)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (all new Supabase access is lazy/cloud-gated; the core offline app is untouched)
- [x] Docs updated where relevant (`CLAUDE.md`, `docs/backend.md`, `docs/plans/0006-user-profiles.md`, `CHANGELOG.md`)
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table — N/A

## Notes for Reviewers

Two deploy steps are required before this works end-to-end:

1. **Apply the two Supabase migrations** (`supabase/migrations/20260627120000_*` and `..._120100_*`). The case-insensitive de-dup is intentionally **destructive** — worth eyeballing on staging first. Also confirm the `public_profiles` view's definer-vs-`security_invoker` semantics on the target Postgres, since the anon `/driver` reads depend on it.
2. **Run `bun run i18n:seed`** to machine-translate the new `driver` namespace + the added `common`/`plugins`/`drawer` keys. There was no `ANTHROPIC_API_KEY` in the build environment, so the 6 non-English languages are stop-gapped with the English strings (keeps the key-parity test green); they carry no `_sourceHashes`, so the seeder will pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_