### PR TITLE
i18n: translate profiles & datalogger stop-gap strings

### DIFF
--- a/src/components/ContactDialog.tsx
+++ b/src/components/ContactDialog.tsx
@@ -12,7 +12,6 @@ import { toast } from "@/hooks/use-toast";
 // The "request a new datalogger" category — exported so the logger picker can
 // open this dialog with it preselected. Keep the VALUE in sync with the edge
 // function's ALLOWED_CATEGORIES + the admin MessagesTab category map.
-// eslint-disable-next-line react-refresh/only-export-components -- co-located with the dialog that owns the categories
 export const CATEGORY_NEW_DATALOGGER = "New Datalogger Connection";
 
 // eslint-disable-next-line react-refresh/only-export-components -- co-located with the dialog that owns the categories

--- a/src/locales/de/admin.json
+++ b/src/locales/de/admin.json
@@ -53,7 +53,7 @@
       "featureRequest": "Funktionswunsch",
       "complaint": "Beschwerde",
       "bugReport": "Fehlerbericht",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Anbindung eines neuen Datenloggers"
     },
     "emailLine": "E-Mail: {{email}}",
     "ipLine": "IP: {{ip}}",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -10,7 +10,7 @@
     "reset": "Auf Standard zurücksetzen",
     "update": "Aktualisieren",
     "updating": "Wird aktualisiert…",
-    "backToHome": "Back to home"
+    "backToHome": "Zurück zur Startseite"
   },
   "language": {
     "heading": "Sprache",

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -75,10 +75,10 @@
     "add": "Fahrzeug hinzufügen",
     "engineRequired": "Ein Motor ist erforderlich.",
     "needsEngine": "Dieses Fahrzeug benötigt einen Motor – bearbeite es, um einen hinzuzufügen.",
-    "showOnProfile": "Show on profile",
-    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup).",
-    "publicBadge": "Public",
-    "publicHint": "Shown on your public driver profile."
+    "showOnProfile": "Im Profil anzeigen",
+    "showOnProfileHint": "Zeigt dieses Fahrzeug in deinem öffentlichen Fahrerprofil an (nur Name, Typ und Motor – niemals Gewicht oder Setup).",
+    "publicBadge": "Öffentlich",
+    "publicHint": "Wird in deinem öffentlichen Fahrerprofil angezeigt."
   },
   "engine": {
     "label": "Motor",

--- a/src/locales/de/driver.json
+++ b/src/locales/de/driver.json
@@ -1,14 +1,14 @@
 {
   "_machine": true,
-  "loading": "Loading profile…",
-  "loadFailed": "Couldn't load this profile.",
-  "notFoundTitle": "Driver not found",
-  "notFoundBody": "No driver named “{{name}}” exists.",
-  "vehiclesTitle": "Vehicles",
-  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
-  "unknownType": "Unknown type",
-  "snapshotsTitle": "Leaderboard snapshots",
-  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight",
-  "openSnapshot": "Open this lap in the viewer"
+  "loading": "Profil wird geladen…",
+  "loadFailed": "Dieses Profil konnte nicht geladen werden.",
+  "notFoundTitle": "Fahrer nicht gefunden",
+  "notFoundBody": "Es gibt keinen Fahrer namens “{{name}}”.",
+  "vehiclesTitle": "Fahrzeuge",
+  "vehiclesEmpty": "Dieser Fahrer hat keine Fahrzeuge geteilt.",
+  "unknownType": "Unbekannter Typ",
+  "snapshotsTitle": "Bestenlisten-Snapshots",
+  "snapshotsEmpty": "Dieser Fahrer hat keine Bestenlisten-Snapshots hochgeladen.",
+  "noWeight": "Kein angegebenes Gewicht",
+  "openSnapshot": "Diese Runde im Viewer öffnen"
 }

--- a/src/locales/de/landing.json
+++ b/src/locales/de/landing.json
@@ -227,7 +227,7 @@
       "featureRequest": "Funktionswunsch",
       "complaint": "Beschwerde",
       "bugReport": "Fehlerbericht",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Anbindung eines neuen Datenloggers"
     },
     "emailLabel": "E-Mail",
     "emailOptional": "(optional, für eine Antwort)",

--- a/src/locales/de/leaderboard.json
+++ b/src/locales/de/leaderboard.json
@@ -28,5 +28,5 @@
   "loadTopSession_one": "Schnellste Runde als eine Sitzung laden",
   "loadTopSession_other": "Top {{count}} Runden als eine Sitzung laden",
   "loadAllSession": "Alle Runden als eine Sitzung laden",
-  "viewProfile": "View driver profile"
+  "viewProfile": "Fahrerprofil ansehen"
 }

