### PR TITLE
Clickable leaderboard avatars → driver profile; clickable snapshot cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Public driver profiles (plan 0006).** A new public `/driver/{name}` page (shareable,
   viewable signed-out) shows a driver's **profile picture**, display name, their **opt-in
   vehicles** (name/type/engine only — never weights or setups), and their uploaded
-  **leaderboard snapshots** grouped by course and weight. URLs are case-insensitive.
+  **leaderboard snapshots** as cards. URLs are case-insensitive. **Click a driver's
+  avatar on the Leaderboards** to open their profile, and **click any snapshot card** to
+  load that lap in the read-only viewer.
 - **Profile pictures.** Tap your profile picture on the Profile tab to upload one; it's
   cropped to a centred square and downscaled to ≤256px on-device, then stored in the
   cloud. Avatar thumbnails now appear next to names on the Leaderboards.

--- a/src/locales/de/driver.json
+++ b/src/locales/de/driver.json
@@ -9,5 +9,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/de/leaderboard.json
+++ b/src/locales/de/leaderboard.json
@@ -27,5 +27,6 @@
   },
   "loadTopSession_one": "Schnellste Runde als eine Sitzung laden",
   "loadTopSession_other": "Top {{count}} Runden als eine Sitzung laden",
-  "loadAllSession": "Alle Runden als eine Sitzung laden"
+  "loadAllSession": "Alle Runden als eine Sitzung laden",
+  "viewProfile": "View driver profile"
 }

--- a/src/locales/en/driver.json
+++ b/src/locales/en/driver.json
@@ -8,5 +8,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/en/leaderboard.json
+++ b/src/locales/en/leaderboard.json
@@ -5,6 +5,7 @@
   "loadFailed": "Couldn't load the leaderboards.",
   "loading": "Loading leaderboards…",
   "showTop": "Show top",
+  "viewProfile": "View driver profile",
   "all": "All",
   "groupByWeight": "Group by weight",
   "bubbles": {

--- a/src/locales/es/driver.json
+++ b/src/locales/es/driver.json
@@ -9,5 +9,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/es/leaderboard.json
+++ b/src/locales/es/leaderboard.json
@@ -27,5 +27,6 @@
   },
   "loadTopSession_one": "Cargar la vuelta más rápida como una sola sesión",
   "loadTopSession_other": "Cargar las {{count}} mejores vueltas como una sola sesión",
-  "loadAllSession": "Cargar todas las vueltas como una sola sesión"
+  "loadAllSession": "Cargar todas las vueltas como una sola sesión",
+  "viewProfile": "View driver profile"
 }

--- a/src/locales/fr/driver.json
+++ b/src/locales/fr/driver.json
@@ -9,5 +9,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/fr/leaderboard.json
+++ b/src/locales/fr/leaderboard.json
@@ -27,5 +27,6 @@
   },
   "loadTopSession_one": "Charger le meilleur tour en une seule session",
   "loadTopSession_other": "Charger les {{count}} meilleurs tours en une seule session",
-  "loadAllSession": "Charger tous les tours en une seule session"
+  "loadAllSession": "Charger tous les tours en une seule session",
+  "viewProfile": "View driver profile"
 }

--- a/src/locales/it/driver.json
+++ b/src/locales/it/driver.json
@@ -9,5 +9,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/it/leaderboard.json
+++ b/src/locales/it/leaderboard.json
@@ -27,5 +27,6 @@
   },
   "loadTopSession_one": "Carica il giro più veloce come singola sessione",
   "loadTopSession_other": "Carica i {{count}} giri più veloci come singola sessione",
-  "loadAllSession": "Carica tutti i giri come singola sessione"
+  "loadAllSession": "Carica tutti i giri come singola sessione",
+  "viewProfile": "View driver profile"
 }

--- a/src/locales/ja/driver.json
+++ b/src/locales/ja/driver.json
@@ -9,5 +9,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/ja/leaderboard.json
+++ b/src/locales/ja/leaderboard.json
@@ -27,5 +27,6 @@
   },
   "loadTopSession_one": "最速ラップを1つのセッションとして読み込む",
   "loadTopSession_other": "上位 {{count}} ラップを1つのセッションとして読み込む",
-  "loadAllSession": "すべてのラップを1つのセッションとして読み込む"
+  "loadAllSession": "すべてのラップを1つのセッションとして読み込む",
+  "viewProfile": "View driver profile"
 }

