### PR TITLE
Branch-tiered Supabase backend (main=base, BETA=_PREVIEW, feature=resolver) + fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,7 +390,7 @@ and the seeder: **→ `docs/i18n.md`**.
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `VITE_FIRMWARE_MANIFEST_URL` | Client | Override the logger firmware OTA manifest URL. Unset: `main` → production manifest, non-`main`/preview → beta channel (same `isPreviewBuild()` switch). |
-| `SUPABASE_ACCESS_TOKEN` | Build (secret) | Supabase PAT. On a preview build, `vite.config.ts` resolves this branch's own Supabase **preview-branch DB** via the Management API (`scripts/resolveSupabaseBranch.ts`) and bakes its creds in, else falls back to the static `*_PREVIEW`/beta creds. Never on `main`/dev/runtime. → plan 0006. |
+| `SUPABASE_ACCESS_TOKEN` | Build (secret) | Supabase PAT. On a **feature-branch** build (not `main`, not `BETA`), `vite.config.ts` resolves that branch's own Supabase **preview-branch DB** via the Management API (`scripts/resolveSupabaseBranch.ts`) and bakes its creds in, else falls back to the static `*_PREVIEW`/beta creds. Never on `main`/`BETA`/dev/runtime. → plan 0006. |
 | `DOVE_PLUGIN_PACKAGES` | Build | Comma-separated external plugin npm packages. Overrides the default when set. |
 | `ANTHROPIC_API_KEY` / `I18N_SEED_MODEL` | Maintainer tool | Used **only** by `bun run i18n:seed` (`ANTHROPIC_API_KEY` = `???`). Never in the app or CI build. |
 | `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` / `VITE_GIT_BRANCH` / `VITE_GIT_COMMIT_DATE` | Build (auto) | Footer version stamp — **not hand-set**; baked from `package.json` + git in `vite.config.ts`. |
@@ -406,14 +406,14 @@ the dashboard). The beta domain `beta.lapwingdata.com` can't bind to a Branch
 Preview URL, so a separate thin reverse-proxy Worker in `beta-proxy/` owns it and
 forwards to `beta-lapwing.perchwerks.workers.dev` (auto-deployed by the
 `deploy-beta-proxy.yml` workflow on `BETA` pushes that touch `beta-proxy/**`;
-see `beta-proxy/README.md`). Per-branch preview backend: `vite.config.ts` `pick()`
-prefers `*_PREVIEW` Supabase creds on any non-`main` branch
-(`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`), so beta deployments bake in a preview DB.
-With a `SUPABASE_ACCESS_TOKEN` build secret, a preview build goes one better and
-resolves *this branch's own* Supabase preview-branch DB via the Management API
-(`scripts/resolveSupabaseBranch.ts`, plan 0006), falling back to the static
-`*_PREVIEW`/beta creds when the branch has no preview DB. `main` and local dev
-never read `_PREVIEW` or the token. See README "Deployment".
+see `beta-proxy/README.md`). Backend by branch (`vite.config.ts` `pick()`, keyed on
+`WORKERS_CI_BRANCH`/`CF_PAGES_BRANCH`): **`main`** → base/production vars;
+**`BETA`** → static `*_PREVIEW` creds (the shared beta DB — never the resolver);
+**any other branch** → with a `SUPABASE_ACCESS_TOKEN` secret, that branch's own
+Supabase preview-branch DB via the Management API (`scripts/resolveSupabaseBranch.ts`,
+plan 0006), else the `*_PREVIEW`/beta fallback. Each build logs `[backend] Supabase
+URL baked: … — <tier>`. `main` and local dev never read `_PREVIEW`/the token. See
+README "Deployment".
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ view. Older JSON with only `sector_2_*`/`sector_3_*` is read as the two majors.
 | `STRIPE_SECRET_KEY` | No (required for paid tiers) | Stripe secret key used by the `create-checkout-session`, `stripe-webhook`, and `create-portal-session` edge functions (edge function secret — `???`) |
 | `STRIPE_WEBHOOK_SECRET` | No (required for paid tiers) | Signing secret for the `stripe-webhook` endpoint, from the Stripe dashboard webhook config (edge function secret — `???`) |
 | `DELETION_CRON_SECRET` | No (required for scheduled account deletion) | Shared secret the `process-account-deletions` edge function requires in the `x-cron-secret` header. Must match the Vault secret `deletion_cron_secret` that the daily pg_cron job sends (edge function secret — `???`) |