--- a/src/locales/de/logger.json
+++ b/src/locales/de/logger.json
@@ -71,5 +71,5 @@
       "cancel": "Abbrechen"
     }
   },
-  "requestLogger": "Request additional dataloggers"
+  "requestLogger": "Weitere Datenlogger anfragen"
 }

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -27,12 +27,12 @@
     "nameProfanity": "Bitte wähle einen saubereren Anzeigenamen.",
     "nameUpdateFailed": "Anzeigename konnte nicht aktualisiert werden.",
     "loadUsageFailed": "Speichernutzung konnte nicht geladen werden",
-    "changeAvatar": "Change profile picture",
-    "avatarUpdated": "Profile picture updated.",
-    "avatarFailed": "Couldn't update profile picture.",
-    "copyProfileLink": "Copy profile link",
-    "linkCopied": "Profile link copied.",
-    "linkCopyFailed": "Couldn't copy profile link."
+    "changeAvatar": "Profilbild ändern",
+    "avatarUpdated": "Profilbild aktualisiert.",
+    "avatarFailed": "Profilbild konnte nicht aktualisiert werden.",
+    "copyProfileLink": "Profillink kopieren",
+    "linkCopied": "Profillink kopiert.",
+    "linkCopyFailed": "Profillink konnte nicht kopiert werden."
   },
   "plan": {
     "title": "Tarif",
@@ -201,7 +201,7 @@
     "alreadySubmitted": "Bereits in den Bestenlisten.",
     "loadFailed": "Deine Einträge konnten nicht geladen werden.",
     "close": "Schließen",
-    "customTrackNotice": "This track isn't in the built-in list — its layout and sectors are submitted with your snapshot so others can view the lap. Please also add it to the community track database.",
-    "trackAdded": "Track sent to the community database for review."
+    "customTrackNotice": "Diese Strecke ist nicht in der integrierten Liste – ihr Layout und ihre Sektoren werden mit deinem Snapshot übermittelt, und die Strecke wird zur Überprüfung der Community-Datenbank hinzugefügt.",
+    "trackAdded": "Strecke zur Überprüfung an die Community-Datenbank gesendet."
   }
 }

--- a/src/locales/es/admin.json
+++ b/src/locales/es/admin.json
@@ -53,7 +53,7 @@
       "featureRequest": "Solicitud de función",
       "complaint": "Queja",
       "bugReport": "Informe de error",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Conexión de nuevo registrador de datos"
     },
     "emailLine": "Correo: {{email}}",
     "ipLine": "IP: {{ip}}",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -10,7 +10,7 @@
     "reset": "Restablecer valores predeterminados",
     "update": "Actualizar",
     "updating": "Actualizando…",
-    "backToHome": "Back to home"
+    "backToHome": "Volver al inicio"
   },
   "language": {
     "heading": "Idioma",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -75,10 +75,10 @@
     "add": "Añadir vehículo",
     "engineRequired": "Se requiere un motor.",
     "needsEngine": "Este vehículo necesita un motor; edítalo para añadir uno.",
-    "showOnProfile": "Show on profile",
-    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup).",
-    "publicBadge": "Public",
-    "publicHint": "Shown on your public driver profile."
+    "showOnProfile": "Mostrar en el perfil",
+    "showOnProfileHint": "Muestra este vehículo en tu perfil público de piloto (solo nombre, tipo y motor, nunca peso ni configuración).",
+    "publicBadge": "Público",
+    "publicHint": "Se muestra en tu perfil público de piloto."
   },
   "engine": {
     "label": "Motor",

--- a/src/locales/es/driver.json
+++ b/src/locales/es/driver.json
@@ -1,14 +1,14 @@
 {
   "_machine": true,
-  "loading": "Loading profile…",
-  "loadFailed": "Couldn't load this profile.",
-  "notFoundTitle": "Driver not found",
-  "notFoundBody": "No driver named “{{name}}” exists.",
-  "vehiclesTitle": "Vehicles",
-  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
-  "unknownType": "Unknown type",
-  "snapshotsTitle": "Leaderboard snapshots",
-  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight",
-  "openSnapshot": "Open this lap in the viewer"
+  "loading": "Cargando perfil…",
+  "loadFailed": "No se pudo cargar este perfil.",
+  "notFoundTitle": "Piloto no encontrado",
+  "notFoundBody": "No existe ningún piloto llamado “{{name}}”.",
+  "vehiclesTitle": "Vehículos",
+  "vehiclesEmpty": "Este piloto no ha compartido ningún vehículo.",
+  "unknownType": "Tipo desconocido",
+  "snapshotsTitle": "Capturas de la clasificación",
+  "snapshotsEmpty": "Este piloto no ha subido ninguna captura a la clasificación.",
+  "noWeight": "Sin peso indicado",
+  "openSnapshot": "Abrir esta vuelta en el visor"
 }

--- a/src/locales/es/landing.json
+++ b/src/locales/es/landing.json
@@ -227,7 +227,7 @@
       "featureRequest": "Solicitud de función",
       "complaint": "Queja",
       "bugReport": "Informe de error",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Conexión de nuevo registrador de datos"
     },
     "emailLabel": "Correo electrónico",
     "emailOptional": "(opcional, para responderte)",