--- a/src/locales/pt-BR/driver.json
+++ b/src/locales/pt-BR/driver.json
@@ -9,5 +9,6 @@
   "unknownType": "Unknown type",
   "snapshotsTitle": "Leaderboard snapshots",
   "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight"
+  "noWeight": "No listed weight",
+  "openSnapshot": "Open this lap in the viewer"
 }

--- a/src/locales/pt-BR/leaderboard.json
+++ b/src/locales/pt-BR/leaderboard.json
@@ -27,5 +27,6 @@
   },
   "loadTopSession_one": "Carregar a volta mais rápida como uma única sessão",
   "loadTopSession_other": "Carregar as {{count}} voltas mais rápidas como uma única sessão",
-  "loadAllSession": "Carregar todas as voltas como uma única sessão"
+  "loadAllSession": "Carregar todas as voltas como uma única sessão",
+  "viewProfile": "View driver profile"
 }

--- a/src/pages/DriverProfile.tsx
+++ b/src/pages/DriverProfile.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Car, Trophy, UserX } from "lucide-react";
+import { Car, Cpu, Trophy, UserX, Weight, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SettingsModal } from "@/components/SettingsModal";
 import { BackToHome } from "@/components/BackToHome";
@@ -9,7 +10,35 @@ import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { useSettings } from "@/hooks/useSettings";
 import { formatLapTime } from "@/lib/lapCalculation";
 import { groupEntriesByCourseWeight, type DriverCourseGroup } from "@/lib/driverProfileGroups";
+import { buildLeaderboardSession } from "@/lib/leaderboardSession";
+import { setPendingLeaderboardSession } from "@/lib/leaderboardHandoff";
 import type { PublicProfile, PublicVehicle } from "@/plugins/cloud-sync/publicProfile";
