### PR TITLE
Fix the six Low findings from the v3.0.0 release review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   user's raw engine string.
 
 ### Changed
+- **An engine is now required on every vehicle.** The vehicle form won't save without
+  one (it drives leaderboard grouping and snapshot matching), and any existing
+  engine-less vehicle is flagged in the garage so you can fill it in.
 - **Display names are now unique case-insensitively** so a name can't be impersonated by
   changing case (existing case-duplicates are auto-suffixed by the migration).
 - **Leaderboard names update live.** A submitter's name on the leaderboards now comes from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,7 +390,7 @@ and the seeder: **→ `docs/i18n.md`**.
 | `VITE_TURNSTILE_SITE_KEY` | Client | Cloudflare Turnstile site key (optional CAPTCHA) |
 | `TURNSTILE_SECRET_KEY` | Server (edge fn) | Turnstile secret — `???` |
 | `VITE_FIRMWARE_MANIFEST_URL` | Client | Override the logger firmware OTA manifest URL. Unset: `main` → production manifest, non-`main`/preview → beta channel (same `isPreviewBuild()` switch). |
-| `SUPABASE_ACCESS_TOKEN` | Build (secret) | Supabase PAT. On a **feature-branch** build (not `main`, not `BETA`), `vite.config.ts` resolves that branch's own Supabase **preview-branch DB** via the Management API (`scripts/resolveSupabaseBranch.ts`) and bakes its creds in, else falls back to the static `*_PREVIEW`/beta creds. Never on `main`/`BETA`/dev/runtime. → plan 0006. |
+| `SUPABASE_ACCESS_TOKEN` | Build (secret) | Supabase PAT. On a **feature-branch** build (not `main`, not `BETA`), `vite.config.ts` resolves that branch's own Supabase **preview-branch DB** via the Management API (`scripts/resolveSupabaseBranch.ts`) and bakes its creds in, else falls back to the static `*_PREVIEW`/beta creds. Never on `main`/`BETA`/dev/runtime. → plan 0007. |
 | `DOVE_PLUGIN_PACKAGES` | Build | Comma-separated external plugin npm packages. Overrides the default when set. |
 | `ANTHROPIC_API_KEY` / `I18N_SEED_MODEL` | Maintainer tool | Used **only** by `bun run i18n:seed` (`ANTHROPIC_API_KEY` = `???`). Never in the app or CI build. |
 | `VITE_APP_VERSION` / `VITE_GIT_HASH` / `VITE_BUILD_DATE` / `VITE_GIT_BRANCH` / `VITE_GIT_COMMIT_DATE` | Build (auto) | Footer version stamp — **not hand-set**; baked from `package.json` + git in `vite.config.ts`. |