--- a/src/locales/es/leaderboard.json
+++ b/src/locales/es/leaderboard.json
@@ -28,5 +28,5 @@
   "loadTopSession_one": "Cargar la vuelta más rápida como una sola sesión",
   "loadTopSession_other": "Cargar las {{count}} mejores vueltas como una sola sesión",
   "loadAllSession": "Cargar todas las vueltas como una sola sesión",
-  "viewProfile": "View driver profile"
+  "viewProfile": "Ver perfil del piloto"
 }

--- a/src/locales/es/logger.json
+++ b/src/locales/es/logger.json
@@ -71,5 +71,5 @@
       "cancel": "Cancelar"
     }
   },
-  "requestLogger": "Request additional dataloggers"
+  "requestLogger": "Solicitar más registradores de datos"
 }

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -27,12 +27,12 @@
     "nameProfanity": "Elige un nombre para mostrar más limpio, por favor.",
     "nameUpdateFailed": "No se pudo actualizar el nombre para mostrar.",
     "loadUsageFailed": "No se pudo cargar el uso de almacenamiento",
-    "changeAvatar": "Change profile picture",
-    "avatarUpdated": "Profile picture updated.",
-    "avatarFailed": "Couldn't update profile picture.",
-    "copyProfileLink": "Copy profile link",
-    "linkCopied": "Profile link copied.",
-    "linkCopyFailed": "Couldn't copy profile link."
+    "changeAvatar": "Cambiar foto de perfil",
+    "avatarUpdated": "Foto de perfil actualizada.",
+    "avatarFailed": "No se pudo actualizar la foto de perfil.",
+    "copyProfileLink": "Copiar enlace del perfil",
+    "linkCopied": "Enlace del perfil copiado.",
+    "linkCopyFailed": "No se pudo copiar el enlace del perfil."
   },
   "plan": {
     "title": "Plan",
@@ -201,7 +201,7 @@
     "alreadySubmitted": "Ya está en las clasificaciones.",
     "loadFailed": "No se pudieron cargar tus envíos.",
     "close": "Cerrar",
-    "customTrackNotice": "This track isn't in the built-in list — its layout and sectors are submitted with your snapshot so others can view the lap. Please also add it to the community track database.",
-    "trackAdded": "Track sent to the community database for review."
+    "customTrackNotice": "Este circuito no está en la lista integrada: su trazado y sectores se envían con tu captura, y el circuito se añade a la base de datos de la comunidad para su revisión.",
+    "trackAdded": "Circuito enviado a la base de datos de la comunidad para su revisión."
   }
 }

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -53,7 +53,7 @@
       "featureRequest": "Demande de fonctionnalité",
       "complaint": "Réclamation",
       "bugReport": "Rapport de bug",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Connexion d'un nouvel enregistreur de données"
     },
     "emailLine": "E-mail : {{email}}",
     "ipLine": "IP : {{ip}}",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -10,7 +10,7 @@
     "reset": "Réinitialiser les valeurs par défaut",
     "update": "Mettre à jour",
     "updating": "Mise à jour…",
-    "backToHome": "Back to home"
+    "backToHome": "Retour à l'accueil"
   },
   "language": {
     "heading": "Langue",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -75,10 +75,10 @@
     "add": "Ajouter un véhicule",
     "engineRequired": "Un moteur est requis.",
     "needsEngine": "Ce véhicule a besoin d'un moteur — modifiez-le pour en ajouter un.",
-    "showOnProfile": "Show on profile",
-    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup).",
+    "showOnProfile": "Afficher sur le profil",
+    "showOnProfileHint": "Affiche ce véhicule sur votre profil public de pilote (nom, type et moteur uniquement — jamais le poids ni les réglages).",
     "publicBadge": "Public",