+
+/** One flattened, clickable uploaded snapshot card. */
+interface SnapshotCard {
+  id: string;
+  courseName: string;
+  trackName: string;
+  engineLabel: string;
+  weightLabel: string | null;
+  lapTimeMs: number;
+}
+
+/** Flatten the course→weight→lap grouping into one card per uploaded snapshot. */
+function flattenSnapshots(courses: DriverCourseGroup[]): SnapshotCard[] {
+  return courses.flatMap((c) =>
+    c.weightGroups.flatMap((wg) =>
+      wg.laps.map((lap) => ({
+        id: lap.id,
+        courseName: c.courseName,
+        trackName: c.trackName,
+        engineLabel: lap.engineLabel,
+        weightLabel: wg.weightLabel,
+        lapTimeMs: lap.lapTimeMs,
+      })),
+    ),
+  );
+}
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -116,93 +145,117 @@ export default function DriverProfile() {
 
 function DriverBody({ data }: { data: LoadedData }) {
   const { t } = useTranslation("driver");
+  const navigate = useNavigate();
   const { profile, vehicles, courses } = data;
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const snapshots = flattenSnapshots(courses);
+
+  // Open one uploaded snapshot in the read-only viewer — the same hand-off the
+  // Leaderboards page uses (fetch the full entry, build a synthetic session, jump).
+  const openSnapshot = async (s: SnapshotCard) => {
+    setLoadingId(s.id);
+    try {
+      const { fetchGroupEntries } = await import("@/plugins/cloud-sync/leaderboardClient");
+      const full = await fetchGroupEntries([s.id], 1);
+      const bundle = buildLeaderboardSession(full, {
+        courseName: s.courseName,
+        engineLabel: s.engineLabel,
+        weightLabel: s.weightLabel ?? undefined,
+      });
+      if (!bundle) {
+        toast.error(t("loadFailed"));
+        return;
+      }
+      setPendingLeaderboardSession(bundle);
+      navigate("/");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : t("loadFailed"));
+    } finally {
+      setLoadingId(null);
+    }
+  };
 
   return (
     <div className="space-y-8">
-      {/* Header: avatar + name */}
-      <div className="flex items-center gap-4">
-        <ProfileAvatar url={profile.avatarUrl} alt={profile.displayName} sizeClassName="h-16 w-16" />
-        <h2 className="text-2xl font-bold text-foreground">{profile.displayName}</h2>
+      {/* Top: avatar + name on the left, public vehicles on the right. */}
+      <div className="flex flex-col gap-6 md:flex-row md:items-start">
+        <div className="flex items-center gap-4 md:shrink-0">
+          <ProfileAvatar url={profile.avatarUrl} alt={profile.displayName} sizeClassName="h-20 w-20" />
+          <h2 className="text-2xl font-bold text-foreground">{profile.displayName}</h2>
+        </div>
+
+        <section className="flex-1 space-y-2">
+          <div className="flex items-center gap-2">
+            <Car className="h-4 w-4 text-primary" />
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {t("vehiclesTitle")}
+            </h3>
+          </div>
+          {vehicles.length === 0 ? (
+            <p className="rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
+              {t("vehiclesEmpty")}
+            </p>
+          ) : (
+            <div className="grid gap-2 sm:grid-cols-2">
+              {vehicles.map((v) => (
+                <div key={v.vehicleId} className="rounded-lg border border-border px-3 py-2">
+                  <div className="text-sm font-medium text-foreground">
+                    {v.number ? `#${v.number} — ` : ""}
+                    {v.name}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {v.typeName ?? t("unknownType")}
+                    {v.engine ? ` · ${v.engine}` : ""}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
 
-      {/* Vehicles (no weights, no setups) */}
-      <section className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Car className="h-5 w-5 text-primary" />
-          <h3 className="text-lg font-semibold text-foreground">{t("vehiclesTitle")}</h3>
-        </div>
-        {vehicles.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
-            {t("vehiclesEmpty")}
-          </p>
-        ) : (
-          <div className="grid gap-2 sm:grid-cols-2">
-            {vehicles.map((v) => (
-              <div key={v.vehicleId} className="rounded-lg border border-border px-3 py-2">
-                <div className="text-sm font-medium text-foreground">
-                  {v.number ? `#${v.number} — ` : ""}
-                  {v.name}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {v.typeName ?? t("unknownType")}
-                  {v.engine ? ` · ${v.engine}` : ""}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* Uploaded leaderboard snapshots, by course + weight */}
+      {/* Below both: uploaded-snapshot cards. Clicking one loads it read-only. */}
       <section className="space-y-3">
         <div className="flex items-center gap-2">
           <Trophy className="h-5 w-5 text-primary" />
           <h3 className="text-lg font-semibold text-foreground">{t("snapshotsTitle")}</h3>
         </div>
-        {courses.length === 0 ? (
+        {snapshots.length === 0 ? (
           <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
             {t("snapshotsEmpty")}
           </p>
         ) : (
-          <div className="space-y-3">
-            {courses.map((course) => (
-              <div key={course.courseKey} className="rounded-lg border border-border">
-                <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2.5">
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {snapshots.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                disabled={loadingId === s.id}
+                onClick={() => void openSnapshot(s)}
+                title={t("openSnapshot")}
+                className="flex flex-col gap-2 rounded-lg border border-border p-3 text-left transition-colors hover:border-primary/50 hover:bg-primary/5 disabled:opacity-60"
+              >
+                <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-foreground">{course.courseName}</p>
-                    <p className="truncate text-xs text-muted-foreground">{course.trackName}</p>
+                    <p className="truncate text-sm font-semibold text-foreground">{s.courseName}</p>
+                    <p className="truncate text-xs text-muted-foreground">{s.trackName}</p>
                   </div>
-                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                    {formatLapTime(course.fastestMs)}
+                  <span className="flex shrink-0 items-center gap-1 font-mono text-sm font-semibold text-primary">
+                    {loadingId === s.id && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                    {formatLapTime(s.lapTimeMs)}
                   </span>
                 </div>
-                <div className="space-y-2 px-2 py-2">
-                  {course.weightGroups.map((wg) => (
-                    <div key={wg.key} className="rounded-md border border-border/60">
-                      <div className="border-b border-border/60 px-3 py-1.5 text-xs font-medium text-muted-foreground">
-                        {wg.weightLabel ?? t("noWeight")}
-                      </div>
-                      <div className="px-2 py-1.5 space-y-1">
-                        {wg.laps.map((lap, i) => (
-                          <div
-                            key={lap.id}
-                            className="flex items-center gap-2 rounded px-2 py-1 text-sm"
-                          >
-                            <span className="w-5 shrink-0 text-center font-mono text-xs text-muted-foreground">
-                              {i + 1}
-                            </span>
-                            <span className="flex-1 truncate text-foreground">{lap.engineLabel}</span>
-                            <span className="font-mono text-xs text-muted-foreground">
-                              {formatLapTime(lap.lapTimeMs)}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
+                <div className="flex flex-wrap gap-1">
+                  <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                    <Cpu className="h-3 w-3" /> {s.engineLabel}
+                  </span>
+                  {s.weightLabel && (
+                    <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                      <Weight className="h-3 w-3" /> {s.weightLabel}
+                    </span>
+                  )}
                 </div>
-              </div>
+              </button>
             ))}
           </div>
         )}

--- a/src/pages/Leaderboards.tsx
+++ b/src/pages/Leaderboards.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ChevronRight, Trophy, Cpu, Hash, Layers } from "lucide-react";
 import { toast } from "sonner";
@@ -299,18 +299,28 @@ function TrackRow({
                                 </Button>
                               )}
                               {group.entries.map((entry, i) => (
-                                <button
+                                <div
                                   key={entry.id}
-                                  type="button"
-                                  disabled={loadingKey === `one:${entry.id}`}
-                                  onClick={() => onOpenSingle(course, group, entry.id)}
-                                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-primary/10 disabled:opacity-60"
+                                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-primary/10"
                                 >
                                   <span className="w-6 shrink-0 text-center font-mono text-xs text-muted-foreground">{i + 1}</span>
-                                  <ProfileAvatar url={avatars.get(entry.userId)} alt={entry.displayName} sizeClassName="h-5 w-5" />
-                                  <span className="flex-1 truncate text-foreground">{entry.displayName}</span>
-                                  <span className="font-mono text-xs text-muted-foreground">{formatLapTime(entry.lapTimeMs)}</span>
-                                </button>
+                                  <Link
+                                    to={`/driver/${encodeURIComponent(entry.displayName)}`}
+                                    title={t("viewProfile")}
+                                    className="shrink-0 rounded-full transition-opacity hover:opacity-80"
+                                  >
+                                    <ProfileAvatar url={avatars.get(entry.userId)} alt={entry.displayName} sizeClassName="h-5 w-5" />
+                                  </Link>
+                                  <button
+                                    type="button"
+                                    disabled={loadingKey === `one:${entry.id}`}
+                                    onClick={() => onOpenSingle(course, group, entry.id)}
+                                    className="flex flex-1 items-center gap-2 text-left disabled:opacity-60"
+                                  >
+                                    <span className="flex-1 truncate text-foreground">{entry.displayName}</span>
+                                    <span className="font-mono text-xs text-muted-foreground">{formatLapTime(entry.lapTimeMs)}</span>
+                                  </button>
+                                </div>
                               ))}
                             </div>
                           )}


### PR DESCRIPTION
## Summary

Wires up the driver profile page (which already existed at `/driver/:username`, reusing the leaderboard sticky header) so you can actually reach it and use it:

- **Leaderboards:** a driver's **avatar thumbnail is now a link** to their `/driver/{name}` profile. The row's name + lap time still open the lap, so the avatar is the only new affordance.
- **Driver profile layout:** restructured so the **avatar + display-name header sit on the left and the public vehicles list sits to the right** (stacks on mobile).
- **Uploaded snapshots are now clickable cards** below both (styled like the history cards). Clicking a card **loads that single snapshot in the read-only viewer** via the *exact same* hand-off the Leaderboards page uses — `fetchGroupEntries([id], 1)` → `buildLeaderboardSession` → `setPendingLeaderboardSession` → `navigate("/")`.

### Note on the slug
You floated `/driver/{id}`, but the page already exists at **`/driver/:username`** (case-insensitive, shareable, and what the "Copy profile link" button uses), so I linked by display name to reuse it rather than fork a second route. The name is unique (case-insensitively) so it's a stable identifier. Easy to switch to id-based later if you'd prefer — say the word.

## Type of Change
- [x] New feature
- [x] Refactor / reusability improvement

## Checklist
- [x] `bun run lint` / `typecheck` pass
- [x] `bun run test:run` passes (2086)
- [x] `bun run build` succeeds
- [x] Works offline (cloud-gated page)
- [x] i18n keys + CHANGELOG updated

## Notes for Reviewers
- The read-only load is identical to the Leaderboards single-entry open, so it inherits the same viewer behavior.
- Non-English strings for the two new keys (`leaderboard.viewProfile`, `driver.openSnapshot`) are stop-gap English; `bun run i18n:seed` to translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_