### PR TITLE
feat(settings): enum control type, and surface race_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Settings with a fixed set of choices are now dropdowns** (plan 0003).
+  Device settings only knew about text and numbers, so anything with a fixed
+  set of values was a free-text box where a typo silently reverted the logger
+  to its default — which reads as the setting not working at all.
+  - **Race Mode** is affected today: it lives on the logger but was never in
+    the settings list, so it showed as a raw text field. It's now a proper
+    Circuit / Sprint picker with an explanation of what it actually does (it
+    only breaks a tie when both a circuit and a sprint track are in range).
+  - **Spark Mode** and **Cylinders** are listed ready for the firmware that
+    adds them; they stay hidden until your logger reports them.
+  - A value the app doesn't recognise — from older or newer firmware, or a
+    hand-edited settings file — is shown as-is rather than silently displayed
+    as one of the choices it does know.
+
 ### Fixed
 - **The sync wizard's course screen no longer pre-fills the track's name**
   (plan 0016). Naming a track and moving to the course step put that same name

--- a/src/components/drawer/DeviceSettingsTab.tsx
+++ b/src/components/drawer/DeviceSettingsTab.tsx
@@ -3,6 +3,13 @@ import { useTranslation } from "react-i18next";
 import { Loader2, Save, AlertCircle, RefreshCw, RotateCcw, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "sonner";
 import { type BleConnection } from "@/lib/bleDatalogger";
 import type { DeviceDetails } from "@/lib/loggers";
@@ -191,13 +198,31 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <Input
-                value={row.value}
-                onChange={(e) => handleChange(i, e.target.value)}
-                className="h-9 text-sm flex-1"
-                type={def?.type === "number" ? "number" : "text"}
-                maxLength={def?.maxLength}
-              />
+              {def?.type === "enum" && def.options?.length ? (
+                <Select value={row.value} onValueChange={(v) => handleChange(i, v)}>
+                  <SelectTrigger className="h-9 flex-1 text-sm">
+                    {/* A device can hold a value this build doesn't know — an
+                        older or newer firmware, or a hand-edited SETTINGS.json.
+                        Show it verbatim rather than an empty box. */}
+                    <SelectValue placeholder={row.value || undefined} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {def.options.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  value={row.value}
+                  onChange={(e) => handleChange(i, e.target.value)}
+                  className="h-9 text-sm flex-1"
+                  type={def?.type === "number" ? "number" : "text"}
+                  maxLength={def?.maxLength}
+                />
+              )}
               <Button
                 variant="outline"
                 size="icon"

--- a/src/lib/deviceSettingsSchema.test.ts
+++ b/src/lib/deviceSettingsSchema.test.ts
@@ -3,6 +3,7 @@ import {
   DEVICE_SETTINGS_SCHEMA,
   getSettingDef,
   validateSettingValue,
+  settingDisplayValue,
 } from "./deviceSettingsSchema";
 
 // ─── schema shape ─────────────────────────────────────────────────────────────
@@ -16,7 +17,7 @@ describe("DEVICE_SETTINGS_SCHEMA", () => {
   it("every def has a non-empty label and a valid type", () => {
     for (const d of DEVICE_SETTINGS_SCHEMA) {
       expect(d.label.length).toBeGreaterThan(0);
-      expect(["string", "number"]).toContain(d.type);
+      expect(["string", "number", "enum"]).toContain(d.type);
     }
   });
 
@@ -159,5 +160,87 @@ describe("validateSettingValue — string fields", () => {
   it("does not apply numeric validation to string fields", () => {
     // bluetooth_name is a string — non-numeric content is fine
     expect(validateSettingValue("bluetooth_name", "My Logger!")).toBeNull();
+  });
+});
+
+// ─── enum fields ──────────────────────────────────────────────────────────────
+
+describe("validateSettingValue — enum fields", () => {
+  it("accepts every declared option", () => {
+    expect(validateSettingValue("race_mode", "circuit")).toBeNull();
+    expect(validateSettingValue("race_mode", "sprint")).toBeNull();
+    expect(validateSettingValue("spark_mode", "wasted")).toBeNull();
+    expect(validateSettingValue("spark_mode", "single")).toBeNull();
+  });
+
+  // The whole point of the type: as a free-text field a typo reached the device
+  // and the firmware silently fell back to its default, which reads as the
+  // setting simply not working.
+  it("rejects a value that isn't an option", () => {
+    expect(validateSettingValue("race_mode", "Circuit")).toBe(
+      "Must be one of: circuit, sprint",
+    );
+    expect(validateSettingValue("spark_mode", "wastedd")).toBe(
+      "Must be one of: wasted, single",
+    );
+  });
+
+  it("rejects an empty value", () => {
+    expect(validateSettingValue("race_mode", "")).toBe("Must be one of: circuit, sprint");
+  });
+
+  it("is case-sensitive, because the device compares the literal", () => {
+    expect(validateSettingValue("spark_mode", "WASTED")).not.toBeNull();
+  });
+});
+
+describe("enum schema entries", () => {
+  it("gives every enum at least one option", () => {
+    for (const def of DEVICE_SETTINGS_SCHEMA.filter((d) => d.type === "enum")) {
+      expect(def.options, `${def.key} needs options`).toBeTruthy();
+      expect(def.options!.length, `${def.key} needs options`).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps option values unique within a setting", () => {
+    for (const def of DEVICE_SETTINGS_SCHEMA.filter((d) => d.type === "enum")) {
+      const values = def.options!.map((o) => o.value);
+      expect(new Set(values).size, `${def.key} has duplicate values`).toBe(values.length);
+    }
+  });
+});
+
+describe("settingDisplayValue", () => {
+  it("maps a known enum value to its label", () => {
+    expect(settingDisplayValue("race_mode", "sprint")).toBe("Sprint");
+  });
+
+  // A device can hold a value this build doesn't know — older/newer firmware, or
+  // a hand-edited SETTINGS.json. Showing it verbatim keeps that visible instead
+  // of silently rendering it as an option we do know.
+  it("passes an unrecognised value through untouched", () => {
+    expect(settingDisplayValue("race_mode", "drag")).toBe("drag");
+  });
+
+  it("leaves non-enum settings alone", () => {
+    expect(settingDisplayValue("driver_name", "Mike")).toBe("Mike");
+    expect(settingDisplayValue("unknown_key", "whatever")).toBe("whatever");
+  });
+});
+
+// ─── the new plan-0003 settings ───────────────────────────────────────────────
+
+describe("cylinder_count", () => {
+  it("accepts a plausible cylinder count", () => {
+    expect(validateSettingValue("cylinder_count", "1")).toBeNull();
+    expect(validateSettingValue("cylinder_count", "2")).toBeNull();
+  });
+
+  it("rejects zero — it would divide RPM by nothing", () => {
+    expect(validateSettingValue("cylinder_count", "0")).toBe("Minimum value is 1");
+  });
+
+  it("rejects a fractional count", () => {
+    expect(validateSettingValue("cylinder_count", "1.5")).toBe("Must be a whole number");
   });
 });

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -2,13 +2,25 @@
 // Declarative definitions for known device settings: labels, types, and validation rules.
 // Unknown keys received from the device are displayed as raw string fields (forward-compatible).
 
+/** One choice in an `enum` setting. `value` is the literal the device stores. */
+export interface DeviceSettingOption {
+  value: string;
+  label: string;
+}
+
 export interface DeviceSettingDef {
   key: string;
   label: string;
-  type: 'string' | 'number';
+  type: 'string' | 'number' | 'enum';
   maxLength?: number;
   min?: number;
   max?: number;
+  /**
+   * Required for `enum`, ignored otherwise. The device stores a bare string, so
+   * a free-text field lets a typo through that the firmware then silently
+   * treats as the default — which reads as the setting not working at all.
+   */
+  options?: DeviceSettingOption[];
   description?: string;
 }
 
@@ -75,6 +87,39 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     max: 1,
     description: 'Save as .dove instead of .dovex (0 = off, 1 = on)',
   },
+  {
+    // Exists on the device already, but was never in this schema — so it showed
+    // up as a raw text box where a typo silently reverts the logger to circuit.
+    key: 'race_mode',
+    label: 'Race Mode Preference',
+    type: 'enum',
+    options: [
+      { value: 'circuit', label: 'Circuit' },
+      { value: 'sprint', label: 'Sprint' },
+    ],
+    description:
+      'Tiebreak when both a circuit and a sprint track are in range. Never overrides a single match',
+  },
+  {
+    key: 'spark_mode',
+    label: 'Spark Mode',
+    type: 'enum',
+    options: [
+      { value: 'wasted', label: 'Wasted spark (1 per rev)' },
+      { value: 'single', label: 'Single fire (1 per 2 revs)' },
+    ],
+    description:
+      'How often the ignition fires per revolution. 2-stroke and wasted-spark 4-stroke fire every rev',
+  },
+  {
+    key: 'cylinder_count',
+    label: 'Cylinders',
+    type: 'number',
+    min: 1,
+    max: 16,
+    description:
+      'Cylinders the pickup SEES — a clamp around one plug wire of a twin sees one, so leave it at 1',
+  },
 ];
 
 /** Look up schema definition for a key, or return null for unknown keys */
@@ -103,5 +148,27 @@ export function validateSettingValue(key: string, value: string): string | null 
     }
   }
 
+  if (def.type === 'enum') {
+    // A definition with no options can't reject anything sensibly; treat it as
+    // free text rather than blocking the user out of a field entirely.
+    if (!def.options || def.options.length === 0) return null;
+    if (!def.options.some((o) => o.value === value)) {
+      return `Must be one of: ${def.options.map((o) => o.value).join(', ')}`;
+    }
+  }
+
   return null;
+}
+
+/**
+ * The label to show for a stored value.
+ *
+ * A device can hold a value this app doesn't know — an older or newer firmware,
+ * or a hand-edited SETTINGS.json. Falling back to the raw value keeps that
+ * visible instead of silently rendering it as one of the options we do know.
+ */
+export function settingDisplayValue(key: string, value: string): string {
+  const def = getSettingDef(key);
+  if (def?.type !== 'enum') return value;
+  return def.options?.find((o) => o.value === value)?.label ?? value;
 }