-    "publicHint": "Shown on your public driver profile."
+    "publicHint": "Affiché sur votre profil public de pilote."
   },
   "engine": {
     "label": "Moteur",

--- a/src/locales/fr/driver.json
+++ b/src/locales/fr/driver.json
@@ -1,14 +1,14 @@
 {
   "_machine": true,
-  "loading": "Loading profile…",
-  "loadFailed": "Couldn't load this profile.",
-  "notFoundTitle": "Driver not found",
-  "notFoundBody": "No driver named “{{name}}” exists.",
-  "vehiclesTitle": "Vehicles",
-  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
-  "unknownType": "Unknown type",
-  "snapshotsTitle": "Leaderboard snapshots",
-  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight",
-  "openSnapshot": "Open this lap in the viewer"
+  "loading": "Chargement du profil…",
+  "loadFailed": "Impossible de charger ce profil.",
+  "notFoundTitle": "Pilote introuvable",
+  "notFoundBody": "Aucun pilote nommé “{{name}}” n'existe.",
+  "vehiclesTitle": "Véhicules",
+  "vehiclesEmpty": "Ce pilote n'a partagé aucun véhicule.",
+  "unknownType": "Type inconnu",
+  "snapshotsTitle": "Instantanés du classement",
+  "snapshotsEmpty": "Ce pilote n'a téléversé aucun instantané au classement.",
+  "noWeight": "Aucun poids indiqué",
+  "openSnapshot": "Ouvrir ce tour dans la visionneuse"
 }

--- a/src/locales/fr/landing.json
+++ b/src/locales/fr/landing.json
@@ -227,7 +227,7 @@
       "featureRequest": "Demande de fonctionnalité",
       "complaint": "Réclamation",
       "bugReport": "Rapport de bug",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Connexion d'un nouvel enregistreur de données"
     },
     "emailLabel": "E-mail",
     "emailOptional": "(facultatif, pour une réponse)",

--- a/src/locales/fr/leaderboard.json
+++ b/src/locales/fr/leaderboard.json
@@ -28,5 +28,5 @@
   "loadTopSession_one": "Charger le meilleur tour en une seule session",
   "loadTopSession_other": "Charger les {{count}} meilleurs tours en une seule session",
   "loadAllSession": "Charger tous les tours en une seule session",
-  "viewProfile": "View driver profile"
+  "viewProfile": "Voir le profil du pilote"
 }

--- a/src/locales/fr/logger.json
+++ b/src/locales/fr/logger.json
@@ -71,5 +71,5 @@
       "cancel": "Annuler"
     }
   },
-  "requestLogger": "Request additional dataloggers"
+  "requestLogger": "Demander d'autres enregistreurs de données"
 }

--- a/src/locales/fr/plugins.json
+++ b/src/locales/fr/plugins.json
@@ -27,12 +27,12 @@
     "nameProfanity": "Veuillez choisir un nom d'affichage plus correct.",
     "nameUpdateFailed": "Impossible de mettre à jour le nom d'affichage.",
     "loadUsageFailed": "Impossible de charger l'utilisation du stockage",
-    "changeAvatar": "Change profile picture",
-    "avatarUpdated": "Profile picture updated.",
-    "avatarFailed": "Couldn't update profile picture.",
-    "copyProfileLink": "Copy profile link",
-    "linkCopied": "Profile link copied.",
-    "linkCopyFailed": "Couldn't copy profile link."
+    "changeAvatar": "Changer la photo de profil",
+    "avatarUpdated": "Photo de profil mise à jour.",
+    "avatarFailed": "Impossible de mettre à jour la photo de profil.",
+    "copyProfileLink": "Copier le lien du profil",
+    "linkCopied": "Lien du profil copié.",
+    "linkCopyFailed": "Impossible de copier le lien du profil."
   },
   "plan": {
     "title": "Forfait",
@@ -201,7 +201,7 @@
     "alreadySubmitted": "Déjà dans les classements.",
     "loadFailed": "Impossible de charger vos envois.",
     "close": "Fermer",
-    "customTrackNotice": "This track isn't in the built-in list — its layout and sectors are submitted with your snapshot so others can view the lap. Please also add it to the community track database.",
-    "trackAdded": "Track sent to the community database for review."
+    "customTrackNotice": "Ce circuit n'est pas dans la liste intégrée : son tracé et ses secteurs sont envoyés avec votre instantané, et le circuit est ajouté à la base de données communautaire pour révision.",
+    "trackAdded": "Circuit envoyé à la base de données communautaire pour révision."
   }
 }

--- a/src/locales/it/admin.json
+++ b/src/locales/it/admin.json
@@ -53,7 +53,7 @@
       "featureRequest": "Richiesta di funzionalità",
       "complaint": "Reclamo",
       "bugReport": "Segnalazione di bug",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Connessione di un nuovo data logger"
     },
     "emailLine": "Email: {{email}}",
     "ipLine": "IP: {{ip}}",

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -10,7 +10,7 @@
     "reset": "Ripristina valori predefiniti",
     "update": "Aggiorna",
     "updating": "Aggiornamento…",
