### PR TITLE
plan 0015: sprint tracks in the Device tab, over Web Bluetooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sprint tracks appear in the Device tab and sync over Bluetooth** (plan
+  0015). The tab now loads both folders off the logger, tags each track with
+  its kind, and marks sprint tracks with a badge — a circuit and a sprint track
+  can legitimately share a short name, so the list would otherwise show two
+  identical-looking rows. Upload, download and delete all target the folder the
+  track actually came from. **This closes the loop**: a sprint course authored
+  in the track editor can now be pushed to the logger and driven.
+  - **Sprint tracks are Bluetooth-only for now.** The native Android path
+    reports that it can't reach the sprint folder rather than showing an empty
+    list, because the bridge doesn't speak the `TS*` verbs yet. That work is
+    sequenced at the end of the plan — it's gated on the native app's release,
+    which isn't live.
 - **Sprint track sync speaks the device's `TS*` verbs** (plan 0015). The BLE
   client can now list, download, upload and delete tracks in the logger's
   `/TRACKS/SPRINT` folder, alongside the existing `/TRACKS` ones. The folder is

--- a/docs/plans/0015-sprint-mode.md
+++ b/docs/plans/0015-sprint-mode.md
@@ -150,16 +150,34 @@ testable (Golden Rule 3).
   `trackSync.ts` function takes an optional `kind` defaulting to `'circuit'`;
   `buildMergedTrackList` keys on **(kind, shortName)**; `trackKind` /
   `isMixedKindTrack` decide which folder a track belongs in.
-- **PR 4 — device seam + Device tab.** The reason sync is not yet reachable
-  from the UI: `DeviceTracksTab` goes through the transport-neutral
-  `DeviceDetails` seam (`lib/loggers/types.ts`), which has **two**
-  implementations — Web Bluetooth (`bleDetails.ts`) and the native Android IPC
-  bridge (`dovesloggerConnection.ts`). Adding `kind` to `listTracks`/`getTrack`
-  is easy on the BLE side and blocked on the Android app for the native one, so
-  the seam needs a deliberate "native returns nothing for sprint until the app
-  catches up" decision rather than being smuggled in with the UI. Also needs a
-  kind indicator in the tab, since a circuit and a sprint track can now share a
-  short name.
+- ~~**PR 4 — device seam + Device tab (Web Bluetooth only).**~~ **Done.** `DeviceTracksTab`
+  goes through the transport-neutral `DeviceDetails` seam
+  (`lib/loggers/types.ts`), which has **two** implementations: Web Bluetooth
+  (`bleDetails.ts`) and the native Android IPC bridge
+  (`dovesloggerConnection.ts`). The seam gains `kind`; BLE implements it; the
+  tab gains a kind indicator, since a circuit and a sprint track can now share
+  a short name.
+
+  **Decided: the native side is deferred to the end of the project.** The
+  native app is not live yet and its release slipped, so there is nothing to
+  regress — the BLE path is the only one users have today. The native
+  implementation reports no sprint tracks until it is updated, which is honest
+  (it genuinely cannot fetch them) rather than a silent failure.
+
+### Android IPC — end-of-project follow-up
+
+When the native app ships, `dovesloggerConnection.ts` and its Android bridge
+need the `TS*` verbs to reach parity with Web Bluetooth:
+
+- `listTracks(kind)` / `getTrack(name, kind)` / `putTrack(name, data, kind)` /
+  `deleteTrack(name, kind)` must route to `TSLIST` / `TSGET:` / `TSPUT:` /
+  `TSDEL:` when `kind === 'sprint'`.
+- Until then the native path returns an empty sprint list. **This is deliberate
+  and must be revisited here, not patched over at a call site** — the seam is
+  the single place the two transports are supposed to agree.
+- Sequenced at the END of this plan on purpose: it is gated on another
+  product's release, not on anything in this repo, and blocking sprint mode on
+  it would have stalled work that is otherwise finished.
 - **PR 5 — reading runs back.** (Was PR 4; renumbered when the seam split out.)
   `race_mode` in `dovexParser`, run derivation, and a run-oriented `LapTable`.
   `calculateLaps` pairs *consecutive* start/finish crossings and wraps the last

