### PR TITLE
plan 0015: sprint course model, validation and device wire format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sprint (autocross / point-to-point) course model — foundation** (plan 0015).
+  Courses can now be typed `circuit` or `sprint`. A sprint course is timed
+  start-line → *separate* finish line rather than lap-to-lap, carries a required
+  `finish` line and a `date_created` stamp, and allows 0–2 optional split lines
+  instead of the circuit model's all-or-nothing three majors. The logger and the
+  timing library have shipped sprint support for a while, but nothing could
+  author a sprint track — this is the app starting to close that loop.
+  **No UI yet**: this change is the data model, validation and device wire
+  format only. The course editor, `TS*` track sync and the runs view follow.
+  - `date_created` is stamped once and preserved across edits. The logger picks
+    which sprint course to load by comparing these stamps as plain **strings**,
+    so the format is a fixed sortable `YYYY-MM-DDTHH:MM` — an edit must not let
+    a course jump the queue on the device, and a non-sortable stamp would
+    silently load the wrong cone layout.
+  - Existing courses are unaffected. The type is optional and absent means
+    circuit, so every saved, bundled and cloud-synced course keeps working with
+    no migration.
+
+### Fixed
+- **Device sync could report a changed course as "synced".** `coursesMatch`
+  compared only start/finish and the two legacy sector lines, so a course
+  carrying data outside that projection looked unchanged — for a sprint course
+  that includes the finish line, the single most likely thing to be edited. It
+  now compares the full device-visible projection per course type, and treats a
+  course that changed type as a different file rather than an edit (the two
+  kinds live in separate folders on the device).
+
+### Added
 - **Device tab works in the native Android app.** Settings, track management,
   and battery now ride the native logger IPC when running inside LapWing —
   previously the whole Device tab was dead there because the webview has no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,9 @@ File Import (drag-drop / BLE download / file manager)
 | `ParserStats` | `totalRows`, `acceptedRows`, `rejected: { nanFields, zeroCoords, outOfRange, speedCap, teleportation, incompleteRow }` |
 | `DovexMetadata` | `datetime?`, `driver?`, `course?`, `shortName?`, `bestLapMs?`, `optimalMs?`, `lapTimesMs?[]` |
 | `Lap` | `lapNumber`, `startTime/endTime`, `lapTimeMs`, speed stats, `startIndex/endIndex`, `sectors?` (S1/S2/S3 major rollup), `sectorTimes?` (fine-grained), `sectorBoundaries?` (per-line sample indices) |
-| `Course` | `name`, `lengthFt?`, `startFinishA/B`, `sectors?: CourseSector[]`, deprecated `sector2/sector3` (legacy mirror), optional `layout?` (`{lat,lon}[]` outline) |
-| `CourseSector` | `{ line: SectorLine, major: boolean }` — one timing line after start/finish |
+| `Course` | `name`, `type?: CourseType` (absent = `circuit`), `lengthFt?`, `startFinishA/B`, `finish?`+`dateCreated?` (sprint only), `sectors?: CourseSector[]`, deprecated `sector2/sector3` (legacy mirror), optional `layout?` (`{lat,lon}[]` outline) |
+| `CourseSector` | `{ line: SectorLine, major: boolean }` — one timing line after start/finish. `major` is circuit-only; sprint splits are stored unflagged |
+| `CourseType` | `'circuit' \| 'sprint'` — lap-to-lap vs point-to-point (start line ≠ finish line). Read via `isSprintCourse()`; see `docs/plans/0015-sprint-mode.md` |
 | `Track` | `name`, `shortName?` (max 8 chars), `courses[]` |
 | `CourseDetectionResult` | `track`, `course`, `direction?`, `laps[]`, `isWaypointMode`, `waypointNotice?` |
 | `FieldMapping` | `index`, `name` (canonical ChannelId or `custom:` slug), `label?`, `unit?`, `enabled` |