-    "backToHome": "Back to home"
+    "backToHome": "Torna alla home"
   },
   "language": {
     "heading": "Lingua",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -75,10 +75,10 @@
     "add": "Aggiungi veicolo",
     "engineRequired": "È richiesto un motore.",
     "needsEngine": "Questo veicolo ha bisogno di un motore — modificalo per aggiungerne uno.",
-    "showOnProfile": "Show on profile",
-    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup).",
-    "publicBadge": "Public",
-    "publicHint": "Shown on your public driver profile."
+    "showOnProfile": "Mostra nel profilo",
+    "showOnProfileHint": "Mostra questo veicolo nel tuo profilo pubblico di pilota (solo nome, tipo e motore — mai peso o assetto).",
+    "publicBadge": "Pubblico",
+    "publicHint": "Mostrato nel tuo profilo pubblico di pilota."
   },
   "engine": {
     "label": "Motore",

--- a/src/locales/it/driver.json
+++ b/src/locales/it/driver.json
@@ -1,14 +1,14 @@
 {
   "_machine": true,
-  "loading": "Loading profile…",
-  "loadFailed": "Couldn't load this profile.",
-  "notFoundTitle": "Driver not found",
-  "notFoundBody": "No driver named “{{name}}” exists.",
-  "vehiclesTitle": "Vehicles",
-  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
-  "unknownType": "Unknown type",
-  "snapshotsTitle": "Leaderboard snapshots",
-  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight",
-  "openSnapshot": "Open this lap in the viewer"
+  "loading": "Caricamento profilo…",
+  "loadFailed": "Impossibile caricare questo profilo.",
+  "notFoundTitle": "Pilota non trovato",
+  "notFoundBody": "Non esiste nessun pilota di nome “{{name}}”.",
+  "vehiclesTitle": "Veicoli",
+  "vehiclesEmpty": "Questo pilota non ha condiviso alcun veicolo.",
+  "unknownType": "Tipo sconosciuto",
+  "snapshotsTitle": "Snapshot della classifica",
+  "snapshotsEmpty": "Questo pilota non ha caricato alcuno snapshot in classifica.",
+  "noWeight": "Nessun peso indicato",
+  "openSnapshot": "Apri questo giro nel visualizzatore"
 }

--- a/src/locales/it/landing.json
+++ b/src/locales/it/landing.json
@@ -227,7 +227,7 @@
       "featureRequest": "Richiesta di funzionalità",
       "complaint": "Reclamo",
       "bugReport": "Segnalazione di bug",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Connessione di un nuovo data logger"
     },
     "emailLabel": "Email",
     "emailOptional": "(facoltativa, per una risposta)",

--- a/src/locales/it/leaderboard.json
+++ b/src/locales/it/leaderboard.json
@@ -28,5 +28,5 @@
   "loadTopSession_one": "Carica il giro più veloce come singola sessione",
   "loadTopSession_other": "Carica i {{count}} giri più veloci come singola sessione",
   "loadAllSession": "Carica tutti i giri come singola sessione",
-  "viewProfile": "View driver profile"
+  "viewProfile": "Vedi profilo pilota"
 }

--- a/src/locales/it/logger.json
+++ b/src/locales/it/logger.json
@@ -71,5 +71,5 @@
       "cancel": "Annulla"
     }
   },
-  "requestLogger": "Request additional dataloggers"
+  "requestLogger": "Richiedi altri data logger"
 }

--- a/src/locales/it/plugins.json
+++ b/src/locales/it/plugins.json
@@ -27,12 +27,12 @@
     "nameProfanity": "Scegli un nome visualizzato più appropriato.",
     "nameUpdateFailed": "Impossibile aggiornare il nome visualizzato.",
     "loadUsageFailed": "Impossibile caricare l'utilizzo dello spazio",
-    "changeAvatar": "Change profile picture",
-    "avatarUpdated": "Profile picture updated.",
-    "avatarFailed": "Couldn't update profile picture.",
-    "copyProfileLink": "Copy profile link",
-    "linkCopied": "Profile link copied.",
-    "linkCopyFailed": "Couldn't copy profile link."
+    "changeAvatar": "Cambia foto profilo",
+    "avatarUpdated": "Foto profilo aggiornata.",
+    "avatarFailed": "Impossibile aggiornare la foto profilo.",
+    "copyProfileLink": "Copia link del profilo",
+    "linkCopied": "Link del profilo copiato.",
+    "linkCopyFailed": "Impossibile copiare il link del profilo."
   },
   "plan": {
     "title": "Piano",
@@ -201,7 +201,7 @@
     "alreadySubmitted": "Già nelle classifiche.",
     "loadFailed": "Impossibile caricare i tuoi invii.",
     "close": "Chiudi",
-    "customTrackNotice": "This track isn't in the built-in list — its layout and sectors are submitted with your snapshot so others can view the lap. Please also add it to the community track database.",
-    "trackAdded": "Track sent to the community database for review."
+    "customTrackNotice": "Questo circuito non è nell'elenco integrato: il suo tracciato e i settori vengono inviati con il tuo snapshot e il circuito viene aggiunto al database della community per la revisione.",
+    "trackAdded": "Circuito inviato al database della community per la revisione."
   }
 }

