### PR TITLE
plan 0012: updates blog follow-ups — draft visibility fix + RSS feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release notes, news, and engineering write-ups — each at its own
   SEO-friendly `/updates/<slug>` URL. Posts support Markdown (headers, bold,
   links, image embeds), tags with tag filtering on the index, and an
-  "AI-assisted" marker. Written and managed from the admin portal.
+  "AI-assisted" marker. Written and managed from the admin portal. An RSS
+  feed (subscribe link on the page + browser autodiscovery) lets readers
+  follow new posts.
 - **Simulator: load your own `.dovex`.** The `/simulator` page now has a
   session picker — feed the firmware any dove-family log
   (`.dovex`/`.dovep`/`.dove`) instead of only the bundled demo, with a

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -191,8 +191,12 @@ in-memory leaderboard handoff. Public sessions also list on `/driver/:username`.
 ## Updates blog (`..._blog_posts.sql`, plan 0012)
 
 Admin-authored articles for the public `/updates` page (`/updates/:slug` per
-post). **All access is through RLS** (no edge function); the client lives in
-`src/plugins/cloud-sync/postsClient.ts`.
+post). **App access is through RLS**; the client lives in
+`src/plugins/cloud-sync/postsClient.ts`. One edge function, `rss-feed`, renders
+the RSS 2.0 feed (feed readers can't run the SPA and hosting is static-only):
+anon-key read of published posts, 15-min cache, linked from `/updates` and
+autodiscoverable via `<link rel="alternate">` (`lib/rssFeed.ts` builds the URL
+from the baked `VITE_SUPABASE_URL`).
 
 | Table | Purpose |
 |-------|---------|

--- a/docs/plans/0012-updates-blog-cms.md
+++ b/docs/plans/0012-updates-blog-cms.md
@@ -56,7 +56,8 @@ ones; public index filters by tag), and a per-post "AI-assisted" flag.
 | Shared renderer | `src/components/MarkdownContent.tsx` (`prose dark:prose-invert` + token overrides; `@tailwindcss/typography` registered in `tailwind.config.ts`) |
 | Public pages | `src/pages/Updates.tsx`, `src/pages/UpdatePost.tsx` (DriverProfile load-state model) |
 | Admin | `src/components/admin/UpdatesTab.tsx` (TracksTab CRUD skeleton, inline editor, Write/Preview toggle) |
-| SEO | `useDocumentHead` extended with `ogType` / `publishedTime` / `modifiedTime` / `jsonLd` (JSON-LD `BlogPosting`); `public/sitemap.xml` + `public/llms.txt` list `/updates` |
+| SEO | `useDocumentHead` extended with `ogType` / `publishedTime` / `modifiedTime` / `jsonLd` (JSON-LD `BlogPosting`) / `feedUrl` (RSS autodiscovery); `public/sitemap.xml` + `public/llms.txt` list `/updates` |
+| RSS | `supabase/functions/rss-feed` renders the RSS 2.0 feed server-side (readers can't run the SPA; hosting is static-only). Anon-key read of published posts, 15-min cache. `lib/rssFeed.ts` builds the per-backend URL; `/updates` shows a subscribe link and both pages emit the autodiscovery `<link>`. The function duplicates a trimmed `deriveExcerpt` (Deno can't import from `src/`) — keep them in step |
 
 `published_at` is set client-side the first time a post is published (kept on
 later unpublish/republish so ordering is stable). `updated_at` is set by the