@@ -411,7 +411,7 @@ see `beta-proxy/README.md`). Backend by branch (`vite.config.ts` `pick()`, keyed
 **`BETA`** → static `*_PREVIEW` creds (the shared beta DB — never the resolver);
 **any other branch** → with a `SUPABASE_ACCESS_TOKEN` secret, that branch's own
 Supabase preview-branch DB via the Management API (`scripts/resolveSupabaseBranch.ts`,
-plan 0006), else the `*_PREVIEW`/beta fallback. Each build logs `[backend] Supabase
+plan 0007), else the `*_PREVIEW`/beta fallback. Each build logs `[backend] Supabase
 URL baked: … — <tier>`. `main` and local dev never read `_PREVIEW`/the token. See
 README "Deployment".
 

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Supabase **Management API** whether a preview branch exists for the build's git
 branch (`scripts/resolveSupabaseBranch.ts`). If one does and it's healthy, that
 branch's URL + anon key + ref are baked in; otherwise it falls back to the static
 `*_PREVIEW`/beta creds. The lookup never throws and times out fast, so it can't
-break a deploy. Full design: [`docs/plans/0006-dynamic-supabase-branch-db.md`](docs/plans/0006-dynamic-supabase-branch-db.md).
+break a deploy. Full design: [`docs/plans/0007-dynamic-supabase-branch-db.md`](docs/plans/0007-dynamic-supabase-branch-db.md).
 
 > Supabase only generates a preview branch when the git branch carries **migration
 > changes**. Branches without DB changes simply fall back to beta. To force a DB

--- a/docs/plans/0007-dynamic-supabase-branch-db.md
+++ b/docs/plans/0007-dynamic-supabase-branch-db.md
@@ -1,4 +1,4 @@
-# Plan 0006 — Dynamic per-branch Supabase preview database
+# Plan 0007 — Dynamic per-branch Supabase preview database
 
 ## Goal / problem
 

--- a/docs/reviews/beta-release-review-2026-06-30.md
+++ b/docs/reviews/beta-release-review-2026-06-30.md
@@ -1,0 +1,76 @@
+# Beta → Main Release Review — 2026-06-30
+
+> Posted as a comment on PR #307. This is the local record copy.
+> **Follow-up:** all six findings below were fixed on branch `fix/release-review-lows`
+> (PR into BETA) — see the CHANGELOG `[3.0.0]` engine entry, `Leaderboards.tsx` /
+> `ProfileAvatar.tsx` fixes, the new `publicProfile.test.ts` / `trackAutoSubmit.test.ts`,
+> and the `0006 → 0007` branch-db plan rename.
+
+## 🚦 Verdict: **GO**
+
+Safe to ship. All seven dimensions ran; every confirmed finding is **Low** severity and **none block the release**. Blockers: **0 Critical, 0 release-blocking High**.
+
+**PR:** #307 (`BETA` → `main`) · **Release:** v3.0.0 · **Since:** v2.9.2
+**Run:** multi-agent (7 finders, single adversarial verify per finding — 6/6 confirmed, 0 dropped) · **Diff:** 145 files, ~7,000 insertions across 17 merged PRs
+**Excluded:** `node_modules/`, `dist/`, generated `src/integrations/supabase/`, `bun.lock` line-noise
+
+### Release contract checklist
+| Gate | Status |
+|------|--------|
+| Coach on production npm (`@perchwerks/eye-in-the-sky@0.5.0`, both `package.json` + `vite.config.ts` + `bun.lock`) | ✅ |
+| `package.json` version (`3.0.0`) == topmost CHANGELOG heading (`[3.0.0]`) | ✅ |
+| CHANGELOG heading dated (`2026-06-30`, not `- unreleased`) | ✅ |
+| CHANGELOG complete vs commits in this release | ⚠️ one user-facing change missing (REL-01, Low) → since fixed |
+| No beta/preview-only config leaked into prod path (`main` → production creds; resolver gated to feature branches) | ✅ |
+| CI green (ESLint / tsc -b / Vitest / coverage / build / CodeQL) | ✅ 11/11 |
+
+> The coach pin is exact `0.5.0` rather than tilde `~0.5.0`. It is the published production package (not the BETA git dep), so the gate passes.
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 0 |
+| Low      | 6 |
+
+Large but well-structured release (leaderboards plan 0005 + user profiles plan 0006 + branch-tiered Supabase backend + Alfano scaffolding + request-datalogger + full i18n). **Security, performance/bundle-budget, and merge/migration integrity all came back clean.** The six findings are polish.
+
+## Findings (Low — by dimension)
+
+### REL-01 — CHANGELOG omits the "engine now required on every vehicle" change
+- `CHANGELOG.md:14` · Blocks release: no
+- Commit 49b1566 makes engine a required field (guard + disabled submit + inline hint) in `VehiclesTab.tsx` and flags pre-existing engine-less vehicles; no mention under `## [3.0.0]` (Golden Rule 4).
+- **Fix:** added a "Changed" bullet under `[3.0.0]`.
+
+### COR-01 — Leaderboards top-session loading key can cross-disable buttons across courses
+- `src/pages/Leaderboards.tsx:117` (disable check `:292`) · Blocks release: no
+- `loadingKey` was `top:${group.key}`, but `group.key` is unique only within a course; the disclosure key already namespaces by `courseKey`.
+- **Fix:** namespaced the loading key as `top:${course.courseKey}|${group.key}`.
+
+### COR-02 — `ProfileAvatar` has no broken-image fallback
+- `src/components/ProfileAvatar.tsx:28` · Blocks release: no
+- `<img>` had no `onError`; a 404 rendered a broken-image glyph instead of the `UserIcon` placeholder.
+- **Fix:** added a `failed` state + `onError` that degrades to the placeholder (resets on `url` change).
+
+### TST-01 — `escapeLike()` ships without a test
+- `src/plugins/cloud-sync/publicProfile.ts:32` · Blocks release: no
+- Pure `ilike`-metacharacter escaper for the `/driver/:username` lookup, untested (Golden Rule 3).
+- **Fix:** exported it + added `publicProfile.test.ts` (covers `_`, `%`, `\`, mixed, passthrough, empty).
+
+### TST-02 — `autoSubmitSnapshotTrack()` skip/dedupe branches untested
+- `src/plugins/cloud-sync/trackAutoSubmit.ts:15` · Blocks release: no
+- Three branches gate the `submit-track` edge call; the pure core was tested but the orchestration wasn't.
+- **Fix:** added `trackAutoSubmit.test.ts` mocking the dynamic imports + `functions.invoke` for every branch.
+
+### DOC-01 — Plan-numbering collision: two plans both numbered 0006
+- `docs/plans/0006-dynamic-supabase-branch-db.md:1` · Blocks release: no
+- The branch-db plan reused 0006 instead of 0007 (Golden Rule 8).
+- **Fix:** renamed to `0007-dynamic-supabase-branch-db.md` + updated its title and the "plan 0006" branch-db references in CLAUDE.md + README (user-profiles refs stay 0006).
+
+## What was not covered
+
+- Single adversarial verify per finding (default depth) — warranted given all findings are Low and verification was unanimous (6/6 survived).
+- The 6-language locale diffs were treated as data (parity enforced by the green `i18n.test.ts`), not line-reviewed for translation quality.
+- Migration runtime behavior was reasoned statically against the diff, not executed against live Postgres.

--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { User as UserIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -16,6 +17,12 @@ interface ProfileAvatarProps {
  * identical. The icon scales to roughly half the circle.
  */
 export function ProfileAvatar({ url, alt = "", sizeClassName = "h-12 w-12", className }: ProfileAvatarProps) {
+  // Fall back to the placeholder when the avatar object 404s (swept path or a
+  // transient CDN miss) instead of rendering the browser's broken-image glyph.
+  // Reset on url change so a fresh upload (new ?v= buster) gets another chance.
+  const [failed, setFailed] = useState(false);
+  useEffect(() => setFailed(false), [url]);
+
   return (
     <div
       className={cn(
@@ -24,8 +31,14 @@ export function ProfileAvatar({ url, alt = "", sizeClassName = "h-12 w-12", clas
         className,
       )}
     >
-      {url ? (
-        <img src={url} alt={alt} className="h-full w-full object-cover" loading="lazy" />
+      {url && !failed ? (
+        <img
+          src={url}
+          alt={alt}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          onError={() => setFailed(true)}
+        />
       ) : (
         <UserIcon className="h-1/2 w-1/2" />
       )}

--- a/src/pages/Leaderboards.tsx
+++ b/src/pages/Leaderboards.tsx
@@ -114,7 +114,7 @@ export default function Leaderboards() {
 
   const openTopSession = useCallback(
     (course: CourseNode, group: GroupNode) =>
-      loadSession(course, group, group.entryIds, top === "all" ? null : top, `top:${group.key}`),
+      loadSession(course, group, group.entryIds, top === "all" ? null : top, `top:${course.courseKey}|${group.key}`),
     [loadSession, top],
   );
 
@@ -289,7 +289,7 @@ function TrackRow({
                                   size="sm"
                                   variant="secondary"
                                   className="w-full h-8 justify-center gap-1.5"
-                                  disabled={loadingKey === `top:${group.key}`}
+                                  disabled={loadingKey === `top:${course.courseKey}|${group.key}`}
                                   onClick={() => onOpenTopSession(course, group)}
                                 >
                                   <Layers className="h-3.5 w-3.5" />

--- a/src/plugins/cloud-sync/publicProfile.test.ts
+++ b/src/plugins/cloud-sync/publicProfile.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+
+// escapeLike is pure, but importing the module pulls in ./profile → ./cloudClient
+// (which would instantiate the supabase client). Stub cloudClient so the import
+// graph stays side-effect-free; we only exercise the pure escaping helper here.
+vi.mock("./cloudClient", () => ({
+  publicProfilesView: () => ({}),
+  publicVehicles: () => ({}),
+  userAvatars: () => ({}),
+}));
+
+import { escapeLike } from "./publicProfile";
+
+describe("escapeLike", () => {
+  it("passes a plain name through unchanged", () => {
+    expect(escapeLike("Ayrton Senna")).toBe("Ayrton Senna");
+  });
+
+  it("escapes an underscore so it isn't an ilike single-char wildcard", () => {
+    expect(escapeLike("a_b")).toBe("a\\_b");
+  });
+
+  it("escapes a percent so it isn't an ilike multi-char wildcard", () => {
+    expect(escapeLike("50%")).toBe("50\\%");
+  });
+
+  it("escapes a literal backslash", () => {
+    expect(escapeLike("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes every wildcard in a mixed name", () => {
+    expect(escapeLike("_100%\\done_")).toBe("\\_100\\%\\\\done\\_");
+  });
+
+  it("leaves the empty string empty", () => {
+    expect(escapeLike("")).toBe("");
+  });
+});

--- a/src/plugins/cloud-sync/publicProfile.ts
+++ b/src/plugins/cloud-sync/publicProfile.ts
@@ -29,7 +29,7 @@ export interface PublicVehicle {
 }
 
 /** Escape PostgREST ilike wildcards so a name is matched literally (not as a pattern). */
-function escapeLike(value: string): string {
+export function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
 }
 

--- a/src/plugins/cloud-sync/trackAutoSubmit.test.ts
+++ b/src/plugins/cloud-sync/trackAutoSubmit.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { LapSnapshot } from "@/lib/lapSnapshot";
+
+// Drive the orchestration branches of autoSubmitSnapshotTrack by faking its
+// dynamically-imported collaborators. buildCourseSubmission's own geometry is
+// covered in trackSubmission.test.ts; here we only assert the skip/dedupe/invoke
+// decisions that gate whether the submit-track edge call fires.
+const { state } = vi.hoisted(() => ({
+  state: {
+    submission: null as Record<string, unknown> | null,
+    submittedRecords: {} as Record<string, { hash: string }>,
+    invokeResult: { data: { batch_id: "b1" } as { batch_id: string } | null, error: null as unknown },
+    invokeCalls: [] as unknown[],
+    marked: [] as unknown[],
+  },
+}));
+
+vi.mock("@/lib/trackStorage", () => ({
+  loadDefaultTracks: async () => [],
+}));
+vi.mock("@/lib/trackSubmission", () => ({
+  buildCourseSubmission: () => state.submission,
+}));
+vi.mock("@/lib/submittedTracksStorage", () => ({
+  loadSubmittedRecords: () => state.submittedRecords,
+  markCoursesSubmitted: (subs: unknown, batchId: unknown) => {
+    state.marked.push({ subs, batchId });
+  },
+}));
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: (name: string, opts: unknown) => {
+        state.invokeCalls.push({ name, opts });
+        return Promise.resolve(state.invokeResult);
+      },
+    },
+  },
+}));
+
+import { autoSubmitSnapshotTrack } from "./trackAutoSubmit";
+
+const sub = {
+  key: "MyTrack|MyCourse",
+  type: "new_track" as const,
+  trackName: "MyTrack",
+  trackShortName: "MYT",
+  courseName: "MyCourse",
+  courseData: { foo: 1 },
+  layout: [{ lat: 1, lon: 2 }],
+  contentHash: "hash-1",
+};
+
+function snapshot(overrides: Partial<LapSnapshot> = {}): LapSnapshot {
+  return {
+    trackName: "MyTrack",
+    courseName: "MyCourse",
+    course: { isUserDefined: true } as LapSnapshot["course"],
+    ...overrides,
+  } as LapSnapshot;
+}
+
+beforeEach(() => {
+  state.submission = sub;
+  state.submittedRecords = {};
+  state.invokeResult = { data: { batch_id: "b1" }, error: null };
+  state.invokeCalls = [];
+  state.marked = [];
+});
+
+describe("autoSubmitSnapshotTrack", () => {
+  it("skips a course that isn't user-defined (no invoke)", async () => {
+    const result = await autoSubmitSnapshotTrack(snapshot({ course: { isUserDefined: false } as LapSnapshot["course"] }));
+    expect(result).toBe(false);
+    expect(state.invokeCalls).toHaveLength(0);
+  });
+
+  it("skips when buildCourseSubmission returns null (matches a built-in)", async () => {
+    state.submission = null;
+    const result = await autoSubmitSnapshotTrack(snapshot());
+    expect(result).toBe(false);
+    expect(state.invokeCalls).toHaveLength(0);
+  });
+
+  it("skips when this exact content was already submitted (dedupe)", async () => {
+    state.submittedRecords = { [sub.key]: { hash: sub.contentHash } };
+    const result = await autoSubmitSnapshotTrack(snapshot());
+    expect(result).toBe(false);
+    expect(state.invokeCalls).toHaveLength(0);
+  });
+
+  it("submits a new course once and records it", async () => {
+    const result = await autoSubmitSnapshotTrack(snapshot());
+    expect(result).toBe(true);
+    expect(state.invokeCalls).toHaveLength(1);
+    expect(state.invokeCalls[0]).toMatchObject({ name: "submit-track" });
+    expect(state.marked).toEqual([{ subs: [sub], batchId: "b1" }]);
+  });
+
+  it("re-submits when the content hash changed (different revision)", async () => {
+    state.submittedRecords = { [sub.key]: { hash: "stale-hash" } };
+    const result = await autoSubmitSnapshotTrack(snapshot());
+    expect(result).toBe(true);
+    expect(state.invokeCalls).toHaveLength(1);
+  });
+
+  it("propagates an edge-function error", async () => {
+    state.invokeResult = { data: null, error: new Error("boom") };
+    await expect(autoSubmitSnapshotTrack(snapshot())).rejects.toThrow("boom");
+    expect(state.marked).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves all six confirmed (Low, non-blocking) findings from the BETA→main release-gate review on #307. None gated the release; this clears them so 3.0.0 ships clean.

| # | Finding | Fix |
|---|---------|-----|
| **REL-01** | CHANGELOG omitted the "engine now required on every vehicle" change | Added a *Changed* bullet under `[3.0.0]` |
| **COR-01** | Leaderboards top-session loading key wasn't course-namespaced, so same-engine groups under different courses cross-disabled their load buttons | Key is now `top:${courseKey}\|${groupKey}` (mirrors the disclosure key) |
| **COR-02** | `ProfileAvatar` rendered the browser broken-image glyph when an avatar URL 404'd | Added an `onError` fallback to the `UserIcon` placeholder (resets on `url` change) |
| **TST-01** | Pure `escapeLike()` (ilike wildcard escaping for `/driver/:username`) had no test | Exported it + new `publicProfile.test.ts` (`_`, `%`, `\`, mixed, passthrough, empty) |
| **TST-02** | `autoSubmitSnapshotTrack()` skip/dedupe/invoke branches untested | New `trackAutoSubmit.test.ts` mocking the dynamic imports + `functions.invoke` for each branch |
| **DOC-01** | Two plans both numbered `0006` (Golden Rule 8 collision) | Renamed branch-db plan → `0007-dynamic-supabase-branch-db.md` + updated its title and the branch-db `plan 0006` refs in CLAUDE.md/README (user-profiles refs stay 0006) |

Also adds the release-review report under `docs/reviews/` for the record.

## Related Issues

Follow-up to the release review on #307.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2098 tests; +12 from the two new test files)
- [x] `bun run build` succeeds
- [x] Feature works **offline** (no new network calls; UI/doc/test-only changes)
- [x] Docs updated where relevant (`CHANGELOG.md`, `CLAUDE.md`, `README.md`, plan rename)
- [ ] For a new parser: n/a

## Notes for Reviewers

All changes are low-risk: two tiny UI fixes, two new tests around existing logic, one changelog line, and a docs/plan rename. The `[3.0.0]` heading is already dated — the engine-required bullet documents a change that shipped *in* 3.0.0, so it belongs under that heading rather than a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUypCCbFtY85CaHxj9VWE6)_