--- a/src/locales/ja/admin.json
+++ b/src/locales/ja/admin.json
@@ -53,7 +53,7 @@
       "featureRequest": "機能リクエスト",
       "complaint": "苦情",
       "bugReport": "バグ報告",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "新しいデータロガーの接続"
     },
     "emailLine": "メール: {{email}}",
     "ipLine": "IP: {{ip}}",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -10,7 +10,7 @@
     "reset": "デフォルトに戻す",
     "update": "更新",
     "updating": "更新中…",
-    "backToHome": "Back to home"
+    "backToHome": "ホームに戻る"
   },
   "language": {
     "heading": "言語",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -75,10 +75,10 @@
     "add": "車両を追加",
     "engineRequired": "エンジンは必須です。",
     "needsEngine": "この車両にはエンジンが必要です。編集して追加してください。",
-    "showOnProfile": "Show on profile",
-    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup).",
-    "publicBadge": "Public",
-    "publicHint": "Shown on your public driver profile."
+    "showOnProfile": "プロフィールに表示",
+    "showOnProfileHint": "この車両を公開ドライバープロフィールに表示します（名前・タイプ・エンジンのみ。重量やセットアップは含みません）。",
+    "publicBadge": "公開",
+    "publicHint": "公開ドライバープロフィールに表示されます。"
   },
   "engine": {
     "label": "エンジン",

--- a/src/locales/ja/driver.json
+++ b/src/locales/ja/driver.json
@@ -1,14 +1,14 @@
 {
   "_machine": true,
-  "loading": "Loading profile…",
-  "loadFailed": "Couldn't load this profile.",
-  "notFoundTitle": "Driver not found",
-  "notFoundBody": "No driver named “{{name}}” exists.",
-  "vehiclesTitle": "Vehicles",
-  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
-  "unknownType": "Unknown type",
-  "snapshotsTitle": "Leaderboard snapshots",
-  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight",
-  "openSnapshot": "Open this lap in the viewer"
+  "loading": "プロフィールを読み込み中…",
+  "loadFailed": "このプロフィールを読み込めませんでした。",
+  "notFoundTitle": "ドライバーが見つかりません",
+  "notFoundBody": "「{{name}}」というドライバーは存在しません。",
+  "vehiclesTitle": "車両",
+  "vehiclesEmpty": "このドライバーは車両を共有していません。",
+  "unknownType": "不明なタイプ",
+  "snapshotsTitle": "リーダーボードのスナップショット",
+  "snapshotsEmpty": "このドライバーはリーダーボードにスナップショットをアップロードしていません。",
+  "noWeight": "重量の記載なし",
+  "openSnapshot": "このラップをビューアで開く"
 }

--- a/src/locales/ja/landing.json
+++ b/src/locales/ja/landing.json
@@ -227,7 +227,7 @@
       "featureRequest": "機能リクエスト",
       "complaint": "苦情",
       "bugReport": "バグ報告",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "新しいデータロガーの接続"
     },
     "emailLabel": "メールアドレス",
     "emailOptional": "（任意、返信用）",

--- a/src/locales/ja/leaderboard.json
+++ b/src/locales/ja/leaderboard.json
@@ -28,5 +28,5 @@
   "loadTopSession_one": "最速ラップを1つのセッションとして読み込む",
   "loadTopSession_other": "上位 {{count}} ラップを1つのセッションとして読み込む",
   "loadAllSession": "すべてのラップを1つのセッションとして読み込む",
-  "viewProfile": "View driver profile"
+  "viewProfile": "ドライバープロフィールを見る"
 }

--- a/src/locales/ja/logger.json
+++ b/src/locales/ja/logger.json
@@ -71,5 +71,5 @@
       "cancel": "キャンセル"
     }
   },
-  "requestLogger": "Request additional dataloggers"
+  "requestLogger": "他のデータロガーをリクエスト"
 }

--- a/src/locales/ja/plugins.json
+++ b/src/locales/ja/plugins.json
@@ -27,12 +27,12 @@
     "nameProfanity": "もっと適切な表示名を選んでください。",
     "nameUpdateFailed": "表示名を更新できませんでした。",
     "loadUsageFailed": "ストレージ使用量を読み込めませんでした",
