### PR TITLE
Release prep v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [2.10.0] - unreleased
+## [3.0.0] - 2026-06-30
 
 ### Added
 - **Public-vehicle badge.** Vehicles marked *Show on profile* now carry a small
@@ -42,14 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Show a vehicle on your profile.** Each vehicle in the garage now has a *Show on
   profile* toggle that publishes a public-safe projection (no weight, no setup).
 - A **← Back to home** button on the Leaderboards and driver-profile pages.
-
-### Changed
-- **Display names are now unique case-insensitively** so a name can't be impersonated by
-  changing case (existing case-duplicates are auto-suffixed by the migration).
-- **Leaderboard names update live.** A submitter's name on the leaderboards now comes from
-  their current profile (linked by account) instead of a copy frozen at submit time, so
-  renaming your display name updates all your existing entries.
-
 - **Leaderboards (plan 0005).** A new public **Leaderboards** page (linked from the
   landing page) where anyone — signed in or not — can browse fastest community laps
   by **track → course → engine class**, with an optional **Group by weight** toggle
@@ -69,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapse free-text engine names ("Tillotson 225" / "225RS" / "Tilly") into one
   class automatically, with a **Reclassify** action — without ever mutating the
   user's raw engine string.
+
+### Changed
+- **Display names are now unique case-insensitively** so a name can't be impersonated by
+  changing case (existing case-duplicates are auto-suffixed by the migration).
+- **Leaderboard names update live.** A submitter's name on the leaderboards now comes from
+  their current profile (linked by account) instead of a copy frozen at submit time, so
+  renaming your display name updates all your existing entries.
 
 ## [2.9.2] - 2026-06-25
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "2.9.2",
+  "version": "3.0.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",


### PR DESCRIPTION
## Summary

Prep `BETA` for the **v3.0.0** release.

- **Version bump** — `package.json` `2.9.2 → 3.0.0`.
- **CHANGELOG** — renamed the topmost unreleased heading `[2.10.0] → [3.0.0]` and dated it **2026-06-30**. Also moved the **Leaderboards / Submit-snapshots / Engine-classification** entries from *Changed* to *Added* (they're new features, were mislabeled).
- **Coach plugin** — already on the production npm package (`@perchwerks/eye-in-the-sky` `0.5.0`) in both `package.json` and `vite.config.ts`, so **no coach flip was needed** (idempotent skip).

Green before merge: `lint`, `typecheck`, `test:run` (2086), `build` all pass.

## ⚠️ Coach-source note (read before merging the release)

The usual release dance flips the coach from BETA's `github:…#BETA` dependency to the published npm package, then flips BETA back afterward. **BETA is already on the published `@perchwerks/eye-in-the-sky` package**, not the github BETA dependency the `CLAUDE.md` block describes. So:
- No flip happened here, and
- **I did *not* open the customary "flip coach back to BETA" PR** — doing so would have *switched* BETA onto the github coach it isn't currently using. If BETA is supposed to track the github coach, that's a separate decision for you to make.

## Type of Change
- [x] Release prep / chore

## Checklist
- [x] `bun run lint` / `typecheck` / `test:run` / `build` pass
- [x] No git tag created (you tag `v3.0.0` on `main` manually after the BETA→main merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_