### PR TITLE
plan 0009: read-only viewer polish — fastest lap, overlays, weather, hide Vehicle tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the file browser or the Cloud Logs panel; a new profile setting makes future
   uploads public by default (private remains the default), and your public sessions
   appear on your driver profile page. Shared copies count toward cloud storage.
+  Opening a shared session selects its fastest lap automatically.
+- **Read-only views gained overlays + weather.** The Overlays menu now works in
+  read-only sessions (leaderboards and shared links), so you can compare those laps
+  against your own local sessions, and historical weather is shown when the session
+  carries a date. Vehicle/setup editing stays hidden — including the pro-mode
+  Vehicle tab, which read-only views previously still showed.
 - **Logger firmware updates in the native app.** The DovesLogger/Fledgling flow's
   connected screen gains a **Firmware update** button: it checks the published OTA
   manifest, confirms the build (asking you to pick the *sense*/*nonsense* variant

--- a/docs/plans/0009-shared-session-links.md
+++ b/docs/plans/0009-shared-session-links.md
@@ -111,6 +111,18 @@ navigates by source (`share` → `/`, `leaderboard` → `/leaderboards`).
 - Edge fns: `process-account-deletions` (wipe shared bucket),
   `export-account-data` (include share rows)
 
+## Follow-up polish (maintainer feedback after the BETA merge)
+
+- Opening a share selects the **fastest lap** (was: whole-session view).
+- **OverlaysMenu is enabled in read-only** (shares AND leaderboards) so viewers
+  can compare read-only laps against their own local sessions.
+- **Weather works in read-only**: the map + pro-mode InfoBox weather panels lost
+  their `readOnly` gates, but the per-session weather cache and the
+  station-metadata write-back are skipped (the synthetic "shared"/"leaderboard"
+  file names must never key a cache entry or a metadata row).
+- The pro-mode **InfoBox Vehicle tab is hidden** in read-only (was missed —
+  saving a vehicle/setup makes no sense on a read-only view).
+
 ## Post-deploy
 
 - Apply the migration, then regenerate `integrations/supabase/types.ts`

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -808,16 +808,18 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], cours
             );
           })()}
           
-          {/* Weather panel - below delta section */}
-          {!readOnly && showWeather && (
+          {/* Weather panel - below delta section. Works in read-only too, but
+              without the per-session cache/metadata writes: the synthetic
+              "shared"/"leaderboard" file name must not key a cache entry. */}
+          {showWeather && (
             <div className="mt-3 pt-2 border-t border-border">
               <WeatherPanel
                 lat={sessionGpsPoint?.lat}
                 lon={sessionGpsPoint?.lon}
                 sessionDate={sessionStartDate}
-                sessionFileName={sessionFileName}
+                sessionFileName={readOnly ? null : sessionFileName}
                 cachedStation={cachedWeatherStation}
-                onStationResolved={onWeatherStationResolved}
+                onStationResolved={readOnly ? undefined : onWeatherStationResolved}
                 onWeatherLoaded={setSessionWeatherData}
               />
             </div>

--- a/src/components/graphview/InfoBox.tsx
+++ b/src/components/graphview/InfoBox.tsx
@@ -52,7 +52,7 @@ interface InfoBoxProps {
   /** Hide the Video tab — the player was relocated into the graph stack (mobile),
    *  and two players can't share the single video element ref. */
   hideVideoTab?: boolean;
-  /** Read-only leaderboard view: hide the Video tab + weather panel. */
+  /** Read-only view: hide the Video + Vehicle tabs (weather stays available). */
   readOnly?: boolean;
 }
 
@@ -75,8 +75,11 @@ export function InfoBox({
 
   useEffect(() => { setSelectedVehicleId(sessionKartId); setSelectedSetupId(sessionSetupId); }, [sessionKartId, sessionSetupId]);
 
-  // If the video panel was relocated while this tab was open, fall back to data.
-  useEffect(() => { if ((hideVideoTab || readOnly) && tab === 'video') setTab('data'); }, [hideVideoTab, readOnly, tab]);
+  // If the open tab became unavailable (video relocated, or read-only hid
+  // video/vehicle), fall back to data.
+  useEffect(() => {
+    if (((hideVideoTab || readOnly) && tab === 'video') || (readOnly && tab === 'vehicle')) setTab('data');
+  }, [hideVideoTab, readOnly, tab]);
 
   const unit = useKph ? 'kph' : 'mph';
   const convertSpeed = (speed: number) => useKph ? speed * 1.60934 : speed;
@@ -117,7 +120,9 @@ export function InfoBox({
     <div className="flex flex-col h-full min-h-0 bg-card border-b border-border">
       <div className="flex shrink-0 border-b border-border">
         <button onClick={() => setTab('data')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'data' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabData')}</button>
-        <button onClick={() => setTab('vehicle')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'vehicle' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabVehicle')}</button>
+        {!readOnly && (
+          <button onClick={() => setTab('vehicle')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'vehicle' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabVehicle')}</button>
+        )}
         {!hideVideoTab && !readOnly && (
           <button onClick={() => setTab('video')} className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'video' ? 'text-primary border-b-2 border-primary bg-primary/5' : 'text-muted-foreground hover:text-foreground'}`}>{t('infoBox.tabVideo')}</button>
         )}
@@ -192,11 +197,11 @@ export function InfoBox({
                 )}
               </div>
             )}
-            {!readOnly && (
-              <div className="pt-2 border-t border-border">
-                <WeatherPanel lat={sessionGpsPoint?.lat} lon={sessionGpsPoint?.lon} sessionDate={sessionStartDate} cachedStation={cachedWeatherStation} onStationResolved={onWeatherStationResolved} detailed />
-              </div>
-            )}
+            {/* Weather works in read-only too — just without the metadata
+                write-back (the synthetic session has no real file to tag). */}
+            <div className="pt-2 border-t border-border">
+              <WeatherPanel lat={sessionGpsPoint?.lat} lon={sessionGpsPoint?.lon} sessionDate={sessionStartDate} cachedStation={cachedWeatherStation} onStationResolved={readOnly ? undefined : onWeatherStationResolved} detailed />
+            </div>
           </>
         ) : (
           /* Vehicle tab */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -210,7 +210,8 @@ export default function Index() {
       sessionData.loadParsedData(bundle.data, "shared");
       setSelection(bundle.selection);
       setLaps(bundle.laps);
-      setSelectedLapNumber(null); // whole-session view first
+      const fastest = [...bundle.laps].sort((a, b) => a.lapTimeMs - b.lapTimeMs)[0];
+      setSelectedLapNumber(fastest?.lapNumber ?? null);
       setLapLabels(bundle.lapLabels);
       setReadOnlyDescriptor(bundle.descriptor);
       setReadOnly(true);
@@ -900,22 +901,22 @@ export default function Index() {
             />
           )}
 
-          {!readOnly && (
-            <OverlaysMenu
-              hasCourse={!!selectedCourse}
-              trackName={selection?.trackName}
-              courseName={selectedCourse?.name}
-              currentFileName={currentFileName}
-              laps={laps}
-              overlayLines={overlayLines}
-              referenceLapNumber={referenceLapNumber}
-              externalRefLabel={externalRefLabel}
-              onLoadOverlayFile={loadOverlayFile}
-              onAddExternalOverlay={addExternalOverlay}
-              onToggleOverlay={toggleOverlay}
-              onSetOverlayReference={handleSetOverlayReference}
-            />
-          )}
+          {/* Overlays stay available in read-only so viewers can compare
+              leaderboard/shared laps against their own local sessions. */}
+          <OverlaysMenu
+            hasCourse={!!selectedCourse}
+            trackName={selection?.trackName}
+            courseName={selectedCourse?.name}
+            currentFileName={currentFileName}
+            laps={laps}
+            overlayLines={overlayLines}
+            referenceLapNumber={referenceLapNumber}
+            externalRefLabel={externalRefLabel}
+            onLoadOverlayFile={loadOverlayFile}
+            onAddExternalOverlay={addExternalOverlay}
+            onToggleOverlay={toggleOverlay}
+            onSetOverlayReference={handleSetOverlayReference}
+          />
 
           <SettingsModal settings={settings} onSettingsChange={setSettings} onToggleFieldDefault={toggleFieldDefault} canHideSampleFiles={fileManager.hasOtherFiles} />
           {readOnly ? (


### PR DESCRIPTION
## Summary

Post-merge polish on the shared-session read-only viewer (#331), from maintainer feedback:

- **Fastest lap auto-selected** — opening a `/s/{token}` share selects the fastest detected lap instead of the whole-session view, matching normal file-load behavior.
- **Overlays menu enabled in read-only** — for both shares and leaderboard sessions, so viewers can load laps from their own local files and compare them against the read-only laps. Snapshot controls and the track editor stay hidden.
- **Weather restored in read-only** — both the map panel and the pro-mode InfoBox. Subtlety: read-only sessions use the synthetic file names `"shared"`/`"leaderboard"`, and the weather system caches per-session by file name + writes the resolved station into file metadata — left alone, every shared session would collide on one cache entry and create junk metadata rows. In read-only, weather fetches live but skips the cache and the metadata write-back. Leaderboard sessions still show no weather (the stitched multi-driver bundle has no session date); shared sessions parse the real file, so they do.
- **Pro-mode Vehicle tab hidden in read-only** — the InfoBox drops the Vehicle tab (falling back to Data if it was open), removing the last vehicle/setup surface from read-only views.

## Related Issues

Follow-up to #331.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (2166 tests / 162 files)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (no new network calls — weather remains the documented online-only exception)
- [x] Docs updated where relevant (`CHANGELOG.md` under `[3.1.0] - unreleased`, `docs/plans/0009`)
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table (N/A)

## Notes for Reviewers

- View-layer only (Index.tsx, RaceLineView, InfoBox) plus docs — no storage/backend changes, hence no new tests (coverage scope excludes the view layer).
- Worth a quick manual glance: open a leaderboard session and a shared link, confirm the Overlays menu populates from your local files, weather shows on the shared session, and the pro-mode InfoBox shows only Data (+Video absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZefCzbyk4ZZPzckLbJvk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZefCzbyk4ZZPzckLbJvk)_