### PR TITLE
plan 0006: dynamic per-branch Supabase preview database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,7 @@ and the seeder: **→ `docs/i18n.md`**.
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `VITE_FIRMWARE_MANIFEST_URL` | Client | Override the logger firmware OTA manifest URL. Unset: `main` → production manifest, non-`main`/preview → beta channel (same `isPreviewBuild()` switch). |
+| `SUPABASE_ACCESS_TOKEN` | Build (secret) | Supabase PAT. On a preview build, `vite.config.ts` resolves this branch's own Supabase **preview-branch DB** via the Management API (`scripts/resolveSupabaseBranch.ts`) and bakes its creds in, else falls back to the static `*_PREVIEW`/beta creds. Never on `main`/dev/runtime. → plan 0006. |
 | `DOVE_PLUGIN_PACKAGES` | Build | Comma-separated external plugin npm packages. Overrides the default when set. |
 | `ANTHROPIC_API_KEY` / `I18N_SEED_MODEL` | Maintainer tool | Used **only** by `bun run i18n:seed` (`ANTHROPIC_API_KEY` = `???`). Never in the app or CI build. |
 | `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` / `VITE_GIT_BRANCH` / `VITE_GIT_COMMIT_DATE` | Build (auto) | Footer version stamp — **not hand-set**; baked from `package.json` + git in `vite.config.ts`. |
@@ -405,7 +406,11 @@ forwards to `beta-lapwing.perchwerks.workers.dev` (auto-deployed by the
 see `beta-proxy/README.md`). Per-branch preview backend: `vite.config.ts` `pick()`
 prefers `*_PREVIEW` Supabase creds on any non-`main` branch
 (`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`), so beta deployments bake in a preview DB.
-`main` and local dev never read `_PREVIEW`. See README "Deployment".
+With a `SUPABASE_ACCESS_TOKEN` build secret, a preview build goes one better and
+resolves *this branch's own* Supabase preview-branch DB via the Management API
+(`scripts/resolveSupabaseBranch.ts`, plan 0006), falling back to the static
+`*_PREVIEW`/beta creds when the branch has no preview DB. `main` and local dev
+never read `_PREVIEW` or the token. See README "Deployment".
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ view. Older JSON with only `sector_2_*`/`sector_3_*` is read as the two majors.
 | `STRIPE_SECRET_KEY` | No (required for paid tiers) | Stripe secret key used by the `create-checkout-session`, `stripe-webhook`, and `create-portal-session` edge functions (edge function secret — `???`) |
 | `STRIPE_WEBHOOK_SECRET` | No (required for paid tiers) | Signing secret for the `stripe-webhook` endpoint, from the Stripe dashboard webhook config (edge function secret — `???`) |
 | `DELETION_CRON_SECRET` | No (required for scheduled account deletion) | Shared secret the `process-account-deletions` edge function requires in the `x-cron-secret` header. Must match the Vault secret `deletion_cron_secret` that the daily pg_cron job sends (edge function secret — `???`) |