--- a/src/components/drawer/DeviceTracksTab.tsx
+++ b/src/components/drawer/DeviceTracksTab.tsx
@@ -85,9 +85,33 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
           const raw = await details.getTrack(fn);
           const text = new TextDecoder().decode(raw);
           const courses = parseDeviceCourseJson(text);
-          files.push({ shortName: fn.replace(/\.json$/i, ""), courses });
+          files.push({ shortName: fn.replace(/\.json$/i, ""), courses, kind: "circuit" });
         } catch (err) {
           console.error(`Failed to download ${fn}:`, err);
+        }
+      }
+
+      // Sprint tracks live in a second folder, reached by the TS* verbs. A
+      // transport that can't get there reports supportsSprintTracks: false and
+      // is skipped entirely, so a missing capability never looks like an empty
+      // folder. Failures here are logged and swallowed: the circuit list is
+      // already loaded and is worth showing on its own.
+      if (details.supportsSprintTracks) {
+        try {
+          const sprintNames = await details.listTracks("sprint");
+          for (let i = 0; i < sprintNames.length; i++) {
+            const fn = sprintNames[i];
+            setLoadProgress({ current: i + 1, total: sprintNames.length, label: fn });
+            try {
+              const raw = await details.getTrack(fn, "sprint");
+              const courses = parseDeviceCourseJson(new TextDecoder().decode(raw));
+              files.push({ shortName: fn.replace(/\.json$/i, ""), courses, kind: "sprint" });
+            } catch (err) {
+              console.error(`Failed to download sprint ${fn}:`, err);
+            }
+          }
+        } catch (err) {
+          console.error("Sprint track list failed:", err);
         }
       }
 
