### PR TITLE
plan 0015: create and edit sprint courses in the track editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sprint courses can be created and edited** (plan 0015). The course editor
+  gained a **Circuit / Sprint** picker, and a sprint course gets a second,
+  separate **finish line** handle on the map — rendered in red after the splits,
+  because that is the order you cross them. The sector list grows a matching
+  Finish row at the bottom, drops the Major switch (meaningless point-to-point),
+  and relabels its rows Split 1/2. Selecting Sprint drops a finish line for you
+  north of the start rather than making you hunt for a button.
+  - The type is fixed once a course exists: retyping a course that already has
+    geometry would silently invalidate it, since a circuit's three majors are
+    not a sprint's splits.
+  - Still no device sync for sprint tracks (`TS*` opcodes) and no runs view —
+    those are the next two steps.
 - **Sprint (autocross / point-to-point) course model — foundation** (plan 0015).
   Courses can now be typed `circuit` or `sprint`. A sprint course is timed
   start-line → *separate* finish line rather than lap-to-lap, carries a required

--- a/docs/plans/0015-sprint-mode.md
+++ b/docs/plans/0015-sprint-mode.md
@@ -127,11 +127,24 @@ handle alone, spread across four duplicated prop bags, and the repo's coverage
 config excludes `src/components/**/*.tsx`. Logic-first keeps the testable part
 testable (Golden Rule 3).
 
-- **PR 1 — model + validation + wire format (this PR).** All in `src/lib` and
+- ~~**PR 1 — model + validation + wire format.**~~ **Done** (#375). All in `src/lib` and
   `src/types`, all unit-tested, no UI. Nothing user-visible yet; it is the
   foundation the other three stand on.
-- **PR 2 — editor.** `LineId` gains a `'finish'` variant, the finish handle,
-  the sprint/circuit toggle, and the four prop bags.
+- ~~**PR 2 — editor.**~~ **Done.** `LineId` gained a `'finish'` variant, the
+  red finish handle (rendered last — driving order), the `CourseTypeToggle`,
+  the Finish row in `SectorListEditor`, and sprint state in
+  `useTrackEditorForm`. Two notes on what landed:
+  - The type picker is **create-only**. Retyping a course that already has
+    geometry would silently invalidate it, so editing keeps the saved type.
+  - `TrackPromptDialog` and the admin `CoursesTab` were left circuit-only.
+    Both keep their own copy of the editor state, and `courseType` defaults to
+    `'circuit'`, so they compile and behave exactly as before. Community
+    submission of sprint courses is already out of scope (see below), and the
+    log-import prompt can follow once the runs view exists.
+  - The save-time fork moved out of the hook into
+    `sprintCourse.finalizeCourseForSave` so it is unit-testable — this repo's
+    coverage config excludes `src/components/**/*.tsx` by design, so logic in
+    a `.tsx` is logic that cannot be tested.
 - **PR 3 — device sync.** `TS*` opcodes in `trackSync.ts`, sprint awareness in
   `deviceTrackSync.ts`'s merge, `DeviceTracksTab` UI. Note `MergedTrackEntry`
   keys on `shortName` alone today, so a sprint and a circuit track sharing a

--- a/src/components/TrackEditor.tsx
+++ b/src/components/TrackEditor.tsx
@@ -426,9 +426,12 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     startFinishA: form.visualEditorStartFinishA,
     startFinishB: form.visualEditorStartFinishB,
     sectors: form.formSectors,
+    courseType: form.formCourseType,
+    finish: form.formFinish,
     selectedLine: form.selectedLine,
     onSelectLine: form.setSelectedLine,
     onStartFinishChange: form.handleVisualStartFinishChange,
+    onFinishChange: form.handleVisualFinishChange,
     onSectorLineChange: form.handleVisualSectorLineChange,
     onAddSector: form.addSector,
     onRemoveSector: form.removeSector,
@@ -436,11 +439,24 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     onReorder: form.reorderSectors,
   } as const;
 
-  // Save is blocked unless the sector layout is valid (0 sectors or 3 majors).
+  // The type picker is offered only when creating a course. Retyping one that
+  // already has geometry would silently invalidate it — a circuit's three
+  // majors are not a sprint's splits — so editing keeps the type it was saved
+  // with.
+  const courseTypeProps = {
+    courseType: form.formCourseType,
+    onCourseTypeChange: form.setFormCourseType,
+  } as const;
+
+  // Save is blocked unless the line layout is valid for the course type:
+  // circuit wants 0 sectors or 3 majors, sprint wants a finish line and at most
+  // MAX_SPRINT_SPLITS splits.
   const sectorsValid = validateCourseSectors({
     name: form.formCourseName,
+    type: form.formCourseType,
     startFinishA: form.visualEditorStartFinishA ?? { lat: 0, lon: 0 },
     startFinishB: form.visualEditorStartFinishB ?? { lat: 0, lon: 0 },
+    finish: form.formFinish ?? undefined,
     sectors: form.formSectors,
   }).valid;
 
