### PR TITLE
plan 0006: add missing SELECT policy on user-avatars (fixes avatar upload 403)

### DIFF
--- a/supabase/migrations/20260629000000_user_avatars_select_policy.sql
+++ b/supabase/migrations/20260629000000_user_avatars_select_policy.sql
@@ -1,0 +1,21 @@
+-- Plan 0006 — avatar upload fix: add the missing SELECT policy on user-avatars.
+--
+-- Avatar uploads use `upsert: true`, so storage-api first checks whether the
+-- object already exists — a SELECT on storage.objects under the caller's role.
+-- The user-avatars bucket got INSERT/UPDATE/DELETE policies but NO SELECT, so
+-- that existence check was denied and the upload 403'd ("Unauthorized") even
+-- though the INSERT policy itself was correct (verified: request folder ==
+-- auth.uid(), valid authenticated JWT). The user-files bucket has always carried
+-- this read policy — mirror it here so the upsert can complete. Public reads of
+-- avatars go through the bucket's public URL and are unaffected either way.
+--
+-- Idempotent + a fresh version, so it self-heals the beta DB (where the bucket's
+-- write policies already exist) and is a clean addition on main / any fresh DB.
+
+drop policy if exists "Users read own avatar" on storage.objects;
+create policy "Users read own avatar"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'user-avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary

Fixes avatar uploads failing with **403** on beta.

**Root cause (confirmed from the live request):** the upload uses `upsert: true`, so `storage-api` does an existence check — a **SELECT on `storage.objects`** under the caller's role — before writing. The `user-avatars` bucket got INSERT/UPDATE/DELETE policies but **no SELECT**, so that check was denied and the whole upload 403'd, even though the INSERT policy was correct.

The failing request proved the INSERT side was fine:
- object path: `user-avatars/824821b3-…-185207488739/avatar.webp`
- JWT `sub` (`auth.uid()`): `824821b3-…-185207488739` — **identical**, valid `authenticated` token, `x-upsert: true`.

The `user-files` bucket never hit this because it has always carried a `"Users read own files"` SELECT policy. This migration mirrors it for `user-avatars`. Public avatar reads go through the bucket's public URL and are unaffected.

One idempotent migration with a fresh version (`20260629000000`), so it self-heals the beta DB (whose avatar write-policies already exist) and is a clean addition on main / any fresh DB.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] Migration only — no app code changed
- [x] Idempotent (`drop policy if exists` → `create policy`), new version so it applies everywhere
- [x] Feature works **offline** (backend-only, cloud-gated)

## Notes for Reviewers

After merge + the beta migrate runs, the avatar upload should succeed. Quick verify:
```sql
select policyname, cmd from pg_policies
where schemaname='storage' and tablename='objects' and policyname = 'Users read own avatar';
```
(one SELECT row) — then upload an avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_