@@ -121,7 +145,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
     try {
       const json = buildTrackJsonForUpload(entry.appTrack);
       const data = new TextEncoder().encode(json);
-      await details.putTrack(entry.shortName + ".json", data);
+      await details.putTrack(entry.shortName + ".json", data, entry.kind);
       toast.success(t("deviceTracks.sentToast", { name: entry.shortName }));
       await syncAll();
     } catch (err) {
@@ -153,7 +177,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
   const handleDeleteTrackFromDevice = async (entry: MergedTrackEntry) => {
     setUploading(entry.shortName);
     try {
-      await details.deleteTrack(entry.shortName + ".json");
+      await details.deleteTrack(entry.shortName + ".json", entry.kind);
       toast.success(t("deviceTracks.deletedToast", { name: entry.shortName }));
       setDeleteConfirm(null);
       await syncAll();
@@ -171,13 +195,13 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
     try {
       if (remaining.length === 0) {
         // No courses left, delete the whole file
-        await details.deleteTrack(trackEntry.shortName + ".json");
+        await details.deleteTrack(trackEntry.shortName + ".json", trackEntry.kind);
         toast.success(t("deviceTracks.deletedNoCoursesToast", { name: trackEntry.shortName }));
       } else {
         // Re-upload without the deleted course
         const json = JSON.stringify(remaining, null, '\t');
         const data = new TextEncoder().encode(json);
-        await details.putTrack(trackEntry.shortName + ".json", data);
+        await details.putTrack(trackEntry.shortName + ".json", data, trackEntry.kind);
         toast.success(t("deviceTracks.removedCourseToast", { name: courseName }));
       }
       setDeleteConfirm(null);
@@ -215,7 +239,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
     try {
       const json = JSON.stringify(allDeviceCourses, null, '\t');
       const data = new TextEncoder().encode(json);
-      await details.putTrack(trackEntry.shortName + ".json", data);
+      await details.putTrack(trackEntry.shortName + ".json", data, trackEntry.kind);
       toast.success(t("deviceTracks.sentCourseToast", { name: courseName }));
       setDiffCourse(null);
       await syncAll();
@@ -237,7 +261,9 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
       const tracks = await loadTracks();
       setAppTracks(tracks);
       setMergedTracks(buildMergedTrackList(tracks, deviceFiles));
-      const updated = buildMergedTrackList(tracks, deviceFiles).find(t => t.shortName === trackEntry.shortName);
+      // Match on kind too: a circuit and a sprint track can share a short name.
+      const updated = buildMergedTrackList(tracks, deviceFiles)
+        .find(t => t.shortName === trackEntry.shortName && t.kind === trackEntry.kind);
       if (updated) setSelectedTrack(updated);
     } catch (err) {
       toast.error(t("deviceTracks.downloadFailedToast", { error: err instanceof Error ? err.message : t("deviceTracks.unknownError") }));
@@ -263,12 +289,12 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
       try {
         // Delete from device if it exists there
         if (isOnDevice(entry)) {
-          await details.deleteTrack(entry.shortName + ".json");
+          await details.deleteTrack(entry.shortName + ".json", entry.kind);
         }
         // Upload from app
         const json = buildTrackJsonForUpload(entry.appTrack!);
         const data = new TextEncoder().encode(json);
-        await details.putTrack(entry.shortName + ".json", data);
+        await details.putTrack(entry.shortName + ".json", data, entry.kind);
       } catch (err) {
         console.error(`Resync failed for ${entry.shortName}:`, err);
         toast.error(t("deviceTracks.resyncFailedToast", { name: entry.shortName, error: err instanceof Error ? err.message : t("deviceTracks.unknownShort") }));
@@ -319,6 +345,11 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
           </Button>
           <StatusIcon status={selectedTrack.status} />
           <span className="font-medium text-sm text-foreground truncate">{selectedTrack.shortName}</span>
+          {selectedTrack.kind === 'sprint' && (
+            <span className="shrink-0 rounded bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+              {t("deviceTracks.sprintBadge")}
+            </span>
+          )}
           {selectedTrack.trackName && selectedTrack.trackName !== selectedTrack.shortName && (
             <span className="text-xs text-muted-foreground truncate">({selectedTrack.trackName})</span>
           )}
@@ -467,7 +498,9 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
         ) : (
           mergedTracks.map((entry) => (
             <div
-              key={entry.shortName}
+              // Keyed on kind too — a circuit and a sprint track can share a
+              // short name, and React would otherwise collapse them into one row.
+              key={`${entry.kind}:${entry.shortName}`}
               className="flex items-center gap-2 px-3 py-2.5 border-b border-border hover:bg-muted/30 transition-colors cursor-pointer"
               onClick={() => { setSelectedTrack(entry); setView("courses"); }}
             >
@@ -475,6 +508,11 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
               <span className="flex-1 text-sm font-medium text-foreground truncate">
                 {entry.shortName}
               </span>
+              {entry.kind === 'sprint' && (
+                <span className="shrink-0 rounded bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                  {t("deviceTracks.sprintBadge")}
+                </span>
+              )}
               {entry.trackName && entry.trackName !== entry.shortName && (
                 <span className="text-xs text-muted-foreground truncate max-w-[100px]">
                   {entry.trackName}

--- a/src/lib/loggers/bleDetails.ts
+++ b/src/lib/loggers/bleDetails.ts
@@ -28,9 +28,11 @@ export function createBleDeviceDetails(connection: BleConnection): DeviceDetails
     listSettings: () => requestSettingsList(connection),
     setSetting: (key, value) => setDeviceSetting(connection, key, value),
     resetSettings: () => resetDeviceSettings(connection),
-    listTracks: () => requestTrackFileList(connection),
-    getTrack: (name) => downloadTrackFile(connection, name),
-    putTrack: (name, data) => uploadTrackFile(connection, name, data),
-    deleteTrack: (name) => deleteTrackFile(connection, name),
+    listTracks: (kind) => requestTrackFileList(connection, kind),
+    getTrack: (name, kind) => downloadTrackFile(connection, name, undefined, kind),
+    putTrack: (name, data, kind) => uploadTrackFile(connection, name, data, kind),
+    deleteTrack: (name, kind) => deleteTrackFile(connection, name, kind),
+    // Web Bluetooth speaks the TS* verbs directly.
+    supportsSprintTracks: true,
   };
 }

--- a/src/lib/loggers/doveslogger/dovesloggerConnection.test.ts
+++ b/src/lib/loggers/doveslogger/dovesloggerConnection.test.ts
@@ -6,6 +6,14 @@ vi.mock("./ipc", () => ({
   loggerListFiles: vi.fn(),
   loggerDownloadFile: vi.fn(),
   loggerDisconnect: vi.fn(),
+  loggerBattery: vi.fn(),
+  loggerListSettings: vi.fn(),
+  loggerSetSetting: vi.fn(),
+  loggerResetSettings: vi.fn(),
+  loggerListTracks: vi.fn(),
+  loggerDownloadTrack: vi.fn(),
+  loggerUploadTrack: vi.fn(),
+  loggerDeleteTrack: vi.fn(),
 }));
 
 function info(overrides: Partial<ipc.LoggerDeviceInfo> = {}): ipc.LoggerDeviceInfo {
@@ -62,5 +70,31 @@ describe("createDovesloggerConnection", () => {
   it("delegates disconnect to the IPC teardown", () => {
     createDovesloggerConnection(info()).disconnect();
     expect(ipc.loggerDisconnect).toHaveBeenCalled();
+  });
+});
+
+// ─── Sprint tracks over the native bridge (plan 0015) ────────────────────────
+
+describe("native device details — sprint tracks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("declares that it cannot reach the sprint folder", () => {
+    // The tab reads this to say so plainly, instead of rendering an empty
+    // sprint list that looks like "no sprint tracks on the device".
+    expect(createDovesloggerConnection(info()).details!.supportsSprintTracks).toBe(false);
+  });
+
+  it("returns an empty sprint list without touching the bridge", async () => {
+    const details = createDovesloggerConnection(info()).details!;
+    await expect(details.listTracks("sprint")).resolves.toEqual([]);
+    expect(ipc.loggerListTracks).not.toHaveBeenCalled();
+  });
+
+  it("still lists circuit tracks through the bridge", async () => {
+    vi.mocked(ipc.loggerListTracks).mockResolvedValue(["OKC.json"]);
+    const details = createDovesloggerConnection(info()).details!;
+    await expect(details.listTracks("circuit")).resolves.toEqual(["OKC.json"]);
+    await expect(details.listTracks()).resolves.toEqual(["OKC.json"]);
+    expect(ipc.loggerListTracks).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/loggers/doveslogger/dovesloggerConnection.ts
+++ b/src/lib/loggers/doveslogger/dovesloggerConnection.ts
@@ -38,10 +38,20 @@ export function createNativeDeviceDetails(): DeviceDetails {
     listSettings: () => loggerListSettings(),
     setSetting: (key, value) => loggerSetSetting(key, value),
     resetSettings: () => loggerResetSettings(),
-    listTracks: () => loggerListTracks(),
+    // Sprint tracks live in a separate folder reached by the TS* BLE verbs,
+    // which the native bridge does not implement yet. Report nothing rather
+    // than throwing: it genuinely cannot fetch them, and the tab says so
+    // explicitly via supportsSprintTracks rather than showing an empty list
+    // that reads as "no sprint tracks on the device".
+    //
+    // Scheduled for the end of plan 0015 — it is gated on the native app's
+    // release, not on anything in this repo. See
+    // docs/plans/0015-sprint-mode.md, "Android IPC — end-of-project follow-up".
+    listTracks: (kind) => (kind === 'sprint' ? Promise.resolve([]) : loggerListTracks()),
     getTrack: (name) => loggerDownloadTrack(name),
     putTrack: (name, data) => loggerUploadTrack(name, data),
     deleteTrack: (name) => loggerDeleteTrack(name),
+    supportsSprintTracks: false,
   };
 }
 

--- a/src/lib/loggers/types.ts
+++ b/src/lib/loggers/types.ts
@@ -11,6 +11,8 @@
  * the eager graph without pulling a protocol bundle in.
  */
 
+import type { TrackKind } from '@/lib/ble/trackOpcodes';
+
 /** Which physical logger a connection talks to. */
 export type LoggerKind = "fledgling" | "mychron" | "alfano";
 
@@ -58,14 +60,31 @@ export interface DeviceDetails {
    * connection is gone — callers must disconnect and reconnect.
    */
   resetSettings(): Promise<void>;
-  /** List the track files stored on the device. */
-  listTracks(): Promise<string[]>;
-  /** Download one track file. */
-  getTrack(name: string): Promise<Uint8Array>;
-  /** Upload a track file. */
-  putTrack(name: string, data: Uint8Array): Promise<void>;
-  /** Delete a track file. */
-  deleteTrack(name: string): Promise<void>;
+  /**
+   * List the track files stored on the device.
+   *
+   * `kind` selects the folder: circuit tracks (`/TRACKS`) or sprint tracks
+   * (`/TRACKS/SPRINT`). Omitted means circuit, which is what every caller
+   * meant before sprint mode existed.
+   *
+   * A transport that cannot reach the sprint folder returns an empty list for
+   * `'sprint'` rather than throwing — see `docs/plans/0015-sprint-mode.md`
+   * ("Android IPC — end-of-project follow-up"). Reporting nothing is honest:
+   * it genuinely cannot fetch them.
+   */
+  listTracks(kind?: TrackKind): Promise<string[]>;
+  /** Download one track file from the folder `kind` selects. */
+  getTrack(name: string, kind?: TrackKind): Promise<Uint8Array>;
+  /** Upload a track file into the folder `kind` selects. */
+  putTrack(name: string, data: Uint8Array, kind?: TrackKind): Promise<void>;
+  /** Delete a track file from the folder `kind` selects. */
+  deleteTrack(name: string, kind?: TrackKind): Promise<void>;
+  /**
+   * Whether this transport can reach the sprint track folder at all. The tab
+   * uses it to say so plainly instead of showing an empty sprint list that
+   * looks like "no sprint tracks on the device".
+   */
+  readonly supportsSprintTracks?: boolean;
 }
 
 /**

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -369,7 +369,8 @@
     "none": "Keine",
     "startLineDistance": "Abstand der Startlinie:",
     "sendToDevice": "An das Gerät senden",
-    "downloadToApp": "In die App herunterladen"
+    "downloadToApp": "In die App herunterladen",
+    "sprintBadge": "Sprint"
   },
   "vehicleTypeEditor": {
     "title": "Fahrzeugtypen verwalten",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -368,7 +368,8 @@
     "none": "None",
     "startLineDistance": "Start line distance:",
     "sendToDevice": "Send to Device",
-    "downloadToApp": "Download to App"
+    "downloadToApp": "Download to App",
+    "sprintBadge": "Sprint"
   },
   "vehicleTypeEditor": {
     "title": "Manage Vehicle Types",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -369,7 +369,8 @@
     "none": "Ninguno",
     "startLineDistance": "Distancia de la línea de salida:",
     "sendToDevice": "Enviar al dispositivo",
-    "downloadToApp": "Descargar a la app"
+    "downloadToApp": "Descargar a la app",
+    "sprintBadge": "Sprint"
   },
   "vehicleTypeEditor": {
     "title": "Gestionar tipos de vehículo",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -369,7 +369,8 @@
     "none": "Aucun",
     "startLineDistance": "Distance de la ligne de départ :",
     "sendToDevice": "Envoyer à l'appareil",
-    "downloadToApp": "Télécharger dans l'app"
+    "downloadToApp": "Télécharger dans l'app",
+    "sprintBadge": "Sprint"
   },
   "vehicleTypeEditor": {
     "title": "Gérer les types de véhicule",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -369,7 +369,8 @@
     "none": "Nessuno",
     "startLineDistance": "Distanza della linea di partenza:",
     "sendToDevice": "Invia al dispositivo",
-    "downloadToApp": "Scarica nell'app"
+    "downloadToApp": "Scarica nell'app",
+    "sprintBadge": "Sprint"
   },
   "vehicleTypeEditor": {
     "title": "Gestisci tipi di veicolo",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -369,7 +369,8 @@
     "none": "なし",
     "startLineDistance": "スタートライン距離：",
     "sendToDevice": "デバイスに送信",
-    "downloadToApp": "アプリにダウンロード"
+    "downloadToApp": "アプリにダウンロード",
+    "sprintBadge": "スプリント"
   },
   "vehicleTypeEditor": {
     "title": "車両タイプを管理",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -369,7 +369,8 @@
     "none": "Nenhum",
     "startLineDistance": "Distância da linha de largada:",
     "sendToDevice": "Enviar ao dispositivo",
-    "downloadToApp": "Baixar para o app"
+    "downloadToApp": "Baixar para o app",
+    "sprintBadge": "Sprint"
   },
   "vehicleTypeEditor": {
     "title": "Gerenciar tipos de veículo",


### PR DESCRIPTION
Fourth of five, and **the one that closes the loop**: a sprint course authored in the track editor can now be pushed to the logger and driven.

## What changed

The `DeviceDetails` seam gains an optional `kind` on `listTracks` / `getTrack` / `putTrack` / `deleteTrack` — absent means circuit, so every existing caller is unchanged — plus a `supportsSprintTracks` capability flag.

The tab loads **both** folders off the logger, tags each file with the folder it came from, and threads that kind through every upload, download and delete, so an operation can never land in the wrong folder.

Two places needed disambiguating now that a circuit and a sprint track can legitimately share a short name:
- the **list row key** — React would otherwise collapse them into a single row
- the **post-refresh re-find** after downloading a course, which matched on `shortName` alone

Sprint tracks get a badge in the list and in the courses header, so two same-named rows aren't indistinguishable.

## Native Android is deferred to the end of the project

Per your call — the native app isn't live, so nothing regresses by waiting, and this work is gated on that app's release rather than on anything in this repo.

The important bit is *how* it's deferred. Rather than throwing, or silently returning nothing:

```ts
listTracks: (kind) => (kind === 'sprint' ? Promise.resolve([]) : loggerListTracks()),
supportsSprintTracks: false,
```

and the tab **skips the sprint folder entirely** when the capability is false. A missing capability must not render as an empty folder — that reads as "no sprint tracks on the device", which is a different and wrong statement.

The plan now carries an `### Android IPC — end-of-project follow-up` section with the exact verb mapping the bridge will need (`listTracks(kind)` → `TSLIST`, etc.) and a note that it must be revisited *at the seam*, not patched at a call site — the seam is the one place the two transports are supposed to agree.

## Test plan

- [x] `bun run test:run` — **2486 pass / 179 files** (3 new)
  - the native capability flag is `false`
  - a sprint list resolves empty **without touching the bridge** (`expect(ipc.loggerListTracks).not.toHaveBeenCalled()`)
  - circuit listing still goes through the bridge, both explicitly and defaulted
- [x] `bun run lint`, `bun run typecheck`, `bun run build` clean
- [x] Verified no `putTrack`/`deleteTrack` call site was left without a kind (grepped the file for `details.` calls missing `kind` — zero)
- [x] Circuit behaviour unchanged: `kind` is optional everywhere and defaults to circuit

## Worth checking when you review

Sprint download failures are logged and swallowed rather than failing the whole load — the circuit list is already fetched by then and is worth showing on its own. If you'd rather a sprint fetch failure surface as a toast, that's a small change.

## Next — PR 5, the last one

Reading runs back: `race_mode` in `dovexParser` (the firmware already emits it and we silently drop it), run derivation, and a run-oriented `LapTable`. `calculateLaps` pairs *consecutive* start/finish crossings and wraps the last segment back to start/finish — both false for a sprint run, so that's the real work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnTP6BdA9xjLR5hSWE9frb)_