### PR TITLE
plan 0015: sprint track sync over the device's TS* verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sprint track sync speaks the device's `TS*` verbs** (plan 0015). The BLE
+  client can now list, download, upload and delete tracks in the logger's
+  `/TRACKS/SPRINT` folder, alongside the existing `/TRACKS` ones. The folder is
+  chosen by the opcode rather than by a path in the filename, matching the
+  firmware — its validator deliberately rejects `/` and `..` to keep a client
+  jailed to the tracks folders.
+  - Track sync entries are now keyed on **(kind, short name)**, not the short
+    name alone. A circuit `OKC` and a sprint `OKC` are two separate files on the
+    device, and keying on the name alone collided them — one would have been
+    reported as a mismatched version of the other.
+  - Not yet reachable from the Device tab: that path runs through the
+    transport-neutral device seam shared with the native Android app, which
+    needs its own pass.
 - **Sprint courses can be created and edited** (plan 0015). The course editor
   gained a **Circuit / Sprint** picker, and a sprint course gets a second,
   separate **finish line** handle on the map — rendered in red after the splits,

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -150,6 +150,10 @@ channel and terminator differ per command.
 | `TGET:<name>` | `0x2A40` then `0x2A3F` | `SIZE:<n>` → data chunks → `DONE` | `TERR:<reason>` / `ERROR` |
 | `TPUT:<name>` | `0x2A40` | `TREADY` → (client uploads) → `TDONE`* → `TOK` | `TERR:<reason>` |
 | `TDEL:<name>` | `0x2A40` | `TOK` | `TERR:<reason>` |
+| `TSLIST` | `0x2A40` | `TSFILE:<name>` … → `TSEND` | — |
+| `TSGET:<name>` | `0x2A40` then `0x2A3F` | `SIZE:<n>` → data chunks → `DONE` | `TERR:<reason>` / `ERROR` |
+| `TSPUT:<name>` | `0x2A40` | `TREADY` → (client uploads) → `TDONE`* → `TOK` | `TERR:<reason>` |
+| `TSDEL:<name>` | `0x2A40` | `TOK` | `TERR:<reason>` |
 | `FWBEGIN:<size>,<crc32>,<variant>` | `0x2A40` | `FWCRC:<crc32>` (echo) | `FWERR:<reason>` (`FWERR:VARIANT`) |
 | `FWPUT:<size>` | `0x2A40` | `FWREADY` → (client uploads) → `FWDONE`* → `FWOK:<crc32>` | `FWERR:<reason>` |
 | `FWAPPLY` | `0x2A40` | `FWSTAGE:<pct>` … → `FWAPPLIED` (or disconnect) | `FWERR:<reason>` |
@@ -304,11 +308,35 @@ Unknown keys are treated as untyped strings with no validation.
 
 ---
 
-## 9. Track-file protocol (`T*`)
+## 9. Track-file protocol (`T*`, `TS*`)
 
 Track files are JSON describing tracks/courses the logger uses for on-device lap
 detection. All control tokens are on `0x2A40`; downloads reuse the `0x2A3F` data
 channel.
+
+### 9.0 Two folders, two verb sets
+
+The logger keeps **circuit** tracks in `/TRACKS` and **sprint** (point-to-point /
+autocross) tracks in `/TRACKS/SPRINT`. The folder is selected by the **opcode**,
+never parsed from the filename: the firmware's filename validator rejects `/` and
+`..` so a BLE client stays jailed to the tracks folders, and a path-carrying
+filename would have punched a hole in that.
+
+So every verb below has a `TS`-prefixed twin — `TSLIST`, `TSGET:`, `TSPUT:`,
+`TSDEL:` — with identical semantics against the sprint folder. **Only the list
+replies differ**: `TSFILE:` / `TSEND` instead of `TFILE:` / `TEND`, so a sprint
+enumeration can never be mistaken for a circuit one. Get/put/delete reuse the
+circuit replies (`SIZE:`/`DONE`, `TREADY`/`TOK`, `TERR:`) verbatim.
+
+A sprint course JSON carries two extra things a circuit course does not:
+`finish_a_lat` / `finish_a_lng` / `finish_b_lat` / `finish_b_lng` (the separate
+finish line, required) and `date_created` (a sortable `YYYY-MM-DDTHH:MM` stamp —
+the device loads the **newest** sprint course by a plain *string* compare of it).
+Its optional split lines ride in the existing `sector_2_*` / `sector_3_*` slots,
+positionally.
+
+Client side: `src/lib/ble/trackOpcodes.ts` owns the verb table; every function in
+`trackSync.ts` takes an optional `kind` that defaults to `'circuit'`.
 
 ### 9.1 List (`TLIST`)
 

