### PR TITLE
Release prep v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [3.1.0] - unreleased
+## [3.1.0] - 2026-07-17
 
 ### Added
 - **Silent auto-update on an idle home page.** When a new build is detected

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - Reference lap overlay & pace delta comparison
 - Lap snapshots — save a "course fastest lap" per engine, frozen for cross-session comparison (local-first, optionally cloud-synced)
 - Public leaderboards — submit your snapshots and browse fastest community laps by track, course and engine class (with optional weight grouping); opens any group in a read-only viewer (cloud-enabled builds)
+- Shareable session links — share a cloud-synced log behind an opaque public link (`/s/…`, no account needed) that never reveals the file name; opens the full session in the read-only viewer with precise lap/sector timing (custom course geometry travels with the share). Opt into public-by-default uploads and your public sessions appear on your driver profile (cloud-enabled builds)
 - Video sync with telemetry playback (incl. GoPro chunked recordings — select all chapter files and they play as one continuous video)
 - 9 overlay gauge types (digital, analog, graph, bar, bubble, map, pace, sector, lap time)
 - MP4 video export with overlays & audio (H.264 + AAC)
@@ -42,6 +43,7 @@
 - Session notes per file
 - BLE device integration (DovesDataLogger)
 - Device track sync over Bluetooth
+- Firmware simulator (`/simulator`) — the real DovesDataLogger firmware compiled to WebAssembly, running in the browser on a simulated OLED so you can watch it boot, acquire GPS, auto-enter race mode and count laps; no account, fully offline
 - Custom track & course editor with community submissions
 - Local weather lookup
 - Optional cloud sync of files & garage data across devices (requires backend + sign-in)