-    "changeAvatar": "Change profile picture",
-    "avatarUpdated": "Profile picture updated.",
-    "avatarFailed": "Couldn't update profile picture.",
-    "copyProfileLink": "Copy profile link",
-    "linkCopied": "Profile link copied.",
-    "linkCopyFailed": "Couldn't copy profile link."
+    "changeAvatar": "プロフィール写真を変更",
+    "avatarUpdated": "プロフィール写真を更新しました。",
+    "avatarFailed": "プロフィール写真を更新できませんでした。",
+    "copyProfileLink": "プロフィールリンクをコピー",
+    "linkCopied": "プロフィールリンクをコピーしました。",
+    "linkCopyFailed": "プロフィールリンクをコピーできませんでした。"
   },
   "plan": {
     "title": "プラン",
@@ -201,7 +201,7 @@
     "alreadySubmitted": "すでにリーダーボードに登録されています。",
     "loadFailed": "あなたの送信を読み込めませんでした。",
     "close": "閉じる",
-    "customTrackNotice": "This track isn't in the built-in list — its layout and sectors are submitted with your snapshot so others can view the lap. Please also add it to the community track database.",
-    "trackAdded": "Track sent to the community database for review."
+    "customTrackNotice": "このコースは組み込みリストにありません。レイアウトとセクターはスナップショットと共に送信され、コースは承認のためコミュニティデータベースに追加されます。",
+    "trackAdded": "コースを承認のためコミュニティデータベースに送信しました。"
   }
 }

--- a/src/locales/pt-BR/admin.json
+++ b/src/locales/pt-BR/admin.json
@@ -53,7 +53,7 @@
       "featureRequest": "Solicitação de recurso",
       "complaint": "Reclamação",
       "bugReport": "Relatório de bug",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Conexão de novo datalogger"
     },
     "emailLine": "E-mail: {{email}}",
     "ipLine": "IP: {{ip}}",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -10,7 +10,7 @@
     "reset": "Restaurar padrões",
     "update": "Atualizar",
     "updating": "Atualizando…",
-    "backToHome": "Back to home"
+    "backToHome": "Voltar ao início"
   },
   "language": {
     "heading": "Idioma",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -75,10 +75,10 @@
     "add": "Adicionar veículo",
     "engineRequired": "Um motor é obrigatório.",
     "needsEngine": "Este veículo precisa de um motor — edite para adicionar um.",
-    "showOnProfile": "Show on profile",
-    "showOnProfileHint": "List this vehicle on your public driver profile (name, type and engine only — never weight or setup).",
-    "publicBadge": "Public",
-    "publicHint": "Shown on your public driver profile."
+    "showOnProfile": "Mostrar no perfil",
+    "showOnProfileHint": "Lista este veículo no seu perfil público de piloto (apenas nome, tipo e motor — nunca peso ou setup).",
+    "publicBadge": "Público",
+    "publicHint": "Exibido no seu perfil público de piloto."
   },
   "engine": {
     "label": "Motor",

--- a/src/locales/pt-BR/driver.json
+++ b/src/locales/pt-BR/driver.json
@@ -1,14 +1,14 @@
 {
   "_machine": true,
-  "loading": "Loading profile…",
-  "loadFailed": "Couldn't load this profile.",
-  "notFoundTitle": "Driver not found",
-  "notFoundBody": "No driver named “{{name}}” exists.",
-  "vehiclesTitle": "Vehicles",
-  "vehiclesEmpty": "This driver hasn't shared any vehicles.",
-  "unknownType": "Unknown type",
-  "snapshotsTitle": "Leaderboard snapshots",
-  "snapshotsEmpty": "This driver hasn't uploaded any leaderboard snapshots.",
-  "noWeight": "No listed weight",
-  "openSnapshot": "Open this lap in the viewer"
+  "loading": "Carregando perfil…",
+  "loadFailed": "Não foi possível carregar este perfil.",
+  "notFoundTitle": "Piloto não encontrado",
+  "notFoundBody": "Não existe nenhum piloto chamado “{{name}}”.",
+  "vehiclesTitle": "Veículos",
+  "vehiclesEmpty": "Este piloto não compartilhou nenhum veículo.",
+  "unknownType": "Tipo desconhecido",
+  "snapshotsTitle": "Snapshots do ranking",
+  "snapshotsEmpty": "Este piloto não enviou nenhum snapshot ao ranking.",
+  "noWeight": "Sem peso informado",
+  "openSnapshot": "Abrir esta volta no visualizador"
 }

--- a/src/locales/pt-BR/landing.json
+++ b/src/locales/pt-BR/landing.json
@@ -227,7 +227,7 @@
       "featureRequest": "Solicitação de recurso",
       "complaint": "Reclamação",
       "bugReport": "Relatório de bug",
-      "newDatalogger": "New datalogger connection"
+      "newDatalogger": "Conexão de novo datalogger"
     },
     "emailLabel": "E-mail",
     "emailOptional": "(opcional, para resposta)",