+| `SUPABASE_ACCESS_TOKEN` | No (preview-branch DBs) | Build-time secret: a Supabase **personal access token**. When set, a preview build resolves its own per-branch Supabase preview database via the Management API and bakes those creds in, falling back to the static `*_PREVIEW`/beta creds when the branch has no preview DB. See *Preview-branch backend* below. Never read by `main` builds, local dev, or the runtime app. |
 | `DOVE_PLUGIN_PACKAGES` | No | Build-time: comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`, the public AI coach) when set |
 | `ANTHROPIC_API_KEY` | No (translation tooling) | Required by `bun run i18n:seed` to machine-translate locale files (`scripts/seed-translations.mjs`). Maintainer tool only — never read by the app or the standard CI build (`???`). |
 | `I18N_SEED_MODEL` | No | Optional model override for `bun run i18n:seed` (default `claude-sonnet-4-6`). |
@@ -455,6 +456,30 @@ whenever that branch isn't `main`, and ignores them on `main` and in local dev.
    Any key works the same way (e.g. `HTT_ENABLE_CLOUD_PREVIEW`). `VITE_*_PREVIEW`
    is also accepted. Add the Cloudflare preview URL to the preview branch's
    **Auth → Redirect URLs** so cloud sign-in works there.
+
+##### Dynamic per-branch databases (optional, recommended)
+
+The static `*_PREVIEW` values above point *every* preview at **one** fixed DB
+(beta). To instead give each branch its **own** Supabase preview-branch database
+— so a feature branch's preview deployment exercises that branch's migrations
+without merging into beta first — add a `SUPABASE_ACCESS_TOKEN` build secret:
+
+1. Create a Supabase **personal access token** (Account → Access Tokens).
+2. Worker → **Settings → Build → Variables and Secrets** → add it as a secret:
+   `SUPABASE_ACCESS_TOKEN` (keep the static `*_PREVIEW` values as the fallback).
+
+On every preview build, `vite.config.ts` then asks the Supabase **Management API**
+whether a preview branch exists for the build's git branch
+(`scripts/resolveSupabaseBranch.ts`). If one does and it's healthy, that branch's
+URL + anon key + ref are baked in; otherwise it falls back to the static
+`*_PREVIEW`/beta creds. The lookup never throws and times out fast, so it can't
+break a deploy. Full design: [`docs/plans/0006-dynamic-supabase-branch-db.md`](docs/plans/0006-dynamic-supabase-branch-db.md).
+
+> Supabase only generates a preview branch when the git branch carries **migration
+> changes**. Branches without DB changes simply fall back to beta. To force a DB
+> for a branch anyway, push a no-op migration or create the branch by hand in the
+> Supabase dashboard. Remember to add each preview URL to the branch's
+> **Auth → Redirect URLs** for cloud sign-in.
 
 #### Custom domains (production + beta)
 

--- a/docs/plans/0006-dynamic-supabase-branch-db.md
+++ b/docs/plans/0006-dynamic-supabase-branch-db.md
@@ -1,0 +1,100 @@
+# Plan 0006 — Dynamic per-branch Supabase preview database
+
+## Goal / problem
+
+Branch-specific front-end previews should talk to **branch-specific Supabase
+preview databases**, automatically, without merging into beta first.
+
+Today the wiring is half-built:
+
+- **Front-end:** Cloudflare Workers Builds deploys every non-`main` branch as a
+  preview. `vite.config.ts` bakes Supabase creds in **at build time**; on a
+  preview build the `pick()` helper prefers `*_PREVIEW` env vars.
+- **The catch:** those `*_PREVIEW` vars are a *single static set* configured once
+  in the Worker settings — they point at **one fixed DB (beta)**. So every branch
+  preview hits the same beta DB. The only way to exercise a migration is to merge
+  it into beta so the beta DB updates.
+- **Supabase side:** Branching is enabled, so Supabase spins up a fresh
+  **preview-branch database** per git branch — *but only when that branch carries
+  migration changes* — each with its own project ref, API URL and anon key.
+  Nothing told the front-end build those creds existed, so they went unused.
+
+The missing piece is the link between "this git branch's Supabase preview DB" and
+"this git branch's front-end build."
+
+## Approach & key decisions
+
+**Build-time resolution via the Supabase Management API.** During the Cloudflare
+build, ask the Management API whether a preview branch exists for the current git
+branch (`WORKERS_CI_BRANCH`); if so, bake *its* creds in. If not, fall back to the
+existing static `_PREVIEW`/beta creds — i.e. today's behaviour, untouched.
+
+Flow (`scripts/resolveSupabaseBranch.ts`):
+1. Skip entirely unless it's a preview build with a `SUPABASE_ACCESS_TOKEN` and a
+   non-`main` branch.
+2. `GET /v1/projects/{prodRef}/branches` → find the non-default branch whose
+   `git_branch` matches the build's branch.
+3. **No match** → return null. This is the common "no DB changes, so Supabase made
+   no branch" case — fall back to beta.
+4. Match but **not healthy** (`status` not in `MIGRATIONS_PASSED` /
+   `FUNCTIONS_DEPLOYED` / `ACTIVE_HEALTHY`) → null. Never point a front-end at a
+   half-provisioned or migration-failed DB.
+5. Healthy → URL `https://{branch.project_ref}.supabase.co`, anon key via
+   `GET /v1/projects/{branch.project_ref}/api-keys`. Return `{ url, anonKey, projectId }`.
+
+`vite.config.ts` calls this (the config factory is now `async`) and threads the
+result into `pick()` as the **top-precedence override** for the three Supabase
+keys only. Everything else flows through the existing precedence chain.
+
+**Why build-time, not a runtime `config.json`?** The whole app is offline-first
+with build-time-baked creds (see the `pick()` comment — "the only place to switch
+backends"). A runtime config endpoint would add a network dependency on load and
+fight that model. Build-time resolution drops into the existing seam with one new
+secret and zero runtime cost. Rejected: runtime config.
+
+**Safety — a backend lookup must never break a deploy.** The resolver never
+throws: it has a 10s timeout, treats any non-OK/parse/network error as "fall
+back", and returns null on every failure path. The static beta creds remain the
+floor, so the worst case is "preview points at beta" — exactly where we are today.
+
+**Why `scripts/`, not `src/`?** It's CI-only build tooling, never shipped to the
+client, so it stays out of the app source tree and out of the `src/`-scoped
+coverage report. `vitest.config.ts` gains a `scripts/**/*.test.ts` include so the
+pure logic is still unit-tested.
+
+## Touch points
+
+- `scripts/resolveSupabaseBranch.ts` — the resolver (new).
+- `scripts/resolveSupabaseBranch.test.ts` — unit tests (new).
+- `vite.config.ts` — async factory; `pick()` gains an override arg; resolves
+  `branchBackend` on preview builds and threads it into the 3 Supabase keys.
+- `vitest.config.ts` — include `scripts/**/*.test.ts`.
+- `README.md`, `CLAUDE.md` — `SUPABASE_ACCESS_TOKEN` env var + operator steps.
+
+## Operator setup (one-time)
+
+1. Create a Supabase **personal access token** (Account → Access Tokens) with
+   access to the project.
+2. Add it as a **secret** in the Worker → Settings → Build → Variables and
+   Secrets: `SUPABASE_ACCESS_TOKEN`. (The static `*_PREVIEW` beta creds stay as
+   the fallback.)
+3. Add each preview branch's Cloudflare preview URL to that branch's Supabase
+   **Auth → Redirect URLs** if cloud sign-in is needed on it.
+
+> **"Branches aren't always generated."** That's inherent to Supabase Branching —
+> a preview branch is created only when the branch has migration changes. This
+> design embraces that: branches *with* DB changes get their own DB; branches
+> without fall back to beta. If you want a branch DB regardless, push a no-op
+> migration, or create the branch manually in the Supabase dashboard so the
+> Management API lists it.
+
+## Status / phasing
+
+- **Done:** resolver + tests, vite wiring, docs. Green across lint / typecheck /
+  test / build. With no `SUPABASE_ACCESS_TOKEN` set, behaviour is byte-identical
+  to before (resolver short-circuits to null).
+- **Pending (operator):** add the `SUPABASE_ACCESS_TOKEN` secret in Cloudflare to
+  activate it.
+- **Follow-ups:** if the new publishable/secret API-key scheme fully replaces the
+  legacy `anon` key on branches, confirm `pickAnonKey` still finds a usable
+  publishable key (it already falls back to `name === "publishable"`).

--- a/scripts/resolveSupabaseBranch.test.ts
+++ b/scripts/resolveSupabaseBranch.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  selectBranchForGit,
+  isBranchReady,
+  pickAnonKey,
+  resolveBranchBackend,
+  type ManagementBranch,
+} from "./resolveSupabaseBranch";
+
+const branch = (over: Partial<ManagementBranch>): ManagementBranch => ({
+  id: "b1",
+  project_ref: "preview123",
+  git_branch: "feature/x",
+  status: "MIGRATIONS_PASSED",
+  is_default: false,
+  ...over,
+});
+
+describe("selectBranchForGit", () => {
+  it("matches a non-default branch by git_branch", () => {
+    const list = [
+      branch({ id: "prod", is_default: true, git_branch: "main" }),
+      branch({ id: "feat", git_branch: "feature/x" }),
+    ];
+    expect(selectBranchForGit(list, "feature/x")?.id).toBe("feat");
+  });
+
+  it("never returns the default (production) branch", () => {
+    const list = [branch({ id: "prod", is_default: true, git_branch: "main" })];
+    expect(selectBranchForGit(list, "main")).toBeNull();
+  });
+
+  it("returns null when no branch tracks the git branch", () => {
+    expect(selectBranchForGit([branch({ git_branch: "other" })], "feature/x")).toBeNull();
+  });
+
+  it("returns null for an empty git branch", () => {
+    expect(selectBranchForGit([branch({})], "")).toBeNull();
+  });
+});
+
+describe("isBranchReady", () => {
+  it.each(["MIGRATIONS_PASSED", "FUNCTIONS_DEPLOYED", "ACTIVE_HEALTHY"])(
+    "treats %s as ready",
+    (status) => expect(isBranchReady(branch({ status }))).toBe(true),
+  );
+
+  it.each(["RUNNING_MIGRATIONS", "MIGRATIONS_FAILED", "CREATING_PROJECT", undefined])(
+    "treats %s as not ready",
+    (status) => expect(isBranchReady(branch({ status }))).toBe(false),
+  );
+});
+
+describe("pickAnonKey", () => {
+  it("prefers the anon key", () => {
+    expect(pickAnonKey([{ name: "service_role", api_key: "s" }, { name: "anon", api_key: "a" }])).toBe("a");
+  });
+  it("falls back to publishable", () => {
+    expect(pickAnonKey([{ name: "publishable", api_key: "p" }])).toBe("p");
+  });
+  it("returns null when neither is present", () => {
+    expect(pickAnonKey([{ name: "secret", api_key: "x" }])).toBeNull();
+  });
+});
+
+describe("resolveBranchBackend", () => {
+  const baseOpts = {
+    gitBranch: "feature/x",
+    prodProjectRef: "prodref",
+    accessToken: "token",
+    warn: () => {},
+  };
+
+  const okFetch = (branches: unknown, keys: unknown): typeof fetch =>
+    vi.fn(async (url: string | URL | Request) => {
+      const u = String(url);
+      const body = u.includes("/branches") ? branches : keys;
+      return new Response(JSON.stringify(body), { status: 200 });
+    }) as unknown as typeof fetch;
+
+  it("resolves a ready branch to its creds", async () => {
+    const res = await resolveBranchBackend({
+      ...baseOpts,
+      fetchImpl: okFetch(
+        [branch({ project_ref: "preview123", git_branch: "feature/x" })],
+        [{ name: "anon", api_key: "anonkey" }],
+      ),
+    });
+    expect(res).toEqual({
+      url: "https://preview123.supabase.co",
+      anonKey: "anonkey",
+      projectId: "preview123",
+    });
+  });
+
+  it("returns null without an access token", async () => {
+    expect(await resolveBranchBackend({ ...baseOpts, accessToken: "" })).toBeNull();
+  });
+
+  it("returns null on main", async () => {
+    expect(await resolveBranchBackend({ ...baseOpts, gitBranch: "main" })).toBeNull();
+  });
+
+  it("falls back when no branch matches (the no-DB-changes case)", async () => {
+    const res = await resolveBranchBackend({
+      ...baseOpts,
+      fetchImpl: okFetch([branch({ git_branch: "unrelated" })], []),
+    });
+    expect(res).toBeNull();
+  });
+
+  it("falls back when the branch is not ready", async () => {
+    const res = await resolveBranchBackend({
+      ...baseOpts,
+      fetchImpl: okFetch(
+        [branch({ git_branch: "feature/x", status: "MIGRATIONS_FAILED" })],
+        [{ name: "anon", api_key: "anonkey" }],
+      ),
+    });
+    expect(res).toBeNull();
+  });
+
+  it("falls back when the anon key is missing", async () => {
+    const res = await resolveBranchBackend({
+      ...baseOpts,
+      fetchImpl: okFetch([branch({ git_branch: "feature/x" })], [{ name: "secret", api_key: "x" }]),
+    });
+    expect(res).toBeNull();
+  });
+
+  it("never throws on a network error", async () => {
+    const res = await resolveBranchBackend({
+      ...baseOpts,
+      fetchImpl: vi.fn(async () => {
+        throw new Error("network down");
+      }) as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+
+  it("falls back on a non-OK list response", async () => {
+    const res = await resolveBranchBackend({
+      ...baseOpts,
+      fetchImpl: vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch,
+    });
+    expect(res).toBeNull();
+  });
+});

--- a/scripts/resolveSupabaseBranch.ts
+++ b/scripts/resolveSupabaseBranch.ts
@@ -1,0 +1,195 @@
+// Build-time resolver: map the CI git branch to its Supabase **preview-branch**
+// database via the Supabase Management API, so a per-branch front-end preview
+// talks to that branch's own ephemeral DB instead of the one static beta DB.
+//
+// Why this exists: Cloudflare Workers Builds deploys every non-`main` branch as a
+// preview, but `vite.config.ts` bakes a single fixed set of `*_PREVIEW` Supabase
+// creds (the beta DB) into all of them. Supabase Branching, meanwhile, spins up a
+// fresh preview database per git branch — but ONLY when that branch carries
+// migration changes — with its own project ref, API URL and anon key. Nothing
+// linked the two. This module is that link: at build time it asks the Management
+// API "is there a Supabase branch for this git branch?" and, if so, returns its
+// creds for vite.config to bake in. When there's no branch (no DB changes) or the
+// branch isn't healthy, it returns null and the caller falls back to the existing
+// static `_PREVIEW`/beta creds — i.e. today's behaviour, unchanged.
+//
+// This is pure build tooling (Node, runs in CI), never shipped to the client, so
+// it has zero bearing on the offline-first runtime.
+
+/** Supabase Management API base. */
+const MANAGEMENT_API = "https://api.supabase.com";
+
+/** How long to wait on the Management API before giving up and falling back. A
+ * slow/Down control plane must never stall or fail a deploy. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Resolved creds for a branch's preview database. Mirrors the three Supabase
+ * `VITE_*` keys vite.config bakes in. */
+export interface BranchBackend {
+  /** `https://{ref}.supabase.co` */
+  url: string;
+  /** The preview branch's anon (publishable) key. */
+  anonKey: string;
+  /** The preview branch's own project ref. */
+  projectId: string;
+}
+
+/** Subset of a Management API branch object (`GET /v1/projects/{ref}/branches`)
+ * that we rely on. The API returns more fields; we only type what we read. */
+export interface ManagementBranch {
+  id: string;
+  /** The preview branch's OWN project ref (a distinct Supabase project). */
+  project_ref: string;
+  /** The git branch this preview branch tracks. */
+  git_branch?: string;
+  /** Provisioning/migration status — see READY_STATUSES. */
+  status?: string;
+  /** True for the production/default branch (parent project) — never a preview. */
+  is_default?: boolean;
+}
+
+/** One entry of `GET /v1/projects/{ref}/api-keys`. */
+interface ApiKey {
+  name?: string;
+  api_key?: string;
+}
+
+/** Branch statuses where the preview database is provisioned and safe to point a
+ * front-end at. A branch mid-provision or with failed migrations is deliberately
+ * skipped so we never bake creds for a half-built/broken DB — we fall back
+ * instead. Source: Supabase branch lifecycle statuses. */
+const READY_STATUSES: ReadonlySet<string> = new Set([
+  "MIGRATIONS_PASSED",
+  "FUNCTIONS_DEPLOYED",
+  "ACTIVE_HEALTHY",
+]);
+
+/**
+ * Pure selection: from a list of Management API branches, pick the (non-default)
+ * preview branch tracking `gitBranch`. Returns null when none matches. Extracted
+ * so the matching logic is unit-testable without any network.
+ */
+export function selectBranchForGit(
+  branches: ManagementBranch[],
+  gitBranch: string,
+): ManagementBranch | null {
+  if (!gitBranch) return null;
+  return (
+    branches.find((b) => !b.is_default && b.git_branch === gitBranch) ?? null
+  );
+}
+
+/** Pure: is this branch's database provisioned enough to use? */
+export function isBranchReady(branch: ManagementBranch): boolean {
+  return !!branch.status && READY_STATUSES.has(branch.status);
+}
+
+/** Pure: pick the anon/publishable key out of an api-keys response. */
+export function pickAnonKey(keys: ApiKey[]): string | null {
+  const anon = keys.find((k) => k.name === "anon");
+  if (anon?.api_key) return anon.api_key;
+  const publishable = keys.find((k) => k.name === "publishable");
+  return publishable?.api_key ?? null;
+}
+
+export interface ResolveOptions {
+  /** The CI git branch being built (e.g. `WORKERS_CI_BRANCH`). */
+  gitBranch: string;
+  /** The PRODUCTION project ref the branches hang off (parent project). */
+  prodProjectRef: string;
+  /** A Supabase personal access token with access to the project. */
+  accessToken: string;
+  /** Injectable fetch (for tests); defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injectable logger (for tests); defaults to console.warn. */
+  warn?: (msg: string) => void;
+}
+
+async function getJson<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  accessToken: string,
+): Promise<T | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetchImpl(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve the Supabase preview-branch database for the current git branch, or
+ * null to fall back to the static `_PREVIEW`/beta creds.
+ *
+ * Returns null (silently falls back) when: the access token or git branch is
+ * missing, the branch is `main`, no Supabase branch tracks this git branch (the
+ * common "no DB changes, so no branch was generated" case), the branch isn't
+ * healthy yet, the anon key can't be read, or the Management API errors/times
+ * out. It NEVER throws — a backend resolution problem must not break a build.
+ */
+export async function resolveBranchBackend(
+  opts: ResolveOptions,
+): Promise<BranchBackend | null> {
+  const {
+    gitBranch,
+    prodProjectRef,
+    accessToken,
+    fetchImpl = fetch,
+    warn = (m) => console.warn(m),
+  } = opts;
+
+  if (!accessToken || !gitBranch || gitBranch === "main" || !prodProjectRef) {
+    return null;
+  }
+
+  try {
+    const branches = await getJson<ManagementBranch[]>(
+      fetchImpl,
+      `${MANAGEMENT_API}/v1/projects/${prodProjectRef}/branches`,
+      accessToken,
+    );
+    if (!Array.isArray(branches)) {
+      warn(`[supabase-branch] could not list branches for ${prodProjectRef}`);
+      return null;
+    }
+
+    const branch = selectBranchForGit(branches, gitBranch);
+    if (!branch) {
+      // No DB changes on this branch → Supabase made no preview branch. Normal.
+      return null;
+    }
+    if (!isBranchReady(branch)) {
+      warn(
+        `[supabase-branch] branch "${gitBranch}" found but status=${branch.status}; falling back`,
+      );
+      return null;
+    }
+
+    const keys = await getJson<ApiKey[]>(
+      fetchImpl,
+      `${MANAGEMENT_API}/v1/projects/${branch.project_ref}/api-keys?reveal=true`,
+      accessToken,
+    );
+    const anonKey = Array.isArray(keys) ? pickAnonKey(keys) : null;
+    if (!anonKey) {
+      warn(`[supabase-branch] no anon key for branch project ${branch.project_ref}`);
+      return null;
+    }
+
+    return {
+      url: `https://${branch.project_ref}.supabase.co`,
+      anonKey,
+      projectId: branch.project_ref,
+    };
+  } catch (err) {
+    warn(`[supabase-branch] resolution failed, falling back: ${String(err)}`);
+    return null;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 import fs from "fs";
 import { execSync } from "child_process";
 import { VitePWA } from "vite-plugin-pwa";
+import { resolveBranchBackend } from "./scripts/resolveSupabaseBranch";
 
 // Build-time version metadata for the footer "what changed" stamp. The app
 // version comes from package.json; the commit hash + build date are baked in at
@@ -110,7 +111,7 @@ const PUBLIC_BACKEND_FALLBACKS = {
 } as const;
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(async ({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   // Some secret stores reject the `VITE_` prefix (those are public, build-time
@@ -135,7 +136,10 @@ export default defineConfig(({ mode }) => {
   const PROD_BRANCH = "main";
   const isPreviewBuild = !!ciBranch && ciBranch !== PROD_BRANCH;
 
-  const pick = (viteKey: string, httKey: string, fallback: string) => {
+  const pick = (viteKey: string, httKey: string, fallback: string, override?: string) => {
+    // A resolved per-branch Supabase preview DB (see below) wins over everything:
+    // it's the whole point — this branch's own ephemeral database.
+    if (override) return override;
     if (isPreviewBuild) {
       const previewVal =
         env[`${viteKey}_PREVIEW`] ||
@@ -146,6 +150,33 @@ export default defineConfig(({ mode }) => {
     }
     return env[viteKey] || process.env[viteKey] || env[httKey] || process.env[httKey] || fallback;
   };
+
+  // DYNAMIC PER-BRANCH BACKEND: on a preview build, ask the Supabase Management
+  // API whether a preview-branch database exists for THIS git branch and, if so,
+  // bake in its creds instead of the one static beta DB. This is the only thing
+  // that makes branch-specific databases reachable from branch-specific previews.
+  // Requires a SUPABASE_ACCESS_TOKEN build secret; without it (or when the branch
+  // has no DB changes, so Supabase made no branch) `branchBackend` stays null and
+  // pick() falls through to the existing `_PREVIEW`/beta chain — today's behaviour.
+  // The resolver never throws and times out fast, so it can't break a deploy.
+  const prodProjectRef =
+    env.VITE_SUPABASE_PROJECT_ID ||
+    process.env.VITE_SUPABASE_PROJECT_ID ||
+    env.HTT_SUPABASE_PROJECT_ID ||
+    process.env.HTT_SUPABASE_PROJECT_ID ||
+    "";
+  const branchBackend = isPreviewBuild
+    ? await resolveBranchBackend({
+        gitBranch: ciBranch ?? "",
+        prodProjectRef,
+        accessToken: process.env.SUPABASE_ACCESS_TOKEN || env.SUPABASE_ACCESS_TOKEN || "",
+      })
+    : null;
+  if (branchBackend) {
+    console.log(
+      `[supabase-branch] using preview DB ${branchBackend.projectId} for branch "${ciBranch}"`,
+    );
+  }
 
   const appVersion = readAppVersion();
   const gitHash = gitShortHash();
@@ -166,13 +197,13 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       "import.meta.env.VITE_SUPABASE_PROJECT_ID": JSON.stringify(
-        pick("VITE_SUPABASE_PROJECT_ID", "HTT_SUPABASE_PROJECT_ID", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_PROJECT_ID),
+        pick("VITE_SUPABASE_PROJECT_ID", "HTT_SUPABASE_PROJECT_ID", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_PROJECT_ID, branchBackend?.projectId),
       ),
       "import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY": JSON.stringify(
-        pick("VITE_SUPABASE_PUBLISHABLE_KEY", "HTT_SUPABASE_PUBLISHABLE_KEY", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_PUBLISHABLE_KEY),
+        pick("VITE_SUPABASE_PUBLISHABLE_KEY", "HTT_SUPABASE_PUBLISHABLE_KEY", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_PUBLISHABLE_KEY, branchBackend?.anonKey),
       ),
       "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(
-        pick("VITE_SUPABASE_URL", "HTT_SUPABASE_URL", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_URL),
+        pick("VITE_SUPABASE_URL", "HTT_SUPABASE_URL", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_URL, branchBackend?.url),
       ),
       "import.meta.env.VITE_ENABLE_ADMIN": JSON.stringify(
         pick("VITE_ENABLE_ADMIN", "HTT_ENABLE_ADMIN", PUBLIC_BACKEND_FALLBACKS.VITE_ENABLE_ADMIN),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
     environment: "node",
     // App tests live under src/; also pick up pure logic extracted from Supabase
     // edge functions (Deno) so it can be unit-tested here (coverage stays src/-only).
-    include: ["src/**/*.{test,spec}.{ts,tsx}", "supabase/functions/**/*.{test,spec}.ts"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "supabase/functions/**/*.{test,spec}.ts",
+      // Build tooling (CI-only, never shipped) — tested here, but kept out of the
+      // src-only coverage scope below.
+      "scripts/**/*.{test,spec}.ts",
+    ],
     exclude: ["node_modules", "dist"],
     setupFiles: ["./vitest.setup.ts"],
     coverage: {


### PR DESCRIPTION
## Summary

Branch-specific front-end previews now resolve **their own** Supabase preview-branch database at build time instead of all sharing one static beta DB.

The wiring was previously half-built: Cloudflare Workers Builds deploys every non-`main` branch as a preview, but `vite.config.ts` baked a single fixed set of `*_PREVIEW` Supabase creds (the beta DB) into all of them. Supabase Branching, meanwhile, was already spinning up a fresh preview database per git branch (when that branch carries migration changes) — nothing read those creds.

This PR is the missing link. On a preview build with a `SUPABASE_ACCESS_TOKEN` secret, `vite.config.ts` asks the Supabase **Management API** whether a preview branch exists for the build's git branch (`scripts/resolveSupabaseBranch.ts`). If one does and it's healthy, that branch's URL + anon key + ref are baked in; otherwise it falls back to the existing static `*_PREVIEW`/beta creds — the common "no DB changes, so Supabase made no branch" case.

**With no `SUPABASE_ACCESS_TOKEN` set, behaviour is byte-identical to before** (the resolver short-circuits to null). The resolver never throws and times out fast (10s), so a flaky/down control plane can't break a deploy.

### Why this design
- **Build-time, not a runtime `config.json`** — fits the existing build-time-baked creds model (`pick()` is "the only place to switch backends"); no runtime network dependency, no offline-first regression.
- **Embraces "branches aren't always generated"** — a branch with migration changes gets its own DB; one without falls back to beta. No half-provisioned/broken-DB previews (status must be `MIGRATIONS_PASSED` / `FUNCTIONS_DEPLOYED` / `ACTIVE_HEALTHY`).
- **Build tooling lives in `scripts/`** (CI-only, never shipped), kept out of the `src/`-scoped coverage report; `vitest.config.ts` gains a `scripts/**/*.test.ts` include so the pure logic is still unit-tested.

### Files
- `scripts/resolveSupabaseBranch.ts` (+ `.test.ts`, 22 tests) — pure branch-matching / anon-key-picking + fail-safe Management API resolver
- `vite.config.ts` — async config factory; `pick()` gains a top-precedence override for the three Supabase keys
- `vitest.config.ts` — include `scripts/**/*.test.ts`
- `README.md`, `CLAUDE.md` — `SUPABASE_ACCESS_TOKEN` env + operator setup
- `docs/plans/0006-dynamic-supabase-branch-db.md` — design record

### Operator step to activate
Add a Supabase **personal access token** as a `SUPABASE_ACCESS_TOKEN` build secret in the Worker → Settings → Build (keep the static `*_PREVIEW` beta creds as the fallback). To force a DB on a branch with no migration changes, push a no-op migration or create the branch by hand in the Supabase dashboard.

## Related Issues

<!-- none -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2043 tests)
- [x] `bun run build` succeeds
- [x] Feature works **offline** (build-time tooling only — no new runtime network calls)
- [x] Docs updated where relevant (`README.md`, `CLAUDE.md`, plan 0006). No `CHANGELOG.md` entry — this is deploy/infra plumbing, not a user-facing change.
- [ ] For a new parser: n/a

## Notes for Reviewers

- One thing to confirm: if the project has fully migrated to the new publishable/secret API-key scheme, double-check branch projects still expose a key named `anon` or `publishable` — `pickAnonKey` looks for those two (anon first, then publishable).
- The resolver is intentionally silent on the "no branch for this git branch" path (the normal case) and only `console.warn`s on genuine anomalies (branch found but unhealthy, missing anon key, API error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcAij6Tqtar9yWGeGwKR7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcAij6Tqtar9yWGeGwKR7Y)_