### PR TITLE
fix: explain the OTA "SIZE" rejection instead of relaying the raw token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A firmware update that fails with "SIZE" now says what to do about it.**
+  The size limit lives in the firmware *already installed on the logger*, not
+  in the image or in this app — anything older than v3.1.0 carved a smaller
+  staging region out of flash and refuses a larger image before the upload
+  even starts. The app relayed the device's bare `SIZE` token, which gave no
+  hint that the fix is to install v3.1.0 first (it fits under the old limit,
+  and carries the bigger region) and then retry. It now says exactly that,
+  naming the version the device reported. Devices that report v3.1.0 or newer
+  and still refuse are pointed at USB instead, rather than sent on a
+  pointless staged upgrade.
+  - Groundwork, not yet surfaced: the check is a pure helper, so the update
+    dialog can warn *before* the download rather than after the handshake.
+
 ### Added
 - **Sprint sessions can finally be read back** (plan 0015). Load a log recorded
   on a sprint course and the app now lists one row per run — start line to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A course created on the logger now actually arrives when you sync it.**
+  Syncing a track the device authored itself brought the track across with
+  **no courses in it** — the walked course was on the card and simply
+  vanished on the way in. The device writes the same track-file shape this
+  app does (a track object with a `courses` list), but the device-sync
+  reader only understood the older bare-list format, so it parsed the file
+  fine, found no list where it expected one, and returned nothing without
+  a word. Both shapes are now read, matching what the logger's own parser
+  accepts.
+- **Sprint finish lines are drawn on the maps, not just in the track
+  editor.** A sprint course's separate finish line only ever appeared while
+  editing it — the session race-line map and the simulator map didn't know
+  the line existed, so a point-to-point course looked identical to a
+  circuit one everywhere it mattered. Both now draw it, and on a sprint
+  course the start line turns green so start and finish read as
+  green-to-end rather than two identical red lines. Circuit maps are
+  unchanged.
 - **A firmware update that fails with "SIZE" now says what to do about it.**
   The size limit lives in the firmware *already installed on the logger*, not
   in the image or in this app — anything older than v3.1.0 carved a smaller

--- a/src/components/RaceLineView.tsx
+++ b/src/components/RaceLineView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import L from 'leaflet';
 import { GpsSample, Course, ParserStats } from '@/types/racing';
 import { normalizeCourseSectors } from '@/lib/courseSectors';
+import { COURSE_LINE_COLORS, finishLineOf, openingLineColor } from '@/lib/courseLineStyle';
 import { findSpeedEvents, SpeedEvent } from '@/lib/speedEvents';
 import { computeHeatmapSpeedBoundsMph } from '@/lib/speedBounds';
 import { buildHeatmapSegments } from '@/lib/speedHeatmap';