--- a/src/locales/pt-BR/leaderboard.json
+++ b/src/locales/pt-BR/leaderboard.json
@@ -28,5 +28,5 @@
   "loadTopSession_one": "Carregar a volta mais rápida como uma única sessão",
   "loadTopSession_other": "Carregar as {{count}} voltas mais rápidas como uma única sessão",
   "loadAllSession": "Carregar todas as voltas como uma única sessão",
-  "viewProfile": "View driver profile"
+  "viewProfile": "Ver perfil do piloto"
 }

--- a/src/locales/pt-BR/logger.json
+++ b/src/locales/pt-BR/logger.json
@@ -71,5 +71,5 @@
       "cancel": "Cancelar"
     }
   },
-  "requestLogger": "Request additional dataloggers"
+  "requestLogger": "Solicitar mais dataloggers"
 }

--- a/src/locales/pt-BR/plugins.json
+++ b/src/locales/pt-BR/plugins.json
@@ -27,12 +27,12 @@
     "nameProfanity": "Escolha um nome de exibição mais adequado.",
     "nameUpdateFailed": "Não foi possível atualizar o nome de exibição.",
     "loadUsageFailed": "Não foi possível carregar o uso de armazenamento",
-    "changeAvatar": "Change profile picture",
-    "avatarUpdated": "Profile picture updated.",
-    "avatarFailed": "Couldn't update profile picture.",
-    "copyProfileLink": "Copy profile link",
-    "linkCopied": "Profile link copied.",
-    "linkCopyFailed": "Couldn't copy profile link."
+    "changeAvatar": "Alterar foto de perfil",
+    "avatarUpdated": "Foto de perfil atualizada.",
+    "avatarFailed": "Não foi possível atualizar a foto de perfil.",
+    "copyProfileLink": "Copiar link do perfil",
+    "linkCopied": "Link do perfil copiado.",
+    "linkCopyFailed": "Não foi possível copiar o link do perfil."
   },
   "plan": {
     "title": "Plano",
@@ -201,7 +201,7 @@
     "alreadySubmitted": "Já está nos rankings.",
     "loadFailed": "Não foi possível carregar seus envios.",
     "close": "Fechar",
-    "customTrackNotice": "This track isn't in the built-in list — its layout and sectors are submitted with your snapshot so others can view the lap. Please also add it to the community track database.",
-    "trackAdded": "Track sent to the community database for review."
+    "customTrackNotice": "Esta pista não está na lista integrada — seu traçado e setores são enviados com o seu snapshot, e a pista é adicionada ao banco de dados da comunidade para revisão.",
+    "trackAdded": "Pista enviada ao banco de dados da comunidade para revisão."
   }
 }


### PR DESCRIPTION
## Summary

The user-profiles (plan 0006) and request-datalogger surfaces shipped with their non-English locale values left as English stop-gaps (the `bun run i18n:seed` script is a local/maintainer-only tool — never run in CI or the app, see `docs/i18n.md` → "Seeding (maintainer tool only)"). This PR replaces those stop-gaps with real translations across **all six** non-English languages (`es`, `fr`, `de`, `it`, `pt-BR`, `ja`).

Surfaces translated:
- **Driver profile page** (`driver` ns): loading / load-failed / not-found / vehicles / snapshots titles + empty states + open-snapshot. `{{name}}` interpolation and locale quote glyphs preserved (e.g. ja uses 「{{name}}」).
- **Avatar + copy-link toasts** (`plugins.account.*`): change avatar, updated/failed, copy profile link, link copied/failed.
- **Leaderboard submission notices** (`plugins.leaderboard.*`): track-added + custom-track notice (current en text, not the original stop-gap).
- **Public-vehicle toggle** (`drawer.vehicles.*`): show-on-profile + hint, public badge + hint.
- **Common / leaderboard / logger**: back-to-home, view-profile, request-additional-dataloggers.
- **Contact + admin** (`landing.contact.categories` / `admin.messages.categories`): "New datalogger connection" category.

Also removes a now-unused `eslint-disable` directive in `ContactDialog.tsx`.

## Related Issues

_None._

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [x] Documentation
- [ ] Other: translations

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (i18n key + placeholder parity holds across all locales)
- [x] `bun run build` succeeds
- [x] Feature works **offline** (locale files are bundled/precached; no new network calls)
- [x] Docs updated where relevant — `docs/i18n.md` already documents the seed script as maintainer-only
- [ ] For a new parser: n/a

## Notes for Reviewers

Translations were applied by replacing the English-identical leaf values only — no keys added or removed, so the i18n parity test (`src/lib/i18n/i18n.test.ts`) stays green. Brand/format names (Dove CSV, AiM MyChron CSV, LapWing, MoTeC, VBO), unit symbols, and pure-placeholder strings were intentionally left literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_