@@ -458,6 +474,7 @@ function CourseDrawingMini({ points, size = 36 }: { points: Array<{ lat: number;
     onSubmit: handleAddCourse,
     onCancel: () => { setIsAddCourseOpen(false); form.resetForm(); },
     ...sectorEditorProps,
+    ...courseTypeProps,
     layoutPoints: form.formLayout,
     onLayoutChange: form.handleVisualLayoutChange,
     laps,

--- a/src/components/track-editor/AddCourseDialog.tsx
+++ b/src/components/track-editor/AddCourseDialog.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/components/ui/dialog';
 import type { GpsPoint } from './VisualEditor';
 import type { SelectedLine } from '@/hooks/useTrackEditorForm';
-import type { CourseSector, SectorLine, Lap, GpsSample } from '@/types/racing';
+import type { CourseSector, CourseType, SectorLine, Lap, GpsSample } from '@/types/racing';
+import { CourseTypeToggle } from './CourseTypeToggle';
 
 // Lazy — CourseSectorEditor pulls in the Leaflet drawing map + the dnd-kit
 // sector list, neither of which belongs in the eager landing bundle.
@@ -32,9 +33,13 @@ interface AddCourseDialogProps {
   startFinishA: GpsPoint | null;
   startFinishB: GpsPoint | null;
   sectors: CourseSector[];
+  courseType?: CourseType;
+  onCourseTypeChange?: (type: CourseType) => void;
+  finish?: SectorLine | null;
   selectedLine: SelectedLine;
   onSelectLine: (id: SelectedLine) => void;
   onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
+  onFinishChange?: (line: SectorLine) => void;
   onSectorLineChange: (index: number, line: SectorLine) => void;
   onAddSector: (insertIndex?: number, center?: GpsPoint) => void;
   onRemoveSector: (index: number) => void;
@@ -52,8 +57,10 @@ export function AddCourseDialog({
   open, onOpenChange,
   courseName, onCourseNameChange, canSubmit,
   onSubmit, onCancel,
-  startFinishA, startFinishB, sectors, selectedLine, onSelectLine,
-  onStartFinishChange, onSectorLineChange,
+  startFinishA, startFinishB, sectors,
+  courseType = 'circuit', onCourseTypeChange, finish = null,
+  selectedLine, onSelectLine,
+  onStartFinishChange, onFinishChange, onSectorLineChange,
   onAddSector, onRemoveSector, onToggleMajor, onReorder,
   initialCenter,
   layoutPoints, onLayoutChange, laps, samples,
@@ -67,14 +74,20 @@ export function AddCourseDialog({
           <DialogTitle>{t('addCourse.title')}</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
+          {onCourseTypeChange && (
+            <CourseTypeToggle value={courseType} onChange={onCourseTypeChange} />
+          )}
           <Suspense fallback={null}>
           <CourseSectorEditor
             startFinishA={startFinishA}
             startFinishB={startFinishB}
             sectors={sectors}
+            courseType={courseType}
+            finish={finish}
             selectedLine={selectedLine}
             onSelectLine={onSelectLine}
             onStartFinishChange={onStartFinishChange}
+            onFinishChange={onFinishChange}
             onSectorLineChange={onSectorLineChange}
             onAddSector={onAddSector}
             onRemoveSector={onRemoveSector}

--- a/src/components/track-editor/CourseSectorEditor.tsx
+++ b/src/components/track-editor/CourseSectorEditor.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useMemo, useRef } from 'react';
-import { Course, CourseSector, SectorLine, Lap, GpsSample } from '@/types/racing';
+import { Course, CourseSector, CourseType, SectorLine, Lap, GpsSample } from '@/types/racing';
 import { centeredSectorLine } from '@/lib/courseSectors';
 import { SectorListEditor } from './SectorListEditor';
 import type { GpsPoint, LineId } from './VisualEditor';
@@ -11,9 +11,14 @@ interface CourseSectorEditorProps {
   startFinishA: GpsPoint | null;
   startFinishB: GpsPoint | null;
   sectors: CourseSector[];
+  /** Timing model of the course being edited. Defaults to circuit. */
+  courseType?: CourseType;
+  /** Sprint only: the separate finish line. */
+  finish?: SectorLine | null;
   selectedLine: SelectedLine;
   onSelectLine: (id: SelectedLine) => void;
   onStartFinishChange: (a: GpsPoint, b: GpsPoint) => void;
+  onFinishChange?: (line: SectorLine) => void;
   onSectorLineChange: (index: number, line: SectorLine) => void;
   /** Add a sector; `center` (when provided) is the live map view center so the
    *  new line drops in the middle of what the user is looking at. */
@@ -37,8 +42,9 @@ interface CourseSectorEditorProps {
  * the control surface — selecting a row puts that line into drag-edit on the map.
  */
 export function CourseSectorEditor({
-  startFinishA, startFinishB, sectors, selectedLine, onSelectLine,
-  onStartFinishChange, onSectorLineChange,
+  startFinishA, startFinishB, sectors, courseType = 'circuit', finish = null,
+  selectedLine, onSelectLine,
+  onStartFinishChange, onFinishChange, onSectorLineChange,
   onAddSector, onRemoveSector, onToggleMajor, onReorder,
   isNewTrack, initialCenter, showDrawTool, showKnownDrawingToggle,
   layoutPoints, onLayoutChange, laps, samples,
@@ -58,6 +64,16 @@ export function CourseSectorEditor({
     onSelectLine('sf');
   }, [onStartFinishChange, onSelectLine]);
 
+  const isSprint = courseType === 'sprint';
+
+  // Re-drop the finish line at the current view center (sprint only).
+  const handleResetFinish = useCallback(() => {
+    const center = viewCenterRef.current;
+    if (!center || !onFinishChange) return;
+    onFinishChange(centeredSectorLine(center));
+    onSelectLine('finish');
+  }, [onFinishChange, onSelectLine]);
+
   // Selecting a line that has no geometry yet — the start/finish on a brand-new
   // course — drops one at the current view center instead of selecting an empty
   // line, so a tap is enough and the user never has to hunt for the reset button.
@@ -72,10 +88,12 @@ export function CourseSectorEditor({
   // Minimal course for the list's labels + validation (coords unused there).
   const course = useMemo<Course>(() => ({
     name: '',
+    type: courseType,
     startFinishA: startFinishA ?? { lat: 0, lon: 0 },
     startFinishB: startFinishB ?? { lat: 0, lon: 0 },
+    finish: finish ?? undefined,
     sectors,
-  }), [startFinishA, startFinishB, sectors]);
+  }), [courseType, startFinishA, startFinishB, finish, sectors]);
 
   return (
     <div className="space-y-3">
@@ -84,9 +102,12 @@ export function CourseSectorEditor({
           startFinishA={startFinishA}
           startFinishB={startFinishB}
           sectors={sectors}
+          finish={finish}
+          isSprint={isSprint}
           selectedLine={selectedLine as LineId | null}
           onSelectLine={handleSelectLine}
           onStartFinishChange={onStartFinishChange}
+          onFinishChange={onFinishChange}
           onSectorLineChange={onSectorLineChange}
           isNewTrack={isNewTrack}
           initialCenter={initialCenter}
@@ -109,6 +130,7 @@ export function CourseSectorEditor({
         onToggleMajor={onToggleMajor}
         onReorder={onReorder}
         onResetStartFinish={isNewTrack ? handleResetStartFinish : undefined}
+        onResetFinish={isSprint && onFinishChange ? handleResetFinish : undefined}
       />
     </div>
   );

--- a/src/components/track-editor/CourseTypeToggle.tsx
+++ b/src/components/track-editor/CourseTypeToggle.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next';
+import { Flag, MoveRight } from 'lucide-react';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import type { CourseType } from '@/types/racing';
+
+interface CourseTypeToggleProps {
+  value: CourseType;
+  onChange: (type: CourseType) => void;
+  /**
+   * Locks the control. Changing the type of a course that already has geometry
+   * would silently invalidate it (a circuit's three majors are not a sprint's
+   * splits, and vice versa), so callers editing an existing course pass this.
+   */
+  disabled?: boolean;
+}
+
+/**
+ * Circuit vs sprint picker for the course editor.
+ *
+ * This is the primary signal for the whole sprint feature — the `race_mode`
+ * device setting is only the tiebreak when both kinds of track are in range of
+ * the logger at once. See `docs/plans/0015-sprint-mode.md`.
+ */
+export function CourseTypeToggle({ value, onChange, disabled = false }: CourseTypeToggleProps) {
+  const { t } = useTranslation('tracks');
+
+  const option = (type: CourseType, Icon: typeof Flag, label: string, hint: string) => {
+    const selected = value === type;
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={selected}
+        onClick={() => onChange(type)}
+        className={cn(
+          'flex-1 rounded-md border px-3 py-2 text-left transition-colors',
+          selected ? 'border-primary bg-primary/10' : 'border-border bg-card hover:bg-accent/40',
+          disabled && 'cursor-not-allowed opacity-60',
+        )}
+      >
+        <span className="flex items-center gap-1.5 text-sm font-semibold">
+          <Icon className="h-4 w-4 shrink-0" />
+          {label}
+        </span>
+        <span className="mt-0.5 block text-xs text-muted-foreground">{hint}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <Label>{t('addCourse.courseType')}</Label>
+      <div className="flex gap-2">
+        {option('circuit', Flag, t('addCourse.typeCircuit'), t('addCourse.typeCircuitHint'))}
+        {option('sprint', MoveRight, t('addCourse.typeSprint'), t('addCourse.typeSprintHint'))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/track-editor/SectorListEditor.tsx
+++ b/src/components/track-editor/SectorListEditor.tsx
@@ -13,9 +13,10 @@ import { Flag, GripVertical, Plus, RotateCcw, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
-import { CourseSector, Course } from '@/types/racing';
+import { CourseSector, Course, isSprintCourse } from '@/types/racing';
 import {
-  sectorLabels, validateCourseSectors, isAtSectorLimit, isAtMajorLimit, MAX_SECTOR_LINES,
+  sectorLabels, validateCourseSectors, isAtSectorLimit, isAtMajorLimit,
+  MAX_SECTOR_LINES, MAX_SPRINT_SPLITS,
 } from '@/lib/courseSectors';
 import type { SelectedLine } from '@/hooks/useTrackEditorForm';
 
@@ -32,6 +33,8 @@ interface SectorListEditorProps {
   /** Re-drop the start/finish line in the center of the current map view.
    *  Drives the reset button on the start/finish row. */
   onResetStartFinish?: () => void;
+  /** Re-drop the sprint finish line. Drives the reset button on its row. */
+  onResetFinish?: () => void;
 }
 
 function sortableId(index: number): string {
@@ -43,12 +46,15 @@ function indexFromId(id: string): number {
 
 export function SectorListEditor({
   course, sectors, selectedLine, onSelectLine, onAddSector, onRemoveSector, onToggleMajor, onReorder,
-  onResetStartFinish,
+  onResetStartFinish, onResetFinish,
 }: SectorListEditorProps) {
   const { t } = useTranslation('tracks');
   const labels = useMemo(() => sectorLabels(course), [course]);
   const validation = useMemo(() => validateCourseSectors(course), [course]);
-  const atLimit = isAtSectorLimit(course);
+  const sprint = isSprintCourse(course);
+  // Sprint caps the splits far lower than the circuit line budget, and has no
+  // major concept at all.
+  const atLimit = sprint ? sectors.length >= MAX_SPRINT_SPLITS : isAtSectorLimit(course);
   // Once all three majors are taken, only existing majors keep their toggle (so
   // they can be un-flagged); non-major rows hide it since none can be promoted.
   const atMajorLimit = isAtMajorLimit(course);
@@ -97,9 +103,11 @@ export function SectorListEditor({
         <span className="w-4" />
         <Flag className="h-4 w-4 shrink-0" style={{ color: '#22c55e' }} />
         <button type="button" onClick={() => onSelectLine('sf')} className="flex-1 text-left text-sm font-semibold">
-          {t('sectors.startFinish', { label: labels[0] })}
+          {sprint ? t('sectors.startLineSprint') : t('sectors.startFinish', { label: labels[0] })}
         </button>
-        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">{t('sectors.major')}</span>
+        {!sprint && (
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">{t('sectors.major')}</span>
+        )}
         {onResetStartFinish && (
           <Button
             variant="ghost"
@@ -124,12 +132,14 @@ export function SectorListEditor({
               <div key={sortableId(i)} className="space-y-1.5">
                 <SectorRow
                   index={i}
-                  label={labels[i + 1] ?? ''}
+                  label={sprint ? String(i + 1) : (labels[i + 1] ?? '')}
+                  labelKey={sprint ? 'sectors.splitRow' : 'sectors.sectorRow'}
                   sector={sec}
                   selected={selectedLine === i}
                   // Hide the major toggle on non-major rows once the 3-major cap
                   // is hit; major rows always keep it so they can be un-flagged.
-                  showMajorToggle={sec.major || !atMajorLimit}
+                  // Sprint has no majors at all.
+                  showMajorToggle={!sprint && (sec.major || !atMajorLimit)}
                   onSelect={() => onSelectLine(i)}
                   onToggleMajor={() => onToggleMajor(i)}
                   onRemove={() => onRemoveSector(i)}
@@ -141,18 +151,52 @@ export function SectorListEditor({
         </SortableContext>
       </DndContext>
 
+      {/* Sprint only: the finish line, LAST because that is driving order. */}
+      {sprint && (
+        <div
+          className={cn(
+            'flex w-full items-center gap-2 rounded-md border px-2 py-2 text-left transition-colors',
+            selectedLine === 'finish' ? 'border-primary bg-primary/10' : 'border-border bg-card hover:bg-accent/40',
+          )}
+        >
+          <span className="w-4" />
+          <Flag className="h-4 w-4 shrink-0" style={{ color: '#ef4444' }} />
+          <button
+            type="button"
+            onClick={() => onSelectLine('finish')}
+            className="flex-1 text-left text-sm font-semibold"
+          >
+            {t('sectors.finishLine')}
+          </button>
+          {onResetFinish && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              aria-label={t('sectors.resetFinish')}
+              title={t('sectors.resetFinish')}
+              onClick={onResetFinish}
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      )}
+
       {/* Validation / guidance note (kept off the line items per the spec). */}
       {!validation.valid && validation.reason && (
         <p className="pt-1 text-xs text-warning">{validation.reason}</p>
       )}
       {atLimit && (
         <p className="pt-1 text-xs text-muted-foreground">
-          {t('sectors.limitReached', { max: MAX_SECTOR_LINES })}
+          {sprint
+            ? t('sectors.sprintSplitLimit', { max: MAX_SPRINT_SPLITS })
+            : t('sectors.limitReached', { max: MAX_SECTOR_LINES })}
         </p>
       )}
       {validation.valid && sectors.length === 0 && (
         <p className="pt-1 text-xs text-muted-foreground">
-          {t('sectors.guidance')}
+          {sprint ? t('sectors.sprintGuidance', { max: MAX_SPRINT_SPLITS }) : t('sectors.guidance')}
         </p>
       )}
     </div>
@@ -162,6 +206,8 @@ export function SectorListEditor({
 interface SectorRowProps {
   index: number;
   label: string;
+  /** i18n key for the row title — sprint rows read "Split n", circuit "Sector n". */
+  labelKey: 'sectors.sectorRow' | 'sectors.splitRow';
   sector: CourseSector;
   selected: boolean;
   /** Whether the "major" toggle is shown — hidden on non-major rows once the
@@ -172,7 +218,7 @@ interface SectorRowProps {
   onRemove: () => void;
 }
 
-function SectorRow({ index, label, sector, selected, showMajorToggle, onSelect, onToggleMajor, onRemove }: SectorRowProps) {
+function SectorRow({ index, label, labelKey, sector, selected, showMajorToggle, onSelect, onToggleMajor, onRemove }: SectorRowProps) {
   const { t } = useTranslation('tracks');
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: sortableId(index) });
   const style = { transform: CSS.Transform.toString(transform), transition };
@@ -200,7 +246,7 @@ function SectorRow({ index, label, sector, selected, showMajorToggle, onSelect, 
       </button>
       <span className="h-3 w-3 shrink-0 rounded-full" style={{ background: color }} />
       <button type="button" onClick={onSelect} className="flex-1 text-left text-sm">
-        {t('sectors.sectorRow', { label })}
+        {t(labelKey, { label })}
       </button>
       {showMajorToggle && (
         <label className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">

--- a/src/components/track-editor/VisualEditor.tsx
+++ b/src/components/track-editor/VisualEditor.tsx
@@ -24,23 +24,42 @@ export interface GpsPoint {
   lon: number;
 }
 
-/** Identifies an editable timing line: 'sf' = start/finish, number = sectors[index]. */
-export type LineId = 'sf' | number;
+/**
+ * Identifies an editable timing line.
+ * - `'sf'` — start/finish on a circuit, the start line on a sprint course
+ * - `number` — `sectors[index]`
+ * - `'finish'` — the separate finish line, sprint courses only
+ */
+export type LineId = 'sf' | 'finish' | number;
 
-// Line colors: start/finish green, major sectors purple, sub-sectors sky-blue.
+// Line colors: start/finish green, major sectors purple, sub-sectors sky-blue,
+// and — sprint only — the separate finish line in red. Green-to-red reads as
+// start-to-end, which is the whole point of a point-to-point course.
 const COLOR_SF = '#22c55e';
 const COLOR_MAJOR = '#a855f7';
 const COLOR_SUB = '#38bdf8';
+const COLOR_FINISH = '#ef4444';
 
 interface VisualEditorProps {
   startFinishA: GpsPoint | null;
   startFinishB: GpsPoint | null;
   /** Ordered sector lines after start/finish. */
   sectors: CourseSector[];
+  /**
+   * Sprint courses only: the separate finish line. When set, the editor grows a
+   * fourth handle rendered after the sectors, since it is last in driving order.
+   */
+  finish?: SectorLine | null;
+  /**
+   * True when the course being edited is point-to-point. Drives the finish-line
+   * auto-drop; the finish handle itself only appears once `finish` is set.
+   */
+  isSprint?: boolean;
   /** Currently-selected line (controlled by the sector list), or null. */
   selectedLine: LineId | null;
   onSelectLine?: (id: LineId | null) => void;
   onStartFinishChange?: (a: GpsPoint, b: GpsPoint) => void;
+  onFinishChange?: (line: SectorLine) => void;
   onSectorLineChange?: (index: number, line: SectorLine) => void;
   isNewTrack?: boolean;
   /** Initial map center from loaded GPS data */
@@ -210,8 +229,9 @@ function VisualEditorToolbar({ drawMode, onToggleDraw, showDrawTool, drawPointCo
 }
 
 export function VisualEditor({
-  startFinishA, startFinishB, sectors, selectedLine, onSelectLine,
-  onStartFinishChange, onSectorLineChange,
+  startFinishA, startFinishB, sectors, finish = null, isSprint = false,
+  selectedLine, onSelectLine,
+  onStartFinishChange, onFinishChange, onSectorLineChange,
   isNewTrack = false, initialCenter: initialCenterProp = null,
   showDrawTool = false, layoutPoints: layoutPointsProp, showKnownDrawingToggle = false, onLayoutChange,
   laps, samples, viewCenterRef,
@@ -283,6 +303,7 @@ export function VisualEditor({
   // Color for a given line id.
   const colorFor = useCallback((id: LineId): string => {
     if (id === 'sf') return COLOR_SF;
+    if (id === 'finish') return COLOR_FINISH;
     return sectors[id]?.major ? COLOR_MAJOR : COLOR_SUB;
   }, [sectors]);
 
@@ -293,12 +314,18 @@ export function VisualEditor({
       if (startFinishA && startFinishB) return { a: startFinishA, b: startFinishB };
       return null;
     }
+    if (id === 'finish') return finish ? { a: finish.a, b: finish.b } : null;
     const sec = sectors[id];
     return sec ? { a: sec.line.a, b: sec.line.b } : null;
-  }, [pendingLine, startFinishA, startFinishB, sectors]);
+  }, [pendingLine, startFinishA, startFinishB, finish, sectors]);
 
-  // All line ids in course order (start/finish first).
-  const allLineIds = useMemo<LineId[]>(() => ['sf', ...sectors.map((_, i) => i)], [sectors]);
+  // All line ids in DRIVING order: start, then the splits, then — on a sprint
+  // course — the finish. The finish is last because that is the order a driver
+  // crosses them, and the same order the list editor renders.
+  const allLineIds = useMemo<LineId[]>(
+    () => ['sf', ...sectors.map((_, i) => i), ...(finish ? (['finish'] as LineId[]) : [])],
+    [sectors, finish],
+  );
 
   // For a brand-new course the start/finish line has no coordinates yet, so it
   // can't be rendered or dragged. Drop it in the center of the chosen view — when
@@ -311,6 +338,18 @@ export function VisualEditor({
     onStartFinishChange?.(line.a, line.b);
     onSelectLineRef.current?.('sf');
   }, [isNewTrack, startFinishA, startFinishB, onStartFinishChange]);
+
+  // A sprint course is unsavable without a finish line, so drop one as soon as
+  // the course is typed sprint rather than making the user hunt for a button.
+  // It lands north of start/finish (same fan-out as a new sector) so the two
+  // don't sit on top of each other; the user drags it to the real finish.
+  useEffect(() => {
+    if (!isSprint || finish || !onFinishChange) return;
+    if (!startFinishA || !startFinishB) return;   // wait for a start line to offset from
+    const midLat = (startFinishA.lat + startFinishB.lat) / 2;
+    const midLon = (startFinishA.lon + startFinishB.lon) / 2;
+    onFinishChange(centeredSectorLine({ lat: midLat + 0.0009, lon: midLon }));
+  }, [isSprint, finish, onFinishChange, startFinishA, startFinishB]);
 
   // Location search using Nominatim
   const handleLocationSearch = useCallback(async () => {
@@ -452,6 +491,7 @@ export function VisualEditor({
         // Save immediately on release — no separate "Done" step.
         setPendingLine({ id, coords: { a: newA, b: newB } });
         if (id === 'sf') onStartFinishChange?.(newA, newB);
+        else if (id === 'finish') onFinishChange?.({ a: newA, b: newB });
         else onSectorLineChange?.(id, { a: newA, b: newB });
       });
 
@@ -461,7 +501,7 @@ export function VisualEditor({
     const markerA = createMarker(coords.a, true);
     const markerB = createMarker(coords.b, false);
     markersRef.current = [markerA, markerB];
-  }, [colorFor, onStartFinishChange, onSectorLineChange]);
+  }, [colorFor, onStartFinishChange, onFinishChange, onSectorLineChange]);
 
   // --- Draw mode helpers ---
   const updateDrawPolyline = useCallback((points: Array<{ lat: number; lon: number }>) => {
@@ -738,7 +778,12 @@ export function VisualEditor({
         : t('visual.drawPoints', { count: drawPoints.length });
     }
     if (selectedLine === null) return '';
-    const name = selectedLine === 'sf' ? t('visual.startFinishLine') : t('sectors.sectorRow', { label: labels[selectedLine + 1] ?? '' });
+    // labels[0] is the start/finish line, so sectors[i] is labels[i + 1]. The
+    // finish line is not in that array at all — it is not a sector.
+    const name =
+      selectedLine === 'sf' ? (isSprint ? t('visual.startLine') : t('visual.startFinishLine'))
+      : selectedLine === 'finish' ? t('visual.finishLine')
+      : t('sectors.sectorRow', { label: labels[selectedLine + 1] ?? '' });
     const coords = coordsFor(selectedLine);
     if (!coords) return t('visual.noLineDefined', { name });
     return t('visual.dragMarkers', { name });

--- a/src/hooks/useTrackEditorForm.ts
+++ b/src/hooks/useTrackEditorForm.ts
@@ -1,11 +1,18 @@
 import { useState, useCallback } from 'react';
-import { Course, CourseSector, SectorLine } from '@/types/racing';
+import { Course, CourseSector, CourseType, SectorLine } from '@/types/racing';
 import { deriveShortName, MAX_SHORT_NAME_LENGTH } from '@/lib/trackUtils';
-import { normalizeCourseSectors, isAtSectorLimit, centeredSectorLine, MAX_MAJOR_SECTORS } from '@/lib/courseSectors';
+import {
+  normalizeCourseSectors, isAtSectorLimit, centeredSectorLine,
+  MAX_MAJOR_SECTORS, MAX_SPRINT_SPLITS,
+} from '@/lib/courseSectors';
+import { finalizeCourseForSave } from '@/lib/sprintCourse';
 import type { GpsPoint } from '@/components/track-editor/VisualEditor';
 
-/** Selection in the visual editor: 'sf' = start/finish, a number = sectors[index]. */
-export type SelectedLine = 'sf' | number | null;
+/**
+ * Selection in the visual editor: 'sf' = start/finish (the start line on a
+ * sprint course), a number = sectors[index], 'finish' = the sprint finish line.
+ */
+export type SelectedLine = 'sf' | 'finish' | number | null;
 
 export function useTrackEditorForm() {
   const [formTrackName, setFormTrackName] = useState('');
@@ -20,6 +27,13 @@ export function useTrackEditorForm() {
   const [formLonB, setFormLonB] = useState('');
   // Ordered sector lines after start/finish (canonical model).
   const [formSectors, setFormSectors] = useState<CourseSector[]>([]);
+  // Timing model. Circuit is the default; sprint adds the separate finish line
+  // below and switches the save rules (see validateCourseSectors).
+  const [formCourseType, setFormCourseType] = useState<CourseType>('circuit');
+  const [formFinish, setFormFinish] = useState<SectorLine | null>(null);
+  // Preserved across edits so revising a course can't make it jump the queue on
+  // the device, which loads the NEWEST sprint course by this stamp.
+  const [formDateCreated, setFormDateCreated] = useState<string | undefined>(undefined);
   // Which line the map is currently editing (driven by the sector list).
   const [selectedLine, setSelectedLine] = useState<SelectedLine>(null);
   // The drawn/generated course outline (polyline). Travels into the created
@@ -32,6 +46,9 @@ export function useTrackEditorForm() {
     setFormCourseName('');
     setFormLatA(''); setFormLonA(''); setFormLatB(''); setFormLonB('');
     setFormSectors([]);
+    setFormCourseType('circuit');
+    setFormFinish(null);
+    setFormDateCreated(undefined);
     setSelectedLine(null);
     setFormLayout([]);
   }, []);
@@ -62,9 +79,18 @@ export function useTrackEditorForm() {
     };
     if (formSectors.length > 0) course.sectors = formSectors;
     if (formLayout.length >= 2) course.layout = formLayout;
-    // Normalize so the legacy mirror (sector2/sector3) is written alongside.
-    return normalizeCourseSectors(course);
-  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSectors, formLayout]);
+
+    if (formCourseType === 'sprint') {
+      course.type = 'sprint';
+      if (formFinish) course.finish = formFinish;
+      if (formDateCreated) course.dateCreated = formDateCreated;
+    }
+
+    // Branches on the type: circuit normalizes (writing the legacy
+    // sector2/sector3 mirror alongside), sprint stamps date_created instead.
+    return finalizeCourseForSave(course);
+  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSectors, formLayout,
+      formCourseType, formFinish, formDateCreated]);
 
   const openEditCourse = useCallback((trackName: string, course: Course) => {
     const norm = normalizeCourseSectors(course);
@@ -76,6 +102,9 @@ export function useTrackEditorForm() {
     setFormLatB(course.startFinishB.lat.toString());
     setFormLonB(course.startFinishB.lon.toString());
     setFormSectors(norm.sectors ?? []);
+    setFormCourseType(course.type ?? 'circuit');
+    setFormFinish(course.finish ?? null);
+    setFormDateCreated(course.dateCreated);
     setSelectedLine(null);
     setFormLayout(course.layout ?? []);
   }, []);
@@ -95,21 +124,26 @@ export function useTrackEditorForm() {
       startFinishB: { lat: parseFloat(formLatB), lon: parseFloat(formLonB) },
       sectors: formSectors,
     };
-    if (isAtSectorLimit(course)) return;
+    const isSprint = formCourseType === 'sprint';
+    if (isSprint ? formSectors.length >= MAX_SPRINT_SPLITS : isAtSectorLimit(course)) return;
     const line = center
       ? centeredSectorLine(center)
       : defaultSectorLine(formLatA, formLonA, formLatB, formLonB, formSectors.length);
     const at = insertIndex === undefined ? formSectors.length : Math.max(0, Math.min(insertIndex, formSectors.length));
-    // Default a new line to "major" while there's still room under the cap
-    // (start/finish is the implicit first major, so MAX_MAJOR_SECTORS - 1 more
-    // are allowed). This makes the common 3-sector course valid after just two
-    // adds with no Major toggling; further lines default to sub-sectors, which
-    // the user can promote if needed.
+    // Circuit: default a new line to "major" while there's still room under the
+    // cap (start/finish is the implicit first major, so MAX_MAJOR_SECTORS - 1
+    // more are allowed). This makes the common 3-sector course valid after just
+    // two adds with no Major toggling; further lines default to sub-sectors,
+    // which the user can promote if needed.
+    //
+    // Sprint: never flag a split. `major` has no meaning point-to-point, and
+    // flagging would let a course retyped to circuit silently look like a valid
+    // three-major layout it never had.
     const flaggedMajors = formSectors.filter((s) => s.major).length;
-    const major = flaggedMajors < MAX_MAJOR_SECTORS - 1;
+    const major = !isSprint && flaggedMajors < MAX_MAJOR_SECTORS - 1;
     setFormSectors([...formSectors.slice(0, at), { line, major }, ...formSectors.slice(at)]);
     setSelectedLine(at);
-  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSectors]);
+  }, [formCourseName, formLatA, formLonA, formLatB, formLonB, formSectors, formCourseType]);
 
   const removeSector = useCallback((index: number) => {
     setFormSectors((prev) => prev.filter((_, i) => i !== index));
@@ -140,6 +174,10 @@ export function useTrackEditorForm() {
     setFormLonB(b.lon.toString());
   }, []);
 
+  const handleVisualFinishChange = useCallback((line: SectorLine) => {
+    setFormFinish(line);
+  }, []);
+
   const handleVisualSectorLineChange = useCallback((index: number, line: SectorLine) => {
     setFormSectors((prev) => prev.map((s, i) => (i === index ? { ...s, line } : s)));
   }, []);
@@ -160,6 +198,9 @@ export function useTrackEditorForm() {
     formCourseName, setFormCourseName,
     formLatA, formLonA, formLatB, formLonB,
     formSectors,
+    formCourseType, setFormCourseType,
+    formFinish, setFormFinish,
+    formDateCreated,
     selectedLine, setSelectedLine,
     formLayout,
     editingCourse, setEditingCourse,
@@ -171,6 +212,7 @@ export function useTrackEditorForm() {
     toggleSectorMajor,
     reorderSectors,
     handleVisualStartFinishChange,
+    handleVisualFinishChange,
     handleVisualSectorLineChange,
     handleVisualLayoutChange,
     visualEditorStartFinishA,

--- a/src/lib/sprintCourse.test.ts
+++ b/src/lib/sprintCourse.test.ts
@@ -6,6 +6,7 @@ import {
   stampSprintDateCreated,
   newestSprintCourse,
   newestSprintCourseIndex,
+  finalizeCourseForSave,
 } from './sprintCourse';
 
 function sprint(name: string, dateCreated?: string): Course {
@@ -150,5 +151,43 @@ describe('newestSprintCourseIndex', () => {
   it('keeps the earlier course on a tie', () => {
     const courses = [sprint('First', '2026-09-05T08:00'), sprint('Second', '2026-09-05T08:00')];
     expect(newestSprintCourseIndex(courses)).toBe(0);
+  });
+});
+
+describe('finalizeCourseForSave', () => {
+  const split = { a: { lat: 2, lon: 0 }, b: { lat: 2, lon: 1 } };
+
+  it('normalizes a circuit course, writing the legacy mirror', () => {
+    const c: Course = {
+      ...circuit('Full Course'),
+      sectors: [
+        { line: { a: { lat: 1, lon: 0 }, b: { lat: 1, lon: 1 } }, major: true },
+        { line: split, major: true },
+      ],
+    };
+    const out = finalizeCourseForSave(c);
+    expect(out.sector2).toBeDefined();
+    expect(out.sector3).toEqual(split);
+  });
+
+  it('stamps a sprint course instead of normalizing it', () => {
+    const out = finalizeCourseForSave(sprint('Run 1'), new Date(2026, 8, 5, 7, 3));
+    expect(out.dateCreated).toBe('2026-09-05T07:03');
+  });
+
+  it('never writes a legacy mirror for a sprint course', () => {
+    // The mirror is derived from MAJORS, and sprint splits are unflagged, so
+    // normalizing would emit an empty mirror and imply a sector layout the
+    // course does not have.
+    const c: Course = { ...sprint('Run 1', '2026-09-05T07:03'), sectors: [{ line: split, major: false }] };
+    const out = finalizeCourseForSave(c);
+    expect(out.sector2).toBeUndefined();
+    expect(out.sector3).toBeUndefined();
+    expect(out.sectors).toEqual([{ line: split, major: false }]);
+  });
+
+  it('keeps a sprint course\'s splits unflagged', () => {
+    const c: Course = { ...sprint('Run 1'), sectors: [{ line: split, major: false }] };
+    expect(finalizeCourseForSave(c).sectors!.every((x) => !x.major)).toBe(true);
   });
 });

--- a/src/lib/sprintCourse.ts
+++ b/src/lib/sprintCourse.ts
@@ -14,6 +14,7 @@
  */
 
 import { Course, isSprintCourse } from '@/types/racing';
+import { normalizeCourseSectors } from '@/lib/courseSectors';
 
 /**
  * `YYYY-MM-DDTHH:MM` — sortable as a plain string, minute precision, local
@@ -98,4 +99,22 @@ export function newestSprintCourseIndex(courses: readonly Course[]): number {
 export function newestSprintCourse(courses: readonly Course[]): Course | undefined {
   const i = newestSprintCourseIndex(courses);
   return i === -1 ? undefined : courses[i];
+}
+
+/**
+ * Final pass over a course on its way to storage, branching on the timing model.
+ *
+ * Circuit courses are normalized so the legacy `sector2`/`sector3` mirror is
+ * written alongside the canonical array, exactly as before.
+ *
+ * Sprint courses deliberately **skip** that normalization. The mirror is derived
+ * from flagged MAJORS, and sprint splits are stored unflagged — normalizing
+ * would write an empty mirror and imply a sector layout the course does not
+ * have. Their splits reach the device positionally instead (see
+ * `deviceTrackSync.deviceSectorProjection`). They are stamped with a
+ * `date_created` here if they do not already carry one.
+ */
+export function finalizeCourseForSave(course: Course, now: Date = new Date()): Course {
+  if (!isSprintCourse(course)) return normalizeCourseSectors(course);
+  return stampSprintDateCreated(course, now);
 }

--- a/src/locales/de/tracks.json
+++ b/src/locales/de/tracks.json
@@ -15,7 +15,12 @@
     "title": "Neuen Kurs hinzufügen",
     "courseName": "Kursname",
     "courseNamePlaceholder": "z. B. Vollständiger Kurs",
-    "create": "Kurs erstellen"
+    "create": "Kurs erstellen",
+    "courseType": "Kursart",
+    "typeCircuit": "Rundkurs",
+    "typeSprint": "Sprint",
+    "typeCircuitHint": "Runden — eine Linie ist zugleich Start und Ziel.",
+    "typeSprintHint": "Punkt zu Punkt (Autocross, Bergrennen, Wertungsprüfung) — separate Ziellinie, als Läufe gewertet."
   },
   "sectors": {
     "addSector": "Sektor hinzufügen",
@@ -27,7 +32,13 @@
     "dragReorder": "Zum Umordnen ziehen",
     "markMajor": "Als Hauptsektor markieren",
     "deleteSector": "Sektor löschen",
-    "resetStartFinish": "Start-/Ziellinie zurücksetzen"
+    "resetStartFinish": "Start-/Ziellinie zurücksetzen",
+    "startLineSprint": "Startlinie",
+    "finishLine": "Ziellinie",
+    "splitRow": "Zwischenzeit {{label}}",
+    "sprintGuidance": "Ein Sprint-Kurs führt von der Startlinie zu einer separaten Ziellinie. Füge dazwischen bis zu {{max}} Zwischenlinien hinzu (optional).",
+    "sprintSplitLimit": "Limit für Zwischenlinien erreicht ({{max}} zwischen Start und Ziel).",
+    "resetFinish": "Ziellinie zurücksetzen"
   },
   "visual": {
     "draw": "Zeichnen",
@@ -67,7 +78,9 @@
     "drawingGenerated": "Zeichnung generiert",
     "drawingGeneratedDesc": "{{label}} ({{count}} Punkte).",
     "generatedFromLap": "Generiert aus Runde {{number}}",
-    "generatedFromSession": "Generiert aus der gesamten Sitzung"
+    "generatedFromSession": "Generiert aus der gesamten Sitzung",
+    "startLine": "Start",
+    "finishLine": "Ziel"
   },
   "prompt": {
     "selectCourse": "Kurs auswählen",

--- a/src/locales/en/tracks.json
+++ b/src/locales/en/tracks.json
@@ -14,7 +14,12 @@
     "title": "Add New Course",
     "courseName": "Course Name",
     "courseNamePlaceholder": "e.g., Full Track",
-    "create": "Create Course"
+    "create": "Create Course",
+    "courseType": "Course type",
+    "typeCircuit": "Circuit",
+    "typeSprint": "Sprint",
+    "typeCircuitHint": "Laps — one line is both start and finish.",
+    "typeSprintHint": "Point-to-point (autocross, hillclimb, stage) — a separate finish line, timed as runs."
   },
   "sectors": {
     "addSector": "Add sector",
@@ -26,7 +31,13 @@
     "dragReorder": "Drag to reorder",
     "markMajor": "Mark as major sector",
     "deleteSector": "Delete sector",
-    "resetStartFinish": "Reset start/finish line"
+    "resetStartFinish": "Reset start/finish line",
+    "startLineSprint": "Start line",
+    "finishLine": "Finish line",
+    "splitRow": "Split {{label}}",
+    "sprintGuidance": "A sprint course runs from the start line to a separate finish line. Add up to {{max}} split lines in between (optional).",
+    "sprintSplitLimit": "Split limit reached ({{max}} between start and finish).",
+    "resetFinish": "Reset finish line"
   },
   "visual": {
     "draw": "Draw",
@@ -66,7 +77,9 @@
     "drawingGenerated": "Drawing generated",
     "drawingGeneratedDesc": "{{label}} ({{count}} points).",
     "generatedFromLap": "Generated from Lap {{number}}",
-    "generatedFromSession": "Generated from the full session"
+    "generatedFromSession": "Generated from the full session",
+    "startLine": "Start",
+    "finishLine": "Finish"
   },
   "prompt": {
     "selectCourse": "Select Course",

--- a/src/locales/es/tracks.json
+++ b/src/locales/es/tracks.json
@@ -15,7 +15,12 @@
     "title": "Añadir nuevo trazado",
     "courseName": "Nombre del trazado",
     "courseNamePlaceholder": "p. ej., Trazado completo",
-    "create": "Crear trazado"
+    "create": "Crear trazado",
+    "courseType": "Tipo de trazado",
+    "typeCircuit": "Circuito",
+    "typeSprint": "Sprint",
+    "typeCircuitHint": "Vueltas: una misma línea es salida y meta.",
+    "typeSprintHint": "Punto a punto (autocross, subida en cuesta, tramo): línea de meta independiente, cronometrado por mangas."
   },
   "sectors": {
     "addSector": "Añadir sector",
@@ -27,7 +32,13 @@
     "dragReorder": "Arrastra para reordenar",
     "markMajor": "Marcar como sector principal",
     "deleteSector": "Eliminar sector",
-    "resetStartFinish": "Restablecer línea de salida/meta"
+    "resetStartFinish": "Restablecer línea de salida/meta",
+    "startLineSprint": "Línea de salida",
+    "finishLine": "Línea de meta",
+    "splitRow": "Parcial {{label}}",
+    "sprintGuidance": "Un trazado sprint va de la línea de salida a una línea de meta independiente. Añade hasta {{max}} líneas parciales intermedias (opcional).",
+    "sprintSplitLimit": "Límite de parciales alcanzado ({{max}} entre salida y meta).",
+    "resetFinish": "Restablecer línea de meta"
   },
   "visual": {
     "draw": "Dibujar",
@@ -67,7 +78,9 @@
     "drawingGenerated": "Dibujo generado",
     "drawingGeneratedDesc": "{{label}} ({{count}} puntos).",
     "generatedFromLap": "Generado a partir de la vuelta {{number}}",
-    "generatedFromSession": "Generado a partir de la sesión completa"
+    "generatedFromSession": "Generado a partir de la sesión completa",
+    "startLine": "Salida",
+    "finishLine": "Meta"
   },
   "prompt": {
     "selectCourse": "Seleccionar trazado",

--- a/src/locales/fr/tracks.json
+++ b/src/locales/fr/tracks.json
@@ -15,7 +15,12 @@
     "title": "Ajouter un nouveau tracé",
     "courseName": "Nom du tracé",
     "courseNamePlaceholder": "p. ex., Tracé complet",
-    "create": "Créer le tracé"
+    "create": "Créer le tracé",
+    "courseType": "Type de parcours",
+    "typeCircuit": "Circuit",
+    "typeSprint": "Sprint",
+    "typeCircuitHint": "Tours — une seule ligne sert de départ et d’arrivée.",
+    "typeSprintHint": "Point à point (autocross, course de côte, spéciale) — ligne d'arrivée distincte, chronométré en manches."
   },
   "sectors": {
     "addSector": "Ajouter un secteur",
@@ -27,7 +32,13 @@
     "dragReorder": "Faites glisser pour réordonner",
     "markMajor": "Marquer comme secteur principal",
     "deleteSector": "Supprimer le secteur",
-    "resetStartFinish": "Réinitialiser la ligne de départ/arrivée"
+    "resetStartFinish": "Réinitialiser la ligne de départ/arrivée",
+    "startLineSprint": "Ligne de départ",
+    "finishLine": "Ligne d'arrivée",
+    "splitRow": "Intermédiaire {{label}}",
+    "sprintGuidance": "Un parcours sprint va de la ligne de départ à une ligne d'arrivée distincte. Ajoutez jusqu'à {{max}} lignes intermédiaires entre les deux (facultatif).",
+    "sprintSplitLimit": "Limite d'intermédiaires atteinte ({{max}} entre le départ et l'arrivée).",
+    "resetFinish": "Réinitialiser la ligne d'arrivée"
   },
   "visual": {
     "draw": "Dessiner",
@@ -67,7 +78,9 @@
     "drawingGenerated": "Tracé généré",
     "drawingGeneratedDesc": "{{label}} ({{count}} points).",
     "generatedFromLap": "Généré à partir du tour {{number}}",
-    "generatedFromSession": "Généré à partir de la session complète"
+    "generatedFromSession": "Généré à partir de la session complète",
+    "startLine": "Départ",
+    "finishLine": "Arrivée"
   },
   "prompt": {
     "selectCourse": "Sélectionner le tracé",

--- a/src/locales/it/tracks.json
+++ b/src/locales/it/tracks.json
@@ -15,7 +15,12 @@
     "title": "Aggiungi nuovo tracciato",
     "courseName": "Nome del tracciato",
     "courseNamePlaceholder": "es., Tracciato completo",
-    "create": "Crea tracciato"
+    "create": "Crea tracciato",
+    "courseType": "Tipo di percorso",
+    "typeCircuit": "Circuito",
+    "typeSprint": "Sprint",
+    "typeCircuitHint": "Giri — un’unica linea è sia partenza sia arrivo.",
+    "typeSprintHint": "Punto a punto (autocross, cronoscalata, prova speciale) — linea di arrivo separata, cronometrato a manche."
   },
   "sectors": {
     "addSector": "Aggiungi settore",
@@ -27,7 +32,13 @@
     "dragReorder": "Trascina per riordinare",
     "markMajor": "Contrassegna come settore principale",
     "deleteSector": "Elimina settore",
-    "resetStartFinish": "Reimposta linea di partenza/arrivo"
+    "resetStartFinish": "Reimposta linea di partenza/arrivo",
+    "startLineSprint": "Linea di partenza",
+    "finishLine": "Linea di arrivo",
+    "splitRow": "Intermedio {{label}}",
+    "sprintGuidance": "Un percorso sprint va dalla linea di partenza a una linea di arrivo separata. Aggiungi fino a {{max}} linee intermedie (opzionale).",
+    "sprintSplitLimit": "Limite di intermedi raggiunto ({{max}} tra partenza e arrivo).",
+    "resetFinish": "Reimposta linea di arrivo"
   },
   "visual": {
     "draw": "Disegna",
@@ -67,7 +78,9 @@
     "drawingGenerated": "Disegno generato",
     "drawingGeneratedDesc": "{{label}} ({{count}} punti).",
     "generatedFromLap": "Generato dal giro {{number}}",
-    "generatedFromSession": "Generato dall'intera sessione"
+    "generatedFromSession": "Generato dall'intera sessione",
+    "startLine": "Partenza",
+    "finishLine": "Arrivo"
   },
   "prompt": {
     "selectCourse": "Seleziona tracciato",

--- a/src/locales/ja/tracks.json
+++ b/src/locales/ja/tracks.json
@@ -15,7 +15,12 @@
     "title": "新しいコースを追加",
     "courseName": "コース名",
     "courseNamePlaceholder": "例: フルコース",
-    "create": "コースを作成"
+    "create": "コースを作成",
+    "courseType": "コースの種類",
+    "typeCircuit": "サーキット",
+    "typeSprint": "スプリント",
+    "typeCircuitHint": "周回 — 1本のラインがスタートとフィニッシュを兼ねます。",
+    "typeSprintHint": "ポイント・トゥ・ポイント（オートクロス、ヒルクライム、SS）— フィニッシュラインが別にあり、走行ごとに計測します。"
   },
   "sectors": {
     "addSector": "セクターを追加",
@@ -27,7 +32,13 @@
     "dragReorder": "ドラッグして並べ替え",
     "markMajor": "メインセクターに指定",
     "deleteSector": "セクターを削除",
-    "resetStartFinish": "スタート/フィニッシュラインをリセット"
+    "resetStartFinish": "スタート/フィニッシュラインをリセット",
+    "startLineSprint": "スタートライン",
+    "finishLine": "フィニッシュライン",
+    "splitRow": "スプリット{{label}}",
+    "sprintGuidance": "スプリントコースはスタートラインから別のフィニッシュラインまで走ります。その間にスプリットラインを最大{{max}}本まで追加できます（任意）。",
+    "sprintSplitLimit": "スプリットの上限に達しました（スタートとフィニッシュの間に{{max}}本）。",
+    "resetFinish": "フィニッシュラインをリセット"
   },
   "visual": {
     "draw": "描画",
@@ -67,7 +78,9 @@
     "drawingGenerated": "描画を生成しました",
     "drawingGeneratedDesc": "{{label}}（{{count}}ポイント）。",
     "generatedFromLap": "ラップ{{number}}から生成",
-    "generatedFromSession": "セッション全体から生成"
+    "generatedFromSession": "セッション全体から生成",
+    "startLine": "スタート",
+    "finishLine": "フィニッシュ"
   },
   "prompt": {
     "selectCourse": "コースを選択",

--- a/src/locales/pt-BR/tracks.json
+++ b/src/locales/pt-BR/tracks.json
@@ -15,7 +15,12 @@
     "title": "Adicionar novo traçado",
     "courseName": "Nome do traçado",
     "courseNamePlaceholder": "ex.: Traçado completo",
-    "create": "Criar traçado"
+    "create": "Criar traçado",
+    "courseType": "Tipo de traçado",
+    "typeCircuit": "Circuito",
+    "typeSprint": "Sprint",
+    "typeCircuitHint": "Voltas — uma mesma linha é largada e chegada.",
+    "typeSprintHint": "Ponto a ponto (autocross, subida de montanha, especial) — linha de chegada separada, cronometrado por baterias."
   },
   "sectors": {
     "addSector": "Adicionar setor",
@@ -27,7 +32,13 @@
     "dragReorder": "Arraste para reordenar",
     "markMajor": "Marcar como setor principal",
     "deleteSector": "Excluir setor",
-    "resetStartFinish": "Redefinir linha de largada/chegada"
+    "resetStartFinish": "Redefinir linha de largada/chegada",
+    "startLineSprint": "Linha de largada",
+    "finishLine": "Linha de chegada",
+    "splitRow": "Parcial {{label}}",
+    "sprintGuidance": "Um traçado sprint vai da linha de largada até uma linha de chegada separada. Adicione até {{max}} linhas parciais entre elas (opcional).",
+    "sprintSplitLimit": "Limite de parciais atingido ({{max}} entre largada e chegada).",
+    "resetFinish": "Redefinir linha de chegada"
   },
   "visual": {
     "draw": "Desenhar",
@@ -67,7 +78,9 @@
     "drawingGenerated": "Desenho gerado",
     "drawingGeneratedDesc": "{{label}} ({{count}} pontos).",
     "generatedFromLap": "Gerado a partir da volta {{number}}",
-    "generatedFromSession": "Gerado a partir da sessão completa"
+    "generatedFromSession": "Gerado a partir da sessão completa",
+    "startLine": "Largada",
+    "finishLine": "Chegada"
   },
   "prompt": {
     "selectCourse": "Selecionar traçado",


### PR DESCRIPTION
Second of four. #375 added the model; this makes it reachable — **you can now actually author a sprint track**, which is the thing that has been missing since the logger shipped sprint support.

## What you get

A **Circuit / Sprint** picker on the course editor, and on a sprint course a second map handle for the separate **finish line**, drawn in red after the splits.

`LineId` grows a `'finish'` variant alongside `'sf' | number`, and the finish is enumerated **last** in `allLineIds` — that's the order a driver crosses the lines, and the same order the sector list renders, so the map and the list agree without a second sort.

Sprint-specific behaviour in the list editor:

| | circuit | sprint |
|---|---|---|
| bottom row | — | **Finish** (red flag, reset button) |
| Major switch | shown | hidden — meaningless point-to-point |
| row label | `Sector n` | `Split n` |
| limit | `MAX_SECTOR_LINES` | `MAX_SPRINT_SPLITS` |
| guidance | three-majors rule | point-to-point shape |

Picking Sprint **drops a finish line for you**, north of the start, rather than making you hunt for a button — mirroring how a brand-new course auto-drops its start/finish.

## Two deliberate scope calls

**The type picker is create-only.** Retyping a course that already has geometry would silently invalidate it — a circuit's three majors are not a sprint's splits, and vice versa. Editing keeps the type it was saved with.

**`TrackPromptDialog` and the admin `CoursesTab` stay circuit-only.** Both keep their own copy of the editor state, and `courseType` defaults to `'circuit'`, so they compile and behave exactly as before. Community submission of sprint courses was already out of scope for this plan, and the log-import prompt wants the runs view (PR 4) before it can do anything useful with a sprint log. Flagging it because it's the kind of asymmetry that looks like an oversight later.

## The save-time fork is extracted, not inlined

`sprintCourse.finalizeCourseForSave` owns it: circuit normalizes (writing the legacy `sector2`/`sector3` mirror), sprint stamps `date_created` and deliberately **skips** normalization — that mirror is derived from flagged *majors*, and sprint splits are unflagged, so normalizing would emit an empty mirror and imply a sector layout the course doesn't have.

It's a pure function rather than hook-internal because this repo's coverage config excludes `src/components/**/*.tsx` by design — logic left in a `.tsx` is logic that can't be tested. 4 new tests cover it, including that a sprint course never gets a legacy mirror.

## Translations

All 13 new strings are in **all six** shipped languages, not English-only — the locale-parity test enforces it, and I'd initially assumed `fallbackLng` made English-only fine. It doesn't; the test is the authority. Each string follows the terminology already in that language's file rather than a literal gloss: de `Zwischenzeit`, fr `intermédiaire`, it `Intermedio`, es/pt `Parcial`, ja `スプリット`.

## Test plan

- [x] `bun run test:run` — **2468 pass / 178 files** (4 new)
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean — including the typed-i18n-key narrowing, which caught a `labelKey: string` that had to become a literal union
- [x] `bun run build` clean
- [x] Circuit path untouched: no existing test changed behaviour, and `courseType` defaults to `'circuit'` everywhere it isn't passed

## Worth a look when you review

The finish auto-drop is a `useEffect` in `VisualEditor` keyed on `isSprint && !finish`. It offsets ~100 m north of the start midpoint so the two lines don't land on top of each other. If that placement feels wrong on a real venue it's a one-line constant.

## Next

**PR 3 — device sync.** `TS*` opcodes in `trackSync.ts` (the strings are inline literals today), sprint awareness in the merge, `DeviceTracksTab` UI. One landmine already spotted: `MergedTrackEntry` keys on `shortName` alone, so a sprint and a circuit track sharing a short name would collide — that needs a kind in the key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnTP6BdA9xjLR5hSWE9frb)_