### PR TITLE
feat(settings): expose the logger's display-colour setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Display Colours** — a new logger setting that inverts the screen, so it
+  shows black on a lit background instead of white on black. Easier to read in
+  direct sun. Appears once your logger has the firmware that supports it; the
+  default matches how the screen has always looked.
 - **Settings with a fixed set of choices are now dropdowns** (plan 0003).
   Device settings only knew about text and numbers, so anything with a fixed
   set of values was a free-text box where a typo silently reverted the logger

--- a/src/lib/deviceSettingsSchema.test.ts
+++ b/src/lib/deviceSettingsSchema.test.ts
@@ -167,6 +167,8 @@ describe("validateSettingValue — string fields", () => {
 
 describe("validateSettingValue — enum fields", () => {
   it("accepts every declared option", () => {
+    expect(validateSettingValue("display_invert", "normal")).toBeNull();
+    expect(validateSettingValue("display_invert", "inverted")).toBeNull();
     expect(validateSettingValue("race_mode", "circuit")).toBeNull();
     expect(validateSettingValue("race_mode", "sprint")).toBeNull();
     expect(validateSettingValue("spark_mode", "wasted")).toBeNull();
@@ -242,5 +244,20 @@ describe("cylinder_count", () => {
 
   it("rejects a fractional count", () => {
     expect(validateSettingValue("cylinder_count", "1.5")).toBe("Must be a whole number");
+  });
+});
+
+describe("display_invert", () => {
+  // The firmware treats anything that is not an exact "inverted" as normal, so
+  // a value this app lets through unchecked would read as the setting silently
+  // doing nothing.
+  it("rejects near misses the firmware would ignore", () => {
+    expect(validateSettingValue("display_invert", "invert")).not.toBeNull();
+    expect(validateSettingValue("display_invert", "Inverted")).not.toBeNull();
+    expect(validateSettingValue("display_invert", "1")).not.toBeNull();
+  });
+
+  it("labels the stored values for display", () => {
+    expect(settingDisplayValue("display_invert", "inverted")).toBe("Inverted (black on white)");
   });
 });

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -101,6 +101,16 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
       'Tiebreak when both a circuit and a sprint track are in range. Never overrides a single match',
   },
   {
+    key: 'display_invert',
+    label: 'Display Colours',
+    type: 'enum',
+    options: [
+      { value: 'normal', label: 'Normal (white on black)' },
+      { value: 'inverted', label: 'Inverted (black on white)' },
+    ],
+    description: "Inverting can be easier to read in direct sun. Normal is how the logger has always looked",
+  },
+  {
     key: 'spark_mode',
     label: 'Spark Mode',
     type: 'enum',


### PR DESCRIPTION
## Summary

Adds `display_invert` to the settings schema as a **Normal / Inverted** dropdown, reusing the enum control from #389.

> **Targets #389**, so the diff shows only this PR's work. Merge #389 first, then retarget this to `BETA` — or merge #389 and this will collapse to just the schema entry.

**Validation matters more than usual here.** The firmware treats anything that isn't an exact `"inverted"` as normal, so a value let through unchecked would read as the setting silently doing nothing. `"invert"`, `"Inverted"` and `"1"` are all rejected — which is precisely why this wants the enum control rather than the free-text box it would otherwise get.

Rows are built from what the *device* reports, so this stays hidden until a logger has the firmware that adds the key.

## Related Issues

Stacked on #389. Pairs with `DovesDataLogger` #135, which is the firmware side. Neither depends on the other.

## Type of Change

- [x] New feature

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2736 tests, 190 files)
- [x] `bun run build` succeeds
- [x] Feature works **offline**
- [x] Docs updated — `CHANGELOG.md`
- [x] No new i18n keys — schema labels/descriptions are plain strings, matching the existing entries

## Notes for Reviewers

Small on purpose. The only judgement call is the option labels — I used "Normal (white on black)" and "Inverted (black on white)" so it's obvious which way round it goes without having to try it. Say if you'd rather they were terser.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_