--- a/docs/plans/0015-sprint-mode.md
+++ b/docs/plans/0015-sprint-mode.md
@@ -145,14 +145,25 @@ testable (Golden Rule 3).
     `sprintCourse.finalizeCourseForSave` so it is unit-testable — this repo's
     coverage config excludes `src/components/**/*.tsx` by design, so logic in
     a `.tsx` is logic that cannot be tested.
-- **PR 3 — device sync.** `TS*` opcodes in `trackSync.ts`, sprint awareness in
-  `deviceTrackSync.ts`'s merge, `DeviceTracksTab` UI. Note `MergedTrackEntry`
-  keys on `shortName` alone today, so a sprint and a circuit track sharing a
-  short name currently collide — that needs a kind in the key.
-- **PR 4 — reading runs back.** `race_mode` in `dovexParser`, run derivation
-  (`calculateLaps` pairs *consecutive* start/finish crossings and wraps the last
-  segment back to start/finish — both assumptions are false for sprint), and a
-  run-oriented `LapTable`.
+- ~~**PR 3 — protocol + merge.**~~ **Done.** `trackOpcodes.ts` owns the verb
+  table (verified against `bluetooth.ino`, not just the protocol doc); every
+  `trackSync.ts` function takes an optional `kind` defaulting to `'circuit'`;
+  `buildMergedTrackList` keys on **(kind, shortName)**; `trackKind` /
+  `isMixedKindTrack` decide which folder a track belongs in.
+- **PR 4 — device seam + Device tab.** The reason sync is not yet reachable
+  from the UI: `DeviceTracksTab` goes through the transport-neutral
+  `DeviceDetails` seam (`lib/loggers/types.ts`), which has **two**
+  implementations — Web Bluetooth (`bleDetails.ts`) and the native Android IPC
+  bridge (`dovesloggerConnection.ts`). Adding `kind` to `listTracks`/`getTrack`
+  is easy on the BLE side and blocked on the Android app for the native one, so
+  the seam needs a deliberate "native returns nothing for sprint until the app
+  catches up" decision rather than being smuggled in with the UI. Also needs a
+  kind indicator in the tab, since a circuit and a sprint track can now share a
+  short name.
+- **PR 5 — reading runs back.** (Was PR 4; renumbered when the seam split out.)
+  `race_mode` in `dovexParser`, run derivation, and a run-oriented `LapTable`.
+  `calculateLaps` pairs *consecutive* start/finish crossings and wraps the last
+  segment back to start/finish — both assumptions are false for sprint.
 
 ## Deliberately kept: "lap" wording
 