@@ -470,23 +471,33 @@ export function RaceLineView({ samples, allSamples, referenceSamples = [], cours
 
     if (!course) return;
 
-    // Draw start/finish line (red)
+    // Opening line: red on a circuit (where it is the finish as well), green
+    // on a sprint course whose finish is the separate line drawn below.
     startFinishRef.current = L.polyline(
       [[course.startFinishA.lat, course.startFinishA.lon], [course.startFinishB.lat, course.startFinishB.lon]],
-      { color: 'hsl(0, 75%, 55%)', weight: 5, opacity: 1 }
+      { color: openingLineColor(course), weight: 5, opacity: 1 }
     ).addTo(map);
 
-    // Draw every sector line: majors purple, sub-sectors sky-blue (secondary).
+    // Sector lines (majors purple, sub-sectors sky-blue) plus — sprint only —
+    // the separate finish line. Both ride the same layer group so the cleanup
+    // above keeps working unchanged.
     const sectors = normalizeCourseSectors(course).sectors ?? [];
-    if (sectors.length > 0) {
+    const finish = finishLineOf(course);
+    if (sectors.length > 0 || finish) {
       const group = L.layerGroup();
       for (const sec of sectors) {
         const major = sec.major;
         L.polyline(
           [[sec.line.a.lat, sec.line.a.lon], [sec.line.b.lat, sec.line.b.lon]],
           major
-            ? { color: 'hsl(280, 70%, 55%)', weight: 4, opacity: 0.9 }
-            : { color: 'hsl(199, 89%, 60%)', weight: 3, opacity: 0.7, dashArray: '6 5' }
+            ? { color: COURSE_LINE_COLORS.major, weight: 4, opacity: 0.9 }
+            : { color: COURSE_LINE_COLORS.sub, weight: 3, opacity: 0.7, dashArray: '6 5' }
+        ).addTo(group);
+      }
+      if (finish) {
+        L.polyline(
+          [[finish.a.lat, finish.a.lon], [finish.b.lat, finish.b.lon]],
+          { color: COURSE_LINE_COLORS.finish, weight: 5, opacity: 1 }
         ).addTo(group);
       }
       group.addTo(map);

--- a/src/components/sim/SimMap.tsx
+++ b/src/components/sim/SimMap.tsx
@@ -16,6 +16,7 @@ import { Moon, Satellite } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { updatePositionMarker } from "@/components/map/positionArrowMarker";
 import type { Course, GpsSample } from "@/types/racing";
+import { COURSE_LINE_COLORS, finishLineOf, openingLineColor } from "@/lib/courseLineStyle";
 import "leaflet/dist/leaflet.css";
 
 const TILE_STYLES = {
@@ -45,6 +46,7 @@ export function SimMap({ samples, course, positionIndex }: SimMapProps) {
   const tilesRef = useRef<L.TileLayer | null>(null);
   const pathRef = useRef<L.Polyline | null>(null);
   const startFinishRef = useRef<L.Polyline | null>(null);
+  const finishRef = useRef<L.Polyline | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
   const [style, setStyle] = useState<TileStyle>("dark");
 
@@ -67,18 +69,32 @@ export function SimMap({ samples, course, positionIndex }: SimMapProps) {
     map.fitBounds(pathRef.current.getBounds(), { padding: [24, 24] });
 
     if (course) {
+      // Red on a circuit (one line doing both jobs); green on a sprint
+      // course, whose separate finish line is drawn red just below.
       startFinishRef.current = L.polyline(
         [
           [course.startFinishA.lat, course.startFinishA.lon],
           [course.startFinishB.lat, course.startFinishB.lon],
         ],
-        { color: "hsl(0, 84%, 60%)", weight: 4, opacity: 0.9 },
+        { color: openingLineColor(course), weight: 4, opacity: 0.9 },
       ).addTo(map);
+
+      const finish = finishLineOf(course);
+      if (finish) {
+        finishRef.current = L.polyline(
+          [
+            [finish.a.lat, finish.a.lon],
+            [finish.b.lat, finish.b.lon],
+          ],
+          { color: COURSE_LINE_COLORS.finish, weight: 4, opacity: 0.9 },
+        ).addTo(map);
+      }
     }
 
     return () => {
       markerRef.current = null;
       startFinishRef.current = null;
+      finishRef.current = null;
       pathRef.current = null;
       tilesRef.current = null;
       map.remove();

--- a/src/hooks/useFirmwareUpdate.ts
+++ b/src/hooks/useFirmwareUpdate.ts
@@ -8,6 +8,7 @@ import { beginFirmwareUpdate, uploadFirmwareImage, applyFirmware } from "@/lib/b
 import {
   acquireFirmwareImage,
   evaluateFirmwareUpdate,
+  explainFirmwareFailure,
   fetchFirmwareManifest,
   readDeviceFirmwareInfo,
   type DeviceFirmwareInfo,
@@ -135,6 +136,9 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
     setFlashingLocal(true);
     setFlashing(true);
     let installing = false;
+    // Kept for the failure path: a device that rejects on SIZE needs to be told
+    // how big the image was and which version unlocks it.
+    let imageBytes: number | null = null;
 
     try {
       // 0. Download the image (prefer the raw .bin), compute its CRC, and verify
@@ -144,6 +148,7 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
       setPhase("downloading");
       fwLog("downloading", build.name, build.appBin ?? build.dfuZip);
       const { image, crc } = await acquireFirmwareImage(build);
+      imageBytes = image.length;
       fwLog("image ready + verified vs manifest", { bytes: image.byteLength, crc });
 
       // 1–3. CRC handshake — verify the control channel, and declare the target
@@ -173,15 +178,23 @@ export function useFirmwareUpdate(connection: BleConnection | null) {
       // tear down the "complete" dialog. The user acknowledges via finish().
     } catch (e) {
       fwLog("update failed", { installing, error: errorMessage(e) });
+      // A raw "SIZE" tells the user nothing — the cap lives in the firmware
+      // already on the device, and the remedy is a hop through an older
+      // release. Say that instead.
+      const explained = explainFirmwareFailure(e, {
+        installedVersion: info?.version,
+        imageBytes,
+      });
+      const message = explained?.message ?? errorMessage(e);
       setPhase("error");
-      setFlashError(errorMessage(e));
+      setFlashError(message);
       setNeedsDisconnect(installing);
       setFlashing(false);
-      toast.error(`Firmware update failed: ${errorMessage(e)}`);
+      toast.error(explained ? message : `Firmware update failed: ${message}`);
     } finally {
       setFlashingLocal(false);
     }
-  }, [connection, pendingBuild, setFlashing]);
+  }, [connection, pendingBuild, setFlashing, info]);
 
   /** Dismiss the error state; drops the connection if the device had rebooted. */
   const dismiss = useCallback(() => {

--- a/src/lib/ble/dfu/firmwareUpdateError.test.ts
+++ b/src/lib/ble/dfu/firmwareUpdateError.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The `SIZE` rejection is the one OTA failure users can't reason about on
+ * their own: the cap lives in the firmware ALREADY INSTALLED on the device,
+ * not in the image or in this app. These tests pin the explanation that says
+ * so — and, just as importantly, pin that it stays quiet for everything else.
+ */
+
+import { describe, it, expect } from "vitest";
+import { FirmwareProtocolError } from "../firmwareUpload";
+import {
+  OTA_LAYOUT_MIN_VERSION,
+  OTA_LEGACY_MAX_BYTES,
+  exceedsLegacyOtaCap,
+  explainFirmwareFailure,
+  needsOtaLayoutUpgrade,
+} from "./firmwareUpdateError";
+
+const sizeError = () => new FirmwareProtocolError("Firmware handshake failed", "SIZE");
+
+describe("needsOtaLayoutUpgrade", () => {
+  it.each(["3.0.0", "3.0.1", "2.2.3", "1.0.0"])(
+    "is true for %s — older than the larger staging layout",
+    (version) => {
+      expect(needsOtaLayoutUpgrade(version)).toBe(true);
+    },
+  );
+
+  it.each([OTA_LAYOUT_MIN_VERSION, "3.1.1", "3.2.0", "4.0.0"])(
+    "is false for %s — already carries the layout",
+    (version) => {
+      expect(needsOtaLayoutUpgrade(version)).toBe(false);
+    },
+  );
+
+  it("never claims an unknown version is out of date", () => {
+    expect(needsOtaLayoutUpgrade(null)).toBe(false);
+    expect(needsOtaLayoutUpgrade(undefined)).toBe(false);
+    expect(needsOtaLayoutUpgrade("")).toBe(false);
+  });
+});
+
+describe("exceedsLegacyOtaCap", () => {
+  it("is true only past the legacy cap", () => {
+    expect(exceedsLegacyOtaCap(OTA_LEGACY_MAX_BYTES + 1)).toBe(true);
+    expect(exceedsLegacyOtaCap(340_868)).toBe(true); // the build that prompted this
+    expect(exceedsLegacyOtaCap(OTA_LEGACY_MAX_BYTES)).toBe(false);
+    expect(exceedsLegacyOtaCap(324_000)).toBe(false);
+  });
+
+  it("is false when the size is unknown", () => {
+    expect(exceedsLegacyOtaCap(null)).toBe(false);
+    expect(exceedsLegacyOtaCap(undefined)).toBe(false);
+  });
+});
+
+describe("explainFirmwareFailure", () => {
+  it("names the device's version and the release that unlocks it", () => {
+    const explained = explainFirmwareFailure(sizeError(), {
+      installedVersion: "3.0.1",
+      imageBytes: 340_868,
+    })!;
+
+    expect(explained.needsLayoutUpgrade).toBe(true);
+    expect(explained.message).toContain("v3.0.1");
+    expect(explained.message).toContain(`v${OTA_LAYOUT_MIN_VERSION}`);
+    expect(explained.message).toContain("333 KiB"); // the image, so it's comparable to the cap
+  });
+
+  it("still points at the fix when the version could not be read", () => {
+    const explained = explainFirmwareFailure(sizeError(), {
+      installedVersion: null,
+      imageBytes: 340_868,
+    })!;
+
+    expect(explained.needsLayoutUpgrade).toBe(true);
+    expect(explained.message).toContain(`v${OTA_LAYOUT_MIN_VERSION}`);
+    expect(explained.message).toContain("320 KiB"); // the cap it's up against
+    // Must not invent a version it never read.
+    expect(explained.message).not.toContain("null");
+    expect(explained.message).not.toContain("undefined");
+  });
+
+  it("does NOT send a new-enough device down the staged-upgrade path", () => {
+    // Reports the layout already and still refused — telling this user to
+    // install 3.1.0 would be a wild goose chase.
+    const explained = explainFirmwareFailure(sizeError(), {
+      installedVersion: "3.2.0",
+      imageBytes: 500_000,
+    })!;
+
+    expect(explained.needsLayoutUpgrade).toBe(false);
+    expect(explained.message).toContain("USB");
+  });
+
+  it("omits the size when it isn't known", () => {
+    const explained = explainFirmwareFailure(sizeError(), { installedVersion: "3.0.1" })!;
+    expect(explained.message).toContain("v3.0.1");
+    expect(explained.message).not.toContain("NaN");
+    expect(explained.message).not.toContain("KiB)");
+  });
+
+  it("stays out of the way for every other protocol token", () => {
+    for (const reason of ["CRC", "WRITE", "BATTERY", "VARIANT", "STATE", "FLASH"]) {
+      const err = new FirmwareProtocolError("Firmware upload failed", reason);
+      expect(explainFirmwareFailure(err, { installedVersion: "3.0.1" })).toBeNull();
+    }
+  });
+
+  it("stays out of the way for non-protocol errors", () => {
+    expect(explainFirmwareFailure(new Error("Timed out"), { installedVersion: "3.0.1" })).toBeNull();
+    expect(explainFirmwareFailure("SIZE", { installedVersion: "3.0.1" })).toBeNull();
+    expect(explainFirmwareFailure(null)).toBeNull();
+  });
+});
+
+describe("FirmwareProtocolError", () => {
+  it("keeps the raw token alongside a readable message", () => {
+    const err = new FirmwareProtocolError("Firmware handshake failed", "SIZE");
+    expect(err.reason).toBe("SIZE");
+    expect(err.message).toBe("Firmware handshake failed: SIZE");
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/src/lib/ble/dfu/firmwareUpdateError.ts
+++ b/src/lib/ble/dfu/firmwareUpdateError.ts
@@ -1,0 +1,122 @@
+import { FirmwareProtocolError } from "../firmwareUpload";
+import { compareVersions } from "./firmwareManifest";
+
+/**
+ * Turning a device-side `FWERR:<token>` into something the user can act on.
+ *
+ * The one that actually strands people is `SIZE`, and it is counter-intuitive:
+ * **the size cap lives in the firmware already installed on the device**, not in
+ * the image being delivered and not in this app (which has never enforced a cap
+ * of its own — it relays what the device says). Firmware older than
+ * `OTA_LAYOUT_MIN_VERSION` carved a 320 KiB staging region out of flash and
+ * rejects anything larger at the `FWBEGIN` handshake, before a single image byte
+ * is uploaded.
+ *
+ * So the fix is not to shrink anything — it is to install
+ * `OTA_LAYOUT_MIN_VERSION` first (it fits under the old cap and carries the
+ * bigger staging region), after which the current build installs normally. A
+ * bare "SIZE" gives the user no way to know that.
+ *
+ * Pure — no I/O, no React.
+ */
+
+/**
+ * First firmware release whose OTA staging region can accept an image larger
+ * than {@link OTA_LEGACY_MAX_BYTES}. Devices below this need one hop through it.
+ */
+export const OTA_LAYOUT_MIN_VERSION = "3.1.0";
+
+/** Image cap enforced by firmware older than {@link OTA_LAYOUT_MIN_VERSION}. */
+export const OTA_LEGACY_MAX_BYTES = 320 * 1024;
+
+export interface FirmwareFailureExplanation {
+  /** User-facing replacement for the raw protocol token. */
+  message: string;
+  /**
+   * True when the remedy is a staged update through
+   * {@link OTA_LAYOUT_MIN_VERSION} rather than anything the user did wrong.
+   */
+  needsLayoutUpgrade: boolean;
+}
+
+export interface FirmwareFailureContext {
+  /** Version reported by the device over DIS, when it could be read. */
+  installedVersion?: string | null;
+  /** Size of the image being installed, when known. */
+  imageBytes?: number | null;
+}
+
+/**
+ * True when firmware `version` predates the larger staging layout, and so
+ * enforces the legacy cap. Unknown versions return `false` — never claim a
+ * device is out of date without knowing.
+ */
+export function needsOtaLayoutUpgrade(version: string | null | undefined): boolean {
+  if (!version) return false;
+  return compareVersions(version, OTA_LAYOUT_MIN_VERSION) < 0;
+}
+
+/**
+ * True when an image is too large for a pre-{@link OTA_LAYOUT_MIN_VERSION}
+ * device to stage. Exported so a pre-flight check can warn before the download
+ * rather than after the handshake.
+ */
+export function exceedsLegacyOtaCap(imageBytes: number | null | undefined): boolean {
+  return typeof imageBytes === "number" && imageBytes > OTA_LEGACY_MAX_BYTES;
+}
+
+/** Bytes as whole KiB, for a message the user can compare against a cap. */
+function kib(bytes: number): string {
+  return `${Math.round(bytes / 1024)} KiB`;
+}
+
+/**
+ * Explain a failed firmware update, or return `null` when there is nothing to
+ * add and the caller should show the raw error.
+ *
+ * Only `SIZE` gets special treatment: every other token either means something
+ * went wrong mid-transfer (retry) or is already self-explanatory.
+ */
+export function explainFirmwareFailure(
+  error: unknown,
+  context: FirmwareFailureContext = {},
+): FirmwareFailureExplanation | null {
+  if (!(error instanceof FirmwareProtocolError) || error.reason !== "SIZE") {
+    return null;
+  }
+
+  const { installedVersion, imageBytes } = context;
+  const size = typeof imageBytes === "number" ? ` (${kib(imageBytes)})` : "";
+
+  // The device told us its version, and it is old enough to be the cause —
+  // name it, so the user isn't left guessing which of their units is behind.
+  if (needsOtaLayoutUpgrade(installedVersion)) {
+    return {
+      needsLayoutUpgrade: true,
+      message:
+        `This device is on v${installedVersion}, whose update layout can't accept an image this large${size}. ` +
+        `Install v${OTA_LAYOUT_MIN_VERSION} first — it fits, and it unlocks the larger updates. Then retry this one.`,
+    };
+  }
+
+  // Version unknown (DIS read failed) but the device rejected on size anyway,
+  // so it is almost certainly running the old layout — say so without asserting
+  // a version we never read.
+  if (!installedVersion) {
+    return {
+      needsLayoutUpgrade: true,
+      message:
+        `The device rejected this image as too large${size}. Firmware older than v${OTA_LAYOUT_MIN_VERSION} ` +
+        `can only take updates up to ${kib(OTA_LEGACY_MAX_BYTES)} — install v${OTA_LAYOUT_MIN_VERSION} first, then retry.`,
+    };
+  }
+
+  // Reported new enough to have the bigger region and still refused: this is
+  // not the staged-upgrade case, so don't send the user down that path.
+  return {
+    needsLayoutUpgrade: false,
+    message:
+      `The device rejected this image as too large${size}, even though it reports v${installedVersion}. ` +
+      `It may need updating over USB instead.`,
+  };
+}

--- a/src/lib/ble/dfu/index.ts
+++ b/src/lib/ble/dfu/index.ts
@@ -35,6 +35,18 @@ export type {
   FirmwareUpdateReason,
 } from "./firmwareManifest";
 
+export {
+  OTA_LAYOUT_MIN_VERSION,
+  OTA_LEGACY_MAX_BYTES,
+  needsOtaLayoutUpgrade,
+  exceedsLegacyOtaCap,
+  explainFirmwareFailure,
+} from "./firmwareUpdateError";
+export type {
+  FirmwareFailureContext,
+  FirmwareFailureExplanation,
+} from "./firmwareUpdateError";
+
 export { parseDfuPackage } from "./dfuPackage";
 
 export { acquireFirmwareImage } from "./firmwareImage";

--- a/src/lib/ble/firmwareUpload.ts
+++ b/src/lib/ble/firmwareUpload.ts
@@ -25,6 +25,23 @@ const encoder = new TextEncoder();
 const decode = (v: DataView | null | undefined) => new TextDecoder().decode(v!);
 const lines = (raw: string) => raw.split("\n").map((l) => l.trim()).filter(Boolean);
 
+/**
+ * A device-side `FWERR:<reason>` rejection, carrying the raw protocol token so
+ * callers can act on it instead of re-parsing an English sentence.
+ *
+ * The tokens are the firmware's: `CRC`, `SIZE`, `WRITE`, `BATTERY`, `VARIANT`,
+ * `STATE`, `FLASH`.
+ */
+export class FirmwareProtocolError extends Error {
+  readonly reason: string;
+
+  constructor(stage: string, reason: string) {
+    super(`${stage}: ${reason}`);
+    this.name = "FirmwareProtocolError";
+    this.reason = reason;
+  }
+}
+
 export interface FirmwareUploadProgress {
   /** Image bytes written so far. */
   sent: number;
@@ -89,7 +106,7 @@ export async function beginFirmwareUpdate(
         }
         if (line.startsWith("FWERR:")) {
           cleanup();
-          reject(new Error(`Firmware handshake failed: ${line.substring(6)}`));
+          reject(new FirmwareProtocolError("Firmware handshake failed", line.substring(6).trim()));
           return;
         }
       }
@@ -184,7 +201,7 @@ export async function uploadFirmwareImage(
         }
         if (line.startsWith("FWERR:")) {
           cleanup();
-          reject(new Error(`Firmware upload failed: ${line.substring(6)}`));
+          reject(new FirmwareProtocolError("Firmware upload failed", line.substring(6).trim()));
           return;
         }
       }
@@ -272,7 +289,7 @@ export async function applyFirmware(
         }
         if (line.startsWith("FWERR:")) {
           cleanup();
-          reject(new Error(`Firmware install failed: ${line.substring(6)}`));
+          reject(new FirmwareProtocolError("Firmware install failed", line.substring(6).trim()));
           return;
         }
       }

--- a/src/lib/courseLineStyle.test.ts
+++ b/src/lib/courseLineStyle.test.ts
@@ -1,0 +1,67 @@
+/**
+ * These two helpers exist because the sprint finish line was rendered in the
+ * track editor and nowhere else — the race-line map and the sim map each had
+ * their own hardcoded start/finish colour and no concept of a finish line at
+ * all. Pinning the rules here is what stops the next map view drifting the
+ * same way.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Course, SectorLine } from '@/types/racing';
+import { COURSE_LINE_COLORS, finishLineOf, openingLineColor } from './courseLineStyle';
+
+const finish: SectorLine = {
+  a: { lat: 1, lon: 2 },
+  b: { lat: 3, lon: 4 },
+};
+
+function course(partial: Partial<Course> = {}): Course {
+  return {
+    name: 'Test',
+    startFinishA: { lat: 0, lon: 0 },
+    startFinishB: { lat: 0, lon: 0.001 },
+    ...partial,
+  };
+}
+
+describe('openingLineColor', () => {
+  it('keeps the existing red for a circuit — one line doing both jobs', () => {
+    expect(openingLineColor(course())).toBe(COURSE_LINE_COLORS.startFinish);
+    expect(openingLineColor(course({ type: 'circuit' }))).toBe(COURSE_LINE_COLORS.startFinish);
+  });
+
+  it('is green on a sprint course, so start and finish are distinguishable', () => {
+    expect(openingLineColor(course({ type: 'sprint', finish }))).toBe(
+      COURSE_LINE_COLORS.sprintStart,
+    );
+    // Green-to-red only reads as start-to-end if the two differ.
+    expect(COURSE_LINE_COLORS.sprintStart).not.toBe(COURSE_LINE_COLORS.finish);
+  });
+
+  it('treats an absent course or type as circuit', () => {
+    expect(openingLineColor(null)).toBe(COURSE_LINE_COLORS.startFinish);
+    expect(openingLineColor(undefined)).toBe(COURSE_LINE_COLORS.startFinish);
+  });
+});
+
+describe('finishLineOf', () => {
+  it('returns the finish line of a sprint course', () => {
+    expect(finishLineOf(course({ type: 'sprint', finish }))).toEqual(finish);
+  });
+
+  it('returns null for a sprint course that has no finish line yet', () => {
+    expect(finishLineOf(course({ type: 'sprint' }))).toBeNull();
+  });
+
+  it('ignores a stray finish line on a circuit course', () => {
+    // Left over from a course that was retyped — stale data, not a line to
+    // draw, and drawing it would put a phantom red line on a circuit map.
+    expect(finishLineOf(course({ finish }))).toBeNull();
+    expect(finishLineOf(course({ type: 'circuit', finish }))).toBeNull();
+  });
+
+  it('tolerates no course at all', () => {
+    expect(finishLineOf(null)).toBeNull();
+    expect(finishLineOf(undefined)).toBeNull();
+  });
+});

--- a/src/lib/courseLineStyle.ts
+++ b/src/lib/courseLineStyle.ts
@@ -1,0 +1,50 @@
+import { type Course, isSprintCourse } from '@/types/racing';
+
+/**
+ * Colours for a course's timing lines, shared by every map that draws them.
+ *
+ * These lived only in the track editor, which is how the separate sprint
+ * finish line ended up rendered there and nowhere else — the race-line map and
+ * the simulator map each had their own hardcoded start/finish colour and no
+ * concept of a finish line at all. One module means the next map to appear
+ * cannot quietly miss a line type.
+ *
+ * Green-to-red reads as start-to-end, which is the whole point of a
+ * point-to-point course. Circuit start/finish keeps its own colour because
+ * there it is one line doing both jobs, and re-colouring it would change every
+ * existing session map for no reason.
+ */
+export const COURSE_LINE_COLORS = {
+  /** Circuit: the single line that is both start and finish. */
+  startFinish: '#ef4444',
+  /** Sprint: the start line (green — you go from here). */
+  sprintStart: '#22c55e',
+  /** Sprint: the separate finish line (red — you stop here). */
+  finish: '#ef4444',
+  /** Major sector lines. */
+  major: '#a855f7',
+  /** Sub-sector lines between majors. */
+  sub: '#38bdf8',
+} as const;
+
+/**
+ * Colour for a course's opening line. On a circuit that line is the finish
+ * too, so it stays red; on a sprint course it is only the start, and the
+ * finish is drawn separately.
+ */
+export function openingLineColor(course: Pick<Course, 'type'> | null | undefined): string {
+  return isSprintCourse(course)
+    ? COURSE_LINE_COLORS.sprintStart
+    : COURSE_LINE_COLORS.startFinish;
+}
+
+/**
+ * The separate finish line to draw, or `null` when there isn't one.
+ *
+ * Guards on the course type as well as the field: a stray `finish` on a course
+ * typed circuit is stale data, not a line to render.
+ */
+export function finishLineOf(course: Course | null | undefined) {
+  if (!course || !isSprintCourse(course)) return null;
+  return course.finish ?? null;
+}

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -254,8 +254,39 @@ describe("parseDeviceCourseJson", () => {
     expect(parseDeviceCourseJson("not json {")).toEqual([]);
   });
 
-  it("returns [] when JSON is valid but not an array (e.g. wrapping object)", () => {
+  // The device's own course creator writes the OBJECT format — the same shape
+  // this app's track files use and that the firmware's parseTrackFile() reads.
+  // Accepting only the bare array meant a walked course synced back as a track
+  // with no courses in it, silently. An earlier test asserted exactly that
+  // behaviour, which is how it survived: it pinned the bug as the contract.
+  it("parses the object format the on-device course creator writes", () => {
+    const raw = JSON.stringify({
+      longName: "N260804_1432",
+      shortName: "08041432",
+      type: "sprint",
+      defaultCourse: "N260804_1432",
+      courses: [makeDeviceCourse()],
+    });
+    expect(parseDeviceCourseJson(raw)).toHaveLength(1);
+  });
+
+  it("keeps course order when the object holds several", () => {
+    const raw = JSON.stringify({
+      longName: "Venue",
+      courses: [makeDeviceCourse({ name: "first" }), makeDeviceCourse({ name: "second" })],
+    });
+    expect(parseDeviceCourseJson(raw).map((c) => c.name)).toEqual(["first", "second"]);
+  });
+
+  it("returns [] for an object with an empty or missing course list", () => {
     expect(parseDeviceCourseJson('{"courses": []}')).toEqual([]);
+    expect(parseDeviceCourseJson('{"longName":"Venue"}')).toEqual([]);
+  });
+
+  it("returns [] for a JSON scalar", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(parseDeviceCourseJson("42")).toEqual([]);
+    expect(parseDeviceCourseJson("null")).toEqual([]);
   });
 
   it("returns [] for empty array", () => {

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -262,16 +262,44 @@ export function buildTrackJsonForUpload(track: Track): string {
   return JSON.stringify(courses, null, '\t');
 }
 
-/** Parse raw JSON string from device into course array. */
+/**
+ * Parse a track JSON file pulled off the device into its course array.
+ *
+ * BOTH on-disk shapes are accepted, matching the firmware's own
+ * `parseTrackFile()`:
+ *
+ * - **object** — `{longName, shortName, type, defaultCourse, courses:[…]}`,
+ *   the format this app's track files use and the one the **on-device course
+ *   creator writes**.
+ * - **bare array** — `[{…course…}]`, the legacy shape, and still what
+ *   `buildTrackJsonForUpload` sends.
+ *
+ * Accepting only the array was a silent data-loss bug the moment the device
+ * could author a track itself: the object parses fine, isn't an array, and
+ * fell through to `[]` — so a walked course synced back as a track with no
+ * courses at all, with nothing logged to say why.
+ */
 export function parseDeviceCourseJson(raw: string): DeviceCourseJson[] {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed;
-    return [];
+    parsed = JSON.parse(raw);
   } catch {
     console.error('Failed to parse device track JSON');
     return [];
   }
+
+  if (Array.isArray(parsed)) return parsed as DeviceCourseJson[];
+
+  if (parsed && typeof parsed === 'object') {
+    const courses = (parsed as { courses?: unknown }).courses;
+    if (Array.isArray(courses)) return courses as DeviceCourseJson[];
+    // A well-formed object with no course list is a real (if empty) track —
+    // distinct from unparseable, so don't shout about it.
+    return [];
+  }
+
+  console.error('Device track JSON is neither a course array nor a track object');
+  return [];
 }
 
 // ─── Track kind ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Hit for real on a logger that had been left a version behind: the update fails with **`Firmware update failed: SIZE`** and nothing else. Nothing is wrong with the image, and nothing is wrong with this app.

**The size cap lives in the firmware already installed on the device.** Anything older than v3.1.0 carved a 320 KiB staging region out of flash and rejects a larger image at the `FWBEGIN` handshake, before a byte is uploaded. This app has never enforced a cap of its own — it was faithfully relaying the device's token, which happens to be the least actionable thing it could say. The fix is to install **v3.1.0 first** (it fits under the old cap *and* carries the larger staging region), then retry, which the user had no way to know.

Concretely: the current beta image is **340,868 B**, and the legacy cap is 327,680 B — over by 13,188 B. The firmware repo's CI already warns about exactly this on every build that crosses the line; the app just wasn't passing the knowledge on.

Three changes:

1. The three `FWERR:` sites throw a typed **`FirmwareProtocolError`** carrying the raw token, so callers act on the protocol instead of re-parsing an English sentence. (Also makes the future error-mapping work trivial.)
2. **`explainFirmwareFailure`** turns a `SIZE` into an actionable message and returns `null` for everything else, so every other token keeps its current wording untouched.
3. The hook uses the explanation when there is one, and the raw message when there isn't.

## Related Issues

Follows the sprint work in #379. Companion to `DovesDataLogger` #128 — the build that pushed the image past the legacy cap.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [x] Refactor / reusability improvement <!-- typed protocol error -->
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes (`tsc -b`)
- [x] `bun run test:run` passes — 2554 tests, 181 files (18 new)
- [x] `bun run build` succeeds
- [x] Feature works **offline** — pure string/version logic, no new network calls
- [x] Docs updated where relevant — `CHANGELOG.md`
- [ ] For a new parser: n/a

## Notes for Reviewers

**Deliberately *not* a version→capability table.** You said update mappings are their own piece of work, so this implements only the single rule that strands people today. The two predicates behind it — `needsOtaLayoutUpgrade` and `exceedsLegacyOtaCap` — are exported precisely so that mapping has somewhere to grow, and so a **pre-flight warning in the confirm dialog is a one-line call** when it lands. Right now the check runs at the handshake, which still costs the user only the download, not an upload.

**A device reporting v3.1.0+ that still refuses is not sent down the staged-upgrade path.** It gets pointed at USB instead — telling that user to install 3.1.0 would be a wild goose chase, and that branch is pinned by a test.

**When the version can't be read** (DIS failed) the message still names v3.1.0 as the fix but never asserts a version it didn't read — there are explicit assertions that `"null"` and `"undefined"` don't leak into user-facing text.

**No i18n keys added.** The surrounding firmware-update toasts in this hook are plain English already (`"Couldn't read the device's firmware version"`, `"No firmware build is available for this device"`), so this matches local convention rather than half-migrating one string. Flagging it explicitly since the repo does have a locale-parity test — if you'd rather this whole hook were localised, that's a clean follow-up.

**Not verified on hardware.** The logic is unit-tested, but the end-to-end path — old logger, real `FWERR:SIZE`, message on screen — needs a device on ≤3.0.1. You have one; it's the unit that prompted this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_