### PR TITLE
fix(sync): course screen copied the track name, and hid the original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The sync wizard's course screen no longer pre-fills the track's name**
+  (plan 0016). Naming a track and moving to the course step put that same name
+  into every course box, which is not what a course is called. Each course now
+  shows its original name, which track it belongs to, and the date it was
+  walked in readable form — the same layout as the track step. The box starts
+  with whatever would be saved if you changed nothing: a sprint course keeps
+  the date it was walked, since a sprint venue re-lays its course every event,
+  and a circuit course starts empty because it needs a real name.
 - **Tracks sent to the logger keep their name and course lengths** (plan 0016).
   Uploading a track wrote it in the older bare-list format, which the logger
   reads but which carries no track name, no short name, and no course length.

--- a/docs/plans/0016-device-track-sync-rename.md
+++ b/docs/plans/0016-device-track-sync-rename.md
@@ -140,9 +140,12 @@ Three behaviours worth knowing before changing anything here:
 
 - **Unchecking a row stops it being validated.** Otherwise one track you don't
   want to name blocks the whole sync with no way past it.
-- **A course name follows its track's name until the user types in it**, and
-  going Back to rename the track re-points every course still following. A name
-  they typed is never overwritten.
+- **Course names are independent of the track name.** The box starts holding
+  what would be saved if you touched nothing: a sprint course keeps its date
+  stamp (valid there — the venue re-lays its course every event), a circuit
+  course starts empty. An earlier build copied the track's new name into every
+  generated course box, which read as a bug on the course screen; a course is
+  not its track.
 - **`canSave` re-checks the track screen**, not just the course screen — going
   forward, then back, then clearing a track name must not leave Save live.
 

