### PR TITLE
fix(sync): stop Resync All duplicating tracks, and stop uploads wasting a quarter of the device budget (plan 0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     hand-edited settings file — is shown as-is rather than silently displayed
     as one of the choices it does know.
 
+### Changed
+- **Tracks are sent to the logger without formatting whitespace** (plan 0017).
+  The logger reads a whole track file into a fixed buffer and parses it there;
+  a file past that buffer is cut mid-file, fails to parse, and the track then
+  isn't recognised at the venue at all rather than just losing its tail. The
+  indentation was about a quarter of every file and nothing reads it, so it's
+  gone — which is roughly a quarter more courses per track before the limit
+  bites. Nothing changes on your logger or in your own track files.
+
 ### Fixed
+- **"Resync All" no longer leaves a duplicate track on the logger** (plan 0017).
+  For a course you created on the logger itself, the track's short name and its
+  filename are different — so Resync All deleted nothing and wrote a *second*
+  copy alongside the original. Every resync added another, filling the card and
+  pushing tracks toward the size limit above. It now writes to the file that is
+  actually there, which is what every other button in the tracks list already
+  did.
 - **The sync wizard's course screen no longer pre-fills the track's name**
   (plan 0016). Naming a track and moving to the course step put that same name
   into every course box, which is not what a course is called. Each course now

--- a/docs/plans/0017-device-course-curation.md
+++ b/docs/plans/0017-device-course-curation.md
@@ -1,0 +1,122 @@
+# Device course curation — fitting a season of courses on the card
+
+> Status: **IN PROGRESS.** Stacked PRs: (1) the two size/correctness fixes below,
+> (2) the pure curation model, (3) the capability gate + sync wiring, (4) the
+> picker modal and the tracks list. Firmware side is
+> `DovesDataLogger/docs/plans/0005-*`.
+
+## Why this exists
+
+A sprint venue re-lays its cones every event, so the on-device course creator
+(`DovesDataLogger/docs/plans/0002-sprint-mode.md` §5) mints a new dated course
+each weekend and they all accumulate in one track file. That file has to fit the
+logger's track JSON buffer, and **the failure past it is total, not partial**:
+the read is cut mid-JSON, `deserializeJson` fails, `buildTrackList()` adds no
+manifest entry, and the track stops being detected at the venue at all.
+
+Plan 0002 §7 Q3 already pre-decided the shape of the answer — *"webapp prunes on
+sync, keeping the device's most recent single day of courses"* — and v1 shipped
+without it, with a disclaimer. This is that work, tightened to **the newest
+course**, not the newest day.
+
+Three things have to be true at the end:
+
+1. **Nothing is lost.** Courses the device can't hold still live in the app and
+   still ride cloud sync (`TRACKS_SYNC_STORE` is already in `DOC_STORES`). Only
+   the *device* holds a subset.
+2. **The sync flow never nags.** A curated device set must be able to reach
+   `synced` — the exact failure mode plan 0016 was written to end.
+3. **The device can save a course when it's full**, without a laptop, in a
+   field, on a battery, at an event. That half is the firmware plan.
+
+## The budget
+
+`JSON_BUFFER_SIZE` is **4096** on released firmware and **8192** on the next
+release. The firmware's own measurements, per course, in the shape its writer
+emits:
+
+| Course shape | Bytes | Fits in 4 KB |
+|---|---|---|
+| circuit, start line only | 148 | ~26 |
+| circuit + 2 sector lines | 384 | ~10 |
+| sprint, finish + 2 splits | 528 | **~7** |
+
+That last row was the live bug: `MAX_LAYOUTS` is 10, but a sprint track hit the
+4 KB budget at eight courses.
+
+Two consequences. **Both guards stay** — at 8 KB the 10-course cap binds first,
+at 4 KB the bytes bind first, and neither subsumes the other. And **the
+projection must measure, not estimate**: it calls the real
+`serializeDeviceTrackFile` and the real `TextEncoder`, so the number shown to
+the user is the number written. The table above is a test sanity-check only.
+
+## Two fixes that come first, because they *cause* the overflow
+
+**Uploads carried their own indentation.** `serializeDeviceTrackFile` emitted
+`JSON.stringify(file, null, '\t')`. Tabs and newlines were roughly a quarter of
+every file, spent on whitespace nothing reads — the device parses with
+ArduinoJson, which is whitespace-insensitive. Dropping it is ~25% more courses
+per track for free, and it is the one choke point all three upload writers
+funnel through, so it is also what the projection measures.
+
+**Resync All orphaned the file it meant to replace.** `deviceFileOf()` exists so
+a write lands on the file the device actually has — for a course the device
+wrote, the identity (`08031432`) and the filename (`N260803_1432.json`) are
+different strings. Five call sites use it; `handleResyncAll` rebuilt
+`shortName + ".json"` for both its delete and its put. So on every
+device-created track it deleted nothing and wrote a *second* file, leaving the
+original behind — one more file per resync, growing the very budget this plan
+is about.
+
+Neither is reachable by test: both live in a component, and the suite runs in
+`node` with no DOM renderer. That is also why everything below is a pure module.
+
+## The model (pure, in `src/lib`, unit-tested)
+
+- **`deviceCourseSelection`** — the single resolver every consumer calls, so no
+  caller re-implements the rule. Default: circuit keeps every course, sprint
+  keeps **only the newest by `dateCreated`**. Then a per-course tri-state
+  override applies (explicit include re-adds an older sprint course, explicit
+  exclude drops one). **Absent an override the default stands** — which is what
+  makes an empty override store a working configuration rather than a broken
+  one.
+- **`deviceTrackBudget`** — `projectDeviceTrackBytes` and the budget constants,
+  selected by one boolean capability.
+- **`deviceCourseOverrides`** — the override store. Device-local, per logger,
+  modelled on `firmwareUpdateReminder`: private key, pure `parse(raw, now)`,
+  bounded and self-pruning. **Deliberately not in `DOC_STORES`** — it describes
+  one physical card, not the user's garage, so it must not follow them to
+  another browser. Every failure mode (unknown logger, expired, corrupt) lands
+  on "absent", and absent means the default rule.
+
+## The capability boolean
+
+`supportsLargeTrackBuffer`, set on `DeviceDetails` in `bleDetails.ts` beside
+`supportsSprintTracks`, mirroring the existing `needsOtaLayoutUpgrade` pattern
+(`ble/dfu/firmwareUpdateError.ts`) over the pure `compareVersions`. One
+comparison, at the edge; nothing downstream sees a version.
+
+**Unknown version assumes the small budget** — the opposite of
+`needsOtaLayoutUpgrade`, deliberately. That one must never nag without
+certainty; this one must never overfill a card, because guessing high takes the
+track out of detection at the venue.
+
+`compareVersions` ignores prerelease suffixes, so a beta build stamped
+`3.0.1-beta.<sha>` compares as `3.0.1`. The firmware's version literal has to
+move past the last release for this to read correctly on beta units.
+
+## Where a curated subset breaks today
+
+| Site | Effect |
+|---|---|
+| `deviceTrackSync.ts` `allSynced` | Every app course must be on the device or the track reads `mismatch` forever → **prompt on every connect, permanently** |
+| `deviceSyncPlan.ts` count guard | An 11-course venue is skipped entirely and can never sync |
+| `deviceSyncOps.ts` / `rebuildDeviceTrackJson` | Accepting the wizard re-uploads every course, **silently destroying the curation** |
+
+The first is the one that matters: it is the same never-reaches-`synced` trap
+plan 0016 closed, reopened by curation.
+
+**A track that still won't fit is reported as a skip with a reason**, surfaced
+in the list the way `too_many_courses` already is — never as an auto-prompt.
+The picker is reachable only from a deliberate user action. That is what keeps
+an empty override store from resuming the nag.

--- a/src/components/drawer/DeviceTracksTab.tsx
+++ b/src/components/drawer/DeviceTracksTab.tsx
@@ -272,12 +272,12 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
       try {
         // Delete from device if it exists there
         if (isOnDevice(entry)) {
-          await details.deleteTrack(entry.shortName + ".json", entry.kind);
+          await details.deleteTrack(deviceFileOf(entry), entry.kind);
         }
         // Upload from app
         const json = buildTrackJsonForUpload(entry.appTrack!);
         const data = new TextEncoder().encode(json);
-        await details.putTrack(entry.shortName + ".json", data, entry.kind);
+        await details.putTrack(deviceFileOf(entry), data, entry.kind);
       } catch (err) {
         console.error(`Resync failed for ${entry.shortName}:`, err);
         toast.error(t("deviceTracks.resyncFailedToast", { name: entry.shortName, error: err instanceof Error ? err.message : t("deviceTracks.unknownShort") }));

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -277,9 +277,20 @@ describe("buildTrackJsonForUpload", () => {
     expect(parsed.courses.map((c) => c.name)).toEqual(["A", "B", "C"]);
   });
 
-  it("uses tab indentation (matches device expectation)", () => {
+  // Bytes are the constraint: the device parses a whole track file inside a
+  // fixed buffer, and one byte past it takes the track out of detection
+  // altogether. Indentation was about a quarter of the file.
+  it("emits compact JSON, with no indentation to spend the budget on", () => {
     const json = buildTrackJsonForUpload(makeAppTrack("OKC", [makeAppCourse()]));
-    expect(json).toContain("\t");
+    expect(json).not.toContain("\t");
+    expect(json).not.toContain("\n");
+  });
+
+  it("is meaningfully smaller than the indented form it replaced", () => {
+    const track = makeAppTrack("OKC", [makeAppCourse(), makeAppCourse({ name: "B" })]);
+    const compact = buildTrackJsonForUpload(track);
+    const indented = JSON.stringify(JSON.parse(compact), null, "\t");
+    expect(compact.length).toBeLessThan(indented.length * 0.85);
   });
 
   // The round trip that decides whether the sync wizard re-prompts forever.

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -327,9 +327,23 @@ export function buildTrackJsonForUpload(track: Track): string {
   });
 }
 
-/** Serialize an object-form track file the way the device expects it. */
+/**
+ * Serialize an object-form track file for the device.
+ *
+ * Compact, with no indentation. The device reads a whole track file into a
+ * fixed buffer and parses it there; a file past that buffer is cut mid-JSON,
+ * the parse fails, no manifest entry is built, and the track stops being
+ * detected at the venue entirely rather than merely losing its tail. In a file
+ * of this shape the tabs and newlines were roughly a quarter of the bytes,
+ * spent on whitespace nothing reads — the device parses with ArduinoJson,
+ * which is whitespace-insensitive, and a human wanting to read one has a
+ * formatter.
+ *
+ * This is the single choke point every upload writer funnels through, so it is
+ * also what any size projection must measure.
+ */
 export function serializeDeviceTrackFile(file: DeviceTrackFileJson): string {
-  return JSON.stringify(file, null, '\t');
+  return JSON.stringify(file);
 }
 
 /**


### PR DESCRIPTION
## Summary

First PR of plan 0017. Two independent fixes, both of which make a track file
on the card *smaller* — which matters because of how the logger fails when one
gets too big.

**The failure mode this is all about.** The logger reads a whole track file into
a fixed buffer (`JSON_BUFFER_SIZE`) and parses it there. One byte past that, the
read is cut mid-JSON, `deserializeJson` fails, `buildTrackList()` adds no
manifest entry, and **the track stops being detected at the venue entirely** —
it doesn't lose its tail, it disappears. On released firmware that buffer is
4 KB, which a sprint track reaches at about seven courses.

### 1. Resync All orphaned the file it meant to replace

`deviceFileOf()` exists so a write lands on the file the device actually has,
and its comment spells out why: for a course the device's own creator wrote, the
identity (`08031432`) and the filename (`N260803_1432.json`) are different
strings. Five call sites use it. `handleResyncAll` rebuilt
`shortName + ".json"` for **both** its delete and its put.

So on any device-created track, Resync All deleted nothing, wrote a *second*
file under the identity name, and left the original sitting there. Every resync
added another one — growing the file count and the bytes on the card, toward the
limit above.

### 2. Uploads carried their own indentation

`serializeDeviceTrackFile` emitted `JSON.stringify(file, null, '\t')`. In a file
of this shape the tabs and newlines are roughly a quarter of the bytes, spent on
whitespace nothing reads: the firmware parses with ArduinoJson, which is
whitespace-insensitive. Dropping it is about **a quarter more courses per
track**, for free, with nothing new asked of any device in the field.

It's also the one choke point all three upload writers funnel through, so it's
what the size projection in the rest of plan 0017 will measure — the number
shown to the user has to be the number actually written.

## Related Issues

Follows plan 0016 (#385 / #386 / #387 / #388). Opens plan 0017; the model,
the capability gate and the picker UI follow in stacked PRs.

## Type of Change

- [x] Bug fix
- [x] Documentation
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2737 tests, 190 files)
- [x] `bun run build` succeeds
- [x] Feature works **offline**
- [x] Docs updated — new `docs/plans/0017-device-course-curation.md`, `CHANGELOG.md`
- [ ] For a new parser: n/a

## Notes for Reviewers

**Neither fix is reachable by a test.** Both call sites live in a component, and
the suite runs in `node` with no DOM renderer — `src/components/**/*.tsx` is
coverage-excluded for the same reason. The helper `handleResyncAll` should have
been using is one line and already documented; everything the rest of plan 0017
adds is a pure module in `src/lib` with its own tests, specifically so this
doesn't recur.

**The indentation test was asserting something untrue.** It read
`uses tab indentation (matches device expectation)` — the device has no such
expectation, and never did. It's replaced with one that pins compact output and
one that pins the saving being worth having (>15% on a two-course track).

**Worth knowing:** these two together are why the picker UI can come later. They
shrink the problem without changing any behaviour a user has to understand, so
they're safe to ship on their own even if the rest of 0017 slips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_