### PR TITLE
plan 0015 (PR 5/5): read sprint runs back out of a DOVEX log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sprint sessions can finally be read back** (plan 0015). Load a log recorded
+  on a sprint course and the app now lists one row per run — start line to the
+  separate finish line — instead of showing nothing at all. Split times, the
+  fastest-run trophy, the map overlay, video sync and leaderboards all keep
+  working, because a run is still modelled as a lap. **This completes sprint
+  mode**: author a course, push it to the logger, drive it, review it.
+  - Runs are timed the way the logger times them: crossing the start line again
+    cancels and restarts the run, so a botched launch and re-run reads the same
+    on screen as it did on the dash.
+  - The **split lines** placed between start and finish now show up as sector
+    times. They previously never rendered at all — a sprint course's splits are
+    stored without the circuit "major sector" flag, and the sector display asked
+    for that flag.
+  - The logger's **`race_mode`** is finally read out of the log header (it was
+    being written and thrown away), along with the device name. It also steers
+    course detection: at a venue with both a circuit and a sprint track, a
+    sprint log no longer risks matching the circuit one and reporting zero runs.
+    Logs recorded before the column existed are unaffected.
+  - **"Lap" wording is kept** — autocross drivers call them laps, and so does
+    the logger. Only the two labels that would be untrue for a point-to-point
+    run change: the empty-state hint, and "Avg Lap Length" → "Avg Run Length".
 - **Sprint tracks appear in the Device tab and sync over Bluetooth** (plan
   0015). The tab now loads both folders off the logger, tags each track with
   its kind, and marks sprint tracks with a badge — a circuit and a sprint track

--- a/docs/plans/0015-sprint-mode.md
+++ b/docs/plans/0015-sprint-mode.md
@@ -1,8 +1,9 @@
 # Sprint Mode (Autocross / Point-to-Point) — DataViewer Side
 
-> Status: **IN PROGRESS** — the logger and the timing library already ship
-> sprint support; this plan is the app catching up. Phase 3 of the cross-repo
-> effort recorded in `DovesDataLogger/docs/plans/0002-sprint-mode.md`.
+> Status: **DONE** (bar the end-of-project Android IPC follow-up below) — the
+> logger and the timing library already shipped sprint support; this plan was
+> the app catching up. Phase 3 of the cross-repo effort recorded in
+> `DovesDataLogger/docs/plans/0002-sprint-mode.md`.
 
 ## Why this exists
 
@@ -178,17 +179,77 @@ need the `TS*` verbs to reach parity with Web Bluetooth:
 - Sequenced at the END of this plan on purpose: it is gated on another
   product's release, not on anything in this repo, and blocking sprint mode on
   it would have stalled work that is otherwise finished.