--- a/src/hooks/useDocumentHead.ts
+++ b/src/hooks/useDocumentHead.ts
@@ -12,6 +12,8 @@ interface DocumentHeadOptions {
   modifiedTime?: string;
   /** Structured data injected as a JSON-LD script, removed on unmount. */
   jsonLd?: Record<string, unknown>;
+  /** RSS autodiscovery: <link rel="alternate" type="application/rss+xml">. */
+  feedUrl?: string;
 }
 
 /**
@@ -28,6 +30,7 @@ export function useDocumentHead({
   publishedTime,
   modifiedTime,
   jsonLd,
+  feedUrl,
 }: DocumentHeadOptions): void {
   // Depend on the serialized form so callers can pass an inline object literal
   // without re-running the effect every render.
@@ -134,10 +137,19 @@ export function useDocumentHead({
       document.head.appendChild(script);
       restorers.push(() => script.remove());
     }
+    if (feedUrl) {
+      const link = document.createElement("link");
+      link.rel = "alternate";
+      link.type = "application/rss+xml";
+      link.title = title;
+      link.href = feedUrl;
+      document.head.appendChild(link);
+      restorers.push(() => link.remove());
+    }
 
     return () => {
       document.title = prevTitle;
       restorers.forEach((r) => r());
     };
-  }, [title, description, canonical, ogType, publishedTime, modifiedTime, jsonLdText]);
+  }, [title, description, canonical, ogType, publishedTime, modifiedTime, jsonLdText, feedUrl]);
 }

--- a/src/lib/rssFeed.ts
+++ b/src/lib/rssFeed.ts
@@ -1,0 +1,4 @@
+// Updates-blog RSS feed URL (plan 0012). The feed is rendered by the rss-feed
+// edge function (feed readers can't run the SPA), so the link follows whichever
+// Supabase backend this build is baked against.
+export const FEED_URL = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/rss-feed`;

--- a/src/locales/de/updates.json
+++ b/src/locales/de/updates.json
@@ -12,5 +12,6 @@
   "readMore": "Weiterlesen",
   "notFoundTitle": "Beitrag nicht gefunden",
   "notFoundBody": "Dieser Beitrag existiert nicht oder wurde nicht veröffentlicht.",
-  "backToUpdates": "Alle Neuigkeiten"
+  "backToUpdates": "Alle Neuigkeiten",
+  "subscribeRss": "RSS-Feed"
 }

--- a/src/locales/en/updates.json
+++ b/src/locales/en/updates.json
@@ -11,5 +11,6 @@
   "readMore": "Read more",
   "notFoundTitle": "Post not found",
   "notFoundBody": "This post doesn't exist or hasn't been published.",
-  "backToUpdates": "All updates"
+  "backToUpdates": "All updates",
+  "subscribeRss": "RSS feed"
 }

--- a/src/locales/es/updates.json
+++ b/src/locales/es/updates.json
@@ -12,5 +12,6 @@
   "readMore": "Leer más",
   "notFoundTitle": "Publicación no encontrada",
   "notFoundBody": "Esta publicación no existe o no se ha publicado.",
-  "backToUpdates": "Todas las novedades"
+  "backToUpdates": "Todas las novedades",
+  "subscribeRss": "Feed RSS"
 }

--- a/src/locales/fr/updates.json
+++ b/src/locales/fr/updates.json
@@ -12,5 +12,6 @@
   "readMore": "Lire la suite",
   "notFoundTitle": "Article introuvable",
   "notFoundBody": "Cet article n'existe pas ou n'a pas été publié.",
-  "backToUpdates": "Toutes les actualités"
+  "backToUpdates": "Toutes les actualités",
+  "subscribeRss": "Flux RSS"
 }

--- a/src/locales/it/updates.json
+++ b/src/locales/it/updates.json
@@ -12,5 +12,6 @@
   "readMore": "Leggi tutto",
   "notFoundTitle": "Articolo non trovato",
   "notFoundBody": "Questo articolo non esiste o non è stato pubblicato.",
-  "backToUpdates": "Tutte le novità"
+  "backToUpdates": "Tutte le novità",
+  "subscribeRss": "Feed RSS"
 }

--- a/src/locales/ja/updates.json
+++ b/src/locales/ja/updates.json
@@ -12,5 +12,6 @@
   "readMore": "続きを読む",
   "notFoundTitle": "記事が見つかりません",
   "notFoundBody": "この記事は存在しないか、まだ公開されていません。",
-  "backToUpdates": "アップデート一覧"
+  "backToUpdates": "アップデート一覧",
+  "subscribeRss": "RSSフィード"
 }

--- a/src/locales/pt-BR/updates.json
+++ b/src/locales/pt-BR/updates.json
@@ -12,5 +12,6 @@
   "readMore": "Leia mais",
   "notFoundTitle": "Publicação não encontrada",
   "notFoundBody": "Esta publicação não existe ou não foi publicada.",
-  "backToUpdates": "Todas as novidades"
+  "backToUpdates": "Todas as novidades",
+  "subscribeRss": "Feed RSS"
 }

--- a/src/pages/UpdatePost.tsx
+++ b/src/pages/UpdatePost.tsx
@@ -8,6 +8,7 @@ import { MarkdownContent } from "@/components/MarkdownContent";
 import { useSettings } from "@/hooks/useSettings";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
 import { deriveExcerpt, type BlogPost } from "@/lib/blogPosts";
+import { FEED_URL } from "@/lib/rssFeed";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -64,6 +65,7 @@ export default function UpdatePost() {
           author: { "@type": "Organization", name: "LapWing" },
         }
       : undefined,
+    feedUrl: FEED_URL,
   });
 
   const settingsButton = (

--- a/src/pages/Updates.tsx
+++ b/src/pages/Updates.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Newspaper, Sparkles } from "lucide-react";
+import { Newspaper, Rss, Sparkles } from "lucide-react";
 import { SiteHeader } from "@/components/SiteHeader";
 import { SettingsModal } from "@/components/SettingsModal";
 import { BackToHome } from "@/components/BackToHome";
 import { useSettings } from "@/hooks/useSettings";
 import { useDocumentHead } from "@/hooks/useDocumentHead";
 import { deriveExcerpt, collectTags, type BlogPost } from "@/lib/blogPosts";
+import { FEED_URL } from "@/lib/rssFeed";
 
 const enableCloud = import.meta.env.VITE_ENABLE_CLOUD === "true";
 
@@ -23,6 +24,7 @@ export default function Updates() {
     title: t("updates:metaTitle"),
     description: t("updates:metaDescription"),
     canonical: "https://lapwingdata.com/updates",
+    feedUrl: FEED_URL,
   });
 
   useEffect(() => {
@@ -74,6 +76,16 @@ export default function Updates() {
           <div className="flex items-center gap-2">
             <Newspaper className="h-5 w-5 text-primary" />
             <h2 className="text-2xl font-bold text-foreground">{t("updates:pageTitle")}</h2>
+            <a
+              href={FEED_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={t("updates:subscribeRss")}
+              className="ml-auto flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
+            >
+              <Rss className="h-3.5 w-3.5" />
+              {t("updates:subscribeRss")}
+            </a>
           </div>
           <p className="text-sm text-muted-foreground">{t("updates:pageSubtitle")}</p>
 

--- a/src/plugins/cloud-sync/postsClient.ts
+++ b/src/plugins/cloud-sync/postsClient.ts
@@ -16,10 +16,16 @@ export function postsTable() {
 
 // ── Public (anon) reads ───────────────────────────────────────────────────────
 
-/** Published posts, newest first. RLS hides drafts — no client filter needed. */
+// The explicit published filter matters even though anon RLS already hides
+// drafts: for a signed-in admin the "Admins read all posts" policy also
+// applies to these queries, so without it drafts would leak onto the public
+// pages in the admin's own browser.
+
+/** Published posts, newest first. */
 export async function fetchPublishedPosts(): Promise<BlogPost[]> {
   const { data, error } = await postsTable()
     .select("*")
+    .eq("published", true)
     .order("published_at", { ascending: false, nullsFirst: false });
   if (error) throw error;
   return ((data ?? []) as PostRow[]).map(mapPostRow);
@@ -27,7 +33,11 @@ export async function fetchPublishedPosts(): Promise<BlogPost[]> {
 
 /** One published post by slug, or null when it doesn't exist (or is a draft). */
 export async function fetchPostBySlug(slug: string): Promise<BlogPost | null> {
-  const { data, error } = await postsTable().select("*").eq("slug", slug).maybeSingle();
+  const { data, error } = await postsTable()
+    .select("*")
+    .eq("slug", slug)
+    .eq("published", true)
+    .maybeSingle();
   if (error) throw error;
   return data ? mapPostRow(data as PostRow) : null;
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -35,3 +35,6 @@ verify_jwt = false
 
 [functions.process-account-deletions]
 verify_jwt = false
+
+[functions.rss-feed]
+verify_jwt = false

--- a/supabase/functions/rss-feed/index.ts
+++ b/supabase/functions/rss-feed/index.ts
@@ -1,0 +1,127 @@
+// RSS 2.0 feed for the updates blog (plan 0012). Feed readers can't run the
+// SPA's JavaScript and the site is served as static assets only, so the feed
+// is rendered here. Reads published posts with the anon key — RLS is the gate.
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SITE_URL = "https://lapwingdata.com";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
+};
+
+function escapeXml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+// Mirror of the client's deriveExcerpt (lib/blogPosts.ts), trimmed to what a
+// feed description needs: first real paragraph, markdown syntax stripped.
+function excerpt(markdown: string, maxChars = 300): string {
+  const lines = markdown.split(/\r?\n/);
+  const paragraph: string[] = [];
+  let inFence = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^(```|~~~)/.test(trimmed)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    if (trimmed === "") { if (paragraph.length > 0) break; continue; }
+    if (/^#{1,6}\s/.test(trimmed) || /^!\[[^\]]*\]\([^)]*\)$/.test(trimmed) || /^([-*_])\s*(\1\s*){2,}$/.test(trimmed)) {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    paragraph.push(trimmed);
+  }
+  const text = paragraph
+    .join(" ")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/~~(.*?)~~/g, "$1")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/^>\s?/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text.length <= maxChars) return text;
+  const cut = text.lastIndexOf(" ", maxChars);
+  return `${text.slice(0, cut > 0 ? cut : maxChars).trimEnd()}…`;
+}
+
+interface FeedPost {
+  slug: string;
+  title: string;
+  body: string;
+  tags: string[] | null;
+  published_at: string | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+    );
+
+    const { data, error } = await supabase
+      .from('posts')
+      .select('slug,title,body,tags,published_at')
+      .eq('published', true)
+      .order('published_at', { ascending: false, nullsFirst: false })
+      .limit(50);
+    if (error) throw error;
+
+    const posts = (data ?? []) as FeedPost[];
+    const lastBuild = posts[0]?.published_at ?? new Date().toISOString();
+
+    const items = posts.map((p) => {
+      const url = `${SITE_URL}/updates/${p.slug}`;
+      const categories = (p.tags ?? [])
+        .map((tag) => `      <category>${escapeXml(tag)}</category>`)
+        .join("\n");
+      return `    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+${p.published_at ? `      <pubDate>${new Date(p.published_at).toUTCString()}</pubDate>\n` : ""}      <description>${escapeXml(excerpt(p.body))}</description>
+${categories ? categories + "\n" : ""}    </item>`;
+    }).join("\n");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>LapWing Updates</title>
+    <link>${SITE_URL}/updates</link>
+    <atom:link href="${new URL(req.url).origin}${new URL(req.url).pathname}" rel="self" type="application/rss+xml"/>
+    <description>News, release notes, and engineering write-ups from the LapWing telemetry viewer.</description>
+    <language>en</language>
+    <lastBuildDate>${new Date(lastBuild).toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>
+`;
+
+    return new Response(xml, {
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/rss+xml; charset=utf-8',
+        // Feeds get polled aggressively; 15 min of edge caching is plenty fresh.
+        'Cache-Control': 'public, max-age=900',
+      },
+    });
+  } catch (e) {
+    console.error('rss-feed error:', e);
+    return new Response('Feed unavailable', {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'text/plain' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Two follow-ups to the updates blog (#352, plan 0012) that landed after that PR merged:

- **Fix: drafts were visible on the public pages for signed-in admins.** RLS policies OR together, so an admin's session satisfied "Admins read all posts" and their own drafts showed up on `/updates`. The public reads (`fetchPublishedPosts`, `fetchPostBySlug`) now filter `published = true` explicitly; RLS remains the gate for everyone else. Anonymous visitors were never affected.
- **RSS feed.** New `rss-feed` edge function renders the RSS 2.0 feed server-side (feed readers can't run the SPA and hosting is static-assets-only): anon-key read of published posts through RLS, excerpt descriptions, tags as `<category>`, 15-minute edge cache. `/updates` gets an "RSS feed" subscribe pill, and both public pages emit the `<link rel="alternate" type="application/rss+xml">` autodiscovery tag (new `feedUrl` option on `useDocumentHead`). `lib/rssFeed.ts` derives the feed URL from the baked `VITE_SUPABASE_URL`, so each deployment links its own backend. Registered in `supabase/config.toml` (`verify_jwt = false`).

The feed lives on the Supabase functions domain; a pretty same-domain URL (`/feed.xml`) would need a Cloudflare Worker script — same deferred infrastructure as per-post OG cards, noted in the plan doc.

## Related Issues

Follow-up to #352.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes
- [x] `npm run build` succeeds
- [x] Feature works **offline** (no new required network calls, except weather / map tiles / admin) — blog pages are cloud-gated; nothing on the offline-first core path changed
- [x] Docs updated where relevant (`README.md`, `CLAUDE.md`, Credits, `CHANGELOG.md`) — `docs/backend.md`, `docs/plans/0012-updates-blog-cms.md`, and the CHANGELOG blog entry now mention the feed
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table

## Notes for Reviewers

- The `rss-feed` edge function duplicates a trimmed copy of `deriveExcerpt` (Deno functions are self-contained and can't import from `src/`) — flagged in the plan doc so the two stay in step.
- Quick feed check once deployed: `curl https://<project-ref>.supabase.co/functions/v1/rss-feed` should return RSS XML listing published posts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su6PHag9FiG2AL3mhmzvSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Su6PHag9FiG2AL3mhmzvSp)_