--- a/src/lib/ble/trackOpcodes.test.ts
+++ b/src/lib/ble/trackOpcodes.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { trackOpcodes } from './trackOpcodes';
+
+describe('trackOpcodes', () => {
+  it('defaults to circuit — the pre-sprint wire behaviour', () => {
+    expect(trackOpcodes()).toEqual(trackOpcodes('circuit'));
+  });
+
+  it('emits the circuit verbs unchanged', () => {
+    // Pinned: these are the bytes older firmware has always answered to.
+    expect(trackOpcodes('circuit')).toEqual({
+      list: 'TLIST',
+      get: 'TGET:',
+      put: 'TPUT:',
+      del: 'TDEL:',
+      filePrefix: 'TFILE:',
+      endToken: 'TEND',
+    });
+  });
+
+  it('emits the sprint verbs the firmware dispatches on', () => {
+    // Verified against BirdsEye/bluetooth.ino:557-604 (dispatch) and :325-326
+    // (listing tokens), not just the protocol doc.
+    expect(trackOpcodes('sprint')).toEqual({
+      list: 'TSLIST',
+      get: 'TSGET:',
+      put: 'TSPUT:',
+      del: 'TSDEL:',
+      filePrefix: 'TSFILE:',
+      endToken: 'TSEND',
+    });
+  });
+
+  it('gives sprint listings distinct tokens from circuit', () => {
+    // The whole point of TSFILE:/TSEND: a sprint enumeration must never be
+    // mistaken for a circuit one if replies ever interleave.
+    const c = trackOpcodes('circuit');
+    const s = trackOpcodes('sprint');
+    expect(s.filePrefix).not.toBe(c.filePrefix);
+    expect(s.endToken).not.toBe(c.endToken);
+  });
+
+  it('never lets a circuit token prefix-match a sprint listing line', () => {
+    // "TSFILE:OKC.json".startsWith("TFILE:") must be false, or a client
+    // parsing both streams would silently mis-bucket sprint files.
+    const c = trackOpcodes('circuit');
+    expect(`${trackOpcodes('sprint').filePrefix}OKC.json`.startsWith(c.filePrefix)).toBe(false);
+    expect(trackOpcodes('sprint').endToken.startsWith(c.endToken)).toBe(false);
+  });
+
+  it('strips its own prefix cleanly', () => {
+    const s = trackOpcodes('sprint');
+    const line = `${s.filePrefix}Autocross.json`;
+    expect(line.substring(s.filePrefix.length)).toBe('Autocross.json');
+  });
+});

--- a/src/lib/ble/trackOpcodes.ts
+++ b/src/lib/ble/trackOpcodes.ts
@@ -1,0 +1,59 @@
+/**
+ * Track-file BLE opcodes, by track kind.
+ *
+ * The logger keeps circuit tracks in `/TRACKS` and sprint tracks in
+ * `/TRACKS/SPRINT`, and the folder is chosen by the **opcode** — never parsed
+ * from the filename. That is deliberate on the firmware side: its filename
+ * validator rejects `/` and `..` so a BLE client stays jailed to the tracks
+ * folders, and adding a path-carrying filename would have punched a hole in
+ * that. The cost is a parallel set of verbs, which this table owns so no call
+ * site hand-builds an opcode string.
+ *
+ * Only the LIST reply tokens differ between the two. Sprint listings answer
+ * `TSFILE:` / `TSEND` so a sprint enumeration can never be mistaken for a
+ * circuit one if the two ever interleave; `TSGET:` / `TSPUT:` / `TSDEL:` reuse
+ * the circuit replies (`SIZE:`/`DONE`, `TREADY`/`TOK`, `TERR:`) verbatim.
+ *
+ * Verified against `BirdsEye/bluetooth.ino` (the dispatch at :557-604 and the
+ * listing tokens at :325-326), not just the protocol doc.
+ */
+
+export type TrackKind = 'circuit' | 'sprint';
+
+export interface TrackOpcodes {
+  /** Enumerate the folder. */
+  list: string;
+  /** Download prefix — a filename is appended. */
+  get: string;
+  /** Upload prefix — a filename is appended. */
+  put: string;
+  /** Delete prefix — a filename is appended. */
+  del: string;
+  /** Prefix of each filename line in a listing reply. */
+  filePrefix: string;
+  /** Terminator line of a listing reply. */
+  endToken: string;
+}
+
+const CIRCUIT: TrackOpcodes = {
+  list: 'TLIST',
+  get: 'TGET:',
+  put: 'TPUT:',
+  del: 'TDEL:',
+  filePrefix: 'TFILE:',
+  endToken: 'TEND',
+};
+
+const SPRINT: TrackOpcodes = {
+  list: 'TSLIST',
+  get: 'TSGET:',
+  put: 'TSPUT:',
+  del: 'TSDEL:',
+  filePrefix: 'TSFILE:',
+  endToken: 'TSEND',
+};
+
+/** The opcode set for a track kind. Defaults to circuit, the pre-sprint behaviour. */
+export function trackOpcodes(kind: TrackKind = 'circuit'): TrackOpcodes {
+  return kind === 'sprint' ? SPRINT : CIRCUIT;
+}