--- a/docs/plans/0015-sprint-mode.md
+++ b/docs/plans/0015-sprint-mode.md
@@ -1,0 +1,169 @@
+# Sprint Mode (Autocross / Point-to-Point) — DataViewer Side
+
+> Status: **IN PROGRESS** — the logger and the timing library already ship
+> sprint support; this plan is the app catching up. Phase 3 of the cross-repo
+> effort recorded in `DovesDataLogger/docs/plans/0002-sprint-mode.md`.
+
+## Why this exists
+
+A prospective buyer runs **autocross**, which the whole system was not designed
+for. Autocross is **point-to-point**: a start line and a *separate* finish line,
+one car at a time, several short runs per session with the engine idling in
+between. Nothing laps anything.
+
+The other two repos are done:
+
+| Repo | State |
+|---|---|
+| `DovesLapTimer` (`BETA`) | `SprintTimer` + the extracted `CrossingEngine`, shipped |
+| `DovesDataLogger` (`BETA`) | `/TRACKS/SPRINT/`, `SprintTimer` backend, `TS*` BLE opcodes, `race_mode` DOVEX column — shipped |
+| **DovesDataViewer** | **nothing — this plan** |
+
+### The gap that makes this urgent
+
+**No tool can author a sprint track.** The logger reads `/TRACKS/SPRINT/*.json`,
+picks the newest course by `date_created`, stands up `SprintTimer`, and will
+sync the folder over `TSLIST`/`TSGET:`/`TSPUT:`/`TSDEL:`. All of it works and
+none of it is reachable, because the only thing that writes those files would be
+this app — and this app has no concept of a course type. Sprint mode is
+currently testable only by hand-writing JSON onto an SD card, which means the
+firmware work has never been exercised on a real course.
+
+Closing that loop is the whole point of this plan: **author a sprint course
+here → push it over `TSPUT:` → drive it → read the runs back.**
+
+## What the firmware already expects
+
+Contract, from `DovesDataLogger/CLAUDE.md` and `BirdsEye/sd_functions.ino`:
+
+- Sprint tracks live in **`/TRACKS/SPRINT/`**. The folder is authoritative for
+  kind — it is chosen by BLE *opcode*, never parsed from a filename, so a
+  client cannot path between the two folders.
+- Same object JSON as circuit tracks, plus:
+  - `"type": "sprint"` at track level (redundant with the folder, but lets the
+    app validate)
+  - per-course **`finish_a_lat` / `finish_a_lng` / `finish_b_lat` /
+    `finish_b_lng`** — required; a course with no finish line cannot be timed
+  - per-course **`date_created`**, a sortable ISO-8601 stamp `YYYY-MM-DDTHH:MM`
+- Sector lines stay optional: **zero, one, or two** (not the circuit model's
+  all-or-nothing three majors).
+- The device loads **the newest course by `date_created`** and only that one.
+  Ordering is a plain string compare in the firmware's `sprint_select` unit —
+  which is exactly why the stamp must be zero-padded ISO. A non-sortable format
+  silently loads the wrong course.
+- Logs carry a trailing **`race_mode`** header column, `CIRCUIT` / `SPRINT`,
+  compared case-insensitively, empty ⇒ circuit.
+
+## Design decisions
+
+### 1. `Course.type`, optional, absent ⇒ circuit
+
+```ts
+export type CourseType = 'circuit' | 'sprint';
+```
+
+Added as `Course.type?: CourseType`. **Optional on purpose** — every existing
+course, every bundled `public/tracks.json` entry, every Supabase row and every
+cloud-synced blob predates the field, and all of them are circuits. A required
+field would need a migration of data we already know the answer for. `isSprint()`
+is the single reader; nothing else compares the literal.
+
+This mirrors how the firmware treats the DOVEX `race_mode` column (empty ⇒
+circuit) and how `Course.sectors` was introduced in plan 0003 — additive,
+normalized at load boundaries, legacy shape still readable.
+
+### 2. The finish line is a `SectorLine`, not four flat fields
+
+`Course.finish?: SectorLine` reuses the existing `{a: {lat, lon}, b: {lat, lon}}`
+shape, so the editor's drag handlers, the `sectorLinesEqual` comparator and the
+device (de)serializers all work on it without new geometry code. The wire format
+still flattens to `finish_a_lat` etc. because that is what the firmware parses.
+
+**Invariant: a sprint course without a finish line is invalid.** The firmware
+cannot time it. Validation enforces this rather than silently shipping a course
+the device will ignore.
+
+### 3. Validation branches on type; it does not get a new function
+
+`validateCourseSectors` already owns "can this course be saved". Sprint gets a
+branch inside it rather than a parallel validator, so the three call sites
+(`SectorListEditor`, `TrackEditor`, `TrackPromptDialog`) keep working unchanged
+and cannot drift apart.
+
+| | circuit (unchanged) | sprint |
+|---|---|---|
+| sector lines | 0, or exactly 3 majors total | **0–2**, `major` ignored |
+| finish line | n/a (start == finish) | **required** |
+
+The `major` flag is meaningless in sprint: the runs are short and the segments
+are just splits. Sprint courses are stored with `major: false` throughout so
+that if a course is ever retyped to circuit, it fails validation loudly instead
+of silently claiming a sector layout it never had.
+
+### 4. `date_created` is stamped on save, in the firmware's collation order
+
+`Course.dateCreated?: string`, format `YYYY-MM-DDTHH:MM` (minute precision,
+local time — it identifies which cone layout was walked, not an instant). It is
+set when a sprint course is first saved and **preserved** thereafter, so editing
+a course does not make it jump the queue on the device.
+
+Minute precision is what the firmware's filename stamps use, and it is enough to
+disambiguate two layouts walked on the same day. It is deliberately *not* an ISO
+instant with seconds/zone — the string is compared byte-wise against stamps the
+device itself writes.
+
+### 5. `coursesMatch` must see the sprint fields
+
+Today it compares 4 start/finish coordinates and the two legacy sector pairs.
+Left alone, it would report a sprint course as "synced" while ignoring a moved
+finish line — the single most likely edit. It gains a type-aware branch. This is
+a correctness fix, not a feature: the current function is *wrong* for any course
+carrying data it does not know about.
+
+## Phasing
+
+Deliberately split — the survey found ~20 call sites for the editor's finish
+handle alone, spread across four duplicated prop bags, and the repo's coverage
+config excludes `src/components/**/*.tsx`. Logic-first keeps the testable part
+testable (Golden Rule 3).
+
+- **PR 1 — model + validation + wire format (this PR).** All in `src/lib` and
+  `src/types`, all unit-tested, no UI. Nothing user-visible yet; it is the
+  foundation the other three stand on.
+- **PR 2 — editor.** `LineId` gains a `'finish'` variant, the finish handle,
+  the sprint/circuit toggle, and the four prop bags.
+- **PR 3 — device sync.** `TS*` opcodes in `trackSync.ts`, sprint awareness in
+  `deviceTrackSync.ts`'s merge, `DeviceTracksTab` UI. Note `MergedTrackEntry`
+  keys on `shortName` alone today, so a sprint and a circuit track sharing a
+  short name currently collide — that needs a kind in the key.
+- **PR 4 — reading runs back.** `race_mode` in `dovexParser`, run derivation
+  (`calculateLaps` pairs *consecutive* start/finish crossings and wraps the last
+  segment back to start/finish — both assumptions are false for sprint), and a
+  run-oriented `LapTable`.
+
+## Deliberately kept: "lap" wording
+
+The AX drivers call them laps. The firmware kept the wording on-device for the
+same reason. Runs are modelled as `Lap[]` so every existing consumer — the lap
+table, the overlay renderer, leaderboards, the video sync — keeps working. Only
+labels change, and only in PR 4.
+
+## Not in scope
+
+- **On-device course creator** (`DovesDataLogger` plan 0002 §5). It emits
+  `NEWTRACK_`/`NEWCOURSE_` files explicitly designed to be renamed in this app
+  afterwards, so it wants this plan finished first.
+- **Supabase `courses` columns** for the sprint fields. Community submission of
+  sprint courses is a later step; local + device sync comes first, and the
+  offline-first rule (Golden Rule 1) means nothing here depends on the cloud.
+- **Firmware upgrade-path mapping** (`DovesDataLogger` plan 0004) — unrelated,
+  parked to the end of the cross-repo effort.
+
+## Cross-repo note found while surveying
+
+`DovesDataLogger/CLAUDE.md` documents the DOVEX metadata columns as
+`driver_name` / `course_name` / `optimal_lap_ms`, but `BirdsEye/dovex_header.cpp`
+actually emits `driver` / `course` / `optimal_ms`. This app matches the `.cpp`
+(`dovexParser.ts` keys off the emitted names), so the **code is right and the
+firmware's doc is wrong**. Worth a one-line fix over there; noted here so the
+next person to read that table does not "correct" the parser to match it.

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -141,6 +141,12 @@ never reasons about sector geometry directly.
   numbering (`sectorLabels`: `1, 1.1, 2, 2.1, 3`). Save is blocked unless there
   are 0 sectors or exactly 3 majors (`validateCourseSectors`). Three line colors
   on every map: S/F green, major purple, sub sky-blue.