-| `SUPABASE_ACCESS_TOKEN` | No (preview-branch DBs) | Build-time secret: a Supabase **personal access token**. When set, a preview build resolves its own per-branch Supabase preview database via the Management API and bakes those creds in, falling back to the static `*_PREVIEW`/beta creds when the branch has no preview DB. See *Preview-branch backend* below. Never read by `main` builds, local dev, or the runtime app. |
+| `SUPABASE_ACCESS_TOKEN` | No (preview-branch DBs) | Build-time secret: a Supabase **personal access token**. When set, a **feature-branch** build (not `main`, not `BETA`) resolves its own per-branch Supabase preview database via the Management API and bakes those creds in, falling back to the static `*_PREVIEW`/beta creds when the branch has no preview DB. See *Preview-branch backend* below. Never read by `main`/`BETA` builds, local dev, or the runtime app. |
 | `DOVE_PLUGIN_PACKAGES` | No | Build-time: comma-separated external plugin npm packages to load. Overrides the default (`@perchwerks/eye-in-the-sky`, the public AI coach) when set |
 | `ANTHROPIC_API_KEY` | No (translation tooling) | Required by `bun run i18n:seed` to machine-translate locale files (`scripts/seed-translations.mjs`). Maintainer tool only — never read by the app or the standard CI build (`???`). |
 | `I18N_SEED_MODEL` | No | Optional model override for `bun run i18n:seed` (default `claude-sonnet-4-6`). |
@@ -435,12 +435,22 @@ static frontend.
 
 #### Preview-branch backend (Supabase Branching → preview deployments)
 
