### PR TITLE
Release prep v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [3.2.0] - unreleased
+## [3.2.0] - 2026-07-28
 
 ### Added
 - **Send failed files to support.** When a datalog fails to parse, you can now

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",


### PR DESCRIPTION
## Summary

Release-prep for **v3.2.0**:

- `package.json` version bumped `3.1.1` → `3.2.0` (matches the topmost CHANGELOG heading; the footer/build stamp bakes from this).
- CHANGELOG `## [3.2.0]` heading dated **2026-07-28**.
- **Coach plugin: no flip needed** — BETA is already on the production npm package (`@perchwerks/eye-in-the-sky 0.5.0` in both `package.json` and `vite.config.ts` `DEFAULT_PLUGIN_PACKAGES`), so there's no `bun.lock` change and **no "flip coach back to BETA" follow-up PR this cycle**.

Commit research (`v3.1.1..BETA`): two merged PRs — #361 (Alfano 6 ADA parser fix) and #362 (support system + admin sidebar) — both fully reflected in the 3.2.0 CHANGELOG block; nothing user-facing missing.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [x] Other: release prep

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (2349 tests)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (version/date strings only)
- [x] Docs updated where relevant (`CHANGELOG.md` dated)
- [ ] For a new parser: n/a

## Notes for Reviewers

Merge order: this PR → then merge #363 (BETA → main) → then tag `v3.2.0` on main manually → then back-merge main into BETA. **No tag was created** (manual step, as always).

---
_Generated by [Claude Code](https://claude.ai/code/session_015poy7cUvn13gDuaureJEvc)_