+- **Sprint courses opt out of the majors rule.** A `type: 'sprint'` course is
+  point-to-point: a required separate `finish` line and 0–`MAX_SPRINT_SPLITS`
+  optional splits, with `major` ignored (splits are stored unflagged so a
+  retype to circuit fails validation loudly). `validateCourseSectors` branches
+  on the type rather than growing a second validator. See
+  `docs/plans/0015-sprint-mode.md`.
 - **The logger only ever sees the 3 majors.** `majorSectorLines`/`legacyMirror`
   project the course down to start/finish + `sector2`/`sector3` —
   **byte-identical** to the pre-overhaul device JSON, submission payload, and

--- a/src/lib/courseSectors.test.ts
+++ b/src/lib/courseSectors.test.ts
@@ -3,7 +3,7 @@ import { Course, SectorLine } from '@/types/racing';
 import {
   normalizeCourseSectors, majorSectorLines, legacyMirror, sectorLabels,
   validateCourseSectors, isAtSectorLimit, isAtMajorLimit, rollupMajorSectors, centeredSectorLine,
-  MAX_SECTOR_LINES, MAX_MAJOR_SECTORS, DEFAULT_SECTOR_HALF_LENGTH_DEG,
+  MAX_SECTOR_LINES, MAX_MAJOR_SECTORS, MAX_SPRINT_SPLITS, DEFAULT_SECTOR_HALF_LENGTH_DEG,
 } from './courseSectors';
 
 const line = (n: number): SectorLine => ({ a: { lat: n, lon: n }, b: { lat: n + 0.001, lon: n + 0.001 } });
@@ -109,6 +109,55 @@ describe('validateCourseSectors', () => {
     const many = Array.from({ length: MAX_SECTOR_LINES }, (_, i) => ({ line: line(i), major: i < MAX_MAJOR_SECTORS - 1 }));
     const c = baseCourse({ sectors: many });
     expect(validateCourseSectors(c).valid).toBe(false);
+  });
+
+  // Sprint courses are point-to-point: a required separate finish line, and
+  // 0-2 optional splits with no "major" concept. See docs/plans/0015-sprint-mode.md.
+  describe('sprint courses', () => {
+    const finish = line(9);
+    const sprintCourse = (partial: Partial<Course> = {}): Course =>
+      baseCourse({ type: 'sprint', finish, ...partial });
+
+    it('accepts a start and finish with no splits', () => {
+      expect(validateCourseSectors(sprintCourse()).valid).toBe(true);
+    });
+
+    it.each([1, MAX_SPRINT_SPLITS])('accepts %i split line(s)', (n) => {
+      const sectors = Array.from({ length: n }, (_, i) => ({ line: line(i), major: false }));
+      expect(validateCourseSectors(sprintCourse({ sectors })).valid).toBe(true);
+    });
+
+    it('rejects more splits than the cap', () => {
+      const sectors = Array.from({ length: MAX_SPRINT_SPLITS + 1 }, (_, i) => ({ line: line(i), major: false }));
+      const v = validateCourseSectors(sprintCourse({ sectors }));
+      expect(v.valid).toBe(false);
+      expect(v.reason).toMatch(/split lines/i);
+    });
+
+    it('rejects a sprint course with no finish line', () => {
+      const v = validateCourseSectors(sprintCourse({ finish: undefined }));
+      expect(v.valid).toBe(false);
+      expect(v.reason).toMatch(/finish line/i);
+    });
+
+    it('does not apply the circuit three-majors rule', () => {
+      // One unflagged split would be rejected outright on a circuit course.
+      const sectors = [{ line: line(1), major: false }];
+      expect(validateCourseSectors(sprintCourse({ sectors })).valid).toBe(true);
+      expect(validateCourseSectors(baseCourse({ sectors })).valid).toBe(false);
+    });
+
+    it('ignores the major flag entirely', () => {
+      const sectors = [{ line: line(1), major: true }, { line: line(2), major: true }];
+      expect(validateCourseSectors(sprintCourse({ sectors })).valid).toBe(true);
+    });
+
+    it('still applies the circuit rules when type is absent', () => {
+      // Absent type means circuit — a stray finish line must not opt a course
+      // into the sprint branch.
+      const c = baseCourse({ finish, sectors: [{ line: line(1), major: false }] });
+      expect(validateCourseSectors(c).valid).toBe(false);
+    });
   });
 });
 

--- a/src/lib/courseSectors.ts
+++ b/src/lib/courseSectors.ts
@@ -1,4 +1,4 @@
-import { Course, CourseSector, SectorLine, SectorTimes } from '@/types/racing';
+import { Course, CourseSector, SectorLine, SectorTimes, isSprintCourse } from '@/types/racing';
 
 /**
  * Sector model — the single source of truth for the "unlimited sectors" feature.
@@ -103,13 +103,36 @@ export interface SectorValidation {
   reason: string | null;
 }
 
+/** Max split lines between a sprint course's start and finish (plan 0015). */
+export const MAX_SPRINT_SPLITS = 2;
+
 /**
- * Save rule: a course must have EITHER zero additional sectors, OR exactly three
- * major sectors total (start/finish + two flagged). The total line count must
- * also stay within `MAX_SECTOR_LINES`.
+ * Save rule, by course type.
+ *
+ * **Circuit** — either zero additional sectors, or exactly three major sectors
+ * total (start/finish + two flagged), within `MAX_SECTOR_LINES` overall.
+ *
+ * **Sprint** — a finish line is REQUIRED (the logger cannot time a run without
+ * one, so saving a course it will ignore is worse than blocking), and there may
+ * be zero to `MAX_SPRINT_SPLITS` optional split lines. The `major` flag carries
+ * no meaning point-to-point and is not checked.
  */
 export function validateCourseSectors(course: Course): SectorValidation {
   const sectors = course.sectors ?? [];
+
+  if (isSprintCourse(course)) {
+    if (!course.finish) {
+      return { valid: false, reason: 'A sprint course needs a finish line — drag one onto the map.' };
+    }
+    if (sectors.length > MAX_SPRINT_SPLITS) {
+      return {
+        valid: false,
+        reason: `A sprint course can have at most ${MAX_SPRINT_SPLITS} split lines between start and finish.`,
+      };
+    }
+    return { valid: true, reason: null };
+  }
+
   if (sectors.length === 0) return { valid: true, reason: null };
 
   if (sectors.length > MAX_COURSE_SECTORS) {

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -445,3 +445,108 @@ describe("device export with sub-sectors", () => {
     expect(coursesMatch(sectorCourse, dev)).toBe(true);
   });
 });