-- **PR 5 — reading runs back.** (Was PR 4; renumbered when the seam split out.)
-  `race_mode` in `dovexParser`, run derivation, and a run-oriented `LapTable`.
-  `calculateLaps` pairs *consecutive* start/finish crossings and wraps the last
-  segment back to start/finish — both assumptions are false for sprint.
+- ~~**PR 5 — reading runs back.**~~ **Done.** (Was PR 4; renumbered when the
+  seam split out.) `race_mode` in `dovexParser`, run derivation in
+  `calculateLaps`, and sprint-aware sector/label handling. Four things landed,
+  each with a decision worth keeping:
+
+  - **`race_mode` and `device_name` are parsed.** The firmware emits eight
+    metadata columns; the parser read six, so `race_mode` was on the wire and
+    silently dropped. Column names come from `BirdsEye/dovex_header.cpp`, not
+    the firmware's own docs (see the cross-repo note below). `parseRaceMode`
+    returns `undefined` — not `'circuit'` — for an absent, empty *or
+    unrecognized* value: an unknown mode should leave behaviour untouched
+    rather than assert a timing model the log never claimed.
+    `lib/gps/dovepWriter.ts` was deliberately **not** widened to emit the two
+    columns; the phone laptimer records circuit sessions only, and an absent
+    `race_mode` already means circuit.
+
+  - **Run derivation follows the device exactly.** `pairSprintRuns` implements
+    `DovesDataLogger` plan 0002 §7 Q4: a start crossing opens a run *and
+    cancels any run in progress* (the botched-course re-launch rule), a finish
+    crossing completes it, and a finish with no armed run is ignored —
+    i.e. each run opens at the **last** start crossing before its finish.
+    That rule is also what makes the derivation robust to a driver crossing the
+    start line on the way back to grid: the launch is always the last start-line
+    crossing before a finish.
+    The per-lap body (speed stats + the sector-boundary walk) was extracted into
+    a shared `buildLap`, since circuit and sprint differ only in *which*
+    crossings get paired. `calculateLaps` keeps its signature, so all six call
+    sites gained sprint for free. A sprint course with no finish line returns
+    `[]` rather than pairing runs off the start line alone.
+
+  - **Splits are the displayed sectors.** `rollupMajorSectors` returned
+    `undefined` for every sprint course (it required three flagged majors, and
+    sprint splits are stored `major: false` on purpose) — so splits the driver
+    placed in the editor rendered as em-dashes. A new
+    `displayedSectorIndices` makes the *reader* type-aware while the stored
+    flags stay untouched: circuit uses the flagged majors, sprint uses every
+    split. With `MAX_SPRINT_SPLITS = 2` a run has at most three segments, which
+    is exactly the S1/S2/S3 the lap table, video overlays and snapshots already
+    render. `courseHasSectors` gained the matching branch, and the lap table's
+    Simple/Full toggle is suppressed for sprint (all splits being unflagged, its
+    "has sub-sectors" test would otherwise say yes and label them "1 / 1.1 /
+    1.2").
+    **Left alone on purpose:** `sectorLabels` still numbers sprint splits
+    `1.1` / `1.2`. It also drives the track editor and `SectorCropSelect`, so
+    retyping it would touch PR 2's landed UI for a cosmetic gain — a follow-up,
+    not part of reading runs back.
+
+  - **`race_mode` narrows detection.** Parsing it was not enough: nothing in the
+    app read `dovexMetadata` at all. A venue can carry both a circuit and a
+    sprint track, so `findNearestTrack` could pick the wrong one outright and
+    the session would show zero runs. `tracksForRaceMode` drops the
+    non-matching courses (then the emptied tracks) before `autoDetectCourse`
+    runs, wired in `useDataLoader` only. It is conservative in both directions —
+    an unknown mode, or a filter that would leave nothing, returns the input
+    unchanged, so no log detects worse than it did before.
+
+  **Wording:** "lap" stays, per the section below. Only the two labels that are
+  factually untrue point-to-point fork on course type: the empty-state hint
+  (which told the user to pick a track with a start/finish line) and "Avg Lap
+  Length" → "Avg Run Length". The column header stays "Lap".
 
 ## Deliberately kept: "lap" wording
 
 The AX drivers call them laps. The firmware kept the wording on-device for the
 same reason. Runs are modelled as `Lap[]` so every existing consumer — the lap
-table, the overlay renderer, leaderboards, the video sync — keeps working. Only
-labels change, and only in PR 4.
+table, the overlay renderer, leaderboards, the video sync — keeps working.
+
+What landed in PR 5: the noun "Lap" is kept everywhere, in the code *and* on
+screen. Only strings that would be **factually untrue** for a point-to-point run
+fork on course type — the empty-state hint and "Avg Lap Length". The lap-number
+column header is still "Lap".
 
 ## Not in scope
 

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -73,8 +73,8 @@ names that `normalizeChannels` canonicalises.
 
 Extended Dove format with an 8192-byte (8 KB) metadata header:
 ```
-Line 1: datetime,driver,course,short_name,best_lap_ms,optimal_ms
-Line 2: 2024-03-15 14:30:00,Mike,Full CW,OKC,62345,61200
+Line 1: datetime,driver,course,short_name,best_lap_ms,optimal_ms,device_name,race_mode
+Line 2: 2024-03-15 14:30:00,Mike,Cones AM,AX1,62345,61200,ApexTurbo,SPRINT
 Line 3: lap_times_ms
 Line 4: 65432,64321,62345,63456   (lap times in ms, comma-separated)
 \n padding to byte 8192
@@ -83,6 +83,17 @@ Byte 8192+: standard .dove CSV (timestamp,sats,hdop,lat,lng,...)
 
 GPS data is always parseable even if metadata is corrupted. Metadata is attached
 as `ParsedData.dovexMetadata`.
+
+**Columns are read by name, not by position** — that is what lets the firmware
+append columns without breaking older logs. `device_name` and `race_mode` are
+the two most recent; six-column logs simply leave them unset.
+
+**`race_mode`** is `CIRCUIT` / `SPRINT`, compared case-insensitively; empty,
+absent and unrecognized all surface as `undefined`, which every reader treats as
+circuit. It is the app's only signal that a log's "laps" are point-to-point runs
+(line 4 then lists run times), and it narrows auto-detection to matching courses
+via `courseDetection.tracksForRaceMode`, so a sprint log can't latch onto a
+circuit course at the same venue. See `docs/plans/0015-sprint-mode.md`.
 
 **Headerless files:** the logger only writes the metadata header on "end
 session", so an unclosed session leaves the reserved region as blank padding

--- a/src/components/LapTable.tsx
+++ b/src/components/LapTable.tsx
@@ -1,6 +1,6 @@
 import { Fragment, memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Lap, courseHasSectors, Course, GpsSample } from '@/types/racing';
+import { Lap, courseHasSectors, isSprintCourse, Course, GpsSample } from '@/types/racing';
 import { formatLapTime, formatSectorTime, calculateOptimalLap } from '@/lib/lapCalculation';
 import { normalizeCourseSectors, sectorLabels } from '@/lib/courseSectors';
 import { Trophy, Zap, Snail, Target } from 'lucide-react';
@@ -58,6 +58,10 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
   const { useKph } = useSettingsContext();
 
   const showSectors = courseHasSectors(course);
+  // Point-to-point session: the rows are runs, not laps. The "lap" wording is
+  // kept on purpose (autocross drivers use it, and so does the logger) — only
+  // the labels that would be untrue for a run change.
+  const sprint = isSprintCourse(course);
   const [view, setView] = useState<'simple' | 'full'>('simple');
   // In Full view, an optional colored "S# Sum" column before each major group
   // showing that major sector's total time (the S1/S2/S3 rollup). Default on.
@@ -67,6 +71,10 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
   // has sub-sectors beyond the three majors.
   const full = useMemo(() => {
     if (!course) return null;
+    // A sprint course caps at two splits, so its three segments ARE the S1/S2/S3
+    // of the simple view — there is no finer breakdown to offer, and every split
+    // is stored unflagged so the sub-sector test below would wrongly say there is.
+    if (isSprintCourse(course)) return null;
     const sectors = normalizeCourseSectors(course).sectors ?? [];
     const hasSubSectors = sectors.some((s) => !s.major);
     if (!hasSubSectors) return null;
@@ -195,7 +203,9 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
       <div className="flex items-center justify-center h-full text-muted-foreground">
         <p className="text-center">
           {t('lapTable.noLaps')}<br />
-          <span className="text-sm">{t('lapTable.noLapsHint')}</span>
+          <span className="text-sm">
+            {sprint ? t('lapTable.noLapsHintSprint') : t('lapTable.noLapsHint')}
+          </span>
         </p>
       </div>
     );
@@ -460,7 +470,9 @@ export const LapTable = memo(function LapTable({ laps, course, samples, onLapSel
           )}
           {avgLapLength !== null && (
             <div>
-              <span className="text-muted-foreground">{t('lapTable.avgLapLength')}: </span>
+              <span className="text-muted-foreground">
+                {sprint ? t('lapTable.avgRunLength') : t('lapTable.avgLapLength')}:{' '}
+              </span>
               <span className="font-mono text-foreground font-semibold">
                 {t('lapTable.avgLapValue', {
                   feet: (avgLapLength * METERS_TO_FEET).toLocaleString(undefined, { maximumFractionDigits: 0 }),

--- a/src/hooks/useDataLoader.ts
+++ b/src/hooks/useDataLoader.ts
@@ -8,7 +8,7 @@ import {
 import { getFileMetadata, updateFileMetadata, type FileMetadata } from "@/lib/fileStorage";
 import { loadTracks } from "@/lib/trackStorage";
 import { findNearestTrack } from "@/lib/trackUtils";
-import { autoDetectCourse } from "@/lib/courseDetection";
+import { autoDetectCourse, tracksForRaceMode } from "@/lib/courseDetection";
 import { parseDatalogFile } from "@/lib/datalogParser";
 import { ensureSampleFile, SAMPLE_FILE_NAME } from "@/lib/sampleData";
 import type { useSessionData } from "@/hooks/useSessionData";
@@ -156,7 +156,13 @@ export function useDataLoader({
 
       setGpsCenter({ lat: validSample.lat, lon: validSample.lon });
 
-      const detection = autoDetectCourse(parsedData.samples, tracks);
+      // Detection only sees the courses matching the log's own race_mode — a
+      // sprint log must not match a circuit course at the same venue. The full
+      // list stays available everywhere else (allTracks, the prompt fallback).
+      const detection = autoDetectCourse(
+        parsedData.samples,
+        tracksForRaceMode(tracks, parsedData.dovexMetadata?.raceMode),
+      );
       setDetectionResult(detection);
 
       if (detection && !detection.isWaypointMode) {

--- a/src/lib/courseDetection.test.ts
+++ b/src/lib/courseDetection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { autoDetectCourse } from "./courseDetection";
+import { autoDetectCourse, tracksForRaceMode } from "./courseDetection";
 import type { GpsSample, Track, Course } from "@/types/racing";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -450,5 +450,64 @@ describe("autoDetectCourse - waypoint mode", () => {
     expect(course.startFinishA.lat).toBeCloseTo(origin.lat, 3);
     expect(course.startFinishB.lat).toBeCloseTo(origin.lat, 3);
     expect(course.startFinishA.lat).not.toBe(course.startFinishB.lat); // offsets differ
+  });
+});
+
+// ─── tracksForRaceMode ───────────────────────────────────────────────────────
+
+describe("tracksForRaceMode", () => {
+  const circuitCourse: Course = {
+    name: "Full CW",
+    lengthFt: 3383,
+    startFinishA: { lat: 0.0001, lon: 0 },
+    startFinishB: { lat: -0.0001, lon: 0 },
+  };
+  const sprintCourse: Course = {
+    name: "Cones AM",
+    type: "sprint",
+    startFinishA: { lat: 0.0001, lon: 0 },
+    startFinishB: { lat: -0.0001, lon: 0 },
+    finish: { a: { lat: 0.0001, lon: 0.006 }, b: { lat: -0.0001, lon: 0.006 } },
+  };
+
+  const circuitTrack: Track = { name: "Circuit venue", courses: [circuitCourse] };
+  const sprintTrack: Track = { name: "AX venue", courses: [sprintCourse] };
+  const mixedTrack: Track = { name: "Both", courses: [circuitCourse, sprintCourse] };
+
+  it("returns the list untouched when the mode is unknown", () => {
+    const tracks = [circuitTrack, sprintTrack];
+    expect(tracksForRaceMode(tracks, undefined)).toBe(tracks);
+  });
+
+  it("keeps only sprint tracks for a sprint log", () => {
+    const result = tracksForRaceMode([circuitTrack, sprintTrack], "sprint");
+    expect(result.map((t) => t.name)).toEqual(["AX venue"]);
+  });
+
+  it("keeps only circuit tracks for a circuit log", () => {
+    const result = tracksForRaceMode([circuitTrack, sprintTrack], "circuit");
+    expect(result.map((t) => t.name)).toEqual(["Circuit venue"]);
+  });
+
+  it("narrows a mixed track to the matching courses without dropping it", () => {
+    const [track] = tracksForRaceMode([mixedTrack], "sprint");
+    expect(track.name).toBe("Both");
+    expect(track.courses.map((c) => c.name)).toEqual(["Cones AM"]);
+  });
+
+  it("does not mutate the input tracks", () => {
+    tracksForRaceMode([mixedTrack], "sprint");
+    expect(mixedTrack.courses).toHaveLength(2);
+  });
+
+  it("falls back to the full list rather than filtering everything away", () => {
+    // A sprint log at a venue whose courses were never retyped still gets a
+    // best-effort detection instead of an empty track list.
+    const tracks = [circuitTrack];
+    expect(tracksForRaceMode(tracks, "sprint")).toBe(tracks);
+  });
+
+  it("treats a course with no type as circuit", () => {
+    expect(tracksForRaceMode([circuitTrack], "circuit")[0].courses).toHaveLength(1);
   });
 });

--- a/src/lib/courseDetection.ts
+++ b/src/lib/courseDetection.ts
@@ -20,7 +20,7 @@
  * - Divide lap distance by 3 for approximate sectors
  */
 
-import { GpsSample, Track, Course, Lap, CourseDirection, CourseDetectionResult } from '@/types/racing';
+import { GpsSample, Track, Course, Lap, CourseDirection, CourseDetectionResult, RaceMode, isSprintCourse } from '@/types/racing';
 import { calculateLaps, detectSectorOrder } from './lapCalculation';
 import { findNearestTrack, DEFAULT_TRACK_SEARCH_RADIUS_M } from './trackUtils';
 import { haversineDistance, METERS_TO_FEET } from './parserUtils';
@@ -71,6 +71,33 @@ function calculateAverageLapDistanceFt(samples: GpsSample[], laps: Lap[]): numbe
 function detectDirection(samples: GpsSample[], course: Course, laps: Lap[]): CourseDirection | undefined {
   if (laps.length === 0) return undefined;
   return detectSectorOrder(samples, course);
+}
+
+/**
+ * Narrow a track list to the timing model a log says it was recorded in.
+ *
+ * A venue can carry both a circuit layout and a sprint one — they are separate
+ * tracks that may even share a short name. Left unfiltered, `findNearestTrack`
+ * can pick the wrong one outright and the session shows zero laps, so the
+ * DOVEX header's `race_mode` column is used to drop the courses (and then the
+ * tracks) that cannot be what was driven.
+ *
+ * Deliberately conservative in both directions: an unknown mode (every log
+ * predating the column) and a filter that would leave nothing both return the
+ * input unchanged, so no log detects worse than it did before this existed.
+ */
+export function tracksForRaceMode(tracks: Track[], raceMode?: RaceMode): Track[] {
+  if (!raceMode) return tracks;
+
+  const wantSprint = raceMode === 'sprint';
+  const narrowed = tracks
+    .map((track) => ({
+      ...track,
+      courses: track.courses.filter((c) => isSprintCourse(c) === wantSprint),
+    }))
+    .filter((track) => track.courses.length > 0);
+
+  return narrowed.length > 0 ? narrowed : tracks;
 }
 
 /**

--- a/src/lib/courseSectors.test.ts
+++ b/src/lib/courseSectors.test.ts
@@ -3,6 +3,7 @@ import { Course, SectorLine } from '@/types/racing';
 import {
   normalizeCourseSectors, majorSectorLines, legacyMirror, sectorLabels,
   validateCourseSectors, isAtSectorLimit, isAtMajorLimit, rollupMajorSectors, centeredSectorLine,
+  displayedSectorIndices,
   MAX_SECTOR_LINES, MAX_MAJOR_SECTORS, MAX_SPRINT_SPLITS, DEFAULT_SECTOR_HALF_LENGTH_DEG,
 } from './courseSectors';
 
@@ -242,5 +243,70 @@ describe('rollupMajorSectors', () => {
   it('returns undefined when there are fewer than three majors', () => {
     const c = baseCourse({ sectors: [{ line: line(1), major: true }] });
     expect(rollupMajorSectors(c, [1000, 2000])).toBeUndefined();
+  });
+
+  // Sprint splits are stored major:false on purpose, so the circuit rule would
+  // report every sprint run as sector-less. They are the sectors here.
+  describe('sprint courses', () => {
+    const sprint = (splits: number) =>
+      baseCourse({
+        type: 'sprint',
+        finish: line(9),
+        sectors: Array.from({ length: splits }, (_, i) => ({ line: line(i + 1), major: false })),
+      });
+
+    it('maps each split to a displayed sector', () => {
+      const roll = rollupMajorSectors(sprint(2), [1000, 2000, 3000])!;
+      expect(roll.s1).toBe(1000);
+      expect(roll.s2).toBe(2000);
+      expect(roll.s3).toBe(3000);
+    });
+
+    it('reports two sectors for a single split, leaving s3 unset', () => {
+      const roll = rollupMajorSectors(sprint(1), [1000, 2000])!;
+      expect(roll.s1).toBe(1000);
+      expect(roll.s2).toBe(2000);
+      expect(roll.s3).toBeUndefined();
+    });
+
+    it('returns undefined with no splits — the single segment IS the run', () => {
+      expect(rollupMajorSectors(sprint(0), [5000])).toBeUndefined();
+    });
+
+    it('marks a sector undefined when its segment is missing', () => {
+      const roll = rollupMajorSectors(sprint(2), [1000, undefined, 3000])!;
+      expect(roll.s1).toBe(1000);
+      expect(roll.s2).toBeUndefined();
+      expect(roll.s3).toBe(3000);
+    });
+  });
+});
+
+describe('displayedSectorIndices', () => {
+  it('lists the flagged majors on a circuit course, opening line first', () => {
+    const course = baseCourse({
+      sectors: [
+        { line: line(1), major: false },
+        { line: line(2), major: true },
+        { line: line(3), major: true },
+      ],
+    });
+    expect(displayedSectorIndices(course)).toEqual([0, 2, 3]);
+  });
+
+  it('lists every split on a sprint course regardless of the major flag', () => {
+    const course = baseCourse({
+      type: 'sprint',
+      finish: line(9),
+      sectors: [
+        { line: line(1), major: false },
+        { line: line(2), major: false },
+      ],
+    });
+    expect(displayedSectorIndices(course)).toEqual([0, 1, 2]);
+  });
+
+  it('is just the opening line for a course with no sectors', () => {
+    expect(displayedSectorIndices(baseCourse())).toEqual([0]);
   });
 });

--- a/src/lib/courseSectors.ts
+++ b/src/lib/courseSectors.ts
@@ -166,23 +166,47 @@ export function isAtMajorLimit(course: Course): boolean {
 }
 
 /**
+ * Timing-line indices that open a displayed sector, the opening line first.
+ * Indices align to [startFinish, ...course.sectors].
+ *
+ * **Circuit** — the flagged majors, so S1/S2/S3 span major-to-major and any
+ * sub-sectors roll up inside them.
+ *
+ * **Sprint** — *every* split. `major` is meaningless point-to-point (the flag
+ * is stored `false` so a course retyped to circuit fails validation loudly
+ * instead of claiming a sector layout it never had), and there are at most
+ * `MAX_SPRINT_SPLITS` of them, so the run divides into at most three segments —
+ * exactly the S1/S2/S3 the rest of the app already renders. This is display
+ * only: the stored `major` flags are never touched.
+ */
+export function displayedSectorIndices(course: Course): number[] {
+  const indices = [0]; // the start (or start/finish) line always opens sector 1
+  (course.sectors ?? []).forEach((s, i) => {
+    if (s.major || isSprintCourse(course)) indices.push(i + 1);
+  });
+  return indices;
+}
+
+/**
  * Roll the fine-grained per-segment times up into the classic S1/S2/S3, where
- * each major sector spans from its major line to the next major line. A major
- * sector is `undefined` if any of its constituent segments is missing.
+ * each displayed sector spans from its opening line to the next one. A sector
+ * is `undefined` if any of its constituent segments is missing.
  *
  * `sectorTimes[k]` is the segment beginning at timing line k (index 0 = start/
  * finish), aligned to the order [startFinish, ...course.sectors].
+ *
+ * Circuit courses need all three majors before anything is reported — a partial
+ * layout has no meaningful S1/S2/S3. A sprint course reports as many sectors as
+ * it has splits (one split ⇒ `{s1, s2}`), and nothing at all with no splits,
+ * where the single segment IS the run.
  */
 export function rollupMajorSectors(
   course: Course,
   sectorTimes: (number | undefined)[],
 ): SectorTimes | undefined {
-  // Indices of the major timing lines (line 0 = start/finish is always major).
-  const majorIdx = [0];
-  (course.sectors ?? []).forEach((s, i) => {
-    if (s.major) majorIdx.push(i + 1);
-  });
-  if (majorIdx.length < MAX_MAJOR_SECTORS) return undefined;
+  const majorIdx = displayedSectorIndices(course);
+  const minSectors = isSprintCourse(course) ? 2 : MAX_MAJOR_SECTORS;
+  if (majorIdx.length < minSectors) return undefined;
 
   const n = sectorTimes.length;
   const groupTotal = (from: number, toExclusive: number): number | undefined => {
@@ -195,9 +219,11 @@ export function rollupMajorSectors(
     return sum;
   };
 
+  // A sprint course may open fewer than three sectors; the trailing ones stay
+  // undefined and render as the same em-dash a missed crossing produces.
   return {
-    s1: groupTotal(majorIdx[0], majorIdx[1]),
-    s2: groupTotal(majorIdx[1], majorIdx[2]),
-    s3: groupTotal(majorIdx[2], n),
+    s1: groupTotal(majorIdx[0], majorIdx[1] ?? n),
+    s2: majorIdx.length > 1 ? groupTotal(majorIdx[1], majorIdx[2] ?? n) : undefined,
+    s3: majorIdx.length > 2 ? groupTotal(majorIdx[2], n) : undefined,
   };
 }

--- a/src/lib/dovexParser.test.ts
+++ b/src/lib/dovexParser.test.ts
@@ -13,6 +13,7 @@ import {
   isDovexFormat,
   isDovexFormatBuffer,
   parseDovexFile,
+  parseRaceMode,
 } from "./dovexParser";
 
 // A Unix ms timestamp inside the Dove parser's accepted window (≈2021-03).
@@ -50,6 +51,24 @@ function makeDovex(
   } = opts;
   const preamble = [metaHeader, metaValues, lapHeader, lapValues].join("\n");
   return preamble + "\n" + makeDoveCsv(rows);
+}
+
+/**
+ * Build a payload carrying the firmware's CURRENT eight-column metadata row —
+ * `device_name` and `race_mode` appended after `optimal_ms`
+ * (`BirdsEye/dovex_header.cpp`). `makeDovex` above keeps the six-column shape
+ * older loggers wrote, so both generations stay covered.
+ */
+function makeDovexV2(
+  opts: { deviceName?: string; raceMode?: string; lapValues?: string } = {}
+): string {
+  const { deviceName = "ApexTurbo", raceMode = "", lapValues } = opts;
+  return makeDovex({
+    metaHeader:
+      "datetime,driver,course,short_name,best_lap_ms,optimal_ms,device_name,race_mode",
+    metaValues: `2024-03-15 14:30:00,Mike,Cones AM,AX1,62345,61200,${deviceName},${raceMode}`,
+    lapValues,
+  });
 }
 
 // ─── isDovexFormat ──────────────────────────────────────────────────────────
@@ -199,6 +218,69 @@ describe("parseDovexFile — metadata", () => {
     // Other fields still come through.
     expect(m.driver).toBe("Mike");
   });
+});
+
+// ─── parseDovexFile: device_name + race_mode (trailing columns) ─────────────
+
+describe("parseDovexFile — device_name / race_mode", () => {
+  it("reads the trailing device_name and race_mode columns", () => {
+    const m = parseDovexFile(makeDovexV2({ raceMode: "SPRINT" })).dovexMetadata!;
+    expect(m.deviceName).toBe("ApexTurbo");
+    expect(m.raceMode).toBe("sprint");
+    // The columns before them are unaffected by the two extra fields.
+    expect(m.shortName).toBe("AX1");
+    expect(m.optimalMs).toBe(61200);
+  });
+
+  it("compares race_mode case-insensitively", () => {
+    expect(parseDovexFile(makeDovexV2({ raceMode: "sprint" })).dovexMetadata!.raceMode).toBe("sprint");
+    expect(parseDovexFile(makeDovexV2({ raceMode: "Circuit" })).dovexMetadata!.raceMode).toBe("circuit");
+  });
+
+  it("leaves race_mode undefined when the column is empty (circuit session)", () => {
+    const m = parseDovexFile(makeDovexV2({ raceMode: "" })).dovexMetadata!;
+    expect(m.raceMode).toBeUndefined();
+    expect(m.deviceName).toBe("ApexTurbo");
+  });
+
+  it("leaves race_mode undefined for an unrecognized mode", () => {
+    expect(parseDovexFile(makeDovexV2({ raceMode: "RALLY" })).dovexMetadata!.raceMode).toBeUndefined();
+  });
+
+  it("still parses a six-column log that predates both columns", () => {
+    const m = parseDovexFile(makeDovex()).dovexMetadata!;
+    expect(m.deviceName).toBeUndefined();
+    expect(m.raceMode).toBeUndefined();
+    expect(m.driver).toBe("Mike");
+    expect(m.lapTimesMs).toEqual([65432, 64321, 62345]);
+  });
+
+  it("keeps reading the lap-times line after the widened metadata row", () => {
+    const m = parseDovexFile(
+      makeDovexV2({ raceMode: "SPRINT", lapValues: "45120,44980,44980" })
+    ).dovexMetadata!;
+    // Identical consecutive run times are normal in sprint — they must not dedupe.
+    expect(m.lapTimesMs).toEqual([45120, 44980, 44980]);
+  });
+});
+
+// ─── parseRaceMode ──────────────────────────────────────────────────────────
+
+describe("parseRaceMode", () => {
+  it.each(["SPRINT", "sprint", " Sprint "])("accepts %j as sprint", (raw) => {
+    expect(parseRaceMode(raw)).toBe("sprint");
+  });
+
+  it.each(["CIRCUIT", "circuit"])("accepts %j as circuit", (raw) => {
+    expect(parseRaceMode(raw)).toBe("circuit");
+  });
+
+  it.each([undefined, "", "   ", "rally", "1"])(
+    "returns undefined for %j rather than defaulting to circuit",
+    (raw) => {
+      expect(parseRaceMode(raw)).toBeUndefined();
+    }
+  );
 });
 
 // ─── Legacy fixed 8192-byte header ──────────────────────────────────────────

--- a/src/lib/dovexParser.ts
+++ b/src/lib/dovexParser.ts
@@ -1,4 +1,4 @@
-import { ParsedData, DovexMetadata } from '@/types/racing';
+import { ParsedData, DovexMetadata, RaceMode } from '@/types/racing';
 import { parseDoveFile, isDoveFormat } from './doveParser';
 
 /**
@@ -6,7 +6,8 @@ import { parseDoveFile, isDoveFormat } from './doveParser';
  *
  * Extended Dove format with a metadata preamble followed by standard .dove CSV.
  * Preamble usually includes:
- *   Line 1: session metadata column names (datetime,driver,course,short_name,best_lap_ms,optimal_ms)
+ *   Line 1: session metadata column names
+ *           (datetime,driver,course,short_name,best_lap_ms,optimal_ms,device_name,race_mode)
  *   Line 2: session metadata values
  *   Line 3: lap data column names (lap_times_ms / laps_ms)
  *   Line 4: lap data values (comma-separated ms values)
@@ -113,7 +114,28 @@ export function isDovexFormatBuffer(buffer: ArrayBuffer): boolean {
 }
 
 /**
+ * Normalize the DOVEX `race_mode` column.
+ *
+ * The firmware writes `CIRCUIT` / `SPRINT` and compares them case-insensitively
+ * (`BirdsEye/dovex_header.cpp`). Anything else — absent, empty, or a token this
+ * build doesn't know — returns `undefined` rather than defaulting to
+ * `'circuit'`: an unknown mode should leave downstream behaviour untouched, not
+ * assert a timing model the log never claimed.
+ */
+export function parseRaceMode(raw: string | undefined): RaceMode | undefined {
+  switch (raw?.trim().toLowerCase()) {
+    case 'circuit': return 'circuit';
+    case 'sprint': return 'sprint';
+    default: return undefined;
+  }
+}
+
+/**
  * Parse metadata header from the preamble section before Dove CSV starts.
+ *
+ * Fields are looked up BY COLUMN NAME, not by position — that is what makes the
+ * firmware's trailing `device_name` / `race_mode` columns readable from newer
+ * logs while six-column logs still parse. Don't make this positional.
  */
 function parseMetadataHeader(headerText: string): DovexMetadata {
   const meta: DovexMetadata = {};
@@ -146,6 +168,12 @@ function parseMetadataHeader(headerText: string): DovexMetadata {
     const v = parseInt(headerMap['optimal_ms'], 10);
     if (!isNaN(v)) meta.optimalMs = v;
   }
+
+  // Trailing columns, appended by the firmware after optimal_ms — absent in
+  // older logs, and race_mode is empty in circuit sessions.
+  if (headerMap['device_name']) meta.deviceName = headerMap['device_name'];
+  const raceMode = parseRaceMode(headerMap['race_mode']);
+  if (raceMode) meta.raceMode = raceMode;
 
   // Lines 3-4: lap data (header row + values row)
   // Line 3 is typically "lap_times_ms" or "laps_ms", line 4 is comma-separated lap times

--- a/src/lib/lapCalculation.test.ts
+++ b/src/lib/lapCalculation.test.ts
@@ -5,8 +5,9 @@ import {
   formatLapTime,
   formatSectorTime,
   calculateOptimalLap,
+  pairSprintRuns,
 } from "./lapCalculation";
-import type { GpsSample, Course, Lap } from "@/types/racing";
+import type { GpsSample, Course, Lap, LapCrossing } from "@/types/racing";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -534,5 +535,169 @@ describe("calculateOptimalLap", () => {
     const result = calculateOptimalLap(laps)!;
     expect(result.optimalTimeMs).toBe(60000);
     expect(result.deltaToFastest).toBe(50000 - 60000); // negative — fastest beats theoretical optimal
+  });
+});
+
+// ─── calculateLaps: sprint (point-to-point) ──────────────────────────────────
+
+/**
+ * Sprint geometry, all lines vertical and lat ∈ [-0.0001, 0.0001]:
+ *   start at lon=0 · split 1 at lon=0.002 · split 2 at lon=0.004 · finish at lon=0.006
+ *
+ * A run drives east through all four; the return to grid loops far north
+ * (lat=0.01), well outside every line's lat range, so it registers nothing.
+ */
+const SPRINT_LINES = {
+  start: { a: { lat: 0.0001, lon: 0 }, b: { lat: -0.0001, lon: 0 } },
+  finish: { a: { lat: 0.0001, lon: 0.006 }, b: { lat: -0.0001, lon: 0.006 } },
+  split1: { a: { lat: 0.0001, lon: 0.002 }, b: { lat: -0.0001, lon: 0.002 } },
+  split2: { a: { lat: 0.0001, lon: 0.004 }, b: { lat: -0.0001, lon: 0.004 } },
+};
+
+const sprintCourse: Course = {
+  name: "TestSprintCourse",
+  type: "sprint",
+  startFinishA: SPRINT_LINES.start.a,
+  startFinishB: SPRINT_LINES.start.b,
+  finish: SPRINT_LINES.finish,
+};
+
+/** The same course with the two optional splits — stored `major: false`, as the editor writes them. */
+const sprintSplitCourse: Course = {
+  ...sprintCourse,
+  name: "TestSprintSplitCourse",
+  sectors: [
+    { line: SPRINT_LINES.split1, major: false },
+    { line: SPRINT_LINES.split2, major: false },
+  ],
+};
+
+/**
+ * One run of duration `d`: start crossed at +0.05d, splits at +0.15d / +0.25d,
+ * finish at +0.35d (so the run itself takes 0.3d), then a northern return leg.
+ */
+function makeSprintRun(startT: number, d: number, speedMps = 20): GpsSample[] {
+  return [
+    makeSample(startT, 0, -0.001, speedMps),
+    makeSample(startT + d * 0.1, 0, 0.001, speedMps), // cross start
+    makeSample(startT + d * 0.2, 0, 0.003, speedMps), // cross split 1
+    makeSample(startT + d * 0.3, 0, 0.005, speedMps), // cross split 2
+    makeSample(startT + d * 0.4, 0, 0.007, speedMps), // cross finish
+    makeSample(startT + d * 0.5, 0.01, 0.007, speedMps), // north, clear of every line
+    makeSample(startT + d * 0.7, 0.01, -0.001, speedMps), // west at high lat
+    makeSample(startT + d * 0.9, 0, -0.001, speedMps), // back on grid
+  ];
+}
+
+const RUN_D = 60000;
+
+describe("calculateLaps - sprint runs", () => {
+  it("pairs each start crossing with the following finish crossing", () => {
+    const samples = [0, 1, 2].flatMap((i) => makeSprintRun(i * RUN_D, RUN_D));
+    const runs = calculateLaps(samples, sprintCourse);
+
+    expect(runs).toHaveLength(3);
+    expect(runs.map((r) => r.lapNumber)).toEqual([1, 2, 3]);
+    runs.forEach((run, i) => {
+      // Run = start (+0.05d) → finish (+0.35d), i.e. 0.3d — NOT the full lap of grid-to-grid.
+      expect(run.lapTimeMs).toBeCloseTo(RUN_D * 0.3, -1);
+      expect(run.startTime).toBeCloseTo(i * RUN_D + RUN_D * 0.05, -1);
+      expect(run.endTime).toBeCloseTo(i * RUN_D + RUN_D * 0.35, -1);
+      expect(run.startIndex).toBeLessThan(run.endIndex);
+    });
+  });
+
+  it("returns no runs when the sprint course has no finish line", () => {
+    const samples = [0, 1].flatMap((i) => makeSprintRun(i * RUN_D, RUN_D));
+    expect(calculateLaps(samples, { ...sprintCourse, finish: undefined })).toEqual([]);
+  });
+
+  it("opens the run at the LAST start crossing before the finish (re-launch rule)", () => {
+    // Launch, abort back over the start line, re-launch, then finish. The device
+    // cancels and restarts the run on the second start crossing, so must we.
+    const samples = [
+      makeSample(0, 0, -0.001),
+      makeSample(1000, 0, 0.001), // first launch — crosses start at t=500
+      makeSample(2000, 0, 0.003),
+      makeSample(8000, 0, -0.001), // aborts back west (reverse crossing at t=6500)
+      makeSample(14000, 0, 0.001), // re-launch — crosses start at t=11000
+      makeSample(20000, 0, 0.007), // crosses finish at t=19000
+      makeSample(26000, 0.01, 0.007),
+      makeSample(32000, 0.01, -0.001),
+    ];
+    const runs = calculateLaps(samples, sprintCourse);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].startTime).toBeCloseTo(11000, -1);
+    expect(runs[0].endTime).toBeCloseTo(19000, -1);
+    expect(runs[0].lapTimeMs).toBeCloseTo(8000, -1);
+  });
+
+  it("splits the run at every split line, closing the last segment on the finish", () => {
+    const samples = [0, 1].flatMap((i) => makeSprintRun(i * RUN_D, RUN_D));
+    const runs = calculateLaps(samples, sprintSplitCourse);
+
+    expect(runs).toHaveLength(2);
+    const run = runs[0];
+    // 2 splits ⇒ 3 segments: start→s1, s1→s2, s2→finish.
+    expect(run.sectorTimes).toHaveLength(3);
+    expect(run.sectorTimes!.every((t) => t !== undefined && t > 0)).toBe(true);
+    const total = run.sectorTimes!.reduce((a, b) => a! + b!, 0)!;
+    expect(total).toBeCloseTo(run.lapTimeMs, -1);
+    // Each leg of this fixture is a tenth of the run duration apart.
+    run.sectorTimes!.forEach((t) => expect(t).toBeCloseTo(RUN_D * 0.1, -1));
+  });
+
+  it("still produces circuit laps for a course of the same geometry typed as circuit", () => {
+    // Guard against the sprint branch leaking: with no `type`, the start line is
+    // crossed once per run, so consecutive crossings pair into grid-to-grid laps.
+    const samples = [0, 1, 2].flatMap((i) => makeSprintRun(i * RUN_D, RUN_D));
+    const laps = calculateLaps(samples, {
+      ...sprintCourse,
+      type: undefined,
+      finish: undefined,
+      name: "AsCircuit",
+    });
+    expect(laps).toHaveLength(2);
+    expect(laps[0].lapTimeMs).toBeCloseTo(RUN_D, -1);
+  });
+});
+
+// ─── pairSprintRuns ──────────────────────────────────────────────────────────
+
+describe("pairSprintRuns", () => {
+  const at = (crossingTime: number): LapCrossing => ({
+    sampleIndex: crossingTime,
+    crossingTime,
+    fraction: 0.5,
+  });
+  const times = (runs: Array<[LapCrossing, LapCrossing]>) =>
+    runs.map(([s, f]) => [s.crossingTime, f.crossingTime]);
+
+  it("pairs alternating start/finish crossings in order", () => {
+    expect(times(pairSprintRuns([at(10), at(100)], [at(50), at(150)]))).toEqual([
+      [10, 50],
+      [100, 150],
+    ]);
+  });
+
+  it("ignores a finish crossing with no armed run", () => {
+    // The car rolls over the finish line on its way to grid before ever starting.
+    expect(times(pairSprintRuns([at(100)], [at(10), at(150)]))).toEqual([[100, 150]]);
+  });
+
+  it("takes the last start crossing when several precede one finish", () => {
+    expect(times(pairSprintRuns([at(10), at(20), at(30)], [at(50)]))).toEqual([[30, 50]]);
+  });
+
+  it("never reuses a start crossing from a completed run", () => {
+    // The second finish has no start after the first finish — it is dropped
+    // rather than re-pairing with the already-consumed start.
+    expect(times(pairSprintRuns([at(10)], [at(50), at(90)]))).toEqual([[10, 50]]);
+  });
+
+  it("returns nothing when either line was never crossed", () => {
+    expect(pairSprintRuns([], [at(50)])).toEqual([]);
+    expect(pairSprintRuns([at(10)], [])).toEqual([]);
   });
 });

--- a/src/lib/lapCalculation.ts
+++ b/src/lib/lapCalculation.ts
@@ -1,4 +1,4 @@
-import { GpsSample, Course, Lap, LapCrossing, SectorTimes, SectorLine, CourseDirection } from '@/types/racing';
+import { GpsSample, Course, CourseSector, Lap, LapCrossing, SectorTimes, SectorLine, CourseDirection, isSprintCourse } from '@/types/racing';
 import { EARTH_RADIUS_M } from './parserUtils';
 import { normalizeCourseSectors, majorSectorLines, rollupMajorSectors } from './courseSectors';
 
@@ -142,17 +142,207 @@ function projectSectorLine(
   };
 }
 
+/**
+ * Pair start-line and finish-line crossings into point-to-point runs.
+ *
+ * Mirrors the device's `SprintTimer` (DovesDataLogger plan 0002 §7 Q4, decided):
+ * a start crossing opens a run **and cancels any run already in progress** — the
+ * botched-course re-launch rule — a finish crossing completes the open run, and
+ * a finish crossing with no open run is ignored. Equivalently, and this is how
+ * it's implemented: each run opens at the LAST start crossing falling after the
+ * previous run's finish and before this finish.
+ *
+ * That rule is also what makes the derivation robust to a driver crossing the
+ * start line on the way back to grid — the actual launch is always the last
+ * start-line crossing before a finish.
+ *
+ * Both lists must be in ascending time order, which `detectLineCrossings`
+ * guarantees.
+ */
+export function pairSprintRuns(
+  starts: LapCrossing[],
+  finishes: LapCrossing[],
+): Array<[LapCrossing, LapCrossing]> {
+  const runs: Array<[LapCrossing, LapCrossing]> = [];
+  let previousFinishTime = -Infinity;
+
+  for (const finish of finishes) {
+    let opener: LapCrossing | undefined;
+    for (const start of starts) {
+      if (start.crossingTime <= previousFinishTime) continue;
+      if (start.crossingTime >= finish.crossingTime) break;
+      opener = start; // keep walking: the last start before the finish wins
+    }
+    if (!opener) continue; // finish crossing with no armed run
+    runs.push([opener, finish]);
+    previousFinishTime = finish.crossingTime;
+  }
+
+  return runs;
+}
+
+/**
+ * Build one `Lap` from a delimited crossing pair: speed stats over the enclosed
+ * samples plus the per-segment sector walk.
+ *
+ * Shared by the circuit and sprint paths — they differ only in which crossings
+ * get paired, never in what a completed lap/run looks like.
+ */
+function buildLap(
+  lapNumber: number,
+  start: LapCrossing,
+  end: LapCrossing,
+  samples: GpsSample[],
+  course: Course,
+  courseSectors: CourseSector[],
+  sectorCrossings: LineCrossing[][],
+): Lap {
+  const lapTimeMs = end.crossingTime - start.crossingTime;
+
+  // Find max and min speed in this lap with glitch filtering
+  const MIN_SPEED_THRESHOLD_MPH = 1.0;
+  const MAX_GLITCH_SAMPLES = 3;
+
+  const glitchIndices = new Set<number>();
+  let runStart = -1;
+
+  for (let j = start.sampleIndex; j <= end.sampleIndex && j < samples.length; j++) {
+    const isLowSpeed = samples[j].speedMph < MIN_SPEED_THRESHOLD_MPH;
+
+    if (isLowSpeed && runStart === -1) {
+      runStart = j;
+    } else if (!isLowSpeed && runStart !== -1) {
+      const runLength = j - runStart;
+      if (runLength <= MAX_GLITCH_SAMPLES) {
+        for (let k = runStart; k < j; k++) {
+          glitchIndices.add(k);
+        }
+      }
+      runStart = -1;
+    }
+  }
+  if (runStart !== -1) {
+    const runLength = (end.sampleIndex + 1) - runStart;
+    if (runLength <= MAX_GLITCH_SAMPLES) {
+      for (let k = runStart; k <= end.sampleIndex && k < samples.length; k++) {
+        glitchIndices.add(k);
+      }
+    }
+  }
+
+  let maxSpeedMph = 0;
+  let maxSpeedKph = 0;
+  let minSpeedMph = Infinity;
+  let minSpeedKph = Infinity;
+
+  for (let j = start.sampleIndex; j <= end.sampleIndex && j < samples.length; j++) {
+    const sample = samples[j];
+
+    if (sample.speedMph > maxSpeedMph) {
+      maxSpeedMph = sample.speedMph;
+      maxSpeedKph = sample.speedKph;
+    }
+
+    if (!glitchIndices.has(j) && sample.speedMph < minSpeedMph) {
+      minSpeedMph = sample.speedMph;
+      minSpeedKph = sample.speedKph;
+    }
+  }
+
+  // Compute fine-grained per-segment times when the course defines sectors.
+  let sectors: SectorTimes | undefined;
+  let sectorTimes: (number | undefined)[] | undefined;
+  let sectorBoundaries: (number | undefined)[] | undefined;
+
+  // Number of timing lines = the opening line + course sectors. Segment k spans
+  // line k → line k+1; the last closes on `end` (the next start/finish crossing
+  // on a circuit lap, the finish-line crossing on a sprint run).
+  const lineCount = courseSectors.length + 1;
+
+  if (courseSectors.length > 0) {
+    // Walk every sector line in order, finding the crossing for this lap. Each
+    // must fall after the previously matched boundary so out-of-order/missed
+    // crossings leave a gap rather than corrupting later sectors.
+    const boundaryTimes: (number | undefined)[] = new Array(lineCount);
+    const boundaryIdx: (number | undefined)[] = new Array(lineCount);
+    boundaryTimes[0] = start.crossingTime; // line 0 = the lap/run's opening line
+    boundaryIdx[0] = start.sampleIndex;
+    let prevTime = start.crossingTime;
+
+    for (let j = 0; j < courseSectors.length; j++) {
+      const cross = sectorCrossings[j].find(
+        c => c.crossingTime > prevTime && c.crossingTime < end.crossingTime,
+      );
+      if (cross) {
+        boundaryTimes[j + 1] = cross.crossingTime;
+        boundaryIdx[j + 1] = cross.sampleIndex;
+        prevTime = cross.crossingTime;
+      } else {
+        boundaryTimes[j + 1] = undefined;
+        boundaryIdx[j + 1] = undefined;
+      }
+    }
+
+    sectorTimes = new Array(lineCount);
+    for (let k = 0; k < lineCount; k++) {
+      const tStart = boundaryTimes[k];
+      const tEnd = k + 1 < lineCount ? boundaryTimes[k + 1] : end.crossingTime;
+      sectorTimes[k] = tStart !== undefined && tEnd !== undefined ? tEnd - tStart : undefined;
+    }
+    sectorBoundaries = boundaryIdx;
+    sectors = rollupMajorSectors(course, sectorTimes);
+  }
+
+  return {
+    lapNumber,
+    startTime: start.crossingTime,
+    endTime: end.crossingTime,
+    lapTimeMs,
+    maxSpeedMph,
+    maxSpeedKph,
+    minSpeedMph: minSpeedMph === Infinity ? 0 : minSpeedMph,
+    minSpeedKph: minSpeedKph === Infinity ? 0 : minSpeedKph,
+    startIndex: start.sampleIndex,
+    endIndex: end.sampleIndex,
+    sectors,
+    sectorTimes,
+    sectorBoundaries,
+  };
+}
+
+/** Drop the detection-only fields, leaving the public crossing shape. */
+function toLapCrossing(c: LineCrossing): LapCrossing {
+  return { sampleIndex: c.sampleIndex, crossingTime: c.crossingTime, fraction: c.fraction };
+}
+
+/**
+ * Derive completed laps (circuit) or runs (sprint) from a GPS trace.
+ *
+ * The two timing models differ only in how crossings become pairs:
+ * - **circuit** — one line, crossed repeatedly; lap i spans crossing i → i+1.
+ * - **sprint** — two lines; a run spans a start-line crossing → a crossing of
+ *   the separate `course.finish` line (see `pairSprintRuns`).
+ *
+ * Runs are returned as `Lap[]` on purpose, so every consumer — the lap table,
+ * overlay renderer, leaderboards, video sync — keeps working unchanged.
+ */
 export function calculateLaps(samples: GpsSample[], inputCourse: Course): Lap[] {
   if (samples.length < 2) return [];
 
   // Operate on the canonical sector model regardless of how the course was stored.
   const course = normalizeCourseSectors(inputCourse);
+  const sprint = isSprintCourse(course);
+
+  // A sprint course with no finish line cannot be timed. Validation blocks
+  // saving one and the device ignores it too, so an empty list is the honest
+  // answer — far better than pairing runs off the start line alone.
+  if (sprint && !course.finish) return [];
 
   // Calculate center for projection
   const centerLat = (course.startFinishA.lat + course.startFinishB.lat) / 2;
   const centerLon = (course.startFinishA.lon + course.startFinishB.lon) / 2;
 
-  // Project start/finish line
+  // Project start/finish line (the start line in sprint)
   const sfA = projectToPlane(course.startFinishA.lat, course.startFinishA.lon, centerLat, centerLon);
   const sfB = projectToPlane(course.startFinishB.lat, course.startFinishB.lon, centerLat, centerLon);
 
@@ -160,11 +350,7 @@ export function calculateLaps(samples: GpsSample[], inputCourse: Course): Lap[] 
   const sfCrossings = detectLineCrossings(samples, sfA, sfB, centerLat, centerLon, 'sf', MIN_CROSSING_INTERVAL_MS);
 
   // Convert to LapCrossing format for backwards compatibility
-  const crossings: LapCrossing[] = sfCrossings.map(c => ({
-    sampleIndex: c.sampleIndex,
-    crossingTime: c.crossingTime,
-    fraction: c.fraction
-  }));
+  const crossings: LapCrossing[] = sfCrossings.map(toLapCrossing);
 
   // Detect crossings for every sector line in course order (index-tagged).
   const courseSectors = course.sectors ?? [];
@@ -172,127 +358,24 @@ export function calculateLaps(samples: GpsSample[], inputCourse: Course): Lap[] 
     const line = projectSectorLine(sec.line, centerLat, centerLon);
     return detectLineCrossings(samples, line.a, line.b, centerLat, centerLon, j, MIN_SECTOR_CROSSING_INTERVAL_MS);
   });
-  // Number of timing lines = start/finish + course sectors. Segment k spans
-  // line k → line k+1 (last segment wraps back to start/finish).
-  const lineCount = courseSectors.length + 1;
 
-  // Calculate laps from crossings
-  const laps: Lap[] = [];
-  
-  for (let i = 0; i < crossings.length - 1; i++) {
-    const start = crossings[i];
-    const end = crossings[i + 1];
-    
-    const lapTimeMs = end.crossingTime - start.crossingTime;
-    
-    // Find max and min speed in this lap with glitch filtering
-    const MIN_SPEED_THRESHOLD_MPH = 1.0;
-    const MAX_GLITCH_SAMPLES = 3;
-    
-    const glitchIndices = new Set<number>();
-    let runStart = -1;
-    
-    for (let j = start.sampleIndex; j <= end.sampleIndex && j < samples.length; j++) {
-      const isLowSpeed = samples[j].speedMph < MIN_SPEED_THRESHOLD_MPH;
-      
-      if (isLowSpeed && runStart === -1) {
-        runStart = j;
-      } else if (!isLowSpeed && runStart !== -1) {
-        const runLength = j - runStart;
-        if (runLength <= MAX_GLITCH_SAMPLES) {
-          for (let k = runStart; k < j; k++) {
-            glitchIndices.add(k);
-          }
-        }
-        runStart = -1;
-      }
+  let pairs: Array<[LapCrossing, LapCrossing]>;
+  if (sprint) {
+    const finishLine = projectSectorLine(course.finish!, centerLat, centerLon);
+    const finishCrossings = detectLineCrossings(
+      samples, finishLine.a, finishLine.b, centerLat, centerLon, 'sf', MIN_CROSSING_INTERVAL_MS,
+    ).map(toLapCrossing);
+    pairs = pairSprintRuns(crossings, finishCrossings);
+  } else {
+    pairs = [];
+    for (let i = 0; i < crossings.length - 1; i++) {
+      pairs.push([crossings[i], crossings[i + 1]]);
     }
-    if (runStart !== -1) {
-      const runLength = (end.sampleIndex + 1) - runStart;
-      if (runLength <= MAX_GLITCH_SAMPLES) {
-        for (let k = runStart; k <= end.sampleIndex && k < samples.length; k++) {
-          glitchIndices.add(k);
-        }
-      }
-    }
-    
-    let maxSpeedMph = 0;
-    let maxSpeedKph = 0;
-    let minSpeedMph = Infinity;
-    let minSpeedKph = Infinity;
-    
-    for (let j = start.sampleIndex; j <= end.sampleIndex && j < samples.length; j++) {
-      const sample = samples[j];
-      
-      if (sample.speedMph > maxSpeedMph) {
-        maxSpeedMph = sample.speedMph;
-        maxSpeedKph = sample.speedKph;
-      }
-      
-      if (!glitchIndices.has(j) && sample.speedMph < minSpeedMph) {
-        minSpeedMph = sample.speedMph;
-        minSpeedKph = sample.speedKph;
-      }
-    }
-    
-    // Compute fine-grained per-segment times when the course defines sectors.
-    let sectors: SectorTimes | undefined;
-    let sectorTimes: (number | undefined)[] | undefined;
-    let sectorBoundaries: (number | undefined)[] | undefined;
-
-    if (courseSectors.length > 0) {
-      // Walk every sector line in order, finding the crossing for this lap. Each
-      // must fall after the previously matched boundary so out-of-order/missed
-      // crossings leave a gap rather than corrupting later sectors.
-      const boundaryTimes: (number | undefined)[] = new Array(lineCount);
-      const boundaryIdx: (number | undefined)[] = new Array(lineCount);
-      boundaryTimes[0] = start.crossingTime; // line 0 = start/finish
-      boundaryIdx[0] = start.sampleIndex;
-      let prevTime = start.crossingTime;
-
-      for (let j = 0; j < courseSectors.length; j++) {
-        const cross = sectorCrossings[j].find(
-          c => c.crossingTime > prevTime && c.crossingTime < end.crossingTime,
-        );
-        if (cross) {
-          boundaryTimes[j + 1] = cross.crossingTime;
-          boundaryIdx[j + 1] = cross.sampleIndex;
-          prevTime = cross.crossingTime;
-        } else {
-          boundaryTimes[j + 1] = undefined;
-          boundaryIdx[j + 1] = undefined;
-        }
-      }
-
-      // Segment k = boundary k → boundary k+1 (last segment closes on start/finish).
-      sectorTimes = new Array(lineCount);
-      for (let k = 0; k < lineCount; k++) {
-        const tStart = boundaryTimes[k];
-        const tEnd = k + 1 < lineCount ? boundaryTimes[k + 1] : end.crossingTime;
-        sectorTimes[k] = tStart !== undefined && tEnd !== undefined ? tEnd - tStart : undefined;
-      }
-      sectorBoundaries = boundaryIdx;
-      sectors = rollupMajorSectors(course, sectorTimes);
-    }
-
-    laps.push({
-      lapNumber: i + 1,
-      startTime: start.crossingTime,
-      endTime: end.crossingTime,
-      lapTimeMs,
-      maxSpeedMph,
-      maxSpeedKph,
-      minSpeedMph: minSpeedMph === Infinity ? 0 : minSpeedMph,
-      minSpeedKph: minSpeedKph === Infinity ? 0 : minSpeedKph,
-      startIndex: start.sampleIndex,
-      endIndex: end.sampleIndex,
-      sectors,
-      sectorTimes,
-      sectorBoundaries
-    });
   }
-  
-  return laps;
+
+  return pairs.map(([start, end], i) =>
+    buildLap(i + 1, start, end, samples, course, courseSectors, sectorCrossings),
+  );
 }
 
 /**

--- a/src/locales/de/session.json
+++ b/src/locales/de/session.json
@@ -28,6 +28,7 @@
   "lapTable": {
     "noLaps": "Keine Runden erkannt.",
     "noLapsHint": "Wähle eine Strecke mit Start-/Ziellinie",
+    "noLapsHintSprint": "Wähle einen Sprint-Kurs mit Start- und Ziellinie",
     "sectorSums": "Sektorsummen",
     "sectorSumsTitle": "Laufende S1/S2/S3-Summe vor jedem Hauptsektor anzeigen",
     "simple": "Einfach",
@@ -44,6 +45,7 @@
     "optimal": "Optimal",
     "delta": "Delta",
     "avgLapLength": "Durchschnittliche Rundenlänge",
+    "avgRunLength": "Durchschnittliche Lauflänge",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/locales/en/session.json
+++ b/src/locales/en/session.json
@@ -27,6 +27,7 @@
   "lapTable": {
     "noLaps": "No laps detected.",
     "noLapsHint": "Select a track with a start/finish line",
+    "noLapsHintSprint": "Select a sprint course with start and finish lines",
     "sectorSums": "Sector sums",
     "sectorSumsTitle": "Show a running S1/S2/S3 total before each major sector",
     "simple": "Simple",
@@ -43,6 +44,7 @@
     "optimal": "Optimal",
     "delta": "Delta",
     "avgLapLength": "Avg Lap Length",
+    "avgRunLength": "Avg Run Length",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/locales/es/session.json
+++ b/src/locales/es/session.json
@@ -28,6 +28,7 @@
   "lapTable": {
     "noLaps": "No se detectaron vueltas.",
     "noLapsHint": "Selecciona un circuito con línea de meta",
+    "noLapsHintSprint": "Selecciona un trazado sprint con líneas de salida y meta",
     "sectorSums": "Sumas de sector",
     "sectorSumsTitle": "Mostrar un total acumulado S1/S2/S3 antes de cada sector principal",
     "simple": "Simple",
@@ -44,6 +45,7 @@
     "optimal": "Óptima",
     "delta": "Delta",
     "avgLapLength": "Longitud media de vuelta",
+    "avgRunLength": "Longitud media de manga",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/locales/fr/session.json
+++ b/src/locales/fr/session.json
@@ -28,6 +28,7 @@
   "lapTable": {
     "noLaps": "Aucun tour détecté.",
     "noLapsHint": "Sélectionnez un circuit avec une ligne d'arrivée",
+    "noLapsHintSprint": "Sélectionnez un parcours sprint avec des lignes de départ et d'arrivée",
     "sectorSums": "Sommes de secteur",
     "sectorSumsTitle": "Afficher un total cumulé S1/S2/S3 avant chaque secteur principal",
     "simple": "Simple",
@@ -44,6 +45,7 @@
     "optimal": "Optimal",
     "delta": "Delta",
     "avgLapLength": "Longueur moyenne du tour",
+    "avgRunLength": "Longueur moyenne de la manche",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/locales/it/session.json
+++ b/src/locales/it/session.json
@@ -28,6 +28,7 @@
   "lapTable": {
     "noLaps": "Nessun giro rilevato.",
     "noLapsHint": "Seleziona una pista con linea del traguardo",
+    "noLapsHintSprint": "Seleziona un percorso sprint con linee di partenza e arrivo",
     "sectorSums": "Somme settore",
     "sectorSumsTitle": "Mostra un totale progressivo S1/S2/S3 prima di ogni settore principale",
     "simple": "Semplice",
@@ -44,6 +45,7 @@
     "optimal": "Ottimale",
     "delta": "Delta",
     "avgLapLength": "Lunghezza media del giro",
+    "avgRunLength": "Lunghezza media della manche",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/locales/ja/session.json
+++ b/src/locales/ja/session.json
@@ -28,6 +28,7 @@
   "lapTable": {
     "noLaps": "ラップが検出されませんでした。",
     "noLapsHint": "スタート／フィニッシュラインのあるコースを選択してください",
+    "noLapsHintSprint": "スタートラインとフィニッシュラインのあるスプリントコースを選択してください",
     "sectorSums": "セクター合計",
     "sectorSumsTitle": "各メジャーセクターの前に S1/S2/S3 の累計を表示",
     "simple": "シンプル",
@@ -44,6 +45,7 @@
     "optimal": "最適ラップ",
     "delta": "デルタ",
     "avgLapLength": "平均ラップ長",
+    "avgRunLength": "平均走行距離",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/locales/pt-BR/session.json
+++ b/src/locales/pt-BR/session.json
@@ -28,6 +28,7 @@
   "lapTable": {
     "noLaps": "Nenhuma volta detectada.",
     "noLapsHint": "Selecione uma pista com linha de chegada",
+    "noLapsHintSprint": "Selecione um traçado sprint com linhas de largada e chegada",
     "sectorSums": "Somas de setor",
     "sectorSumsTitle": "Mostrar um total acumulado S1/S2/S3 antes de cada setor principal",
     "simple": "Simples",
@@ -44,6 +45,7 @@
     "optimal": "Ótima",
     "delta": "Delta",
     "avgLapLength": "Comprimento médio da volta",
+    "avgRunLength": "Comprimento médio da bateria",
     "avgLapValue": "{{feet}} ft / {{meters}} m"
   },
   "snapshots": {

--- a/src/types/racing.test.ts
+++ b/src/types/racing.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the course predicates that live alongside the type
+ * definitions. Both are single-source-of-truth readers — `isSprintCourse` owns
+ * the "absent type means circuit" default, and `courseHasSectors` decides
+ * whether any view shows sector columns at all — so their edges are worth
+ * pinning independently of the callers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Course, SectorLine, courseHasSectors, isSprintCourse } from './racing';
+
+const line = (n: number): SectorLine => ({
+  a: { lat: n, lon: n },
+  b: { lat: n + 0.001, lon: n + 0.001 },
+});
+
+function baseCourse(partial: Partial<Course> = {}): Course {
+  return {
+    name: 'Test',
+    startFinishA: { lat: 0, lon: 0 },
+    startFinishB: { lat: 0, lon: 0.001 },
+    ...partial,
+  };
+}
+
+describe('isSprintCourse', () => {
+  it('is true only for an explicit sprint type', () => {
+    expect(isSprintCourse(baseCourse({ type: 'sprint' }))).toBe(true);
+    expect(isSprintCourse(baseCourse({ type: 'circuit' }))).toBe(false);
+  });
+
+  it('treats an absent type as circuit — every course predates the field', () => {
+    expect(isSprintCourse(baseCourse())).toBe(false);
+  });
+
+  it('tolerates null/undefined', () => {
+    expect(isSprintCourse(null)).toBe(false);
+    expect(isSprintCourse(undefined)).toBe(false);
+  });
+});
+
+describe('courseHasSectors', () => {
+  it('is false without a course', () => {
+    expect(courseHasSectors(null)).toBe(false);
+  });
+
+  describe('circuit', () => {
+    it('needs two flagged majors alongside the implicit start/finish one', () => {
+      expect(
+        courseHasSectors(
+          baseCourse({ sectors: [{ line: line(1), major: true }, { line: line(2), major: true }] }),
+        ),
+      ).toBe(true);
+      expect(
+        courseHasSectors(baseCourse({ sectors: [{ line: line(1), major: true }] })),
+      ).toBe(false);
+    });
+
+    it('ignores sub-sectors that are not flagged major', () => {
+      expect(
+        courseHasSectors(
+          baseCourse({
+            sectors: [{ line: line(1), major: false }, { line: line(2), major: false }],
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('falls back to the legacy sector2/sector3 pair on un-normalized courses', () => {
+      expect(courseHasSectors(baseCourse({ sector2: line(1), sector3: line(2) }))).toBe(true);
+      expect(courseHasSectors(baseCourse({ sector2: line(1) }))).toBe(false);
+    });
+  });
+
+  describe('sprint', () => {
+    const sprint = (partial: Partial<Course> = {}) =>
+      baseCourse({ type: 'sprint', finish: line(9), ...partial });
+
+    it('counts any split, even though splits are stored unflagged', () => {
+      expect(courseHasSectors(sprint({ sectors: [{ line: line(1), major: false }] }))).toBe(true);
+      expect(
+        courseHasSectors(
+          sprint({ sectors: [{ line: line(1), major: false }, { line: line(2), major: false }] }),
+        ),
+      ).toBe(true);
+    });
+
+    it('is false with no splits — the whole run is one segment', () => {
+      expect(courseHasSectors(sprint())).toBe(false);
+      expect(courseHasSectors(sprint({ sectors: [] }))).toBe(false);
+    });
+
+    it('does not consult the legacy sector2/sector3 mirror', () => {
+      expect(courseHasSectors(sprint({ sector2: line(1), sector3: line(2) }))).toBe(false);
+    });
+  });
+});

--- a/src/types/racing.ts
+++ b/src/types/racing.ts
@@ -101,12 +101,20 @@ export function isSprintCourse(course: Pick<Course, 'type'> | null | undefined):
 }
 
 /**
- * True when a course produces the classic three major sectors (start/finish +
- * two flagged majors). Reads the canonical `sectors` array, falling back to the
- * legacy `sector2`/`sector3` pair for un-normalized courses.
+ * True when a course produces sector times worth displaying.
+ *
+ * **Circuit** — the classic three majors (start/finish + two flagged). Reads
+ * the canonical `sectors` array, falling back to the legacy `sector2`/`sector3`
+ * pair for un-normalized courses.
+ *
+ * **Sprint** — any split at all. Splits are stored `major: false` (the flag is
+ * meaningless point-to-point), so the circuit rule would report every sprint
+ * course as sector-less and hide splits the driver deliberately placed. One
+ * split already divides the run into two timed segments.
  */
 export function courseHasSectors(course: Course | null): boolean {
   if (!course) return false;
+  if (isSprintCourse(course)) return (course.sectors?.length ?? 0) > 0;
   if (course.sectors && course.sectors.length > 0) {
     const majors = course.sectors.filter((s) => s.major).length;
     return majors >= 2; // + the implicit start/finish major = 3 total
@@ -184,6 +192,16 @@ export interface FieldMapping {
   enabled: boolean;
 }
 
+/**
+ * How a logged session was timed, from the DOVEX header's `race_mode` column.
+ *
+ * The device writes `CIRCUIT` / `SPRINT` (compared case-insensitively) and
+ * leaves it empty in circuit sessions; logs predating the column have no such
+ * field at all. Both cases surface as `undefined` — "unknown, assume circuit" —
+ * so a reader never has to distinguish "old log" from "circuit log".
+ */
+export type RaceMode = 'circuit' | 'sprint';
+
 export interface DovexMetadata {
   datetime?: string;
   driver?: string;
@@ -191,6 +209,14 @@ export interface DovexMetadata {
   shortName?: string;
   bestLapMs?: number;
   optimalMs?: number;
+  /** The logging device's name (`device_name`). Trailing column; older logs omit it. */
+  deviceName?: string;
+  /**
+   * Timing model the session was recorded in (`race_mode`). Trailing column;
+   * absent, empty or unrecognized ⇒ `undefined` (treat as circuit).
+   */
+  raceMode?: RaceMode;
+  /** Per-lap times from the header. In a sprint session these are run times. */
   lapTimesMs?: number[];
 }
 


### PR DESCRIPTION
## Summary

The last piece of sprint (autocross / point-to-point) support. PRs 1–4 (#375, #376, #377, #378) let a user author a sprint course and push it to the logger. What they couldn't do is look at the resulting log — a sprint session showed **zero laps**. This closes that loop: author → push → drive → **review**.

Three problems, in dependency order, plus one that surfaced while wiring them up.

**1. `race_mode` was on the wire and being dropped.** The firmware emits eight metadata columns; `parseMetadataHeader` read six. Column names are taken from `BirdsEye/dovex_header.cpp`, not the firmware's own docs, which still list the pre-rename `driver_name`/`course_name`/`optimal_lap_ms` (the code is right, that doc is wrong — worth a one-line fix in the other repo). The lookup stays keyed by name, which is what makes appending columns readable from new logs while six-column logs keep parsing untouched. `parseRaceMode` returns `undefined` — not `'circuit'` — for absent/empty/**unrecognized**: an unknown mode should leave behaviour exactly as it was rather than assert a timing model the log never claimed.

**2. `calculateLaps` was circuit-only by construction.** It detected crossings of one line and paired *consecutive* ones. Pairing is the only thing that actually differs, so the per-lap body (speed stats + the sector-boundary walk) is extracted into a shared `buildLap` — the walk was already correct for a run once `end` is the finish crossing, since its last segment simply closes on `end`. `pairSprintRuns` then mirrors the device's `SprintTimer` exactly (`DovesDataLogger` plan 0002 §7 Q4): a start crossing opens a run **and cancels any run in progress** — the botched-course re-launch rule — a finish crossing completes it, a finish with no armed run is ignored. Equivalently: each run opens at the **last** start crossing before its finish, which is also what makes the derivation robust to a driver crossing the start line on the way back to grid. Signature unchanged, so all six call sites gained sprint without being touched. Runs stay `Lap[]` on purpose.

**3. Splits never rendered.** Sprint splits are stored `major: false` deliberately (the flag is meaningless point-to-point, and flagging them would let a course retyped to circuit look like a valid three-major layout it never had) — but *both* readers of that flag treat its absence as "no sectors", so `courseHasSectors` returned false and `rollupMajorSectors` bailed. Fixed in the readers, not the data: `displayedSectorIndices` names the lines that open a displayed sector — flagged majors on a circuit, every split on a sprint course. With `MAX_SPRINT_SPLITS = 2` a run has at most three segments, i.e. exactly the S1/S2/S3 the lap table, video overlays and snapshots already render.

**4. (Added after discussion) `race_mode` now steers detection.** Parsing it wasn't enough on its own — nothing in the app read `dovexMetadata` at all, so the column would have gone from "dropped by the parser" to "dropped by every consumer". A venue can carry both a circuit and a sprint track; unfiltered, `findNearestTrack` can pick the wrong one outright and the session reports zero runs with nothing on screen to explain why. `tracksForRaceMode` is conservative in both directions: an unknown mode (every pre-column log) and a filter that would leave nothing both return the input unchanged, so **no log detects worse than it did before**.

**Wording:** "Lap" is kept, in the code *and* on screen — autocross drivers call them laps and the logger kept the wording on-device for the same reason. Only the two strings that are factually untrue for a point-to-point run fork on course type: the empty-state hint (it told you to pick a track with a start/finish line) and "Avg Lap Length" → "Avg Run Length". The lap-number column header is unchanged.

## Related Issues

Completes `docs/plans/0015-sprint-mode.md` (PR 5 of 5) — phase 3 of the cross-repo effort in `DovesDataLogger/docs/plans/0002-sprint-mode.md`. Follows #375, #376, #377, #378.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [x] Refactor / reusability improvement <!-- buildLap extraction; displayedSectorIndices -->
- [x] Documentation

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes (`tsc -b`)
- [x] `bun run test:run` passes — 2536 tests, 180 files
- [x] `bun run build` succeeds
- [x] Feature works **offline** (no new network calls; all of it is local parsing and geometry)
- [x] Docs updated where relevant — `CHANGELOG.md`, `docs/plans/0015-sprint-mode.md`, `docs/subsystems.md`
- [ ] For a new parser: n/a — extends the existing `.dovex` parser, no new format

## Notes for Reviewers

**The strongest signal in this diff is what *didn't* change.** The pre-existing circuit assertions in `lapCalculation.test.ts` pass **unmodified** — that is the proof the `buildLap` extraction is behaviour-preserving. Worth confirming that when reviewing commit 2.

**Not verified end-to-end.** I have no sprint-mode `.dovex` to load, so everything here is unit-tested against synthetic geometry. Before merge, ideally: load a real sprint log and cross-check the derived run times against the header's own `laps_ms` line (the firmware's own numbers, already parsed into `metadata.lapTimesMs`) — they should agree to within interpolation tolerance. That's a genuinely useful oracle and it's free.

**Two deliberate non-changes**, both recorded in the plan doc so they don't read as oversights:
- `lib/gps/dovepWriter.ts` still emits six columns. The phone laptimer records circuit sessions only, and an absent `race_mode` already means circuit.
- `sectorLabels` still numbers sprint splits `1.1` / `1.2`. It also drives the track editor and `SectorCropSelect`, so renumbering is a cosmetic change to PR 2's landed UI, not part of reading runs back. The lap table's Simple/Full toggle is suppressed for sprint anyway (with every split unflagged, its "has sub-sectors" test would otherwise say yes and surface those labels).

**Coverage:** `src/types/racing.test.ts` is new — `isSprintCourse` owns the "absent type means circuit" default and `courseHasSectors` decides whether *any* view shows sector columns, so their edges are pinned independently of the callers. No logic was added to `LapTable.tsx` beyond calls to already-tested lib helpers, per the coverage config's exclusion of `src/components/**/*.tsx`.

**i18n:** two new `session:lapTable.*` keys, seeded to all seven locales by hand (the seeder needs an API key), matching each file's existing sprint terminology from the track editor — manga / manche / Lauf / manche / 走行 / bateria. Diff is exactly +2 lines per file, no reformatting.

Six commits, one concern each, all citing the plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_