### PR TITLE
plan 0010: /simulator — the firmware running in the browser (sim panel + playback engine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.0] - unreleased
 
 ### Added
+- **Firmware simulator page (`/simulator`).** The real DovesDataLogger
+  firmware — the vendored WebAssembly build — running in the browser on a
+  simulated 128×64 OLED, replaying the bundled Orlando Kart Center sample
+  session: watch it boot, acquire GPS, auto-enter race mode, detect the
+  track and count laps, exactly as the physical device does (the same wasm
+  core reproduces this session's 13 hardware lap times to the millisecond).
+  Three on-screen buttons (plus ← Enter →) drive the real firmware menus,
+  even mid-playback. Includes play/pause, 1–10× speed, a scrubbable
+  timeline (rewinds re-boot the firmware and fast-replay — it's a real
+  device, not a video), an integer-scale zoom picker, and a true-size
+  toggle showing the display at its physical 1.3″ size. Fully offline-capable.
+  (plan 0010, Phase A)
 - **Vendored BirdsEye firmware simulator (`public/sim/`, groundwork).** The
   real DovesDataLogger firmware compiled to WebAssembly (207 KB), pinned by
   construction: `birdseye-sim.mjs` (API contract v1 — see `BirdsEye/sim/API.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ src/
 │   ├── Index.tsx          # ★ Main SPA — file import, tab views, all state orchestration. Also hosts the read-only viewer (plans 0005+0009): consumes a leaderboardHandoff bundle on mount OR self-loads a /s/:token shared session (anon fetch → parse → calculateLaps vs the share's frozen course), injects prebuilt laps/selection, flips a `readOnly` flag that alert-colours the header + hides Coach/Tools/Setups + video/weather/snapshots.
 │   ├── Leaderboards.tsx   # ★ Public /leaderboards page (cloud-gated): Track→Course→engine/weight accordion (Group-by-weight + Show-top), opens a group into Index's read-only viewer via leaderboardHandoff; shows uploader avatar thumbnails
 │   ├── DriverProfile.tsx  # ★ Public /driver/:username page (plan 0006, anon, case-insensitive via .ilike): avatar + name + opt-in vehicles (no weights/setups) + the driver's approved leaderboard snapshots grouped by course/weight
+│   ├── Simulator.tsx      # ★ Public /simulator page (plan 0010): the vendored firmware wasm (public/sim/) on a canvas OLED, replaying the bundled sample via lib/sim + useSimPlayback
 │   ├── Admin.tsx          # Admin panel (behind VITE_ENABLE_ADMIN)
 │   └── …                  # Login / Register / Privacy / Terms / NotFound
 ├── components/
@@ -130,6 +131,7 @@ src/
 │   ├── garageEvents.ts    # ★ Host pub/sub: storage emits {store,key,put|delete}; cloud-sync syncs off it
 │   ├── fileLoadingState.ts # ★ Host pub/sub for the global file-load overlay
 │   ├── *Storage.ts        # IDB/localStorage store modules (file, vehicle, engine, template, note, setup, …)
+│   ├── sim/               # ★ Firmware simulator (plan 0010): simClient (typed loader for the vendored /sim/birdseye-sim.mjs, API contract v1 — reset() is async/re-instantiating) + simPlayback (PURE tick/pre-roll/scrub planning, Vitest-covered). The rAF loop lives in hooks/useSimPlayback; the device chrome in components/sim/SimDevicePanel
 │   ├── gps/               # ★ Phone-as-datalogger layer: gpsFix, customGps, sessionGate, realtimeTimer, dovepWriter
 │   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=web BLE, mychron/=MyChron over native (Tauri) Wi-Fi IPC, doveslogger/=same Fledgling hardware over native (Tauri) BLE IPC (scan→connect→list→download), alfano/=Alfano over native (Tauri) Bluetooth-serial IPC (SKELETON: web-side seam only, Rust backend TBD — Bluetooth serial can't be reached in-browser so there's no web path); native/ipc.ts = shared kind-agnostic native IPC (all lazy; @tauri-apps/api dynamic-imported, native-only). progress.ts = transport-neutral formatters + computeProgress; errors.ts = pure error-prefix classifier + recovery-action table — every download flow renders classified, translated errors via the shared ErrorPanel, never raw backend strings. Native Fledgling firmware OTA (plan 0008): doveslogger/`loggerUpdateFirmware` + `firmwareInfo.ts` + `useNativeFirmwareUpdate`/`NativeFirmwarePanel`, reusing lib/ble/dfu; availability runtime-detected (→ docs/ble.md, docs/android.md)
 │   ├── speedHeatmap.ts / mapMarker.ts / brakingZones / gforceCalculation / …  # racing math

--- a/docs/plans/0010-firmware-simulator-viewer.md
+++ b/docs/plans/0010-firmware-simulator-viewer.md
@@ -1,0 +1,75 @@
+# 0010 — Firmware Simulator in the Viewer (`/simulator`)
+
+**Status:** Phase A (sim panel + playback engine) shipped; Phase B (map +
+cursor) and Phase C (session capture/share) pending.
+
+## Context
+
+The DovesDataLogger firmware now compiles to WebAssembly (the real sketch
+sources — same lap timing, same display stack) and is vendored, pinned by
+construction, under `public/sim/` (viewer PR #336; firmware repo PRs
+#91–#96). The wasm module reproduces a hardware-recorded session's 13 lap
+times to the exact millisecond in the firmware repo's CI oracle, and that
+hardware session is **byte-identical** to our bundled sample
+(`public/samples/okc-tillotson-data.dovex`) — so the viewer can demo the
+real device replaying the real session it already ships.
+
+External design record: the "BirdsEye WASM Simulator — Phased Handoff
+Spec" (firmware-repo effort; its API contract v1 lives at
+`BirdsEye/sim/API.md` in that repo). This plan covers the viewer-side
+phases of that spec (its Phases 5–7 = our Phases A–C).
+
+## Phase A — `/simulator` page (this plan's first shipping slice)
+
+- `lib/sim/simClient.ts` — typed loader for `/sim/birdseye-sim.mjs`
+  (runtime dynamic import, `@vite-ignore`; the module is same-origin and
+  SW-precached). Types mirror API contract v1. `reset()` is async
+  (module re-instantiation = true fresh boot).
+- `lib/sim/simPlayback.ts` — PURE playback model (Vitest-covered):
+  sample→PVT-JSON mapping (canonical channel ids from `channels.ts`),
+  tick planning (each dovex row injected at its own timestamp, stepMillis
+  between rows — max one injection per step batch, per the contract),
+  no-fix boot pre-roll frames, scrub planning (backward = reset +
+  headless fast-replay).
+- `hooks/useSimPlayback.ts` — owns the sim instance + rAF loop:
+  play/pause, 1/2/5/10× speed, seek, live state JSON at ~10 Hz,
+  frame-hash-gated canvas blits (fw refreshes at 3 Hz; don't repaint 60).
+- `components/sim/SimDevicePanel.tsx` — the "device": 128×64 canvas,
+  integer scaling (4/6/8×) with `image-rendering: pixelated`, never
+  fractional; true-size toggle (55 × 27.5 mm active area via CSS mm,
+  default ON for first-time visitors with a "why so small?" tooltip);
+  bezel; three buttons (pointer + ←/Enter/→ keyboard) wired to the real
+  firmware debounce.
+- `pages/Simulator.tsx` — public, lazy, offline-first route: loads the
+  bundled sample (via `ensureSampleFile`'s IDB cache), transport bar
+  (play/pause/skip-pre-roll/speed/timeline), status line from
+  `getStateJson()`.
+- SW: `mjs` added to the precache glob so the sim module works offline
+  (the `.wasm` glob already covered the binary).
+
+Done-criteria (from the external spec): bundled OKC demo Play → boot →
+lock → auto race mode → laps count up; buttons navigate real firmware
+menus mid-playback; scrubbing works.
+
+## Phase B — map + playback cursor (external spec Phase 6)
+
+Map above the sim panel reusing the existing Leaflet/track rendering;
+one virtual clock drives map cursor + sim; session picker incl. "upload
+your own .dovex".
+
+## Phase C — session capture + share (external spec Phase 7)
+
+Record inputs with virtual timestamps; Supabase `sim_sessions` table;
+`/sim/<id>` share links; firmware-sha pinning banner. Determinism (CI-
+enforced in the firmware repo) is what makes replays reproduce exactly.
+
+## Decisions & constraints
+
+- **Never re-implement timing/pixels client-side** — the wasm module IS
+  the firmware; the viewer only feeds it rows and blits its framebuffer.
+- Scrub-backward budget: a full 15-min session fast-replays in ~0.2 s
+  native / low seconds wasm; if a scrub ever exceeds ~2 s, coarsen the
+  scrub granularity rather than snapshotting wasm memory (out of scope
+  in v1).
+- The sim page must stay out of the main bundle (lazy route) and add no
+  new dependencies.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,9 @@ const Register = lazy(() => import("./pages/Register"));
 const Leaderboards = lazy(() => import("./pages/Leaderboards"));
 const DriverProfile = lazy(() => import("./pages/DriverProfile"));
 const Privacy = lazy(() => import("./pages/Privacy"));
+// The firmware simulator (plan 0010): public + offline-first — the wasm
+// module and demo session are same-origin, SW-cached assets.
+const Simulator = lazy(() => import("./pages/Simulator"));
 const Terms = lazy(() => import("./pages/Terms"));
 // Public, no-login account-deletion request page. Mounted un-gated (below) so the
 // URL Google Play requires resolves on every build, even offline-only ones.
@@ -74,6 +77,7 @@ const App = () => {
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/privacy" element={<Privacy />} />
+              <Route path="/simulator" element={<Simulator />} />
               <Route path="/terms" element={<Terms />} />
               {/* Un-gated: Google Play requires a publicly reachable account-deletion
                   URL. The page itself adapts when cloud accounts are disabled. */}

--- a/src/components/sim/SimDevicePanel.tsx
+++ b/src/components/sim/SimDevicePanel.tsx
@@ -1,0 +1,187 @@
+/**
+ * SimDevicePanel — "the device" (plan 0010, Phase A).
+ *
+ * Renders the firmware's REAL 128×64 framebuffer on a canvas: offscreen
+ * 1:1 ImageData, blitted at an INTEGER scale only (fractional scaling
+ * would interpolate away the pixel-perfection the wasm build guarantees),
+ * `image-rendering: pixelated`, inside a subtle bezel so it reads as
+ * hardware. A true-size toggle renders the panel at its physical active
+ * area (≈55 × 27.5 mm) via CSS millimetres — blown-up looks great and
+ * lies; legibility critique needs true size. Defaults ON for first-time
+ * visitors.
+ *
+ * The three buttons feed the sim's pin map (pointer events + ←/Enter/→),
+ * so presses go through the real firmware debounce — including during
+ * playback.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronLeft, ChevronRight, CircleDot } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip, TooltipContent, TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { BirdsEyeSim } from "@/lib/sim/simClient";
+
+const FB_W = 128;
+const FB_H = 64;
+/** SH1106 128×64 panel active area, mm (the spec's "true size"). */
+const PANEL_W_MM = 55.0;
+const PANEL_H_MM = 27.5;
+
+export interface SimDevicePanelProps {
+  /** Register/unregister the blit sink (called when the frame hash changes). */
+  setFrameSink: (sink: ((sim: BirdsEyeSim) => void) | null) => void;
+  buttonDown: (idx: number) => void;
+  buttonUp: (idx: number) => void;
+  trueSize: boolean;
+  onTrueSizeChange: (v: boolean) => void;
+  scale: number;
+  onScaleChange: (s: number) => void;
+}
+
+export function SimDevicePanel({
+  setFrameSink, buttonDown, buttonUp,
+  trueSize, onTrueSizeChange, scale, onScaleChange,
+}: SimDevicePanelProps) {
+  const { t } = useTranslation("simulator");
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const imageRef = useRef<ImageData | null>(null);
+
+  // Blit sink: firmware page layout -> 1:1 ImageData -> canvas. The host
+  // hook only calls this when the frame hash actually changed (fw paints
+  // at 3 Hz — no 60 fps repaints of identical pixels).
+  const blit = useCallback((sim: BirdsEyeSim) => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+    let img = imageRef.current;
+    if (!img) {
+      img = ctx.createImageData(FB_W, FB_H);
+      imageRef.current = img;
+    }
+    const fb = sim.getFramebuffer();
+    const px = img.data;
+    for (let y = 0; y < FB_H; y++) {
+      const page = (y >> 3) * FB_W;
+      const bit = y & 7;
+      for (let x = 0; x < FB_W; x++) {
+        const on = (fb[x + page] >> bit) & 1;
+        const o = (y * FB_W + x) * 4;
+        // Warm OLED white on near-black, like the real panel.
+        px[o] = on ? 240 : 6;
+        px[o + 1] = on ? 244 : 8;
+        px[o + 2] = on ? 248 : 10;
+        px[o + 3] = 255;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+  }, []);
+
+  useEffect(() => {
+    setFrameSink(blit);
+    return () => setFrameSink(null);
+  }, [blit, setFrameSink]);
+
+  // Keyboard: ← Enter → (ignore auto-repeat; the fw does its own timing).
+  useEffect(() => {
+    const keyIdx = (key: string) =>
+      key === "ArrowLeft" ? 0 : key === "Enter" ? 1 : key === "ArrowRight" ? 2 : -1;
+    const down = (e: KeyboardEvent) => {
+      const idx = keyIdx(e.key);
+      if (idx < 0 || e.repeat) return;
+      const el = document.activeElement;
+      if (el instanceof HTMLElement && ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName)) return;
+      e.preventDefault();
+      buttonDown(idx);
+    };
+    const up = (e: KeyboardEvent) => {
+      const idx = keyIdx(e.key);
+      if (idx >= 0) buttonUp(idx);
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, [buttonDown, buttonUp]);
+
+  const sizeStyle = trueSize
+    ? { width: `${PANEL_W_MM}mm`, height: `${PANEL_H_MM}mm` }
+    : { width: FB_W * scale, height: FB_H * scale };
+
+  const deviceButton = (idx: number, label: string, icon: React.ReactNode) => (
+    <Button
+      variant="secondary"
+      size="sm"
+      className="touch-none select-none px-5"
+      aria-label={label}
+      onPointerDown={() => buttonDown(idx)}
+      onPointerUp={() => buttonUp(idx)}
+      onPointerCancel={() => buttonUp(idx)}
+      onPointerLeave={() => buttonUp(idx)}
+    >
+      {icon}
+    </Button>
+  );
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="rounded-xl border border-border bg-zinc-900 p-4 shadow-inner dark:bg-zinc-950">
+        <canvas
+          ref={canvasRef}
+          width={FB_W}
+          height={FB_H}
+          style={{ ...sizeStyle, imageRendering: "pixelated" }}
+          className="block bg-black"
+          aria-label={t("display.canvasLabel")}
+        />
+      </div>
+
+      <div className="flex items-center gap-2" role="group" aria-label={t("buttons.group")}>
+        {deviceButton(0, t("buttons.left"), <ChevronLeft className="h-4 w-4" />)}
+        {deviceButton(1, t("buttons.select"), <CircleDot className="h-4 w-4" />)}
+        {deviceButton(2, t("buttons.right"), <ChevronRight className="h-4 w-4" />)}
+        <span className="ml-2 hidden text-xs text-muted-foreground sm:inline">
+          {t("buttons.keyboardHint")}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-4 text-sm">
+        <div className="flex items-center gap-2">
+          <Switch id="sim-true-size" checked={trueSize} onCheckedChange={onTrueSizeChange} />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Label htmlFor="sim-true-size" className="cursor-help underline decoration-dotted">
+                {t("display.trueSize")}
+              </Label>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-56">{t("display.trueSizeWhy")}</TooltipContent>
+          </Tooltip>
+        </div>
+        {!trueSize && (
+          <div className="flex items-center gap-2">
+            <Label>{t("display.scale")}</Label>
+            <Select value={String(scale)} onValueChange={(v) => onScaleChange(Number(v))}>
+              <SelectTrigger className="h-8 w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[4, 6, 8].map((s) => (
+                  <SelectItem key={s} value={String(s)}>{s}×</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSimPlayback.ts
+++ b/src/hooks/useSimPlayback.ts
@@ -1,0 +1,286 @@
+/**
+ * useSimPlayback — owns the firmware-sim instance and the playback loop
+ * (plan 0010, Phase A). One concern: virtual time. The page renders; the
+ * pure math lives in lib/sim/simPlayback.
+ *
+ * The rAF tick advances the virtual clock by wall-delta × speed, executes
+ * the tick plan (inject rows at their own timestamps, stepMillis between),
+ * and publishes throttled UI state. Scrubbing backward awaits the sim's
+ * async reset() (true fresh boot) and headless-fast-replays to the target.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ParsedData } from "@/types/racing";
+import { createSim, type BirdsEyeSim, type SimState, type SimVersion } from "@/lib/sim/simClient";
+import {
+  PRE_ROLL_MS,
+  buildTickPlan,
+  planScrub,
+  preRollFrames,
+  sessionEndMs,
+  type TickAction,
+} from "@/lib/sim/simPlayback";
+
+export type SimPlaybackStatus = "loading" | "ready" | "error";
+
+export interface SimPlayback {
+  status: SimPlaybackStatus;
+  /** Live firmware state (throttled to ~10 Hz). */
+  simState: SimState | null;
+  version: SimVersion | null;
+  playing: boolean;
+  speed: number;
+  /** Playback position in session ms (0 = session start; negative = pre-roll). */
+  positionMs: number;
+  durationMs: number;
+  inPreRoll: boolean;
+  play: () => void;
+  pause: () => void;
+  setSpeed: (x: number) => void;
+  /** Seek to a session-relative position (ms since session start). */
+  seek: (sessionMs: number) => void;
+  skipPreRoll: () => void;
+  buttonDown: (idx: number) => void;
+  buttonUp: (idx: number) => void;
+  /** Blit target: called with the sim whenever the frame hash changes. */
+  setFrameSink: (sink: ((sim: BirdsEyeSim) => void) | null) => void;
+}
+
+export function useSimPlayback(data: ParsedData | null): SimPlayback {
+  const [status, setStatus] = useState<SimPlaybackStatus>("loading");
+  const [simState, setSimState] = useState<SimState | null>(null);
+  const [version, setVersion] = useState<SimVersion | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeedState] = useState(1);
+  const [positionMs, setPositionMs] = useState(-PRE_ROLL_MS);
+
+  const simRef = useRef<BirdsEyeSim | null>(null);
+  const frameSinkRef = useRef<((sim: BirdsEyeSim) => void) | null>(null);
+  const lastHashRef = useRef(-1);
+  const lastUiPushRef = useRef(0);
+  const playingRef = useRef(false);
+  const speedRef = useRef(1);
+  const busyRef = useRef(false); // guards reset/seek re-entrancy
+
+  // Virtual playback cursor, absolute unix-ms (matches sample timestamps).
+  const cursorRef = useRef(0);
+  const sampleIndexRef = useRef(0);
+  const preRollLeftRef = useRef<TickAction[]>([]);
+
+  const epochMs = data?.startDate ? data.startDate.getTime() : 0;
+  const durationMs = data ? sessionEndMs(data.samples, epochMs) - epochMs : 0;
+
+  const publish = useCallback((force = false) => {
+    const sim = simRef.current;
+    if (!sim) return;
+    const hash = sim.getFrameHash();
+    if (hash !== lastHashRef.current) {
+      lastHashRef.current = hash;
+      frameSinkRef.current?.(sim);
+    }
+    const now = performance.now();
+    if (force || now - lastUiPushRef.current > 100) {
+      lastUiPushRef.current = now;
+      setSimState(sim.getStateJson());
+      setPositionMs(
+        preRollLeftRef.current.length > 0
+          ? -preRollLeftRef.current.length * 200
+          : cursorRef.current - epochMs,
+      );
+    }
+  }, [epochMs]);
+
+  const runActions = useCallback((actions: TickAction[]) => {
+    const sim = simRef.current;
+    if (!sim) return;
+    for (const a of actions) {
+      if (a.pvt) sim.injectPvt(JSON.stringify(a.pvt));
+      if (a.rpm !== undefined) sim.setRpm(a.rpm);
+      if (a.stepMs > 0) sim.stepMillis(a.stepMs);
+    }
+  }, []);
+
+  /** Fresh boot + arm the pre-roll queue; cursor parks at session start. */
+  const bootFresh = useCallback(async (sim: BirdsEyeSim) => {
+    await sim.reset();
+    sim.init();
+    preRollLeftRef.current = preRollFrames(epochMs);
+    cursorRef.current = epochMs;
+    sampleIndexRef.current = 0;
+    lastHashRef.current = -1;
+  }, [epochMs]);
+
+  // Instance lifecycle.
+  useEffect(() => {
+    if (!data) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const sim = await createSim();
+        if (cancelled) return;
+        sim.init();
+        simRef.current = sim;
+        preRollLeftRef.current = preRollFrames(epochMs);
+        cursorRef.current = epochMs;
+        sampleIndexRef.current = 0;
+        setVersion(sim.getVersion());
+        setStatus("ready");
+        publish(true);
+      } catch (err) {
+        console.error("sim load failed", err);
+        if (!cancelled) setStatus("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+      simRef.current = null;
+    };
+  }, [data, epochMs, publish]);
+
+  // The playback loop.
+  useEffect(() => {
+    if (status !== "ready" || !data) return;
+    let raf = 0;
+    let prev = performance.now();
+
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      const wallDelta = Math.min(now - prev, 100);
+      prev = now;
+      const sim = simRef.current;
+      if (!sim || busyRef.current) return;
+
+      if (!playingRef.current) {
+        // Paused: keep the firmware's own clock breathing so held buttons,
+        // menu timers and the display loop stay live for interaction.
+        sim.stepMillis(wallDelta);
+        publish();
+        return;
+      }
+
+      const delta = wallDelta * speedRef.current;
+
+      // Pre-roll queue first (skippable, fixed cadence).
+      if (preRollLeftRef.current.length > 0) {
+        let budget = delta;
+        while (budget > 0 && preRollLeftRef.current.length > 0) {
+          const a = preRollLeftRef.current.shift()!;
+          runActions([a]);
+          budget -= a.stepMs;
+        }
+        publish();
+        return;
+      }
+
+      const from = cursorRef.current;
+      const to = Math.min(from + delta, epochMs + durationMs);
+      if (to > from) {
+        const { actions, nextIndex } = buildTickPlan(
+          data.samples, epochMs, from, to, sampleIndexRef.current,
+        );
+        runActions(actions);
+        cursorRef.current = to;
+        sampleIndexRef.current = nextIndex;
+        if (to >= epochMs + durationMs) {
+          playingRef.current = false;
+          setPlaying(false);
+        }
+      } else {
+        // At the end: keep the firmware alive for menu interaction.
+        sim.stepMillis(wallDelta);
+      }
+      publish();
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [status, data, durationMs, epochMs, publish, runActions]);
+
+  const seek = useCallback((sessionMs: number) => {
+    const sim = simRef.current;
+    if (!sim || !data || busyRef.current) return;
+    const targetAbs = epochMs + Math.max(0, Math.min(sessionMs, durationMs));
+    const plan = planScrub(cursorRef.current, targetAbs, epochMs);
+    busyRef.current = true;
+    (async () => {
+      try {
+        if (plan.reset) {
+          await bootFresh(sim);
+          // Headless pre-roll: run it at once (no rendering between).
+          runActions(preRollLeftRef.current);
+          preRollLeftRef.current = [];
+        } else if (preRollLeftRef.current.length > 0) {
+          runActions(preRollLeftRef.current);
+          preRollLeftRef.current = [];
+        }
+        // Headless fast-replay in one plan (row-accurate, no paints).
+        const { actions, nextIndex } = buildTickPlan(
+          data.samples, epochMs, cursorRef.current, targetAbs,
+          sampleIndexRef.current,
+        );
+        runActions(actions);
+        cursorRef.current = targetAbs;
+        sampleIndexRef.current = nextIndex;
+        publish(true);
+      } finally {
+        busyRef.current = false;
+      }
+    })();
+  }, [bootFresh, data, durationMs, epochMs, publish, runActions]);
+
+  const skipPreRoll = useCallback(() => {
+    if (busyRef.current || preRollLeftRef.current.length === 0) return;
+    runActions(preRollLeftRef.current);
+    preRollLeftRef.current = [];
+    publish(true);
+  }, [publish, runActions]);
+
+  const play = useCallback(() => {
+    playingRef.current = true;
+    setPlaying(true);
+  }, []);
+  const pause = useCallback(() => {
+    playingRef.current = false;
+    setPlaying(false);
+  }, []);
+  const setSpeed = useCallback((x: number) => {
+    speedRef.current = x;
+    setSpeedState(x);
+  }, []);
+
+  const buttonDown = useCallback((idx: number) => {
+    simRef.current?.buttonDown(idx);
+  }, []);
+  const buttonUp = useCallback((idx: number) => {
+    simRef.current?.buttonUp(idx);
+  }, []);
+
+  const setFrameSink = useCallback(
+    (sink: ((sim: BirdsEyeSim) => void) | null) => {
+      frameSinkRef.current = sink;
+      if (sink && simRef.current) {
+        lastHashRef.current = -1; // force a first blit
+      }
+    },
+    [],
+  );
+
+  return {
+    status,
+    simState,
+    version,
+    playing,
+    speed,
+    positionMs,
+    durationMs,
+    inPreRoll: preRollLeftRef.current.length > 0,
+    play,
+    pause,
+    setSpeed,
+    seek,
+    skipPreRoll,
+    buttonDown,
+    buttonUp,
+    setFrameSink,
+  };
+}

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -35,7 +35,7 @@ export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
  * migrated (see docs/plans/0004-i18n-translation-system.md). `common` is always
  * loaded; the rest load on demand for their surface.
  */
-export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin", "logger", "leaderboard", "driver"] as const;
+export const NAMESPACES = ["common", "landing", "settings", "session", "video", "drawer", "weather", "tracks", "plugins", "auth", "admin", "logger", "leaderboard", "driver", "simulator"] as const;
 export type Namespace = (typeof NAMESPACES)[number];
 
 export const DEFAULT_NAMESPACE: Namespace = "common";

--- a/src/lib/sim/simClient.ts
+++ b/src/lib/sim/simClient.ts
@@ -1,0 +1,77 @@
+/**
+ * Typed loader for the vendored BirdsEye firmware simulator
+ * (`public/sim/birdseye-sim.mjs` — the REAL DovesDataLogger firmware
+ * compiled to WebAssembly, pinned by construction; see plan 0010 and
+ * `BirdsEye/sim/API.md` in the firmware repo for contract v1).
+ *
+ * The module is same-origin and precached by the service worker, so the
+ * simulator works offline. Loaded lazily — only the /simulator route
+ * pays for it.
+ */
+
+/** Parsed result of `getStateJson()` (API contract v1). */
+export interface SimState {
+  page: number;
+  raceActive: boolean;
+  lapCount: number;
+  bestLapMs: number;
+  lastLapMs: number;
+  currentLapMs: number;
+  gpsFix: boolean;
+  sats: number;
+  rpm: number;
+  loggingActive: boolean;
+  trackDetected: boolean;
+  courseName: string;
+  millis: number;
+}
+
+/** Parsed result of `getVersion()` — build provenance of the vendored wasm. */
+export interface SimVersion {
+  firmwareSha: string;
+  buildDate: string;
+  simApiVersion: number;
+  dovesLapTimerSha: string;
+  adafruitGfx: string;
+  adafruitSh110x: string;
+}
+
+/** The simulator instance (API contract v1). */
+export interface BirdsEyeSim {
+  init(): void;
+  /** TRUE fresh boot — re-instantiates the wasm module. Await it. */
+  reset(): Promise<void>;
+  /** Advance virtual time; returns loop() iterations (or -1 on fw reboot). */
+  stepMillis(deltaMs: number): number;
+  /** idx: 0=Left, 1=Select, 2=Right. Real firmware debounce applies. */
+  buttonDown(idx: number): void;
+  buttonUp(idx: number): void;
+  /** JSON string per the contract schema; false on parse error. */
+  injectPvt(pvtJson: string): boolean;
+  setRpm(rpm: number): void;
+  /** 1024-byte view; bit = buf[x + (y>>3)*128] >> (y&7) & 1. Re-take per use. */
+  getFramebuffer(): Uint8Array;
+  getFrameHash(): number;
+  getStateJson(): SimState;
+  getVersion(): SimVersion;
+  resetRequested(): boolean;
+  readFile(path: string): Uint8Array | null;
+  listFiles(): string[];
+}
+
+export const SIM_MODULE_URL = "/sim/birdseye-sim.mjs";
+
+let cachedFactory: ((opts?: object) => Promise<BirdsEyeSim>) | null = null;
+
+/** Load (once) the vendored module and create a fresh sim instance. */
+export async function createSim(): Promise<BirdsEyeSim> {
+  if (!cachedFactory) {
+    // Runtime URL import on purpose: the module is a vendored static
+    // asset, not a bundled source — Vite must leave the specifier alone.
+    const mod = (await import(/* @vite-ignore */ SIM_MODULE_URL)) as {
+      default: (opts?: object) => Promise<BirdsEyeSim>;
+    };
+    cachedFactory = mod.default;
+  }
+  return cachedFactory();
+}

--- a/src/lib/sim/simPlayback.test.ts
+++ b/src/lib/sim/simPlayback.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import type { GpsSample } from "@/types/racing";
+import {
+  PRE_ROLL_MS,
+  buildTickPlan,
+  planScrub,
+  preRollFrames,
+  sampleRpm,
+  sampleTimeMs,
+  sampleToPvt,
+  sessionEndMs,
+} from "./simPlayback";
+
+const EPOCH = 1_775_319_260_000;
+
+function mkSample(t: number, extra: Record<string, number> = {}): GpsSample {
+  return {
+    t,
+    lat: 28.41 + t * 1e-9,
+    lon: -81.37,
+    speedMps: 10,
+    speedMph: 22.37,
+    speedKph: 36,
+    heading: 90,
+    extraFields: {
+      satellites: 11,
+      hdop: 0.8,
+      altitude: 30,
+      h_acc: 0.4,
+      rpm: 8100.4,
+      accel_x: -0.2,
+      accel_y: 0.1,
+      accel_z: -1.0,
+      ...extra,
+    },
+  };
+}
+
+describe("sampleToPvt", () => {
+  it("maps a parsed sample onto the injectPvt contract fields", () => {
+    const pvt = sampleToPvt(mkSample(40), EPOCH);
+    expect(pvt.timestamp).toBe(EPOCH + 40);
+    expect(pvt.lat).toBeCloseTo(28.41, 5);
+    expect(pvt.lng).toBeCloseTo(-81.37, 5);
+    expect(pvt.sats).toBe(11);
+    expect(pvt.hdop).toBeCloseTo(0.8);
+    expect(pvt.speed_mph).toBeCloseTo(22.37);
+    expect(pvt.altitude_m).toBe(30);
+    expect(pvt.heading_deg).toBe(90);
+    expect(pvt.h_acc_m).toBeCloseTo(0.4);
+    expect(pvt.fix).toBe(true);
+    expect(pvt.accelX).toBeCloseTo(-0.2);
+    expect(pvt.accelZ).toBeCloseTo(-1.0);
+  });
+
+  it("fills sane defaults when optional channels are absent", () => {
+    const bare: GpsSample = {
+      t: 0,
+      lat: 1,
+      lon: 2,
+      speedMps: 0,
+      speedMph: 0,
+      speedKph: 0,
+      extraFields: {},
+    };
+    const pvt = sampleToPvt(bare, EPOCH);
+    expect(pvt.sats).toBe(10);
+    expect(pvt.hdop).toBe(1.0);
+    expect(pvt.heading_deg).toBe(0);
+    expect(pvt.accelZ).toBe(1);
+  });
+});
+
+describe("sampleRpm", () => {
+  it("rounds the rpm channel", () => {
+    expect(sampleRpm(mkSample(0))).toBe(8100);
+  });
+  it("is 0 when the channel is missing or non-positive", () => {
+    expect(sampleRpm(mkSample(0, { rpm: -5 }))).toBe(0);
+    const s = mkSample(0);
+    delete s.extraFields["rpm"];
+    expect(sampleRpm(s)).toBe(0);
+  });
+});
+
+describe("preRollFrames", () => {
+  it("emits no-fix frames strictly before the session epoch", () => {
+    const frames = preRollFrames(EPOCH);
+    expect(frames.length).toBe(PRE_ROLL_MS / 200);
+    for (const f of frames) {
+      expect(f.pvt!.fix).toBe(false);
+      expect(f.pvt!.timestamp).toBeLessThan(EPOCH);
+      expect(f.rpm).toBe(0);
+      expect(f.stepMs).toBe(200);
+    }
+    // Satellite count creeps upward but never "locks".
+    expect(frames[0].pvt!.sats).toBeLessThanOrEqual(frames.at(-1)!.pvt!.sats);
+  });
+});
+
+describe("buildTickPlan", () => {
+  const samples = [mkSample(0), mkSample(40), mkSample(80), mkSample(120)];
+
+  it("injects every row inside the window at its own timestamp", () => {
+    const { actions, nextIndex } = buildTickPlan(
+      samples, EPOCH, EPOCH, EPOCH + 100, 0,
+    );
+    // rows at +40 and +80 land; +0 is at the window start (already done),
+    // +120 is beyond it. Final remainder step lands exactly on toMs.
+    expect(actions.map((a) => a.pvt?.timestamp)).toEqual([
+      EPOCH + 40,
+      EPOCH + 80,
+      undefined,
+    ]);
+    expect(actions.map((a) => a.stepMs)).toEqual([40, 40, 20]);
+    expect(actions[0].rpm).toBe(8100);
+    expect(nextIndex).toBe(3);
+  });
+
+  it("resumes from nextIndex without re-scanning", () => {
+    const first = buildTickPlan(samples, EPOCH, EPOCH, EPOCH + 100, 0);
+    const second = buildTickPlan(
+      samples, EPOCH, EPOCH + 100, EPOCH + 200, first.nextIndex,
+    );
+    expect(second.actions.map((a) => a.pvt?.timestamp)).toEqual([
+      EPOCH + 120,
+      undefined,
+    ]);
+    // 20 ms from the window start to the row, 80 ms remainder.
+    expect(second.actions.map((a) => a.stepMs)).toEqual([20, 80]);
+  });
+
+  it("produces a bare step when no rows fall inside the window", () => {
+    const { actions } = buildTickPlan(samples, EPOCH, EPOCH + 130, EPOCH + 150, 4);
+    expect(actions).toEqual([{ stepMs: 20 }]);
+  });
+
+  it("total stepped time always equals the window span", () => {
+    const span = (from: number, to: number) => {
+      const { actions } = buildTickPlan(samples, EPOCH, from, to, 0);
+      return actions.reduce((ms, a) => ms + a.stepMs, 0);
+    };
+    expect(span(EPOCH, EPOCH + 100)).toBe(100);
+    expect(span(EPOCH - 50, EPOCH + 130)).toBe(180);
+    expect(span(EPOCH + 500, EPOCH + 700)).toBe(200);
+  });
+});
+
+describe("planScrub", () => {
+  it("fast-forwards in place when seeking forward", () => {
+    expect(planScrub(1000, 5000, 0)).toEqual({
+      reset: false,
+      replayFromMs: 1000,
+    });
+  });
+  it("requires a fresh boot when seeking backward", () => {
+    expect(planScrub(5000, 1000, 100)).toEqual({
+      reset: true,
+      replayFromMs: 100,
+    });
+  });
+});
+
+describe("sessionEndMs", () => {
+  it("is the last sample's absolute timestamp", () => {
+    expect(
+      sessionEndMs([mkSample(0), mkSample(40)], EPOCH),
+    ).toBe(EPOCH + 40);
+  });
+  it("degrades to the epoch for an empty session", () => {
+    expect(sessionEndMs([], EPOCH)).toBe(EPOCH);
+  });
+});

--- a/src/lib/sim/simPlayback.ts
+++ b/src/lib/sim/simPlayback.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure playback model for the firmware simulator (plan 0010, Phase A).
+ *
+ * Maps parsed session samples (`ParsedData` — the SAME parser output the
+ * rest of the app uses; never a second dovex parser) onto the sim's
+ * input contract:
+ *
+ *  - every sample is injected at its own timestamp, with `stepMillis`
+ *    advancing virtual time BETWEEN injections (the contract allows at
+ *    most one `injectPvt` per step batch);
+ *  - the RPM channel rides along with each sample and drives the sim's
+ *    real tach ISR;
+ *  - a short no-fix "pre-roll" before the session start exercises the
+ *    firmware's real GPS-acquisition boot UX.
+ *
+ * Everything here is pure and Vitest-covered; the rAF loop in
+ * `useSimPlayback` just executes the plans this module produces.
+ */
+
+import type { GpsSample } from "@/types/racing";
+
+/** injectPvt JSON payload (API contract v1 — see firmware repo API.md). */
+export interface SimPvtFrame {
+  timestamp: number;
+  lat: number;
+  lng: number;
+  sats: number;
+  hdop: number;
+  speed_mph: number;
+  altitude_m: number;
+  heading_deg: number;
+  h_acc_m: number;
+  fix: boolean;
+  accelX: number;
+  accelY: number;
+  accelZ: number;
+}
+
+/** One playback action: optionally inject a frame + rpm, then advance. */
+export interface TickAction {
+  pvt?: SimPvtFrame;
+  rpm?: number;
+  stepMs: number;
+}
+
+/** Boot pre-roll length: matches the real GPS acquisition feel. */
+export const PRE_ROLL_MS = 3000;
+/** Pre-roll no-fix frame cadence (the boot status page runs 5 Hz). */
+const PRE_ROLL_STEP_MS = 200;
+
+/** Absolute (unix-ms) timestamp of a sample. */
+export function sampleTimeMs(sample: GpsSample, epochMs: number): number {
+  return epochMs + sample.t;
+}
+
+/** RPM channel of a sample (canonical id from channels.ts), 0 when absent. */
+export function sampleRpm(sample: GpsSample): number {
+  const rpm = sample.extraFields["rpm"];
+  return Number.isFinite(rpm) && rpm > 0 ? Math.round(rpm) : 0;
+}
+
+/** Map one parsed sample to the sim's injectPvt frame. */
+export function sampleToPvt(sample: GpsSample, epochMs: number): SimPvtFrame {
+  const f = sample.extraFields;
+  return {
+    timestamp: sampleTimeMs(sample, epochMs),
+    lat: sample.lat,
+    lng: sample.lon,
+    sats: Number.isFinite(f["satellites"]) ? f["satellites"] : 10,
+    hdop: Number.isFinite(f["hdop"]) ? f["hdop"] : 1.0,
+    speed_mph: sample.speedMph,
+    altitude_m: Number.isFinite(f["altitude"]) ? f["altitude"] : 0,
+    heading_deg: sample.heading ?? 0,
+    h_acc_m: Number.isFinite(f["h_acc"]) ? f["h_acc"] : 1.0,
+    // Rows only exist in a log while the fix was valid.
+    fix: true,
+    accelX: Number.isFinite(f["accel_x"]) ? f["accel_x"] : 0,
+    accelY: Number.isFinite(f["accel_y"]) ? f["accel_y"] : 0,
+    accelZ: Number.isFinite(f["accel_z"]) ? f["accel_z"] : 1,
+  };
+}
+
+/**
+ * The no-fix boot pre-roll: frames before `epochMs` so viewers see the
+ * real "ACQUIRING" status page, with the satellite count creeping up.
+ */
+export function preRollFrames(epochMs: number): TickAction[] {
+  const actions: TickAction[] = [];
+  const count = Math.floor(PRE_ROLL_MS / PRE_ROLL_STEP_MS);
+  for (let i = 0; i < count; i++) {
+    actions.push({
+      pvt: {
+        timestamp: epochMs - PRE_ROLL_MS + i * PRE_ROLL_STEP_MS,
+        lat: 0,
+        lng: 0,
+        sats: Math.min(3 + (i >> 2), 7),
+        hdop: 9.9,
+        speed_mph: 0,
+        altitude_m: 0,
+        heading_deg: 0,
+        h_acc_m: 50,
+        fix: false,
+        accelX: 0,
+        accelY: 0,
+        accelZ: 1,
+      },
+      rpm: 0,
+      stepMs: PRE_ROLL_STEP_MS,
+    });
+  }
+  return actions;
+}
+
+/**
+ * Plan one playback tick: inject every sample with
+ * `fromMs < timestamp <= toMs` (absolute unix-ms window) at its own
+ * timestamp, stepping virtual time between them, with a final step to
+ * land exactly on `toMs`. `startIndex` avoids re-scanning from zero each
+ * frame; the returned `nextIndex` is the cursor for the next call.
+ */
+export function buildTickPlan(
+  samples: readonly GpsSample[],
+  epochMs: number,
+  fromMs: number,
+  toMs: number,
+  startIndex: number,
+): { actions: TickAction[]; nextIndex: number } {
+  const actions: TickAction[] = [];
+  let cursor = fromMs;
+  let i = Math.max(0, startIndex);
+
+  // Skip anything at or before the window start (already injected).
+  while (i < samples.length && sampleTimeMs(samples[i], epochMs) <= fromMs) {
+    i++;
+  }
+
+  while (i < samples.length) {
+    const ts = sampleTimeMs(samples[i], epochMs);
+    if (ts > toMs) break;
+    actions.push({
+      pvt: sampleToPvt(samples[i], epochMs),
+      rpm: sampleRpm(samples[i]),
+      stepMs: Math.max(0, ts - cursor),
+    });
+    cursor = ts;
+    i++;
+  }
+
+  if (toMs > cursor) {
+    actions.push({ stepMs: toMs - cursor });
+  }
+  return { actions, nextIndex: i };
+}
+
+/** How a seek is executed. */
+export interface ScrubPlan {
+  /** Rewinds need a true fresh boot (reset + headless fast-replay). */
+  reset: boolean;
+  /** Absolute ms to fast-replay from (session start after a reset). */
+  replayFromMs: number;
+}
+
+/**
+ * Seeking forward just fast-replays the gap; seeking backward needs a
+ * fresh boot first (firmware state is cumulative — there is no rewind).
+ */
+export function planScrub(
+  currentMs: number,
+  targetMs: number,
+  sessionStartMs: number,
+): ScrubPlan {
+  if (targetMs >= currentMs) {
+    return { reset: false, replayFromMs: currentMs };
+  }
+  return { reset: true, replayFromMs: sessionStartMs };
+}
+
+/** Absolute end of the session (timestamp of the last sample). */
+export function sessionEndMs(
+  samples: readonly GpsSample[],
+  epochMs: number,
+): number {
+  return samples.length
+    ? sampleTimeMs(samples[samples.length - 1], epochMs)
+    : epochMs;
+}

--- a/src/locales/de/simulator.json
+++ b/src/locales/de/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "Firmware-Simulator",
+  "subtitle": "Die echte DovesDataLogger-Firmware, kompiliert zu WebAssembly, spielt eine echte Streckensession ab. Die Tasten bedienen die echten Menüs — auch mitten in der Runde.",
+  "loading": "Firmware startet…",
+  "loadError": "Der Simulator konnte nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.",
+  "display": {
+    "canvasLabel": "Simuliertes Gerätedisplay",
+    "trueSize": "Originalgröße",
+    "trueSizeWhy": "Warum so klein? Das ist die echte Größe des 1,3″-Displays — so sieht es am Lenkrad aus.",
+    "scale": "Zoom"
+  },
+  "buttons": {
+    "group": "Gerätetasten",
+    "left": "Linke Taste",
+    "select": "Auswahltaste",
+    "right": "Rechte Taste",
+    "keyboardHint": "Tastatur: ← Enter →"
+  },
+  "transport": {
+    "play": "Abspielen",
+    "pause": "Pause",
+    "skipPreRoll": "GPS-Erfassung überspringen",
+    "preRoll": "GPS-Erfassung…",
+    "timeline": "Session-Zeitleiste"
+  },
+  "state": {
+    "racing": "Rennmodus",
+    "idle": "Menü",
+    "laps_one": "{{count}} Runde",
+    "laps_other": "{{count}} Runden",
+    "best": "Beste",
+    "gpsLocked": "GPS {{sats}} Sat.",
+    "gpsAcquiring": "Kein GPS-Fix"
+  },
+  "footer": {
+    "provenance": "Firmware-Build {{sha}} · {{date}} — identischer Code wie auf dem physischen Gerät."
+  }
+}

--- a/src/locales/en/simulator.json
+++ b/src/locales/en/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "Firmware Simulator",
+  "subtitle": "The real DovesDataLogger firmware, compiled to WebAssembly, replaying a real track session. The buttons drive the actual menus — even mid-lap.",
+  "loading": "Booting the firmware…",
+  "loadError": "The simulator could not be loaded. Check your connection and try again.",
+  "display": {
+    "canvasLabel": "Simulated device display",
+    "trueSize": "True size",
+    "trueSizeWhy": "Why so small? This is the device's real 1.3″ screen size — what it actually looks like on a steering wheel.",
+    "scale": "Zoom"
+  },
+  "buttons": {
+    "group": "Device buttons",
+    "left": "Left button",
+    "select": "Select button",
+    "right": "Right button",
+    "keyboardHint": "Keyboard: ← Enter →"
+  },
+  "transport": {
+    "play": "Play",
+    "pause": "Pause",
+    "skipPreRoll": "Skip GPS acquisition",
+    "preRoll": "Acquiring GPS…",
+    "timeline": "Session timeline"
+  },
+  "state": {
+    "racing": "Race mode",
+    "idle": "Menu",
+    "laps_one": "{{count}} lap",
+    "laps_other": "{{count}} laps",
+    "best": "Best",
+    "gpsLocked": "GPS {{sats}} sats",
+    "gpsAcquiring": "No GPS fix"
+  },
+  "footer": {
+    "provenance": "Firmware build {{sha}} · {{date}} — identical code to the physical device."
+  }
+}

--- a/src/locales/es/simulator.json
+++ b/src/locales/es/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "Simulador de firmware",
+  "subtitle": "El firmware real del DovesDataLogger, compilado a WebAssembly, reproduciendo una sesión real en pista. Los botones manejan los menús reales, incluso en plena vuelta.",
+  "loading": "Arrancando el firmware…",
+  "loadError": "No se pudo cargar el simulador. Comprueba tu conexión e inténtalo de nuevo.",
+  "display": {
+    "canvasLabel": "Pantalla del dispositivo simulado",
+    "trueSize": "Tamaño real",
+    "trueSizeWhy": "¿Por qué tan pequeño? Este es el tamaño real de la pantalla de 1,3″ del dispositivo: así se ve montado en el volante.",
+    "scale": "Zoom"
+  },
+  "buttons": {
+    "group": "Botones del dispositivo",
+    "left": "Botón izquierdo",
+    "select": "Botón de selección",
+    "right": "Botón derecho",
+    "keyboardHint": "Teclado: ← Intro →"
+  },
+  "transport": {
+    "play": "Reproducir",
+    "pause": "Pausa",
+    "skipPreRoll": "Omitir adquisición GPS",
+    "preRoll": "Adquiriendo GPS…",
+    "timeline": "Línea de tiempo de la sesión"
+  },
+  "state": {
+    "racing": "Modo carrera",
+    "idle": "Menú",
+    "laps_one": "{{count}} vuelta",
+    "laps_other": "{{count}} vueltas",
+    "best": "Mejor",
+    "gpsLocked": "GPS {{sats}} sat.",
+    "gpsAcquiring": "Sin señal GPS"
+  },
+  "footer": {
+    "provenance": "Compilación de firmware {{sha}} · {{date}} — código idéntico al dispositivo físico."
+  }
+}

--- a/src/locales/fr/simulator.json
+++ b/src/locales/fr/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "Simulateur de firmware",
+  "subtitle": "Le vrai firmware du DovesDataLogger, compilé en WebAssembly, rejouant une vraie session sur circuit. Les boutons pilotent les vrais menus, même en plein tour.",
+  "loading": "Démarrage du firmware…",
+  "loadError": "Impossible de charger le simulateur. Vérifiez votre connexion et réessayez.",
+  "display": {
+    "canvasLabel": "Écran de l'appareil simulé",
+    "trueSize": "Taille réelle",
+    "trueSizeWhy": "Pourquoi si petit ? C'est la taille réelle de l'écran 1,3″ de l'appareil — tel qu'il apparaît sur un volant.",
+    "scale": "Zoom"
+  },
+  "buttons": {
+    "group": "Boutons de l'appareil",
+    "left": "Bouton gauche",
+    "select": "Bouton de sélection",
+    "right": "Bouton droit",
+    "keyboardHint": "Clavier : ← Entrée →"
+  },
+  "transport": {
+    "play": "Lecture",
+    "pause": "Pause",
+    "skipPreRoll": "Passer l'acquisition GPS",
+    "preRoll": "Acquisition GPS…",
+    "timeline": "Chronologie de la session"
+  },
+  "state": {
+    "racing": "Mode course",
+    "idle": "Menu",
+    "laps_one": "{{count}} tour",
+    "laps_other": "{{count}} tours",
+    "best": "Meilleur",
+    "gpsLocked": "GPS {{sats}} sat.",
+    "gpsAcquiring": "Pas de signal GPS"
+  },
+  "footer": {
+    "provenance": "Version du firmware {{sha}} · {{date}} — code identique à l'appareil physique."
+  }
+}

--- a/src/locales/it/simulator.json
+++ b/src/locales/it/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "Simulatore firmware",
+  "subtitle": "Il vero firmware del DovesDataLogger, compilato in WebAssembly, che riproduce una vera sessione in pista. I pulsanti comandano i menu reali, anche a metà giro.",
+  "loading": "Avvio del firmware…",
+  "loadError": "Impossibile caricare il simulatore. Controlla la connessione e riprova.",
+  "display": {
+    "canvasLabel": "Display del dispositivo simulato",
+    "trueSize": "Dimensioni reali",
+    "trueSizeWhy": "Perché così piccolo? Questa è la dimensione reale dello schermo da 1,3″ — così appare montato sul volante.",
+    "scale": "Zoom"
+  },
+  "buttons": {
+    "group": "Pulsanti del dispositivo",
+    "left": "Pulsante sinistro",
+    "select": "Pulsante di selezione",
+    "right": "Pulsante destro",
+    "keyboardHint": "Tastiera: ← Invio →"
+  },
+  "transport": {
+    "play": "Riproduci",
+    "pause": "Pausa",
+    "skipPreRoll": "Salta acquisizione GPS",
+    "preRoll": "Acquisizione GPS…",
+    "timeline": "Timeline della sessione"
+  },
+  "state": {
+    "racing": "Modalità gara",
+    "idle": "Menu",
+    "laps_one": "{{count}} giro",
+    "laps_other": "{{count}} giri",
+    "best": "Migliore",
+    "gpsLocked": "GPS {{sats}} sat.",
+    "gpsAcquiring": "Nessun fix GPS"
+  },
+  "footer": {
+    "provenance": "Build firmware {{sha}} · {{date}} — codice identico al dispositivo fisico."
+  }
+}

--- a/src/locales/ja/simulator.json
+++ b/src/locales/ja/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "ファームウェアシミュレーター",
+  "subtitle": "DovesDataLogger の実機ファームウェアを WebAssembly にコンパイルし、実際の走行セッションを再生します。ボタンは本物のメニューを操作できます — ラップ中でも。",
+  "loading": "ファームウェアを起動中…",
+  "loadError": "シミュレーターを読み込めませんでした。接続を確認して再試行してください。",
+  "display": {
+    "canvasLabel": "シミュレートされたデバイスの画面",
+    "trueSize": "実寸大",
+    "trueSizeWhy": "なぜ小さい？これがデバイスの実際の1.3インチ画面サイズです — ステアリングに付けた実際の見え方です。",
+    "scale": "ズーム"
+  },
+  "buttons": {
+    "group": "デバイスのボタン",
+    "left": "左ボタン",
+    "select": "選択ボタン",
+    "right": "右ボタン",
+    "keyboardHint": "キーボード: ← Enter →"
+  },
+  "transport": {
+    "play": "再生",
+    "pause": "一時停止",
+    "skipPreRoll": "GPS捕捉をスキップ",
+    "preRoll": "GPS捕捉中…",
+    "timeline": "セッションのタイムライン"
+  },
+  "state": {
+    "racing": "レースモード",
+    "idle": "メニュー",
+    "laps_one": "{{count}} 周",
+    "laps_other": "{{count}} 周",
+    "best": "ベスト",
+    "gpsLocked": "GPS {{sats}} 衛星",
+    "gpsAcquiring": "GPS未取得"
+  },
+  "footer": {
+    "provenance": "ファームウェアビルド {{sha}} · {{date}} — 実機と同一のコードです。"
+  }
+}

--- a/src/locales/pt-BR/simulator.json
+++ b/src/locales/pt-BR/simulator.json
@@ -1,0 +1,38 @@
+{
+  "title": "Simulador de firmware",
+  "subtitle": "O firmware real do DovesDataLogger, compilado para WebAssembly, reproduzindo uma sessão real de pista. Os botões controlam os menus reais — até no meio da volta.",
+  "loading": "Iniciando o firmware…",
+  "loadError": "Não foi possível carregar o simulador. Verifique sua conexão e tente novamente.",
+  "display": {
+    "canvasLabel": "Tela do dispositivo simulado",
+    "trueSize": "Tamanho real",
+    "trueSizeWhy": "Por que tão pequeno? Este é o tamanho real da tela de 1,3″ — é assim que ela aparece no volante.",
+    "scale": "Zoom"
+  },
+  "buttons": {
+    "group": "Botões do dispositivo",
+    "left": "Botão esquerdo",
+    "select": "Botão de seleção",
+    "right": "Botão direito",
+    "keyboardHint": "Teclado: ← Enter →"
+  },
+  "transport": {
+    "play": "Reproduzir",
+    "pause": "Pausar",
+    "skipPreRoll": "Pular aquisição de GPS",
+    "preRoll": "Adquirindo GPS…",
+    "timeline": "Linha do tempo da sessão"
+  },
+  "state": {
+    "racing": "Modo corrida",
+    "idle": "Menu",
+    "laps_one": "{{count}} volta",
+    "laps_other": "{{count}} voltas",
+    "best": "Melhor",
+    "gpsLocked": "GPS {{sats}} sat.",
+    "gpsAcquiring": "Sem sinal de GPS"
+  },
+  "footer": {
+    "provenance": "Build do firmware {{sha}} · {{date}} — código idêntico ao dispositivo físico."
+  }
+}

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -1,0 +1,235 @@
+/**
+ * /simulator — "da simulator" (plan 0010, Phase A).
+ *
+ * The REAL DovesDataLogger firmware (vendored wasm, `public/sim/`) booted
+ * in the browser and driven by the bundled OKC sample session — the same
+ * file the firmware repo's CI oracle proves reproduces the hardware's 13
+ * lap times to the exact millisecond. Press Play: the device boots,
+ * acquires GPS (real firmware UX), auto-enters race mode when the engine
+ * "starts", detects the track, and counts laps. The three buttons drive
+ * the real menus at any time, including mid-playback.
+ *
+ * Phase B (plan 0010) adds the map + cursor above this panel; Phase C
+ * adds capture/share.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Loader2, Pause, Play, SkipForward } from "lucide-react";
+import { SiteHeader } from "@/components/SiteHeader";
+import { SettingsModal } from "@/components/SettingsModal";
+import { BackToHome } from "@/components/BackToHome";
+import { useSettings } from "@/hooks/useSettings";
+import { SimDevicePanel } from "@/components/sim/SimDevicePanel";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { useSimPlayback } from "@/hooks/useSimPlayback";
+import { ensureSampleFile, SAMPLE_FILE_NAME } from "@/lib/sampleData";
+import { parseDatalogFile } from "@/lib/datalogParser";
+import { formatLapTime } from "@/lib/lapCalculation";
+import type { ParsedData } from "@/types/racing";
+
+const TRUE_SIZE_SEEN_KEY = "dove-sim-true-size-seen";
+
+function fmtClock(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
+
+const Simulator = () => {
+  const { t } = useTranslation("simulator");
+  const navigate = useNavigate();
+  const { settings, setSettings, toggleFieldDefault } = useSettings();
+  const [data, setData] = useState<ParsedData | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  // True-size default ON for first-time visitors (the spec's honesty rule);
+  // remembered once toggled so returning users keep their preference.
+  const [trueSize, setTrueSize] = useState(
+    () => localStorage.getItem(TRUE_SIZE_SEEN_KEY) === null ||
+          localStorage.getItem(TRUE_SIZE_SEEN_KEY) === "true",
+  );
+  const [scale, setScale] = useState(4);
+
+  const sim = useSimPlayback(data);
+
+  // Load + parse the bundled demo session (IDB-cached after first fetch).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const blob = await ensureSampleFile();
+        if (!blob) throw new Error("sample unavailable");
+        const file = new File([blob], SAMPLE_FILE_NAME);
+        const parsed = await parseDatalogFile(file);
+        if (!cancelled) setData(parsed);
+      } catch (e) {
+        console.error("simulator: demo session load failed", e);
+        if (!cancelled) setLoadError(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const onTrueSizeChange = (v: boolean) => {
+    setTrueSize(v);
+    localStorage.setItem(TRUE_SIZE_SEEN_KEY, String(v));
+  };
+
+  const st = sim.simState;
+  const positionLabel = useMemo(() => {
+    if (sim.positionMs < 0) return t("transport.preRoll");
+    return `${fmtClock(sim.positionMs)} / ${fmtClock(sim.durationMs)}`;
+  }, [sim.positionMs, sim.durationMs, t]);
+
+  const loading = !loadError && (data === null || sim.status === "loading");
+
+  const settingsButton = (
+    <SettingsModal
+      settings={settings}
+      onSettingsChange={setSettings}
+      onToggleFieldDefault={toggleFieldDefault}
+      canHideSampleFiles
+      triggerLabelBreakpoint="sm"
+    />
+  );
+
+  return (
+    <div className="min-h-screen bg-background safe-area-x">
+      <SiteHeader
+        settingsButton={settingsButton}
+        enableCloud={enableCloud}
+        onOpenProfile={() => navigate("/", { state: { openProfile: true } })}
+        showSupportedFiles={false}
+        showAbout={false}
+      />
+
+      <main className="container mx-auto max-w-3xl px-4 py-6">
+        <BackToHome className="mb-4" />
+
+        <div className="mb-4 text-center">
+          <h1 className="text-2xl font-bold">{t("title")}</h1>
+          <p className="mx-auto mt-1 max-w-xl text-sm text-muted-foreground">
+            {t("subtitle")}
+          </p>
+        </div>
+
+        {loadError && (
+          <p className="py-16 text-center text-sm text-destructive">{t("loadError")}</p>
+        )}
+        {loading && !loadError && (
+          <div className="flex items-center justify-center gap-2 py-16 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>{t("loading")}</span>
+          </div>
+        )}
+        {sim.status === "error" && (
+          <p className="py-16 text-center text-sm text-destructive">{t("loadError")}</p>
+        )}
+
+        {!loading && sim.status === "ready" && (
+          <div className="flex flex-col gap-6">
+            <SimDevicePanel
+              setFrameSink={sim.setFrameSink}
+              buttonDown={sim.buttonDown}
+              buttonUp={sim.buttonUp}
+              trueSize={trueSize}
+              onTrueSizeChange={onTrueSizeChange}
+              scale={scale}
+              onScaleChange={setScale}
+            />
+
+            {/* Transport */}
+            <div className="rounded-lg border border-border p-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  size="sm"
+                  onClick={sim.playing ? sim.pause : sim.play}
+                  aria-label={sim.playing ? t("transport.pause") : t("transport.play")}
+                >
+                  {sim.playing
+                    ? <Pause className="h-4 w-4" />
+                    : <Play className="h-4 w-4" />}
+                </Button>
+                {sim.inPreRoll && (
+                  <Button size="sm" variant="outline" onClick={sim.skipPreRoll}>
+                    <SkipForward className="mr-1 h-4 w-4" />
+                    {t("transport.skipPreRoll")}
+                  </Button>
+                )}
+                <Select
+                  value={String(sim.speed)}
+                  onValueChange={(v) => sim.setSpeed(Number(v))}
+                >
+                  <SelectTrigger className="h-9 w-20">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[1, 2, 5, 10].map((x) => (
+                      <SelectItem key={x} value={String(x)}>{x}×</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <span className="ml-auto font-mono text-sm text-muted-foreground">
+                  {positionLabel}
+                </span>
+              </div>
+
+              <div className="mt-4">
+                <Slider
+                  value={[Math.max(0, sim.positionMs)]}
+                  min={0}
+                  max={Math.max(1, sim.durationMs)}
+                  step={1000}
+                  onValueChange={(v) => sim.seek(v[0])}
+                  aria-label={t("transport.timeline")}
+                />
+              </div>
+            </div>
+
+            {/* Live firmware state */}
+            {st && (
+              <div className="flex flex-wrap items-center justify-center gap-2 text-xs">
+                <Badge variant={st.raceActive ? "default" : "secondary"}>
+                  {st.raceActive ? t("state.racing") : t("state.idle")}
+                </Badge>
+                <Badge variant="secondary">
+                  {t("state.laps", { count: st.lapCount })}
+                </Badge>
+                {st.bestLapMs > 0 && (
+                  <Badge variant="secondary">
+                    {t("state.best")} {formatLapTime(st.bestLapMs)}
+                  </Badge>
+                )}
+                <Badge variant="secondary">{st.rpm} RPM</Badge>
+                <Badge variant={st.gpsFix ? "default" : "outline"}>
+                  {st.gpsFix ? t("state.gpsLocked", { sats: st.sats }) : t("state.gpsAcquiring")}
+                </Badge>
+                {st.trackDetected && st.courseName && (
+                  <Badge variant="secondary">{st.courseName}</Badge>
+                )}
+              </div>
+            )}
+
+            {sim.version && (
+              <p className="text-center text-[11px] text-muted-foreground">
+                {t("footer.provenance", {
+                  sha: sim.version.firmwareSha,
+                  date: sim.version.buildDate,
+                })}
+              </p>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default Simulator;

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -20,6 +20,7 @@ import type admin from "@/locales/en/admin.json";
 import type logger from "@/locales/en/logger.json";
 import type leaderboard from "@/locales/en/leaderboard.json";
 import type driver from "@/locales/en/driver.json";
+import type simulator from "@/locales/en/simulator.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -39,6 +40,7 @@ declare module "i18next" {
       logger: typeof logger;
       leaderboard: typeof leaderboard;
       driver: typeof driver;
+      simulator: typeof simulator;
     };
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -299,7 +299,9 @@ export default defineConfig(async ({ mode }) => {
           skipWaiting: true,
           // woff2 only: every SW-capable browser supports it, so the legacy
           // .woff fallbacks @fontsource emits would just be dead precache weight.
-          globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2,json,nmea,wasm}"],
+          // mjs: the vendored firmware-simulator module (public/sim/) — precached
+          // so the /simulator page works offline like everything else.
+          globPatterns: ["**/*.{js,mjs,css,html,ico,png,svg,woff2,json,nmea,wasm}"],
           // version.json must never be precached — it's the freshness signal the
           // running tab fetches uncached to detect a newer deploy (see versionCheck.ts).
           globIgnores: ["**/tracks.zip", "version.json"],


### PR DESCRIPTION
## Summary

**Phase A of plan 0010** (external sim-spec Phase 5): a public `/simulator` page that boots the real DovesDataLogger firmware — the vendored wasm from #336 — on a simulated 128×64 OLED and replays the bundled OKC sample session (the byte-identical file the firmware repo's CI oracle proves reproduces the hardware's 13 lap times to the millisecond).

- **`lib/sim/simClient.ts`** — typed loader for `/sim/birdseye-sim.mjs` (API contract v1; `reset()` is async = true fresh boot by module re-instantiation).
- **`lib/sim/simPlayback.ts`** — pure, Vitest-covered playback model: parsed-sample → `injectPvt` mapping on canonical channel ids (reuses the standard `datalogParser` output — **no second dovex parser**), tick planning that injects every row at its own timestamp with `stepMillis` between (one injection per step batch, per the contract), the no-fix boot pre-roll, and scrub planning.
- **`hooks/useSimPlayback.ts`** — rAF loop: play/pause, 1/2/5/10×, seek (backward = await async reset + headless fast-replay), frame-hash-gated blits (fw paints at 3 Hz — no 60 fps repaints), ~10 Hz state publishing; pausing keeps the firmware clock breathing so the menus stay interactive.
- **`components/sim/SimDevicePanel.tsx`** — integer-scale canvas (4/6/8×, `image-rendering: pixelated`, never fractional) or **true size** (55 × 27.5 mm via CSS mm — default ON for first-timers, "why so small?" tooltip); bezel; three buttons (pointer + ← Enter →) through the real firmware debounce.
- **`pages/Simulator.tsx`** — lazy public route: transport bar, skip-GPS-acquisition, live firmware-state chips (`getStateJson`), provenance footer (`getVersion`).
- **i18n**: new `simulator` namespace across all 7 languages (key parity enforced by the existing i18n test). **SW**: `mjs` added to the precache glob → the simulator works fully offline.

## Verified end-to-end (Chromium against the production build)

- boot page renders on the canvas (real firmware pixels)
- Select navigates the real firmware menu before/without playback
- Play runs the session with live RPM/GPS/lap chips
- **scrub-to-end headless-fast-replays the entire 15-minute session and the badge lands on exactly 13 laps** (matching the hardware header)
- rewind (reset + fast-replay) works

Screenshot of the running page (device on the firmware's tach page at 1891 RPM from the replayed session) is in the session log; reproduce locally with `bun run build && bunx vite preview` → `/simulator`.

## Related Issues

Plan `docs/plans/0010-firmware-simulator-viewer.md` (new). Builds on #336; firmware-side work in DovesDataLogger #91–#96. Phase B (map + cursor + session picker) and Phase C (capture/share) follow.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (2191 tests incl. new `simPlayback` suite + i18n key parity for the new namespace)
- [x] `npm run build` succeeds (sim module precached; page is a lazy chunk — main bundle untouched)
- [x] Feature works **offline** (same-origin sim assets now SW-precached; demo session IDB-cached via `ensureSampleFile`)
- [x] Docs updated where relevant (`CLAUDE.md` map, `CHANGELOG.md`, plan 0010)
- [ ] For a new parser: n/a (deliberately reuses the existing parser)

## Notes for Reviewers

- No new dependencies; no `Index.tsx` changes; nothing added to the main bundle (lazy route + runtime-URL module import with `@vite-ignore`).
- There's no nav link to `/simulator` yet — deliberate while Phases B/C land; say the word if you want it on the landing page already.
- The `state.laps` badge uses i18next plurals; ja carries the `_one` key for the repo's key-parity test, matching existing ja files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BCdGxqExj9ojEQgZj4f6G

---
_Generated by [Claude Code](https://claude.ai/code/session_013BCdGxqExj9ojEQgZj4f6G)_