--- a/src/components/drawer/DeviceSyncWizard.tsx
+++ b/src/components/drawer/DeviceSyncWizard.tsx
@@ -300,12 +300,14 @@ export function DeviceSyncWizard({
               row.courses.map((course) => {
                 const draft = state.courseDrafts[course.key];
                 const problem = courseIssues[course.key];
+                const walked = parseDeviceGeneratedName(course.name);
+                const trackLabel = state.trackDrafts[row.key]?.name || row.name;
                 return (
-                  <div key={course.key} className="space-y-1">
+                  <div key={course.key} className="space-y-1.5">
+                    {/* Same shape as a track row: the ORIGINAL name, then the
+                        badges, then when it was walked, then the box. */}
                     <div className="flex flex-wrap items-center gap-2 text-sm">
-                      <span className="text-muted-foreground">
-                        {state.trackDrafts[row.key]?.name || row.name}
-                      </span>
+                      <span className="text-foreground">{course.name}</span>
                       <span
                         className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
                           course.kind === "sprint"
@@ -317,7 +319,18 @@ export function DeviceSyncWizard({
                           ? t("deviceTracks.sprintBadge")
                           : t("deviceTracks.wizard.circuitBadge")}
                       </span>
+                      {/* Which track this course belongs to — several tracks can
+                          be on this screen at once, and a bare course name is
+                          ambiguous between them. */}
+                      <span className="text-xs text-muted-foreground">{trackLabel}</span>
                     </div>
+                    {walked && (
+                      <p className="text-xs text-muted-foreground">
+                        {t("deviceTracks.wizard.walkedOn", {
+                          date: formatWalkedOn(walked, i18n.language),
+                        })}
+                      </p>
+                    )}
                     <Input
                       value={draft?.name ?? course.name}
                       onChange={(e) => setState((s) => setCourseName(s, course.key, e.target.value))}

--- a/src/lib/deviceSyncNames.test.ts
+++ b/src/lib/deviceSyncNames.test.ts
@@ -6,7 +6,6 @@ import {
   editTrackShortName,
   initialCourseDraft,
   editCourseName,
-  retargetCourseDraft,
   validateTrackDraft,
   validateCourseDraft,
 } from "./deviceSyncNames";
@@ -125,29 +124,42 @@ describe("editTrackShortName", () => {
 // ─── Course name editing ─────────────────────────────────────────────────────
 
 describe("course name drafts", () => {
-  // The firmware gives a new track and its first course the same stamp, so the
-  // course is the track named twice — following the track name is the right default.
-  it("follows the track's new name when generated", () => {
-    expect(initialCourseDraft(courseRow(), "Sunset Park")).toEqual({
-      name: "Sunset Park",
+  // The box always starts holding what would be saved if you touched nothing, so
+  // nothing is ever written that the user never saw.
+  //
+  // It used to copy the TRACK's new name — an earlier reading of "auto-populated
+  // by the name". That was wrong: a course is not its track, and the screen read
+  // as broken because every course came up pre-filled with the track's name.
+  it("does not copy the track name", () => {
+    expect(initialCourseDraft(courseRow()).name).not.toBe("Sunset Park");
+  });
+
+  // The stamp is not a valid answer for a circuit course, and pre-filling
+  // anything invites clicking straight past the one thing this screen asks.
+  it("starts empty for a generated circuit course", () => {
+    expect(initialCourseDraft(courseRow({ kind: "circuit" }))).toEqual({
+      name: "",
+      touched: false,
+    });
+  });
+
+  // A sprint venue re-lays its course every event, so the walked date IS a valid
+  // final answer — showing it means the user can see what will be saved.
+  it("keeps the stamp for a generated sprint course", () => {
+    expect(initialCourseDraft(courseRow({ kind: "sprint" }))).toEqual({
+      name: "N260803_1432",
       touched: false,
     });
   });
 
   it("keeps a real course name", () => {
-    const d = initialCourseDraft(courseRow({ name: "Full CW", needsRename: false }), "Sunset Park");
+    const d = initialCourseDraft(courseRow({ name: "Full CW", needsRename: false }));
     expect(d.name).toBe("Full CW");
   });
 
-  it("re-points an untouched draft when the track is renamed", () => {
-    const d = initialCourseDraft(courseRow(), "Sunset Park");
-    expect(retargetCourseDraft(d, "Sunset Park North").name).toBe("Sunset Park North");
-  });
-
-  it("never overwrites a course name the user typed", () => {
-    let d = initialCourseDraft(courseRow(), "Sunset Park");
-    d = editCourseName(d, "Sunset Park - Reverse");
-    expect(retargetCourseDraft(d, "Anything Else").name).toBe("Sunset Park - Reverse");
+  it("marks the draft touched once the user types", () => {
+    const d = editCourseName(initialCourseDraft(courseRow()), "Morning Run");
+    expect(d).toEqual({ name: "Morning Run", touched: true });
   });
 });
 

--- a/src/lib/deviceSyncNames.ts
+++ b/src/lib/deviceSyncNames.ts
@@ -5,8 +5,8 @@
  *
  * 1. **The edit rules.** A short name follows the long name until the user
  *    takes it over — and, by explicit decision, editing the long name after
- *    that takes it back. A course name follows its track's new name the same
- *    way. Simple and predictable beats clever here.
+ *    that takes it back. Course names are independent: a course is not its
+ *    track. Simple and predictable beats clever here.
  * 2. **The save gate.** A name that reaches the device has to be legal there,
  *    unique, and actually chosen by a human rather than left as a date stamp.
  */
@@ -35,7 +35,7 @@ export interface TrackNameDraft {
 
 export interface CourseNameDraft {
   name: string;
-  /** True once the user has typed here; stops the track name overwriting it. */
+  /** True once the user has typed here. */
   touched: boolean;
 }
 
@@ -97,29 +97,29 @@ export function editTrackShortName(draft: TrackNameDraft, shortName: string): Tr
 /**
  * The starting state for a course's name field.
  *
- * A generated course name follows the track's new name — the firmware gives a
- * new track and its first course the same stamp, so they are the same thing
- * named twice.
+ * The box always starts holding **what would be saved if you touched nothing**,
+ * so nothing is ever written that the user never saw:
+ *
+ * - a name the user already chose is kept;
+ * - a **sprint** course keeps its generated stamp — that is a valid final
+ *   answer, since a sprint venue re-lays its course every event;
+ * - a **circuit** course starts EMPTY, because the stamp is not a valid answer
+ *   there and pre-filling anything invites clicking straight past the one thing
+ *   this screen exists to ask.
+ *
+ * It deliberately does NOT copy the track's new name. That was an earlier
+ * reading of "auto-populated by the name" and it was wrong: a course is not its
+ * track, and silently pre-filling the track name made the screen read as broken.
  */
-export function initialCourseDraft(row: SyncCourseRow, trackName: string): CourseNameDraft {
-  if (isDeviceGeneratedName(row.name)) return { name: trackName, touched: false };
+export function initialCourseDraft(row: SyncCourseRow): CourseNameDraft {
+  if (isDeviceGeneratedName(row.name)) {
+    return { name: row.kind === 'sprint' ? row.name : '', touched: false };
+  }
   return { name: row.name, touched: false };
 }
 
 export function editCourseName(draft: CourseNameDraft, name: string): CourseNameDraft {
   return { name, touched: true };
-}
-
-/**
- * Re-point an untouched course name at a track name that just changed — the
- * user went Back, renamed the track, and came forward again. A course name they
- * typed themselves is left alone.
- */
-export function retargetCourseDraft(
-  draft: CourseNameDraft,
-  trackName: string,
-): CourseNameDraft {
-  return draft.touched ? draft : { name: trackName, touched: false };
 }
 
 // ─── Validation ──────────────────────────────────────────────────────────────

--- a/src/lib/deviceSyncWizard.test.ts
+++ b/src/lib/deviceSyncWizard.test.ts
@@ -48,11 +48,16 @@ function plan(rows: SyncTrackRow[]): SyncPlan {
   return { rows, skipped: [] };
 }
 
-/** The common case: one walked track, renamed properly. */
+/** One walked track, renamed properly, sitting on the course screen. */
 function named(): WizardState {
   let s = initWizard(plan([trackRow()]));
   s = setTrackName(s, "circuit:08031432", "Sunset Park");
   return goToCourses(s);
+}
+
+/** …and with its circuit course named too, so the plan is actually saveable. */
+function fullyNamed(): WizardState {
+  return setCourseName(named(), "circuit:08031432::N260803_1432", "Full CW");
 }
 
 // ─── Setup ───────────────────────────────────────────────────────────────────
@@ -118,31 +123,39 @@ describe("selection", () => {
   });
 });
 
-// ─── Navigation and the follow-the-track-name rule ───────────────────────────
+// ─── Navigation ──────────────────────────────────────────────────────────────
 
 describe("navigation", () => {
-  it("carries the track's new name onto its course", () => {
-    const s = named();
-    expect(s.step).toBe("courses");
-    expect(s.courseDrafts["circuit:08031432::N260803_1432"].name).toBe("Sunset Park");
-  });
-
-  // Back, rename, forward again — the course name should follow.
-  it("re-points an untouched course name after the track is renamed", () => {
+  it("moves between the two screens", () => {
     let s = named();
+    expect(s.step).toBe("courses");
     s = goToTracks(s);
-    s = setTrackName(s, "circuit:08031432", "Sunset Park North");
-    s = goToCourses(s);
-    expect(s.courseDrafts["circuit:08031432::N260803_1432"].name).toBe("Sunset Park North");
+    expect(s.step).toBe("tracks");
   });
 
-  it("never overwrites a course name the user typed", () => {
+  // A course is not its track. This used to copy the track's new name into
+  // every generated course box, which read as a bug on the course screen.
+  it("never copies the track name into a course box", () => {
+    const s = named();
+    expect(s.courseDrafts["circuit:08031432::N260803_1432"].name).not.toBe("Sunset Park");
+    expect(s.courseDrafts["circuit:08031432::N260803_1432"].name).toBe("");
+  });
+
+  it("leaves course names alone when the track is renamed", () => {
     let s = named();
     s = setCourseName(s, "circuit:08031432::N260803_1432", "Morning Run");
     s = goToTracks(s);
     s = setTrackName(s, "circuit:08031432", "Anything Else");
     s = goToCourses(s);
     expect(s.courseDrafts["circuit:08031432::N260803_1432"].name).toBe("Morning Run");
+  });
+
+  it("does not resurrect a course name the user cleared", () => {
+    let s = named();
+    s = setCourseName(s, "circuit:08031432::N260803_1432", "");
+    s = goToTracks(s);
+    s = goToCourses(s);
+    expect(s.courseDrafts["circuit:08031432::N260803_1432"].name).toBe("");
   });
 });
 
@@ -230,20 +243,26 @@ describe("courseProblems", () => {
 
 describe("canSave", () => {
   it("is true for a fully named plan", () => {
-    expect(canSave(named())).toBe(true);
+    expect(canSave(fullyNamed())).toBe(true);
+  });
+
+  // The circuit course box now starts empty rather than inheriting the track
+  // name, so naming only the track is no longer enough to save.
+  it("is false while a circuit course is still unnamed", () => {
+    expect(canSave(named())).toBe(false);
   });
 
   // Going forward, then back and clearing the track name, must not leave Save
   // live just because the course screen looks fine.
   it("re-checks the track screen, not just the course screen", () => {
-    let s = named();
+    let s = fullyNamed();
     expect(canSave(s)).toBe(true);
     s = setTrackName(s, "circuit:08031432", "");
     expect(canSave(s)).toBe(false);
   });
 
   it("is false with nothing selected", () => {
-    let s = named();
+    let s = fullyNamed();
     s = toggleRow(s, "circuit:08031432");
     expect(canSave(s)).toBe(false);
   });

--- a/src/lib/deviceSyncWizard.ts
+++ b/src/lib/deviceSyncWizard.ts
@@ -17,7 +17,6 @@ import {
   editTrackShortName,
   initialCourseDraft,
   initialTrackDraft,
-  retargetCourseDraft,
   validateCourseDraft,
   validateTrackDraft,
   type CourseNameDraft,
@@ -59,7 +58,7 @@ export function initWizard(
     const draft = initialTrackDraft(row);
     trackDrafts[row.key] = draft;
     for (const course of row.courses) {
-      courseDrafts[course.key] = initialCourseDraft(course, draft.name);
+      courseDrafts[course.key] = initialCourseDraft(course);
     }
   }
 
@@ -131,19 +130,13 @@ export function setCourseName(
 // ─── Navigation ──────────────────────────────────────────────────────────────
 
 /**
- * Move to the course screen, re-pointing any course name still following its
- * track — the user may have gone Back and renamed the track since.
+ * Move to the course screen.
+ *
+ * Course names are independent of the track name — renaming the track and
+ * coming forward again does not touch them, because a course is not its track.
  */
 export function goToCourses(state: WizardState): WizardState {
-  const courseDrafts = { ...state.courseDrafts };
-  for (const row of state.plan.rows) {
-    const trackName = state.trackDrafts[row.key]?.name ?? row.name;
-    for (const course of row.courses) {
-      const draft = courseDrafts[course.key];
-      if (draft) courseDrafts[course.key] = retargetCourseDraft(draft, trackName);
-    }
-  }
-  return { ...state, step: 'courses', courseDrafts };
+  return { ...state, step: 'courses' };
 }
 
 export function goToTracks(state: WizardState): WizardState {


### PR DESCRIPTION
## Summary

Follow-up to plan 0016 from your first run through the wizard: the track screen looked right, the course screen didn't.

**The bug you hit.** Every generated course name came up pre-filled with the track name you'd just typed on the previous screen. That was my reading of *"new courses get the same text box, auto-populated by the name"*, and it was wrong — a course is not its track. I flagged the guess in the original PR rather than asking, which is what let it reach you.

The box now starts holding **what would actually be saved if you touched nothing**:

| | starts as |
|---|---|
| name you already chose | kept |
| **sprint** course, still a stamp | the stamp — valid there, since a sprint venue re-lays its course every event |
| **circuit** course, still a stamp | **empty** — the stamp isn't a valid answer, and pre-filling invites clicking past the one thing the screen asks |

Course names no longer follow the track name at all, so `retargetCourseDraft` is gone and `goToCourses` is a plain step change.

**The layout.** The course row now mirrors the track row: the **original name** first, then the circuit/sprint badge, then **which track it belongs to**, then the walked date decoded to readable text (`Walked 3 Aug 2026, 14:32` rather than `N260803_1432`), then the box.

The track label is there because several tracks can be on that screen at once, so a bare course name is ambiguous between them. It's also why the copied value looked like it belonged — the old row was showing the *track* name in the slot where the course name should have been.

## Related Issues

Follows #387 / #385 / #386 (plan 0016).

## Type of Change

- [x] Bug fix
- [x] Documentation

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2722 tests, 190 files)
- [x] `bun run build` succeeds
- [x] Feature works **offline**
- [x] Docs updated — plan 0016's course-name rule corrected, `CHANGELOG.md`
- [x] No new i18n keys — reuses `walkedOn`, already in all seven locales

## Notes for Reviewers

**Verified the new tests bite** by restoring the copy behaviour: five fail, including `canSave` going true while a circuit course is still unnamed. That last one matters — under the old rule the inherited track name satisfied validation, so you could save a circuit course named after its track without ever being asked.

One consequence worth knowing: **naming only the track is no longer enough to reach "Save & import"** for a circuit course. That's the intended reading of "circuit courses REQUIRE a name", but it is one more box to fill than before. Sprint is unaffected — its stamp is pre-filled and passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_