### PR DESCRIPTION
## Summary

Device settings only knew `'string'` and `'number'`, so anything with a fixed set of values was a free-text box. That's worse than it sounds: the firmware compares the literal, so a typo doesn't error — it silently falls back to the default, which reads as **the setting not working at all**.

**`race_mode` is the case that already existed.** It lives on the logger but was never in this schema, so it rendered as a raw text field with no hint of what it does. It's now a Circuit / Sprint dropdown, described accurately — it only breaks a tie when *both* a circuit and a sprint track are in range, and never overrides a single match.

**`spark_mode` and `cylinder_count` are added ahead of the firmware PR.** Rows are built from what the *device* reports (`k in settings`), not from the schema, so these stay invisible until a logger actually has them — the schema entry just means they render properly when it does. That's why this can land before or after the firmware side without either being broken.

Also added `settingDisplayValue`: a value this build doesn't recognise — older or newer firmware, or a hand-edited `SETTINGS.json` — is shown verbatim rather than rendered as one of the options we *do* know.

## Related Issues

Groundwork for `DovesDataLogger` plan 0003 (RPM spark type & cylinder count), which the firmware PR implements.

## Type of Change

- [x] New feature
- [x] Bug fix (race_mode was unreachable as a proper control)

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2734 tests, 190 files — +12 here)
- [x] `bun run build` succeeds
- [x] Feature works **offline**
- [x] Docs updated — `CHANGELOG.md`
- [x] No new i18n keys — schema labels/descriptions are plain strings, matching the existing entries

## Notes for Reviewers

One thing to sanity-check: **`cylinder_count` is "cylinders the pickup SEES"**, not the engine's cylinder count. A clamp around one plug wire of a twin sees one, so that stays at 1 — only a shared coil or all-cylinder harness sees them all. I put that in the field description because getting it wrong halves or doubles every RPM reading, but you know the users better than I do and may want it worded differently.

Two deliberate calls:

- **Enum validation is case-sensitive** (`WASTED` is rejected), because the device compares the literal. Being lenient here would let a value through that the firmware then ignores — exactly the failure this replaces.
- **An enum with no options falls back to free text** rather than locking the user out of the field. Defensive only; nothing ships that way.

I did **not** add `camera_serial` to the schema even though it's on the device and missing here — it's captured automatically by the pairing flow and has its own page, so a hand-editable text box seemed like a way to break pairing rather than a feature. Easy to add if you disagree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_