--- a/docs/reviews/beta-release-review-2026-07-17.md
+++ b/docs/reviews/beta-release-review-2026-07-17.md
@@ -1,0 +1,84 @@
+# Beta → Main Release Review — 2026-07-17
+
+## 🚦 Verdict: **GO-WITH-FIXES** → all confirmed findings fixed in PR #343 (now effectively **GO**)
+No Critical and no release-blocking High. Four confirmed findings (2 Medium, 2 Low), all non-blocking; every one has been addressed on the release-prep branch. Blockers: **0**.
+
+**PR:** #332 (`BETA` → `main`) · **Release:** v3.1.0 · **Since:** v2.9.2
+**Run:** multi-agent (7 finders, single adversarial verify per finding) · **Diff:** 131 files, 25 commits
+**Excluded:** node_modules, dist, generated supabase client, lockfile line-noise, vendored `public/sim/*` wasm blobs
+
+### Release contract checklist
+| Gate | Status |
+|------|--------|
+| Coach on production npm (`@perchwerks/eye-in-the-sky`, both package.json + vite.config.ts) | ✅ (already production on BETA; no flip needed) |
+| `package.json` version == topmost CHANGELOG heading | ✅ (bumped 3.0.0 → 3.1.0 in PR #343) |
+| CHANGELOG heading dated (not `- unreleased`) | ✅ (dated 2026-07-17 in PR #343) |
+| CHANGELOG complete vs commits in this release | ✅ |
+| No beta/preview-only config leaked into prod path | ✅ |
+| CI green (lint / typecheck / test / build) | ✅ (2209 tests) |
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 2 |
+| Low      | 2 |
+
+Two headline features drive this release — a public firmware simulator (`/simulator`) and shareable public session links (`/s/…`) — plus native firmware OTA and friendlier logger-download errors. The release contract is satisfied: coach is on the production npm package, version/changelog are set and dated (PR #343), and CI is green. The only confirmed issues were quality gaps on the new surfaces (a simulator backward-scrub perf/correctness pair on a non-core novelty page, one untested new anon-read module, and stale README). None block the release, and all four have been fixed on the release-prep branch. A notable **High was refuted**: the `shared_sessions` RLS is a deliberate public-read design (see "What was not covered").
+
+## Findings (sorted: Critical → Low, then by dimension)
+
+### [Medium] PERF-01 — Backward scrub re-boots the wasm sim and synchronously replays the whole session from start
+- **Dimension:** performance · **Blocks release:** no
+- **Location:** `src/hooks/useSimPlayback.ts:238-263`
+- **Evidence:** `planScrub` returns `{reset:true, replayFromMs:sessionStartMs}` for any backward target, so `seek()` does `await sim.reset()` (re-instantiates the ~208 KB wasm) then a synchronous `injectPvt`+`stepMillis` loop over every sample from session start to target. The scrubber is wired via Radix `onValueChange` (fires continuously during a drag), so a near-end backward drag replays nearly the whole multi-minute session on the main thread.
+- **Impact:** UI-thread jank/stutter (potentially seconds) on the public `/simulator` demo when dragging the timeline backward.
+- **Recommendation:** Coalesce drag seeks to the latest target so only the settled value drives a reset+replay.
+- **Effort:** M · **Confidence:** High
+- **Status:** ✅ Fixed in PR #343 — `seek()` now coalesces via `pendingSeekRef`, collapsing an N-tick backward drag to at most two replays and rendering only the released position.
+
+### [Medium] TEST-01 — New anon-read module `publicShare.ts` shipped with zero tests
+- **Dimension:** testing · **Blocks release:** no
+- **Location:** `src/plugins/cloud-sync/publicShare.ts:35-40`
+- **Evidence:** New 89-line module powering the `/s/:token` viewer and the driver-profile "Shared sessions" list. It has testable pure logic — `embeddedDisplayName()` normalizes the Supabase profile embed across array/object shapes, and the fetch mappers null-guard date parsing — but no test referenced it (its write-side sibling `sessionShare.ts` has 16). Golden Rule 3.
+- **Impact:** A silent regression (embed shape flips to array → driver name renders null; bad date) would ship undetected on a public, offline-first release.
+- **Recommendation:** Add `publicShare.test.ts` covering both embed shapes, the null/absent-profile case, and the row→object mappings with present/null dates.
+- **Effort:** S · **Confidence:** High
+- **Status:** ✅ Fixed in PR #343 — added `publicShare.test.ts` (12 tests) covering both embed shapes, null profile, null dates, not-found, and error paths.
+
+### [Low] COR-01 — Backward scrub drops the released slider value, snapping the thumb to a stale intermediate position
+- **Dimension:** correctness · **Blocks release:** no
+- **Location:** `src/hooks/useSimPlayback.ts:232-260`
+- **Evidence:** `seek()` bailed immediately while `busyRef` was set and never queued the dropped request, so during a backward drag the first value locked the guard and every later value — including the final release value — was silently discarded; the controlled slider then snapped the thumb to the first intermediate target.
+- **Impact:** Scrubbing backward on `/simulator` lands the cursor/thumb at a stale position (self-corrects on next interaction). Minor, novelty surface.
+- **Recommendation:** Remember the latest requested target while busy and re-run to it once the in-flight seek clears.
+- **Effort:** S · **Confidence:** Medium
+- **Status:** ✅ Fixed in PR #343 — same `pendingSeekRef` coalescing fix as PERF-01.
+
+### [Low] DOC-01 — README not updated for the new `/simulator` page and shareable session links
+- **Dimension:** docs · **Blocks release:** no
+- **Location:** `README.md:24-49`
+- **Evidence:** Both features are documented in CHANGELOG, CLAUDE.md and docs/backend.md, but `README.md` is not in the 131-file diff — its Features list never mentions the simulator or session sharing. Golden Rule 5.
+- **Impact:** The OSS front door omits two headline v3.1.0 features (a public page needing no account, and public link sharing).
+- **Recommendation:** Add Features bullets for the firmware simulator and shareable session links.
+- **Effort:** S · **Confidence:** High
+- **Status:** ✅ Fixed in PR #343 — added README Features bullets for both.
+
+## Must-fix before merge
+
+**None.** No confirmed finding blocks the release, and all four have been fixed on the release-prep branch (PR #343 → BETA). Merge order still matters: land PR #343 into BETA before merging PR #332 (BETA → main).
+
+## Themes & systemic notes
+
+- The new **firmware simulator** (plan 0010) is well-isolated (pure `simPlayback` is Vitest-covered) but its React playback hook shipped with a scrub-coalescing gap on the public demo page — now fixed.
+- New **cloud sharing** logic (plan 0009) was well tested on the write side; the anon **read** side (`publicShare.ts`) was the one untested unit — now covered.
+- Docs were otherwise kept in sync (CLAUDE.md, docs/backend.md, docs/ble.md) — README was the lone straggler.
+
+## What was not covered
+
+- **SEC-01 (High) — refuted, not a finding.** A finder flagged the `shared_sessions` RLS `SELECT` policy (`using(true)`) as "fully enumerable by anon." The verifier refuted it on the merits: the same PR intentionally ships `fetchSharedSessionsByUser(userId)` — an anon `.eq("user_id", …)` query consumed by the public `DriverProfile` "Shared sessions" list — so public per-user enumeration is a deliberate, load-bearing feature mirroring the app's existing `leaderboard_entries` public-read pattern. The protected secret per the migration's own comments is the *filename*, and there is no filename column. Enumerable columns (track/course/date) plus the blob in the intentionally-`public` bucket are content the user explicitly published (and already surfaces on `/driver/:username`). No private data leaks. **Recommend a human sanity-check** of `supabase/migrations/20260715000000_shared_sessions.sql` given it's a new public surface, but it is not a release blocker.
+- Two more refuted/pre-existing: CFG-01 (a landing "Build your own logger" tile rewired to a modal — the CHANGELOG covers it) and PERF-02 (the ~234 KB sim wasm added to the SW precache — intended, offline-first). Both verified as introduced-but-intended, not defects.
+- Vendored `public/sim/*` wasm/mjs binaries were reviewed for wiring/intent only, not byte contents.
+- Single adversarial verify per finding (default depth). No completeness-critic pass.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/hooks/useSimPlayback.ts
+++ b/src/hooks/useSimPlayback.ts
@@ -68,6 +68,7 @@ export function useSimPlayback(data: ParsedData | null): SimPlayback {
   const playingRef = useRef(false);
   const speedRef = useRef(1);
   const busyRef = useRef(false); // guards reset/seek re-entrancy
+  const pendingSeekRef = useRef<number | null>(null); // latest target requested mid-seek
 
   // Virtual playback cursor, absolute unix-ms (matches sample timestamps).
   const cursorRef = useRef(0);
@@ -235,29 +236,46 @@ export function useSimPlayback(data: ParsedData | null): SimPlayback {
 
   const seek = useCallback((sessionMs: number) => {
     const sim = simRef.current;
-    if (!sim || !data || busyRef.current) return;
-    const targetAbs = epochMs + Math.max(0, Math.min(sessionMs, durationMs));
-    const plan = planScrub(cursorRef.current, targetAbs, epochMs);
+    if (!sim || !data) return;
+    // Coalesce while a seek is in flight: the Radix slider fires onValueChange
+    // for every value during a drag, and a backward seek re-boots the wasm +
+    // replays headlessly (slow). Rather than drop those events — which would
+    // strand the thumb at a stale intermediate target and replay once per tick —
+    // remember only the latest requested target and let the running seek pick it
+    // up when it finishes, so exactly the released position is rendered.
+    if (busyRef.current) {
+      pendingSeekRef.current = sessionMs;
+      return;
+    }
     busyRef.current = true;
     (async () => {
       try {
-        if (plan.reset) {
-          await bootFresh(sim);
-          // Headless pre-roll: run it at once (no rendering between).
-          runActions(preRollLeftRef.current);
-          preRollLeftRef.current = [];
-        } else if (preRollLeftRef.current.length > 0) {
-          runActions(preRollLeftRef.current);
-          preRollLeftRef.current = [];
+        let target = sessionMs;
+        for (;;) {
+          const targetAbs = epochMs + Math.max(0, Math.min(target, durationMs));
+          const plan = planScrub(cursorRef.current, targetAbs, epochMs);
+          if (plan.reset) {
+            await bootFresh(sim);
+            // Headless pre-roll: run it at once (no rendering between).
+            runActions(preRollLeftRef.current);
+            preRollLeftRef.current = [];
+          } else if (preRollLeftRef.current.length > 0) {
+            runActions(preRollLeftRef.current);
+            preRollLeftRef.current = [];
+          }
+          // Headless fast-replay in one plan (row-accurate, no paints).
+          const { actions, nextIndex } = buildTickPlan(
+            data.samples, epochMs, cursorRef.current, targetAbs,
+            sampleIndexRef.current,
+          );
+          runActions(actions);
+          cursorRef.current = targetAbs;
+          sampleIndexRef.current = nextIndex;
+          // A newer target arrived mid-seek — run once more to it, otherwise stop.
+          if (pendingSeekRef.current === null) break;
+          target = pendingSeekRef.current;
+          pendingSeekRef.current = null;
         }
-        // Headless fast-replay in one plan (row-accurate, no paints).
-        const { actions, nextIndex } = buildTickPlan(
-          data.samples, epochMs, cursorRef.current, targetAbs,
-          sampleIndexRef.current,
-        );
-        runActions(actions);
-        cursorRef.current = targetAbs;
-        sampleIndexRef.current = nextIndex;
         publish(true);
       } finally {
         busyRef.current = false;

--- a/src/plugins/cloud-sync/publicShare.test.ts
+++ b/src/plugins/cloud-sync/publicShare.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// publicShare is the anon read side of shared sessions (plan 0009). Its cloud seam
+// (`./cloudClient`) is mocked with a tiny chainable builder whose terminal result
+// (`maybeSingle` for the single fetch, `order` for the list) is set per test — the
+// same style as the other cloud-sync unit tests, kept minimal for these pure maps.
+
+const state = vi.hoisted(() => ({
+  single: { data: null as unknown, error: null as { message: string } | null },
+  list: { data: null as unknown, error: null as { message: string } | null },
+  publicUrl: undefined as string | undefined,
+  lastPath: undefined as string | undefined,
+}));
+
+vi.mock("./cloudClient", () => {
+  const builder: Record<string, unknown> = {};
+  builder.select = () => builder;
+  builder.eq = () => builder;
+  builder.maybeSingle = () => Promise.resolve(state.single);
+  builder.order = () => Promise.resolve(state.list);
+  return {
+    sharedSessions: () => builder,
+    sharedFiles: () => ({
+      getPublicUrl: (path: string) => {
+        state.lastPath = path;
+        return { data: state.publicUrl ? { publicUrl: state.publicUrl } : null };
+      },
+    }),
+  };
+});
+
+import {
+  fetchSharedSession,
+  fetchSharedSessionsByUser,
+  sharedBlobUrl,
+} from "./publicShare";
+
+const fullRow = (overrides: Record<string, unknown> = {}) => ({
+  token: "tok123",
+  user_id: "user-1",
+  file_ext: "dovex",
+  course: { name: "OKC" },
+  track_name: "Orlando Kart Center",
+  course_name: "Full",
+  session_date: "2026-06-30T12:00:00.000Z",
+  fastest_lap_ms: 41234,
+  size_bytes: 2048,
+  profiles: { display_name: "Dove" },
+  ...overrides,
+});
+
+beforeEach(() => {
+  state.single = { data: null, error: null };
+  state.list = { data: null, error: null };
+  state.publicUrl = undefined;
+  state.lastPath = undefined;
+});
+
+describe("fetchSharedSession", () => {
+  it("returns null for an empty/whitespace token without touching the cloud", async () => {
+    // If it queried, maybeSingle's null data would still yield null, so also assert
+    // via a non-null row that a blank token short-circuits before the map runs.
+    state.single = { data: fullRow(), error: null };
+    expect(await fetchSharedSession("")).toBeNull();
+    expect(await fetchSharedSession("   ")).toBeNull();
+  });
+
+  it("maps a full row, parsing the session date and the object-shaped profile embed", async () => {
+    state.single = { data: fullRow(), error: null };
+    const s = await fetchSharedSession("  tok123  ");
+    expect(s).not.toBeNull();
+    expect(s!.token).toBe("tok123");
+    expect(s!.userId).toBe("user-1");
+    expect(s!.fileExt).toBe("dovex");
+    expect(s!.course).toEqual({ name: "OKC" });
+    expect(s!.trackName).toBe("Orlando Kart Center");
+    expect(s!.fastestLapMs).toBe(41234);
+    expect(s!.sessionDate).toBeInstanceOf(Date);
+    expect(s!.sessionDate!.toISOString()).toBe("2026-06-30T12:00:00.000Z");
+    expect(s!.driverName).toBe("Dove");
+  });
+
+  it("reads the display name from the array-shaped profile embed", async () => {
+    state.single = { data: fullRow({ profiles: [{ display_name: "Raven" }] }), error: null };
+    const s = await fetchSharedSession("tok123");
+    expect(s!.driverName).toBe("Raven");
+  });
+
+  it("yields a null driver name when the profile embed is absent or empty", async () => {
+    state.single = { data: fullRow({ profiles: null }), error: null };
+    expect((await fetchSharedSession("tok123"))!.driverName).toBeNull();
+    state.single = { data: fullRow({ profiles: [] }), error: null };
+    expect((await fetchSharedSession("tok123"))!.driverName).toBeNull();
+  });
+
+  it("yields a null session date when the row has none", async () => {
+    state.single = { data: fullRow({ session_date: null }), error: null };
+    expect((await fetchSharedSession("tok123"))!.sessionDate).toBeNull();
+  });
+
+  it("returns null when the token resolves to no row", async () => {
+    state.single = { data: null, error: null };
+    expect(await fetchSharedSession("missing")).toBeNull();
+  });
+
+  it("throws the cloud error message", async () => {
+    state.single = { data: null, error: { message: "boom" } };
+    await expect(fetchSharedSession("tok123")).rejects.toThrow("boom");
+  });
+});
+
+describe("fetchSharedSessionsByUser", () => {
+  it("maps rows newest-first, null-guarding both dates", async () => {
+    state.list = {
+      data: [
+        fullRow({ token: "a", created_at: "2026-07-01T00:00:00.000Z" }),
+        fullRow({ token: "b", session_date: null, created_at: null }),
+      ],
+      error: null,
+    };
+    const list = await fetchSharedSessionsByUser("user-1");
+    expect(list).toHaveLength(2);
+    expect(list[0].token).toBe("a");
+    expect(list[0].createdAt).toBeInstanceOf(Date);
+    expect(list[0].sessionDate).toBeInstanceOf(Date);
+    expect(list[1].sessionDate).toBeNull();
+    expect(list[1].createdAt).toBeNull();
+  });
+
+  it("returns an empty array when the driver has no shares", async () => {
+    state.list = { data: null, error: null };
+    expect(await fetchSharedSessionsByUser("user-1")).toEqual([]);
+  });
+
+  it("throws the cloud error message", async () => {
+    state.list = { data: null, error: { message: "nope" } };
+    await expect(fetchSharedSessionsByUser("user-1")).rejects.toThrow("nope");
+  });
+});
+
+describe("sharedBlobUrl", () => {
+  it("builds the public URL from user id + token and returns it", () => {
+    state.publicUrl = "https://cdn.example/shared/user-1/tok123";
+    expect(sharedBlobUrl("user-1", "tok123")).toBe("https://cdn.example/shared/user-1/tok123");
+    expect(state.lastPath).toBe("user-1/tok123");
+  });
+
+  it("returns null when no public URL is available", () => {
+    state.publicUrl = undefined;
+    expect(sharedBlobUrl("user-1", "tok123")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Release prep v3.1.0

Prepares `BETA` to merge into `main` for the **v3.1.0** release.

### Changes
- **Version bump** — `package.json` `3.0.0` → `3.1.0`, matching the topmost `CHANGELOG.md` heading (the footer/build stamp is baked from `package.json`, so this is the only version string to touch).
- **Dated changelog** — `## [3.1.0] - unreleased` → `## [3.1.0] - 2026-07-17`. Older headings untouched; no new `[Unreleased]` block (started after this ships).
- **Coach plugin** — already on the production npm package (`@perchwerks/eye-in-the-sky` `0.5.0`) on `BETA`, matching `main`, so **no flip was needed** and `bun.lock` is unchanged. (See note below.)

### Green before merge
- ✅ `bun run lint`
- ✅ `bun run typecheck`
- ✅ `bun run test:run` (2197 passed)
- ✅ `bun run build` (production coach package resolves and bundles)

### ⚠️ Notes for the maintainer
- **Coach source anomaly:** per the documented workflow, `BETA` normally carries the coach as the `github:TheAngryRaven/DataViewer_coach#BETA` git dependency and only flips to the published `@perchwerks/eye-in-the-sky` package for a release. `BETA` is *already* on the production package, so the usual flip/flip-back dance is a no-op this cycle. No "flip coach back to BETA" PR was opened because there is nothing to revert. If you intend to keep developing against the coach BETA branch, flip `BETA` back to the git dependency after release.
- **Tagging:** no tag was created (per policy). Tag `v3.1.0` manually after the `BETA → main` PR merges, then back-merge `main` into `BETA`. Heads-up: `v3.0.0` was shipped to `main` but never tagged (last tag is `v2.9.2`), so the release-notes compare link `v3.0.0...v3.1.0` will only resolve once `v3.0.0` is also tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTBXGG2rNGSSqeozPyfjxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTBXGG2rNGSSqeozPyfjxy)_