-Pushes to a **non-production branch** produce a preview version/URL of the same
-Worker. To point those preview builds at a Supabase **preview-branch database**
-(so beta work doesn't touch production data), set parallel `*_PREVIEW` build
-variables. Workers Builds exposes `WORKERS_CI_BRANCH` (Pages: `CF_PAGES_BRANCH`)
-on every build; `vite.config.ts` prefers the `_PREVIEW` value of each key
-whenever that branch isn't `main`, and ignores them on `main` and in local dev.
+The build picks its Supabase backend by **git branch**, in three tiers:
+
+| Branch | Database | How it's chosen |
+|--------|----------|-----------------|
+| `main` | production | base build vars (`VITE_*` / `HTT_*`) |
+| `BETA` | the shared beta DB | the `*_PREVIEW` build vars |
+| any other branch | that branch's **own** Supabase preview-branch DB | resolved via the Management API, falling back to `*_PREVIEW`/beta when none exists |
+
+`BETA` is the shared integration database and is **never** routed onto a per-branch
+DB — only feature branches consult the resolver. Each build logs the result
+(`[backend] Supabase URL baked: … — <tier>`) so a deploy always states which DB it
+baked and why. Set the `*_PREVIEW` vars so non-`main` builds don't touch production:
+
+Workers Builds exposes `WORKERS_CI_BRANCH` (Pages: `CF_PAGES_BRANCH`) on every
+build; `vite.config.ts` prefers the `_PREVIEW` value of each key whenever the
+branch isn't `main`, and ignores them on `main` and in local dev.
 
 1. Enable **Branching** in Supabase, then copy the preview branch's URL, anon
    key, and project ref from the **Branches** panel.
@@ -457,21 +467,22 @@ whenever that branch isn't `main`, and ignores them on `main` and in local dev.
    is also accepted. Add the Cloudflare preview URL to the preview branch's
    **Auth → Redirect URLs** so cloud sign-in works there.
 
-##### Dynamic per-branch databases (optional, recommended)
+##### Dynamic per-branch databases (feature branches)
 
-The static `*_PREVIEW` values above point *every* preview at **one** fixed DB
-(beta). To instead give each branch its **own** Supabase preview-branch database
-— so a feature branch's preview deployment exercises that branch's migrations
-without merging into beta first — add a `SUPABASE_ACCESS_TOKEN` build secret:
+Without a token, every non-`main` preview (including feature branches) uses the
+static `*_PREVIEW`/beta DB. To instead give each **feature** branch its **own**
+Supabase preview-branch database — so its preview deployment exercises that
+branch's migrations without merging into beta first — add a `SUPABASE_ACCESS_TOKEN`
+build secret (`BETA` always stays on `*_PREVIEW` regardless):
 
 1. Create a Supabase **personal access token** (Account → Access Tokens).
 2. Worker → **Settings → Build → Variables and Secrets** → add it as a secret:
    `SUPABASE_ACCESS_TOKEN` (keep the static `*_PREVIEW` values as the fallback).
 
-On every preview build, `vite.config.ts` then asks the Supabase **Management API**
-whether a preview branch exists for the build's git branch
-(`scripts/resolveSupabaseBranch.ts`). If one does and it's healthy, that branch's
-URL + anon key + ref are baked in; otherwise it falls back to the static
+On a **feature-branch** build (not `main`, not `BETA`), `vite.config.ts` asks the
+Supabase **Management API** whether a preview branch exists for the build's git
+branch (`scripts/resolveSupabaseBranch.ts`). If one does and it's healthy, that
+branch's URL + anon key + ref are baked in; otherwise it falls back to the static
 `*_PREVIEW`/beta creds. The lookup never throws and times out fast, so it can't
 break a deploy. Full design: [`docs/plans/0006-dynamic-supabase-branch-db.md`](docs/plans/0006-dynamic-supabase-branch-db.md).
 

--- a/docs/plans/0006-dynamic-supabase-branch-db.md
+++ b/docs/plans/0006-dynamic-supabase-branch-db.md
@@ -30,8 +30,10 @@ branch (`WORKERS_CI_BRANCH`); if so, bake *its* creds in. If not, fall back to t
 existing static `_PREVIEW`/beta creds — i.e. today's behaviour, untouched.
 
 Flow (`scripts/resolveSupabaseBranch.ts`):
-1. Skip entirely unless it's a preview build with a `SUPABASE_ACCESS_TOKEN` and a
-   non-`main` branch.
+1. Skip entirely unless it's a **feature-branch** build with a `SUPABASE_ACCESS_TOKEN`
+   — i.e. a branch that is neither `main` nor `BETA`. (`BETA` is the shared
+   integration DB and always uses the static `*_PREVIEW` creds; only feature
+   branches get their own per-branch database.)
 2. `GET /v1/projects/{prodRef}/branches` → find the non-default branch whose
    `git_branch` matches the build's branch.
 3. **No match** → return null. This is the common "no DB changes, so Supabase made

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -132,13 +132,24 @@ export default defineConfig(async ({ mode }) => {
   // instead of production. Production (`main`) builds and local dev never see
   // the _PREVIEW values, so they're untouched. The creds are build-time-baked,
   // not runtime — picking them here is the only place to switch backends.
+  // Backend tier is chosen by the build's git branch:
+  //   main          → base build vars (production database)
+  //   BETA          → static `*_PREVIEW` vars (the one shared beta database)
+  //   any other     → that branch's OWN Supabase preview-branch DB (resolved
+  //                   below via the Management API), falling back to the
+  //                   `*_PREVIEW`/beta creds when no such branch exists.
+  // `_PREVIEW` is preferred for BETA *and* feature branches; only feature
+  // branches additionally consult the resolver (BETA must never be hijacked onto
+  // a per-branch DB — it's the shared integration database).
   const ciBranch = process.env.WORKERS_CI_BRANCH || process.env.CF_PAGES_BRANCH;
   const PROD_BRANCH = "main";
+  const BETA_BRANCH = "BETA";
   const isPreviewBuild = !!ciBranch && ciBranch !== PROD_BRANCH;
+  const isFeatureBranch = isPreviewBuild && ciBranch !== BETA_BRANCH;
 
   const pick = (viteKey: string, httKey: string, fallback: string, override?: string) => {
-    // A resolved per-branch Supabase preview DB (see below) wins over everything:
-    // it's the whole point — this branch's own ephemeral database.
+    // A resolved per-branch Supabase preview DB (feature branches only) wins over
+    // everything — it's the whole point: this branch's own database.
     if (override) return override;
     if (isPreviewBuild) {
       const previewVal =
@@ -151,32 +162,41 @@ export default defineConfig(async ({ mode }) => {
     return env[viteKey] || process.env[viteKey] || env[httKey] || process.env[httKey] || fallback;
   };
 
-  // DYNAMIC PER-BRANCH BACKEND: on a preview build, ask the Supabase Management
-  // API whether a preview-branch database exists for THIS git branch and, if so,
-  // bake in its creds instead of the one static beta DB. This is the only thing
-  // that makes branch-specific databases reachable from branch-specific previews.
-  // Requires a SUPABASE_ACCESS_TOKEN build secret; without it (or when the branch
-  // has no DB changes, so Supabase made no branch) `branchBackend` stays null and
-  // pick() falls through to the existing `_PREVIEW`/beta chain — today's behaviour.
-  // The resolver never throws and times out fast, so it can't break a deploy.
+  // DYNAMIC PER-BRANCH BACKEND — FEATURE BRANCHES ONLY (never main, never BETA).
+  // Ask the Supabase Management API whether a preview-branch database exists for
+  // THIS git branch and, if so, bake its creds in; otherwise fall back to the
+  // `*_PREVIEW`/beta chain via pick(). Requires a SUPABASE_ACCESS_TOKEN build
+  // secret; without it (or when Supabase made no branch) `branchBackend` stays
+  // null. The resolver never throws and times out fast, so it can't break a deploy.
   const prodProjectRef =
     env.VITE_SUPABASE_PROJECT_ID ||
     process.env.VITE_SUPABASE_PROJECT_ID ||
     env.HTT_SUPABASE_PROJECT_ID ||
     process.env.HTT_SUPABASE_PROJECT_ID ||
     "";
-  const branchBackend = isPreviewBuild
+  const branchBackend = isFeatureBranch
     ? await resolveBranchBackend({
         gitBranch: ciBranch ?? "",
         prodProjectRef,
         accessToken: process.env.SUPABASE_ACCESS_TOKEN || env.SUPABASE_ACCESS_TOKEN || "",
       })
     : null;
-  if (branchBackend) {
-    console.log(
-      `[supabase-branch] using preview DB ${branchBackend.projectId} for branch "${ciBranch}"`,
-    );
-  }
+
+  // Resolve the URL once and log which database this build baked in, so a deploy's
+  // logs always state plainly which backend (and why) it points at.
+  const supabaseUrl = pick(
+    "VITE_SUPABASE_URL", "HTT_SUPABASE_URL", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_URL, branchBackend?.url,
+  );
+  const backendTier = !ciBranch
+    ? "local/dev (base vars)"
+    : ciBranch === PROD_BRANCH
+      ? "main (base/production vars)"
+      : ciBranch === BETA_BRANCH
+        ? "BETA (*_PREVIEW vars)"
+        : branchBackend
+          ? `feature "${ciBranch}" (branch DB ${branchBackend.projectId})`
+          : `feature "${ciBranch}" (no branch DB → *_PREVIEW fallback)`;
+  console.log(`[backend] Supabase URL baked: ${supabaseUrl || "(none — offline-only build)"} — ${backendTier}`);
 
   const appVersion = readAppVersion();
   const gitHash = gitShortHash();
@@ -202,9 +222,7 @@ export default defineConfig(async ({ mode }) => {
       "import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY": JSON.stringify(
         pick("VITE_SUPABASE_PUBLISHABLE_KEY", "HTT_SUPABASE_PUBLISHABLE_KEY", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_PUBLISHABLE_KEY, branchBackend?.anonKey),
       ),
-      "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(
-        pick("VITE_SUPABASE_URL", "HTT_SUPABASE_URL", PUBLIC_BACKEND_FALLBACKS.VITE_SUPABASE_URL, branchBackend?.url),
-      ),
+      "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(supabaseUrl),
       "import.meta.env.VITE_ENABLE_ADMIN": JSON.stringify(
         pick("VITE_ENABLE_ADMIN", "HTT_ENABLE_ADMIN", PUBLIC_BACKEND_FALLBACKS.VITE_ENABLE_ADMIN),
       ),


### PR DESCRIPTION
## Summary

Makes the build choose its Supabase database **by git branch**, exactly as intended — and stops the resolver from ever being able to route `BETA` onto a per-branch DB (the behavior that kicked off the recent debugging).

Three deterministic tiers:

| Branch | Database | Source |
|--------|----------|--------|
| `main` | production | base build vars (`VITE_*`/`HTT_*`) |
| `BETA` | the shared beta DB | static `*_PREVIEW` vars — **never** the resolver |
| any other branch | that branch's **own** Supabase preview-branch DB | Management-API resolver, falling back to `*_PREVIEW`/beta when none exists |

### Changes
- **`vite.config.ts`** — added `isFeatureBranch` (non-`main` AND non-`BETA`) and gated `resolveBranchBackend` to it. `BETA` now always uses `*_PREVIEW`; only feature branches consult the resolver. `_PREVIEW` preference for `pick()` is unchanged (still applies to `BETA` + feature branches).
- **Build-time log** — every build prints `[backend] Supabase URL baked: <url> — <tier>`, so a deploy's logs always state which DB it baked and why (this is what would have made the whole avatar saga a 5-second check).
- Docs (`README.md`, `CLAUDE.md`, `docs/plans/0006-dynamic-supabase-branch-db.md`) updated to the three-tier rule.

Verified by simulating each branch's build:
```
WORKERS_CI_BRANCH=main     → … — main (base/production vars)
WORKERS_CI_BRANCH=BETA     → … — BETA (*_PREVIEW vars)            [resolver NOT called]
WORKERS_CI_BRANCH=feature  → … — feature "feature" (no branch DB → *_PREVIEW fallback)
```

## Type of Change

- [x] Bug fix
- [x] Refactor / reusability improvement

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2082)
- [x] `bun run build` succeeds (and logs the baked backend)
- [x] Works **offline** (build-time only)
- [x] Docs updated (`README.md`, `CLAUDE.md`, plan 0006)

## Notes

- This **supersedes #314** (the "rip out the resolver" revert) — you wanted it *working*, not removed. Closing #314.
- No DB credentials are in code; this only governs which build var set is baked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_