+
+// ─── Sprint courses (plan 0015) ──────────────────────────────────────────────
+
+describe("sprint course wire format", () => {
+  const finish: SectorLine = {
+    a: { lat: 35.41000, lon: -97.31000 },
+    b: { lat: 35.41010, lon: -97.31010 },
+  };
+  const split = (n: number): SectorLine => ({
+    a: { lat: 35.405 + n / 1000, lon: -97.305 },
+    b: { lat: 35.405 + n / 1000, lon: -97.304 },
+  });
+
+  const makeSprintCourse = (overrides: Partial<Course> = {}): Course =>
+    makeAppCourse({ type: "sprint", finish, dateCreated: "2026-09-05T07:03", ...overrides });
+
+  it("round-trips a bare sprint course through the device JSON", () => {
+    const original = makeSprintCourse();
+    const back = deviceCourseToAppCourse(appCourseToDeviceJson(original));
+
+    expect(back.type).toBe("sprint");
+    expect(back.finish).toEqual(finish);
+    expect(back.dateCreated).toBe("2026-09-05T07:03");
+    expect(back.startFinishA).toEqual(original.startFinishA);
+    expect(back.startFinishB).toEqual(original.startFinishB);
+  });
+
+  it("round-trips split lines positionally, keeping them unflagged", () => {
+    const original = makeSprintCourse({
+      sectors: [{ line: split(1), major: false }, { line: split(2), major: false }],
+    });
+    const dc = appCourseToDeviceJson(original);
+
+    // Splits ride in the device's existing sector_2/sector_3 slots.
+    expect(dc.sector_2_a_lat).toBe(split(1).a.lat);
+    expect(dc.sector_3_a_lat).toBe(split(2).a.lat);
+
+    const back = deviceCourseToAppCourse(dc);
+    expect(back.sectors).toHaveLength(2);
+    expect(back.sectors!.map((s) => s.line)).toEqual([split(1), split(2)]);
+    // `major` is meaningless point-to-point and must not be set — a course
+    // retyped to circuit has to fail validation loudly, not look like a
+    // three-major layout it never had.
+    expect(back.sectors!.every((s) => !s.major)).toBe(true);
+  });
+
+  it("emits an unflagged single split, which legacyMirror would have dropped", () => {
+    const dc = appCourseToDeviceJson(makeSprintCourse({
+      sectors: [{ line: split(1), major: false }],
+    }));
+    expect(dc.sector_2_a_lat).toBe(split(1).a.lat);
+    expect(dc.sector_3_a_lat).toBeUndefined();
+  });
+
+  it("emits no sprint fields for a circuit course", () => {
+    const dc = appCourseToDeviceJson(makeAppCourse());
+    expect(dc.finish_a_lat).toBeUndefined();
+    expect(dc.date_created).toBeUndefined();
+  });
+
+  it("reads a device course with no finish line back as circuit", () => {
+    const back = deviceCourseToAppCourse(makeDeviceCourse());
+    expect(back.type).toBeUndefined();
+    expect(back.finish).toBeUndefined();
+  });
+
+  it("matches an unchanged sprint course", () => {
+    const course = makeSprintCourse();
+    expect(coursesMatch(course, appCourseToDeviceJson(course))).toBe(true);
+  });
+
+  it("flags a moved finish line as a mismatch", () => {
+    // The single most likely edit to a sprint course. Before the sprint branch
+    // in coursesMatch this compared only start/finish and reported "synced".
+    const course = makeSprintCourse();
+    const dc = appCourseToDeviceJson(course);
+    const moved = makeSprintCourse({
+      finish: { a: { lat: 35.42000, lon: -97.32000 }, b: finish.b },
+    });
+    expect(coursesMatch(moved, dc)).toBe(false);
+  });
+
+  it("flags a changed date_created as a mismatch", () => {
+    // It decides which course the device loads, so it is not cosmetic.
+    const dc = appCourseToDeviceJson(makeSprintCourse());
+    expect(coursesMatch(makeSprintCourse({ dateCreated: "2026-09-06T08:00" }), dc)).toBe(false);
+  });
+
+  it("flags a moved split as a mismatch", () => {
+    const dc = appCourseToDeviceJson(makeSprintCourse({
+      sectors: [{ line: split(1), major: false }],
+    }));
+    const moved = makeSprintCourse({ sectors: [{ line: split(5), major: false }] });
+    expect(coursesMatch(moved, dc)).toBe(false);
+  });
+
+  it("never matches across a kind change, in either direction", () => {
+    // The two kinds live in different folders on the device, so this is a
+    // different file rather than an edit.
+    const sprintJson = appCourseToDeviceJson(makeSprintCourse());
+    const circuitJson = appCourseToDeviceJson(makeAppCourse());
+    expect(coursesMatch(makeAppCourse(), sprintJson)).toBe(false);
+    expect(coursesMatch(makeSprintCourse(), circuitJson)).toBe(false);
+  });
+});

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -4,7 +4,7 @@
  * and determines sync status per track and per course.
  */
 
-import { Track, Course, SectorLine } from '@/types/racing';
+import { Track, Course, CourseSector, SectorLine, isSprintCourse } from '@/types/racing';
 import { haversineDistance } from '@/lib/parserUtils';
 import { legacyMirror, majorSectorLines, normalizeCourseSectors } from '@/lib/courseSectors';
 