--- a/src/lib/ble/trackSync.ts
+++ b/src/lib/ble/trackSync.ts
@@ -3,6 +3,7 @@
 import type { BleConnection, DownloadProgress } from "./types";
 import { bleLog } from "./internal";
 import { formatSpeed, formatTime } from "./format";
+import { trackOpcodes, type TrackKind } from "./trackOpcodes";
 
 /**
  * Track-File Protocol.
@@ -13,10 +14,18 @@ import { formatSpeed, formatTime } from "./format";
  *   TPUT:<name>      -> TREADY on `fileStatus`, then app sends chunks + TDONE,
  *                       device responds TOK or TERR:reason
  *   TDEL:<name>      -> TOK or TERR:reason on `fileStatus`
+ *
+ * Every command takes an optional `kind`. Sprint tracks live in a separate
+ * folder on the device and are addressed by the TS* twins of these verbs — the
+ * folder is chosen by the opcode, never by the filename. See `trackOpcodes.ts`.
  */
 
-/** Request list of track files on device via TLIST. Returns filenames (e.g. ["OKC.json"]). */
-export async function requestTrackFileList(connection: BleConnection): Promise<string[]> {
+/** Request list of track files on device. Returns filenames (e.g. ["OKC.json"]). */
+export async function requestTrackFileList(
+  connection: BleConnection,
+  kind: TrackKind = "circuit",
+): Promise<string[]> {
+  const ops = trackOpcodes(kind);
   // eslint-disable-next-line no-async-promise-executor -- inner try/catch handles rejection; preserve original semantics during the split
   return new Promise(async (resolve, reject) => {
     const files: string[] = [];
@@ -25,18 +34,18 @@ export async function requestTrackFileList(connection: BleConnection): Promise<s
     const handleNotification = (event: Event) => {
       const target = event.target as BluetoothRemoteGATTCharacteristic;
       const raw = new TextDecoder().decode(target.value!);
-      bleLog("TLIST raw:", JSON.stringify(raw));
+      bleLog(`${ops.list} raw:`, JSON.stringify(raw));
 
       const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
 
       for (const line of lines) {
-        if (line === "TEND") {
+        if (line === ops.endToken) {
           cleanup();
           resolve(files);
           return;
         }
-        if (line.startsWith("TFILE:")) {
-          files.push(line.substring(6));
+        if (line.startsWith(ops.filePrefix)) {
+          files.push(line.substring(ops.filePrefix.length));
         }
       }
 
@@ -64,7 +73,7 @@ export async function requestTrackFileList(connection: BleConnection): Promise<s
       );
 
       const encoder = new TextEncoder();
-      await connection.characteristics.fileRequest.writeValue(encoder.encode("TLIST"));
+      await connection.characteristics.fileRequest.writeValue(encoder.encode(ops.list));
 
       setTimeout(() => {
         cleanup();
@@ -85,7 +94,9 @@ export async function downloadTrackFile(
   connection: BleConnection,
   filename: string,
   onProgress?: (progress: DownloadProgress) => void,
+  kind: TrackKind = "circuit",
 ): Promise<Uint8Array> {
+  const ops = trackOpcodes(kind);
   const updateProgress = onProgress || (() => {});
 
   // eslint-disable-next-line no-async-promise-executor -- inner try/catch handles rejection; preserve original semantics during the split
@@ -200,7 +211,7 @@ export async function downloadTrackFile(
       );
 
       const encoder = new TextEncoder();
-      await connection.characteristics.fileRequest.writeValue(encoder.encode("TGET:" + filename));
+      await connection.characteristics.fileRequest.writeValue(encoder.encode(ops.get + filename));
 
       setTimeout(() => {
         if (!resolved) {
@@ -233,7 +244,9 @@ export async function uploadTrackFile(
   connection: BleConnection,
   filename: string,
   data: Uint8Array,
+  kind: TrackKind = "circuit",
 ): Promise<void> {
+  const ops = trackOpcodes(kind);
   // eslint-disable-next-line no-async-promise-executor -- inner try/catch handles rejection; preserve original semantics during the split
   return new Promise(async (resolve, reject) => {
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -305,7 +318,7 @@ export async function uploadTrackFile(
       );
 
       const encoder = new TextEncoder();
-      await connection.characteristics.fileRequest.writeValue(encoder.encode("TPUT:" + filename));
+      await connection.characteristics.fileRequest.writeValue(encoder.encode(ops.put + filename));
 
       // Timeout waiting for TREADY
       timeout = setTimeout(() => {
@@ -326,7 +339,9 @@ export async function uploadTrackFile(
 export async function deleteTrackFile(
   connection: BleConnection,
   filename: string,
+  kind: TrackKind = "circuit",
 ): Promise<void> {
+  const ops = trackOpcodes(kind);
   // eslint-disable-next-line no-async-promise-executor -- inner try/catch handles rejection; preserve original semantics during the split
   return new Promise(async (resolve, reject) => {
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -366,7 +381,7 @@ export async function deleteTrackFile(
       );
 
       const encoder = new TextEncoder();
-      await connection.characteristics.fileRequest.writeValue(encoder.encode("TDEL:" + filename));
+      await connection.characteristics.fileRequest.writeValue(encoder.encode(ops.del + filename));
 
       timeout = setTimeout(() => {
         cleanup();

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -9,6 +9,8 @@ import {
   countDeviceSectors,
   countAppSectors,
   startADistance,
+  trackKind,
+  isMixedKindTrack,
   type DeviceCourseJson,
   type DeviceTrackFile,
 } from "./deviceTrackSync";
@@ -548,5 +550,98 @@ describe("sprint course wire format", () => {
     const circuitJson = appCourseToDeviceJson(makeAppCourse());
     expect(coursesMatch(makeAppCourse(), sprintJson)).toBe(false);
     expect(coursesMatch(makeSprintCourse(), circuitJson)).toBe(false);
+  });
+});
+
+// ─── Track kind + merge namespacing (plan 0015) ──────────────────────────────
+
+describe("trackKind / isMixedKindTrack", () => {
+  const sprintCourse = (name: string): Course => ({
+    name,
+    type: "sprint",
+    startFinishA: { lat: 1, lon: 1 },
+    startFinishB: { lat: 1, lon: 2 },
+    finish: { a: { lat: 2, lon: 1 }, b: { lat: 2, lon: 2 } },
+  });
+
+  it("calls a track with no sprint courses circuit", () => {
+    expect(trackKind({ courses: [makeAppCourse()] })).toBe("circuit");
+  });
+
+  it("calls a track with a sprint course sprint", () => {
+    expect(trackKind({ courses: [sprintCourse("Run 1")] })).toBe("sprint");
+  });
+
+  it("treats an empty track as circuit", () => {
+    expect(trackKind({ courses: [] })).toBe("circuit");
+  });
+
+  it("flags a track carrying both kinds", () => {
+    // Unrepresentable on the device — the two kinds are separate files in
+    // separate folders, so such a track would have to be split.
+    expect(isMixedKindTrack({ courses: [makeAppCourse(), sprintCourse("Run 1")] })).toBe(true);
+  });
+
+  it("does not flag a single-kind track either way", () => {
+    expect(isMixedKindTrack({ courses: [makeAppCourse()] })).toBe(false);
+    expect(isMixedKindTrack({ courses: [sprintCourse("Run 1")] })).toBe(false);
+    expect(isMixedKindTrack({ courses: [] })).toBe(false);
+  });
+});
+
+describe("buildMergedTrackList — kind namespacing", () => {
+  const sprintCourse = (name: string): Course => ({
+    name,
+    type: "sprint",
+    startFinishA: { lat: 1, lon: 1 },
+    startFinishB: { lat: 1, lon: 2 },
+    finish: { a: { lat: 2, lon: 1 }, b: { lat: 2, lon: 2 } },
+    dateCreated: "2026-09-05T07:03",
+  });
+
+  it("keeps a circuit and a sprint track with the SAME shortName separate", () => {
+    // The device stores these as /TRACKS/OKC.json and /TRACKS/SPRINT/OKC.json —
+    // two distinct files. Keying on shortName alone collided them and reported
+    // one as a mismatch of the other.
+    const appTracks: Track[] = [
+      makeAppTrack("OKC", [makeAppCourse()]),
+      { ...makeAppTrack("OKC", [sprintCourse("Run 1")]), name: "OKC Autocross" },
+    ];
+    const deviceFiles: DeviceTrackFile[] = [
+      { shortName: "OKC", kind: "circuit", courses: [appCourseToDeviceJson(makeAppCourse())] },
+      { shortName: "OKC", kind: "sprint", courses: [appCourseToDeviceJson(sprintCourse("Run 1"))] },
+    ];
+
+    const merged = buildMergedTrackList(appTracks, deviceFiles);
+    expect(merged).toHaveLength(2);
+    expect(merged.every((e) => e.status === "synced")).toBe(true);
+    expect(merged.map((e) => e.kind).sort()).toEqual(["circuit", "sprint"]);
+  });
+
+  it("does not match an app sprint track against a circuit device file", () => {
+    const appTracks = [{ ...makeAppTrack("OKC", [sprintCourse("Run 1")]) }];
+    const deviceFiles: DeviceTrackFile[] = [
+      { shortName: "OKC", kind: "circuit", courses: [appCourseToDeviceJson(makeAppCourse())] },
+    ];
+    const merged = buildMergedTrackList(appTracks, deviceFiles);
+    expect(merged).toHaveLength(2);
+    expect(merged.find((e) => e.kind === "sprint")?.status).toBe("app_only");
+    expect(merged.find((e) => e.kind === "circuit")?.status).toBe("device_only");
+  });
+
+  it("treats a device file with no kind as circuit, so old callers still match", () => {
+    const appTracks = [makeAppTrack("OKC", [makeAppCourse()])];
+    const deviceFiles: DeviceTrackFile[] = [
+      { shortName: "OKC", courses: [appCourseToDeviceJson(makeAppCourse())] },
+    ];
+    const merged = buildMergedTrackList(appTracks, deviceFiles);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].status).toBe("synced");
+    expect(merged[0].kind).toBe("circuit");
+  });
+
+  it("tags every entry with a kind", () => {
+    const merged = buildMergedTrackList([makeAppTrack("OKC", [makeAppCourse()])], []);
+    expect(merged[0].kind).toBe("circuit");
   });
 });

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -5,6 +5,7 @@
  */
 
 import { Track, Course, CourseSector, SectorLine, isSprintCourse } from '@/types/racing';
+import type { TrackKind } from '@/lib/ble/trackOpcodes';
 import { haversineDistance } from '@/lib/parserUtils';
 import { legacyMirror, majorSectorLines, normalizeCourseSectors } from '@/lib/courseSectors';
 
@@ -46,6 +47,13 @@ export interface DeviceCourseJson {
 export interface DeviceTrackFile {
   shortName: string;              // filename without .json
   courses: DeviceCourseJson[];
+  /**
+   * Which folder this file came out of. Circuit (`/TRACKS`) and sprint
+   * (`/TRACKS/SPRINT`) are separate namespaces on the device, so the same
+   * shortName can legitimately exist in both — the kind is part of a file's
+   * identity, not a property of its contents.
+   */
+  kind?: TrackKind;
 }
 
 export type TrackSyncStatus =
@@ -69,6 +77,8 @@ export interface MergedCourseEntry {
 
 export interface MergedTrackEntry {
   shortName: string;
+  /** Circuit or sprint. Entries are keyed on (kind, shortName), never shortName alone. */
+  kind: TrackKind;
   trackName?: string;              // full name from webapp (if known)
   status: TrackSyncStatus;
   appTrack?: Track;
@@ -264,6 +274,32 @@ export function parseDeviceCourseJson(raw: string): DeviceCourseJson[] {
   }
 }
 
+// ─── Track kind ───────────────────────────────────────────────────────────────
+
+/**
+ * Which device folder a track belongs in.
+ *
+ * A track file on the device is wholly one kind — it lives in `/TRACKS` or in
+ * `/TRACKS/SPRINT`, never both — so the kind is derived from the courses it
+ * carries. Any sprint course makes the whole track sprint.
+ */
+export function trackKind(track: Pick<Track, 'courses'>): TrackKind {
+  return track.courses.some(isSprintCourse) ? 'sprint' : 'circuit';
+}
+
+/**
+ * True when a track carries both circuit and sprint courses.
+ *
+ * This cannot be represented on the device: the two kinds are separate files in
+ * separate folders, so such a track would have to be split. Callers surface it
+ * rather than silently pushing half the courses — the editor has no way to
+ * create one today, but a cloud-synced or hand-edited track could be.
+ */
+export function isMixedKindTrack(track: Pick<Track, 'courses'>): boolean {
+  const sprint = track.courses.filter(isSprintCourse).length;
+  return sprint > 0 && sprint < track.courses.length;
+}
+
 // ─── Merge Logic ──────────────────────────────────────────────────────────────
 
 /** Build merged course list for a single track. */
@@ -307,21 +343,28 @@ export function buildMergedTrackList(
   deviceFiles: DeviceTrackFile[]
 ): MergedTrackEntry[] {
   const entries: MergedTrackEntry[] = [];
-  const deviceByShortName = new Map(deviceFiles.map(df => [df.shortName, df]));
-  const seenDeviceShortNames = new Set<string>();
+  // Keyed on (kind, shortName): the device keeps circuit and sprint tracks in
+  // different folders, so "OKC" in each is two distinct files. Keying on the
+  // short name alone would collide them and report one as a mismatch of the
+  // other.
+  const key = (kind: TrackKind, shortName: string) => `${kind}:${shortName}`;
+  const deviceByKey = new Map(deviceFiles.map(df => [key(df.kind ?? 'circuit', df.shortName), df]));
+  const seenDeviceKeys = new Set<string>();
 
   // Process app tracks first (ones with shortName)
   for (const track of appTracks) {
     const sn = track.shortName;
     if (!sn) continue; // Skip tracks without shortName — can't match to device
 
-    const df = deviceByShortName.get(sn);
+    const kind = trackKind(track);
+    const df = deviceByKey.get(key(kind, sn));
     if (df) {
-      seenDeviceShortNames.add(sn);
+      seenDeviceKeys.add(key(kind, sn));
       const mergedCourses = buildMergedCourses(track.courses, df.courses);
       const allSynced = mergedCourses.every(c => c.status === 'synced');
       entries.push({
         shortName: sn,
+        kind,
         trackName: track.name,
         status: allSynced ? 'synced' : 'mismatch',
         appTrack: track,
@@ -332,6 +375,7 @@ export function buildMergedTrackList(
     } else {
       entries.push({
         shortName: sn,
+        kind,
         trackName: track.name,
         status: 'app_only',
         appTrack: track,
@@ -348,9 +392,11 @@ export function buildMergedTrackList(
 
   // Device-only tracks
   for (const df of deviceFiles) {
-    if (!seenDeviceShortNames.has(df.shortName)) {
+    const dfKind = df.kind ?? 'circuit';
+    if (!seenDeviceKeys.has(key(dfKind, df.shortName))) {
       entries.push({
         shortName: df.shortName,
+        kind: dfKind,
         status: 'device_only',
         appCourses: [],
         deviceCourses: df.courses,


### PR DESCRIPTION
Third of five. The client can now address the logger's `/TRACKS/SPRINT` folder alongside `/TRACKS` — list, download, upload, delete.

## What's here

`src/lib/ble/trackOpcodes.ts` owns the verb table instead of leaving opcode strings as inline literals at four call sites. Every `trackSync.ts` function takes an optional `kind` defaulting to `'circuit'`, so nothing existing changes on the wire.

The folder is chosen by the **opcode**, never by a path in the filename. That's the firmware's design, not an accident — its validator rejects `/` and `..` so a BLE client stays jailed to the tracks folders, and a path-carrying filename would have punched a hole in that. The cost is a parallel verb set, which is what this table is for.

Only the **list** replies differ (`TSFILE:`/`TSEND` vs `TFILE:`/`TEND`); get/put/delete reuse the circuit replies verbatim. I verified that by reading `bluetooth.ino` — the dispatch at `:557-604` and the listing tokens at `:325-326` — rather than trusting the protocol doc, which is now updated to match.

## A collision sprint mode would otherwise have introduced

`buildMergedTrackList` keyed entries on `shortName` alone. But a circuit `OKC` and a sprint `OKC` are two distinct files in two distinct folders on the device. Keyed on the name alone, one would have been reported as a *mismatched version* of the other — and "syncing" it would have overwritten the wrong file.

Now keyed on **(kind, shortName)**. `DeviceTrackFile.kind` is optional and absent means circuit, so existing callers are unaffected. Both directions are tested.

`trackKind()` derives which folder a track belongs in (any sprint course makes the track sprint). `isMixedKindTrack()` flags the one shape the device can't represent — a track carrying both kinds would have to be split across two files. The editor can't create one, but a cloud-synced or hand-edited track could be, so it's surfaced rather than silently half-pushed.

## Why this still isn't reachable from the Device tab

Deliberate, and worth your call before I do it. `DeviceTracksTab` goes through the transport-neutral `DeviceDetails` seam (`lib/loggers/types.ts`), which has **two** implementations:

- `bleDetails.ts` — Web Bluetooth. Adding `kind` here is trivial.
- `dovesloggerConnection.ts` — the **native Android IPC bridge**. This one can't speak `TS*` until the Android app does.

So wiring the tab means deciding what native does for sprint in the meantime — most likely "return nothing for sprint until the app catches up", which is a product decision rather than something to smuggle in with a UI change. Recorded as PR 4 in the plan; renumbered the runs view to PR 5.

## Test plan

- [x] `bun run test:run` — **2483 pass / 179 files** (15 new)
  - opcode table, including a prefix-collision check: `"TSFILE:x".startsWith("TFILE:")` must be false, or a client parsing both streams would silently mis-bucket sprint files
  - `trackKind` / `isMixedKindTrack`
  - merge namespacing in both directions, plus that a device file with **no** kind still matches a circuit track (back-compat)
- [x] `bun run lint`, `bun run typecheck`, `bun run build` clean
- [x] Circuit wire behaviour unchanged — `kind` defaults to `'circuit'` everywhere, and the existing `trackSync` tests pass untouched

## Docs

`docs/ble-protocol.md` §4 gains the four `TS*` rows, and a new §9.0 explains the two-folder model, why the opcode carries the folder, and what extra fields a sprint course JSON has (`finish_*`, `date_created`, splits riding in the `sector_2/3` slots positionally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnTP6BdA9xjLR5hSWE9frb)_