@@ -26,6 +26,21 @@ export interface DeviceCourseJson {
   sector_3_a_lng?: number;
   sector_3_b_lat?: number;
   sector_3_b_lng?: number;
+  /**
+   * Sprint only, required there: the separate finish line. Circuit courses omit
+   * these — start and finish are the same line.
+   * See `docs/plans/0015-sprint-mode.md`.
+   */
+  finish_a_lat?: number;
+  finish_a_lng?: number;
+  finish_b_lat?: number;
+  finish_b_lng?: number;
+  /**
+   * Sprint only: sortable `YYYY-MM-DDTHH:MM` stamp. The logger picks the newest
+   * course by a plain STRING compare of this field, so the zero-padded shape is
+   * load-bearing.
+   */
+  date_created?: string;
 }
 
 export interface DeviceTrackFile {
@@ -91,9 +106,30 @@ function sectorLinesEqual(a?: SectorLine, b?: SectorLine): boolean {
 }
 
 /**
+ * The two timing lines this course projects into the device's `sector_2_*` /
+ * `sector_3_*` slots.
+ *
+ * Circuit takes the two flagged majors (app-only sub-sectors are never sent).
+ * Sprint takes its split lines positionally — `major` is meaningless
+ * point-to-point, so sprint splits are stored unflagged and `legacyMirror`
+ * would drop them.
+ */
+function deviceSectorProjection(course: Course): { sector2?: SectorLine; sector3?: SectorLine } {
+  if (isSprintCourse(course)) {
+    const splits = course.sectors ?? [];
+    return { sector2: splits[0]?.line, sector3: splits[1]?.line };
+  }
+  return legacyMirror(normalizeCourseSectors(course));
+}
+
+/**
  * Compare an app Course with a device course JSON. Only the device-visible
- * projection (start/finish + the two major lines) is compared — app-only
- * sub-sectors never flag a mismatch, since they're never sent to the device.
+ * projection is compared — app-only sub-sectors never flag a mismatch, since
+ * they're never sent to the device.
+ *
+ * For sprint courses that projection also covers the finish line and
+ * `date_created`: without them a moved finish line — the single most likely
+ * edit to a sprint course — would read as "synced".
  */
 export function coursesMatch(appCourse: Course, dc: DeviceCourseJson): boolean {
   // Compare start/finish
@@ -102,8 +138,22 @@ export function coursesMatch(appCourse: Course, dc: DeviceCourseJson): boolean {
   if (!coordsEqual(appCourse.startFinishB.lat, dc.start_b_lat)) return false;
   if (!coordsEqual(appCourse.startFinishB.lon, dc.start_b_lng)) return false;
 
-  // Compare the two major sectors (mirror) against the device's two sector lines.
-  const { sector2, sector3 } = legacyMirror(normalizeCourseSectors(appCourse));
+  // A course that changed kind is never a match, whichever way it went: the
+  // device stores the two kinds in different folders, so this is a different
+  // file, not an edit.
+  const deviceIsSprint = dc.finish_a_lat != null;
+  if (isSprintCourse(appCourse) !== deviceIsSprint) return false;
+
+  if (deviceIsSprint) {
+    const deviceFinish = sectorLineFromDevice(
+      dc.finish_a_lat, dc.finish_a_lng, dc.finish_b_lat, dc.finish_b_lng,
+    );
+    if (!sectorLinesEqual(appCourse.finish, deviceFinish)) return false;
+    if ((appCourse.dateCreated ?? undefined) !== (dc.date_created ?? undefined)) return false;
+  }
+
+  // Compare the projected sector lines against the device's two sector slots.
+  const { sector2, sector3 } = deviceSectorProjection(appCourse);
   const deviceS2 = sectorLineFromDevice(dc.sector_2_a_lat, dc.sector_2_a_lng, dc.sector_2_b_lat, dc.sector_2_b_lng);
   const deviceS3 = sectorLineFromDevice(dc.sector_3_a_lat, dc.sector_3_a_lng, dc.sector_3_b_lat, dc.sector_3_b_lng);
 
@@ -127,6 +177,24 @@ export function deviceCourseToAppCourse(dc: DeviceCourseJson): Course {
 
   const s2 = sectorLineFromDevice(dc.sector_2_a_lat, dc.sector_2_a_lng, dc.sector_2_b_lat, dc.sector_2_b_lng);
   const s3 = sectorLineFromDevice(dc.sector_3_a_lat, dc.sector_3_a_lng, dc.sector_3_b_lat, dc.sector_3_b_lng);
+
+  // A finish line is what makes it a sprint course — the device only ever emits
+  // these four fields for tracks out of /TRACKS/SPRINT.
+  const finish = sectorLineFromDevice(dc.finish_a_lat, dc.finish_a_lng, dc.finish_b_lat, dc.finish_b_lng);
+  if (finish) {
+    course.type = 'sprint';
+    course.finish = finish;
+    if (dc.date_created) course.dateCreated = dc.date_created;
+    // Splits are positional and unflagged: `major` has no meaning in a run, and
+    // flagging them would let a retype-to-circuit silently look like a valid
+    // three-major layout it never had.
+    const splits: CourseSector[] = [];
+    if (s2) splits.push({ line: s2, major: false });
+    if (s3) splits.push({ line: s3, major: false });
+    if (splits.length > 0) course.sectors = splits;
+    return course;
+  }
+
   if (s2 && s3) {
     course.sector2 = s2;
     course.sector3 = s3;
@@ -153,7 +221,7 @@ export function appCourseToDeviceJson(course: Course): DeviceCourseJson {
     dc.lengthFt = course.lengthFt;
   }
 
-  const { sector2, sector3 } = legacyMirror(normalizeCourseSectors(course));
+  const { sector2, sector3 } = deviceSectorProjection(course);
   if (sector2) {
     dc.sector_2_a_lat = sector2.a.lat;
     dc.sector_2_a_lng = sector2.a.lon;
@@ -165,6 +233,14 @@ export function appCourseToDeviceJson(course: Course): DeviceCourseJson {
     dc.sector_3_a_lng = sector3.a.lon;
     dc.sector_3_b_lat = sector3.b.lat;
     dc.sector_3_b_lng = sector3.b.lon;
+  }
+
+  if (isSprintCourse(course) && course.finish) {
+    dc.finish_a_lat = course.finish.a.lat;
+    dc.finish_a_lng = course.finish.a.lon;
+    dc.finish_b_lat = course.finish.b.lat;
+    dc.finish_b_lng = course.finish.b.lon;
+    if (course.dateCreated) dc.date_created = course.dateCreated;
   }
 
   return dc;

--- a/src/lib/sprintCourse.test.ts
+++ b/src/lib/sprintCourse.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { Course } from '@/types/racing';
+import {
+  formatSprintDateCreated,
+  isValidSprintDateCreated,
+  stampSprintDateCreated,
+  newestSprintCourse,
+  newestSprintCourseIndex,
+} from './sprintCourse';
+
+function sprint(name: string, dateCreated?: string): Course {
+  return {
+    name,
+    type: 'sprint',
+    startFinishA: { lat: 0, lon: 0 },
+    startFinishB: { lat: 0, lon: 1 },
+    finish: { a: { lat: 1, lon: 0 }, b: { lat: 1, lon: 1 } },
+    dateCreated,
+  };
+}
+
+function circuit(name: string): Course {
+  return {
+    name,
+    startFinishA: { lat: 0, lon: 0 },
+    startFinishB: { lat: 0, lon: 1 },
+  };
+}
+
+describe('formatSprintDateCreated', () => {
+  it('formats as zero-padded YYYY-MM-DDTHH:MM in local time', () => {
+    // Month is 0-based in the Date constructor: 8 = September.
+    expect(formatSprintDateCreated(new Date(2026, 8, 5, 7, 3))).toBe('2026-09-05T07:03');
+  });
+
+  it('zero-pads every field so stamps stay the same width', () => {
+    expect(formatSprintDateCreated(new Date(2026, 0, 1, 0, 0))).toHaveLength(16);
+    expect(formatSprintDateCreated(new Date(2026, 11, 31, 23, 59))).toBe('2026-12-31T23:59');
+  });
+
+  it('produces stamps that sort chronologically as plain strings', () => {
+    // This is the whole contract with the firmware: it compares these with a
+    // string compare, never a date parse.
+    const stamps = [
+      new Date(2026, 8, 5, 9, 0),
+      new Date(2026, 8, 5, 10, 0),   // 10 must sort AFTER 9, not before
+      new Date(2026, 9, 1, 8, 0),    // October after September
+      new Date(2027, 0, 1, 0, 0),
+    ].map(formatSprintDateCreated);
+
+    expect([...stamps].sort()).toEqual(stamps);
+  });
+});
+
+describe('isValidSprintDateCreated', () => {
+  it('accepts the exact device shape', () => {
+    expect(isValidSprintDateCreated('2026-09-05T07:03')).toBe(true);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['empty', ''],
+    ['no zero padding', '2026-9-5T7:03'],
+    ['US ordering', '09/05/2026 07:03'],
+    ['full ISO instant with seconds', '2026-09-05T07:03:00'],
+    ['zoned ISO instant', '2026-09-05T07:03:00Z'],
+    ['date only', '2026-09-05'],
+  ])('rejects %s', (_label, value) => {
+    expect(isValidSprintDateCreated(value as string | undefined)).toBe(false);
+  });
+});
+
+describe('stampSprintDateCreated', () => {
+  it('stamps an unstamped sprint course', () => {
+    const out = stampSprintDateCreated(sprint('Run 1'), new Date(2026, 8, 5, 7, 3));
+    expect(out.dateCreated).toBe('2026-09-05T07:03');
+  });
+
+  it('preserves an existing stamp so an edit cannot jump the device queue', () => {
+    const original = sprint('Run 1', '2026-09-05T07:03');
+    const out = stampSprintDateCreated(original, new Date(2027, 0, 1, 12, 0));
+    expect(out.dateCreated).toBe('2026-09-05T07:03');
+  });
+
+  it('replaces a malformed stamp, which would collate wrong on the device', () => {
+    const out = stampSprintDateCreated(sprint('Run 1', '9/5/2026'), new Date(2026, 8, 5, 7, 3));
+    expect(out.dateCreated).toBe('2026-09-05T07:03');
+  });
+
+  it('leaves circuit courses untouched', () => {
+    const c = circuit('Full Course');
+    expect(stampSprintDateCreated(c, new Date(2026, 8, 5, 7, 3))).toBe(c);
+  });
+
+  it('does not mutate its input', () => {
+    const original = sprint('Run 1');
+    stampSprintDateCreated(original, new Date(2026, 8, 5, 7, 3));
+    expect(original.dateCreated).toBeUndefined();
+  });
+});
+
+describe('newestSprintCourseIndex', () => {
+  it('returns -1 when there are no courses at all', () => {
+    expect(newestSprintCourseIndex([])).toBe(-1);
+  });
+
+  it('returns -1 when no course is a sprint course', () => {
+    expect(newestSprintCourseIndex([circuit('A'), circuit('B')])).toBe(-1);
+  });
+
+  it('picks the newest stamp, not the last in the array', () => {
+    const courses = [
+      sprint('Morning', '2026-09-05T08:00'),
+      sprint('Afternoon', '2026-09-05T14:30'),
+      sprint('Midday', '2026-09-05T11:15'),
+    ];
+    expect(newestSprintCourseIndex(courses)).toBe(1);
+    expect(newestSprintCourse(courses)?.name).toBe('Afternoon');
+  });
+
+  it('orders by string compare, so 10:00 beats 09:00', () => {
+    // The naive-sort trap: without zero padding "9:00" > "10:00" lexically.
+    const courses = [sprint('Nine', '2026-09-05T09:00'), sprint('Ten', '2026-09-05T10:00')];
+    expect(newestSprintCourse(courses)?.name).toBe('Ten');
+  });
+
+  it('ignores circuit courses when choosing', () => {
+    const courses = [circuit('Full Course'), sprint('Run', '2026-09-05T08:00')];
+    expect(newestSprintCourseIndex(courses)).toBe(1);
+  });
+
+  it('sorts an unstamped sprint course oldest rather than dropping it', () => {
+    const courses = [sprint('Unstamped'), sprint('Stamped', '2020-01-01T00:00')];
+    // Even a very old real stamp beats no stamp.
+    expect(newestSprintCourse(courses)?.name).toBe('Stamped');
+  });
+
+  it('still returns an unstamped course when it is the only candidate', () => {
+    // The device would see the file either way; hiding it here would make the
+    // app disagree with the card.
+    const courses = [circuit('Full Course'), sprint('Unstamped')];
+    expect(newestSprintCourse(courses)?.name).toBe('Unstamped');
+  });
+
+  it('treats a malformed stamp as unstamped', () => {
+    const courses = [sprint('Bad', '9/5/2026'), sprint('Good', '2020-01-01T00:00')];
+    expect(newestSprintCourse(courses)?.name).toBe('Good');
+  });
+
+  it('keeps the earlier course on a tie', () => {
+    const courses = [sprint('First', '2026-09-05T08:00'), sprint('Second', '2026-09-05T08:00')];
+    expect(newestSprintCourseIndex(courses)).toBe(0);
+  });
+});

--- a/src/lib/sprintCourse.ts
+++ b/src/lib/sprintCourse.ts
@@ -1,0 +1,101 @@
+/**
+ * Sprint-course helpers — the `date_created` stamp and the "which course will
+ * the device actually load" question.
+ *
+ * The logger does not let you pick a sprint course. It loads exactly one: the
+ * newest by `date_created`, chosen with a plain **string** comparison in the
+ * firmware's `sprint_select` unit. That makes the stamp format load-bearing
+ * rather than cosmetic — anything that isn't zero-padded and
+ * big-endian-ordered collates wrong and the device silently runs the wrong
+ * layout. Everything here exists to keep this app on the same ordering.
+ *
+ * See `docs/plans/0015-sprint-mode.md` and, in the firmware repo,
+ * `BirdsEye/sprint_select.{h,cpp}`.
+ */
+
+import { Course, isSprintCourse } from '@/types/racing';
+
+/**
+ * `YYYY-MM-DDTHH:MM` — sortable as a plain string, minute precision, local
+ * time. Minute precision is deliberate: the stamp identifies *which cone layout
+ * was walked*, not an instant, and it matches the resolution of the filename
+ * stamps the device generates itself. Notably NOT a full ISO instant — no
+ * seconds and no zone suffix, because the string is compared byte-wise against
+ * stamps the device writes.
+ */
+export const SPRINT_DATE_CREATED_LENGTH = 16;
+
+const STAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** Format a Date as the sortable `YYYY-MM-DDTHH:MM` stamp, in local time. */
+export function formatSprintDateCreated(date: Date): string {
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}` +
+    `T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+  );
+}
+
+/**
+ * True when a stamp is in the exact shape the device's string ordering relies
+ * on. Anything else must not be trusted to sort — see `newestSprintCourseIndex`.
+ */
+export function isValidSprintDateCreated(stamp: string | undefined | null): boolean {
+  return typeof stamp === 'string' && STAMP_RE.test(stamp);
+}
+
+/**
+ * Stamp a sprint course with its creation time, **preserving an existing
+ * stamp**. Editing a course must not make it jump the queue on the device —
+ * `date_created` records when the layout was walked, not when the record was
+ * last touched. Circuit courses are returned untouched.
+ */
+export function stampSprintDateCreated(course: Course, now: Date = new Date()): Course {
+  if (!isSprintCourse(course)) return course;
+  if (isValidSprintDateCreated(course.dateCreated)) return course;
+  return { ...course, dateCreated: formatSprintDateCreated(now) };
+}
+
+/**
+ * Index of the course the device would load: the newest sprint course by
+ * `date_created`, compared as a string exactly as the firmware does.
+ *
+ * Returns -1 when there is nothing loadable. Courses with a missing or
+ * malformed stamp sort **oldest** rather than being dropped — the device would
+ * still see the file, and silently hiding it here would make the app disagree
+ * with the hardware about what is on the card. A course with no valid stamp
+ * only wins if it is the only candidate.
+ *
+ * Ties keep the earlier course: two layouts stamped the same minute are
+ * genuinely ambiguous, and first-wins at least makes this app deterministic.
+ */
+export function newestSprintCourseIndex(courses: readonly Course[]): number {
+  let best = -1;
+  let bestStamp: string | null = null;
+
+  courses.forEach((course, i) => {
+    if (!isSprintCourse(course)) return;
+    const stamp = isValidSprintDateCreated(course.dateCreated) ? course.dateCreated! : null;
+    if (best === -1) {
+      best = i;
+      bestStamp = stamp;
+      return;
+    }
+    if (stamp === null) return;                 // unstamped never displaces
+    if (bestStamp === null || stamp > bestStamp) {
+      best = i;
+      bestStamp = stamp;
+    }
+  });
+
+  return best;
+}
+
+/** The course the device would load, or undefined when there is no sprint course. */
+export function newestSprintCourse(courses: readonly Course[]): Course | undefined {
+  const i = newestSprintCourseIndex(courses);
+  return i === -1 ? undefined : courses[i];
+}

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -32,11 +32,44 @@ export interface CourseSector {
   major: boolean;
 }
 
+/**
+ * How a course is timed.
+ *
+ * - `circuit` — the classic model: one line that is both start and finish, laps
+ *   formed from consecutive crossings of it.
+ * - `sprint` — point-to-point (autocross, hillclimb, rally stage): a start line
+ *   and a SEPARATE finish line, timed as runs rather than laps.
+ *
+ * Absent means `circuit`. The field is optional because every course that
+ * existed before sprint mode is a circuit — requiring it would mean migrating
+ * data whose answer we already know. Read it through `isSprintCourse()` rather
+ * than comparing the literal. See `docs/plans/0015-sprint-mode.md`.
+ */
+export type CourseType = 'circuit' | 'sprint';
+
 export interface Course {
   name: string;
+  /** Timing model; absent means `circuit`. See {@link CourseType}. */
+  type?: CourseType;
   lengthFt?: number; // known course length in feet (from track database)
   startFinishA: { lat: number; lon: number };
   startFinishB: { lat: number; lon: number };
+  /**
+   * Sprint only, and REQUIRED there: the separate finish line. A sprint course
+   * without one cannot be timed by the logger, so validation rejects it rather
+   * than shipping a course the device will silently ignore. Unset on circuit
+   * courses, where start and finish are the same line.
+   */
+  finish?: SectorLine;
+  /**
+   * Sprint only: when this course's cone layout was walked, as a sortable
+   * `YYYY-MM-DDTHH:MM` local stamp. The logger loads the NEWEST course by this
+   * field and compares the stamps as plain strings, so the zero-padded ISO
+   * shape is load-bearing — a non-sortable format silently loads the wrong
+   * course. Stamped on first save and preserved across edits, so revising a
+   * course doesn't make it jump the queue on the device.
+   */
+  dateCreated?: string;
   /**
    * Ordered sector lines after start/finish (canonical model). Normalized in
    * from the legacy `sector2`/`sector3` fields at every load boundary via
@@ -55,6 +88,16 @@ export interface Course {
    * from public/drawings.json instead (see loadCourseDrawings).
    */
   layout?: Array<{ lat: number; lon: number }>;
+}
+
+/**
+ * True when a course is timed point-to-point (start line ≠ finish line).
+ *
+ * The single reader of `Course.type` — everything else asks this, so the
+ * "absent means circuit" default lives in exactly one place.
+ */
+export function isSprintCourse(course: Pick<Course, 'type'> | null | undefined): boolean {
+  return course?.type === 'sprint';
 }
 
 /**


### PR DESCRIPTION
First of four PRs bringing sprint (autocross / point-to-point) support to the app. **Model, validation and wire format only — no UI in this PR.**

## Why now

The logger and DovesLapTimer have shipped sprint support for weeks, but **nothing can author a sprint track.** The device reads `/TRACKS/SPRINT/*.json`, picks the newest course by `date_created`, stands up `SprintTimer`, and will sync the folder over `TSLIST`/`TSGET:`/`TSPUT:`/`TSDEL:`. All of it works and none of it is reachable, because the only thing that would write those files is this app — which had no concept of a course type.

Right now sprint mode is testable only by hand-writing JSON onto an SD card, which means the firmware work has never been exercised on a real course. Closing that loop is the point: **author a sprint course here → push it over `TSPUT:` → drive it → read the runs back.**

## What's in this PR

`Course` gains three optional fields:

| Field | Notes |
|---|---|
| `type?: 'circuit' \| 'sprint'` | Absent means circuit, so every existing saved, bundled and cloud-synced course keeps working with **no migration**. Read through `isSprintCourse()` so the default lives in one place. |
| `finish?: SectorLine` | Sprint only and **required** there — the device can't time a run without it, so validation rejects rather than shipping a course the device will silently ignore. |
| `dateCreated?: string` | Sprint only, sortable `YYYY-MM-DDTHH:MM`. |

### `date_created` is load-bearing, not cosmetic

The firmware picks which sprint course to load by comparing these stamps as plain **strings** (`sprint_select`). A stamp that isn't zero-padded and big-endian-ordered collates wrong and the device runs the wrong cone layout — `"9:00" > "10:00"` lexically. New `src/lib/sprintCourse.ts` owns the format and is tested against exactly that trap.

It also **stamps once and preserves**: editing a course must not make it jump the queue on the device, since the stamp records when the cone layout was walked, not when the record was last touched.

`newestSprintCourseIndex` mirrors the firmware's choice. Courses with a missing or malformed stamp sort *oldest* rather than being hidden — the device would still see the file, and dropping it here would make the app disagree with the card.

### Validation branches, it doesn't fork

`validateCourseSectors` gains a sprint branch rather than a parallel validator, so its three call sites (`SectorListEditor`, `TrackEditor`, `TrackPromptDialog`) keep working and can't drift apart.

| | circuit (unchanged) | sprint |
|---|---|---|
| sector lines | 0, or exactly 3 majors total | **0–2 splits**, `major` ignored |
| finish line | n/a | **required** |

### Why sprint splits are stored unflagged

`major` is meaningless point-to-point, and storing splits as majors would let a course retyped to circuit silently look like a valid three-major layout it never had. The tradeoff is that `legacyMirror` would then drop them on export — so the device projection is now type-aware (`deviceSectorProjection`) and maps splits into the existing `sector_2`/`sector_3` slots positionally.

## Bug found and fixed along the way

`coursesMatch` compared only start/finish and the two legacy sector lines, so **any** course carrying data outside that projection read as "synced". For a sprint course that includes the finish line — the single most likely thing to be edited. It now compares the full per-type projection, and treats a course that changed type as a different file rather than an edit (the two kinds live in separate folders on the device).

This is latent today since nothing produces sprint courses yet, but it's a correctness fix to existing code, not new behavior.

## Test plan

- [x] `bun run test:run` — **2464 pass / 178 files**, including 44 new
  - 25 for `sprintCourse` — format, the plain-string sort contract, stamp preservation, and every malformed-stamp shape
  - 9 for the sprint validation branch, incl. that an absent type still gets circuit rules (a stray finish line must not opt a course in)
  - 10 round-tripping the wire format and pinning the `coursesMatch` fix in both directions
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [x] No existing test changed behavior — the circuit path is untouched

## What follows

- **PR 2 — editor.** `LineId` gains a `'finish'` variant plus the handle, the circuit/sprint toggle, and the four duplicated prop bags (`TrackEditor` / `TrackPromptDialog` / `AddCourseDialog` / admin `CoursesTab`).
- **PR 3 — device sync.** `TS*` opcodes in `trackSync.ts`, sprint awareness in the merge. Note `MergedTrackEntry` keys on `shortName` alone today, so a sprint and a circuit track sharing a short name would collide — that needs a kind in the key.
- **PR 4 — reading runs back.** `race_mode` in `dovexParser` (the firmware already emits it and we silently drop it), run derivation, run-oriented `LapTable`. `calculateLaps` pairs *consecutive* start/finish crossings and wraps the last segment back to start/finish — both false for sprint.

## Note for the firmware repo

While surveying: `DovesDataLogger/CLAUDE.md` documents the DOVEX metadata columns as `driver_name` / `course_name` / `optimal_lap_ms`, but `BirdsEye/dovex_header.cpp` actually emits `driver` / `course` / `optimal_ms`. This app matches the `.cpp`, so the **code is right and that doc is wrong**. Recorded in plan 0015 so nobody "corrects" the parser to match the doc later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnTP6BdA9xjLR5hSWE9frb)_