### PR TITLE
feat(sync): the model for which courses belong on the device (plan 0017)

### DIFF
--- a/src/lib/deviceCourseOverrides.test.ts
+++ b/src/lib/deviceCourseOverrides.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  clearCourseOverrides,
+  isEmptyOverrides,
+  loadTrackOverrides,
+  loggerOverrideKey,
+  parseCourseOverrides,
+  saveTrackOverrides,
+  trackOverrideKey,
+} from "./deviceCourseOverrides";
+import { NO_OVERRIDES, selectedDeviceCourses } from "./deviceCourseSelection";
+import type { Course } from "@/types/racing";
+
+const NOW = 1_800_000_000_000;
+
+function stubStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  });
+  return store;
+}
+
+// ─── Keys ────────────────────────────────────────────────────────────────────
+
+describe("loggerOverrideKey", () => {
+  it("separates loggers, because they hold different cards", () => {
+    expect(loggerOverrideKey("Logger-A")).not.toBe(loggerOverrideKey("Logger-B"));
+  });
+
+  it("still produces a key for an unnamed logger", () => {
+    expect(loggerOverrideKey(null)).toBe("unknown");
+    expect(loggerOverrideKey("")).toBe("unknown");
+  });
+});
+
+describe("trackOverrideKey", () => {
+  // A circuit and a sprint track are separate files in separate folders and may
+  // legitimately share a short name.
+  it("separates the two kinds under one short name", () => {
+    expect(trackOverrideKey("circuit", "OKC")).not.toBe(trackOverrideKey("sprint", "OKC"));
+  });
+});
+
+describe("isEmptyOverrides", () => {
+  it("is true for no deviations", () => {
+    expect(isEmptyOverrides(NO_OVERRIDES)).toBe(true);
+  });
+
+  it("is false once anything is overridden", () => {
+    expect(isEmptyOverrides({ include: ["A"], exclude: [] })).toBe(false);
+    expect(isEmptyOverrides({ include: [], exclude: ["A"] })).toBe(false);
+  });
+});
+
+// ─── parseCourseOverrides ────────────────────────────────────────────────────
+
+describe("parseCourseOverrides", () => {
+  const good = {
+    "Logger-A": { ts: NOW, tracks: { "sprint:OKC": { include: ["Old"], exclude: [] } } },
+  };
+
+  it("round-trips a well-formed store", () => {
+    expect(parseCourseOverrides(JSON.stringify(good))).toEqual(good);
+  });
+
+  // Every failure mode has to land on "no overrides", because that means the
+  // default rule applies — a working configuration rather than a broken one.
+  it("returns nothing for null, junk, or the wrong shape", () => {
+    expect(parseCourseOverrides(null)).toEqual({});
+    expect(parseCourseOverrides("")).toEqual({});
+    expect(parseCourseOverrides("not json")).toEqual({});
+    expect(parseCourseOverrides("[1,2,3]")).toEqual({});
+    expect(parseCourseOverrides("null")).toEqual({});
+  });
+
+  it("drops a logger entry with no usable timestamp", () => {
+    const raw = JSON.stringify({ "Logger-A": { tracks: {} } });
+    expect(parseCourseOverrides(raw)).toEqual({});
+  });
+
+  it("drops a track entry whose lists are not string arrays", () => {
+    const raw = JSON.stringify({
+      "Logger-A": {
+        ts: NOW,
+        tracks: {
+          "sprint:OKC": { include: "Old", exclude: [] },
+          "sprint:BAD": { include: [1, 2], exclude: [] },
+          "sprint:OK": { include: ["Keep"], exclude: [] },
+        },
+      },
+    });
+    const out = parseCourseOverrides(raw);
+    expect(Object.keys(out["Logger-A"].tracks)).toEqual(["sprint:OK"]);
+  });
+
+  it("keeps a logger whose tracks all turned out to be junk, with none of them", () => {
+    const raw = JSON.stringify({
+      "Logger-A": { ts: NOW, tracks: { "sprint:OKC": "nope" } },
+    });
+    expect(parseCourseOverrides(raw)).toEqual({ "Logger-A": { ts: NOW, tracks: {} } });
+  });
+
+  it("bounds a runaway logger list, keeping the most recently written", () => {
+    const many: Record<string, unknown> = {};
+    for (let i = 0; i < 40; i++) {
+      many[`Logger-${i}`] = { ts: NOW + i, tracks: {} };
+    }
+    const out = parseCourseOverrides(JSON.stringify(many));
+    expect(Object.keys(out)).toHaveLength(20);
+    expect(out["Logger-39"]).toBeDefined();
+    expect(out["Logger-0"]).toBeUndefined();
+  });
+});
+
+// ─── Round trip through storage ──────────────────────────────────────────────
+
+describe("override round trip", () => {
+  beforeEach(() => stubStorage());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns no overrides for a logger it has never seen", () => {
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC")).toEqual(NO_OVERRIDES);
+  });
+
+  it("stores and reads back one track's overrides", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC")).toEqual({
+      include: ["Old"],
+      exclude: [],
+    });
+  });
+
+  it("keeps loggers apart", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    expect(loadTrackOverrides("Logger-B", "sprint", "OKC")).toEqual(NO_OVERRIDES);
+  });
+
+  it("keeps the two track kinds apart", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    expect(loadTrackOverrides("Logger-A", "circuit", "OKC")).toEqual(NO_OVERRIDES);
+  });
+
+  it("keeps several tracks on one logger", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    saveTrackOverrides("Logger-A", "circuit", "TWS", { include: [], exclude: ["CCW"] });
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC").include).toEqual(["Old"]);
+    expect(loadTrackOverrides("Logger-A", "circuit", "TWS").exclude).toEqual(["CCW"]);
+  });
+
+  it("replaces an earlier entry rather than merging into it", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Older"], exclude: [] });
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC").include).toEqual(["Older"]);
+  });
+
+  // "Put it back the way it was" has to be representable, and a store full of
+  // empty entries is just noise.
+  it("removes the entry when the overrides become empty", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    saveTrackOverrides("Logger-A", "sprint", "OKC", NO_OVERRIDES);
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC")).toEqual(NO_OVERRIDES);
+    expect(localStorage.getItem("dove-device-course-overrides")).toBe("{}");
+  });
+
+  it("does not store anything for a logger whose only track reverts to default", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", NO_OVERRIDES);
+    expect(localStorage.getItem("dove-device-course-overrides")).toBe("{}");
+  });
+
+  it("clears everything on request", () => {
+    saveTrackOverrides("Logger-A", "sprint", "OKC", { include: ["Old"], exclude: [] });
+    clearCourseOverrides();
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC")).toEqual(NO_OVERRIDES);
+  });
+
+  it("does not alias the caller's arrays", () => {
+    const overrides = { include: ["Old"], exclude: [] as string[] };
+    saveTrackOverrides("Logger-A", "sprint", "OKC", overrides);
+    overrides.include.push("Mutated");
+    expect(loadTrackOverrides("Logger-A", "sprint", "OKC").include).toEqual(["Old"]);
+  });
+
+  it("degrades quietly when storage throws", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    });
+    expect(() =>
+      saveTrackOverrides("A", "sprint", "OKC", { include: ["x"], exclude: [] }),
+    ).not.toThrow();
+    expect(loadTrackOverrides("A", "sprint", "OKC")).toEqual(NO_OVERRIDES);
+    expect(() => clearCourseOverrides()).not.toThrow();
+  });
+});
+
+// ─── The property the whole design rests on ──────────────────────────────────
+
+describe("an empty store is a working configuration", () => {
+  beforeEach(() => stubStorage());
+  afterEach(() => vi.unstubAllGlobals());
+
+  function sprint(name: string, dateCreated: string): Course {
+    return {
+      name,
+      type: "sprint",
+      dateCreated,
+      startFinishA: { lat: 35.4, lon: -97.3 },
+      startFinishB: { lat: 35.4001, lon: -97.3001 },
+      finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      isUserDefined: true,
+    };
+  }
+
+  // On a browser that has never seen this logger, the default rule alone must
+  // produce a set the device can hold — otherwise the sync flow would prompt on
+  // every connect, which is the trap plan 0016 closed.
+  it("a never-seen logger still gets a single sprint course", () => {
+    const courses = Array.from({ length: 25 }, (_, i) =>
+      sprint(`Run ${i + 1}`, `2026-08-${String(i + 1).padStart(2, "0")}T09:00`),
+    );
+    const overrides = loadTrackOverrides("Brand-New-Browser", "sprint", "OKC");
+    expect(overrides).toEqual(NO_OVERRIDES);
+    expect(selectedDeviceCourses(courses, overrides)).toHaveLength(1);
+  });
+});

--- a/src/lib/deviceCourseOverrides.ts
+++ b/src/lib/deviceCourseOverrides.ts
@@ -1,0 +1,186 @@
+/**
+ * Which courses the user has explicitly chosen to keep on, or off, a logger
+ * (plan 0017).
+ *
+ * Only DEVIATIONS from the default rule live here — see
+ * `overridesFromSelection`. A track the user never curated stores nothing and
+ * follows the rule forever.
+ *
+ * Deliberately **not** a cloud-synced doc store. This describes one physical SD
+ * card: which subset of a track's courses is currently written to it. Syncing it
+ * would push one card's contents onto every logger the user owns, and the
+ * penalty for getting that wrong is a track file over the device's parse buffer
+ * — which is not a degraded track, it is a track that stops being detected at
+ * the venue. The courses themselves are already cloud-synced with the garage, so
+ * nothing is lost by keeping this local; the user re-picks on a new browser, and
+ * until they do, the default rule produces a set the device can hold.
+ *
+ * Keyed by logger, because the owner runs more than one and they hold different
+ * cards.
+ */
+
+import type { TrackKind } from '@/lib/ble/trackOpcodes';
+import type { TrackCourseOverrides } from '@/lib/deviceCourseSelection';
+import { NO_OVERRIDES } from '@/lib/deviceCourseSelection';
+
+const KEY = 'dove-device-course-overrides';
+
+/** Enough for a large fleet; keeps a corrupt or runaway store bounded. */
+const MAX_LOGGERS = 20;
+/** Far more tracks than a card holds; the same bound, one level down. */
+const MAX_TRACKS = 200;
+
+/**
+ * Deliberately no time-based expiry.
+ *
+ * An expiring curation silently re-adds courses to a card that was deliberately
+ * trimmed, pushing the file back over the buffer — and the user finds out at the
+ * venue, when the track no longer registers. A stale entry costs a few bytes of
+ * localStorage; a lapsed one costs a track day. Growth is bounded by count
+ * instead, evicting the least recently written.
+ */
+export interface LoggerCourseOverrides {
+  /** Last write, for eviction order only. */
+  ts: number;
+  /** Keyed by `trackOverrideKey`. */
+  tracks: Record<string, TrackCourseOverrides>;
+}
+
+export type CourseOverrideStore = Record<string, LoggerCourseOverrides>;
+
+/**
+ * The store key for one logger.
+ *
+ * An unnamed logger still gets a key rather than being skipped: on the web the
+ * BLE name is all we have, and no name at all is better treated as one anonymous
+ * logger than as "never remember anything".
+ */
+export function loggerOverrideKey(deviceName: string | null | undefined): string {
+  return deviceName || 'unknown';
+}
+
+/**
+ * The key for one track within a logger.
+ *
+ * `(kind, shortName)` — the same pair the device sync merge keys on, because a
+ * circuit and a sprint track are separate files in separate folders and may
+ * legitimately share a short name.
+ */
+export function trackOverrideKey(kind: TrackKind, shortName: string): string {
+  return `${kind}:${shortName}`;
+}
+
+function isOverrides(v: unknown): v is TrackCourseOverrides {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Partial<TrackCourseOverrides>;
+  return (
+    Array.isArray(o.include) &&
+    Array.isArray(o.exclude) &&
+    o.include.every((n) => typeof n === 'string') &&
+    o.exclude.every((n) => typeof n === 'string')
+  );
+}
+
+/**
+ * Parse the stored blob, dropping anything malformed. Pure, so the validation
+ * rules are testable without touching storage.
+ *
+ * Anything unrecognised decays to "no overrides", which means the default rule
+ * applies — a working configuration, not a broken one.
+ */
+export function parseCourseOverrides(raw: string | null): CourseOverrideStore {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+
+    const out: CourseOverrideStore = {};
+    const loggers = Object.entries(parsed as Record<string, unknown>)
+      .filter((e): e is [string, LoggerCourseOverrides] => {
+        const v = e[1];
+        if (!v || typeof v !== 'object') return false;
+        const l = v as Partial<LoggerCourseOverrides>;
+        return typeof l.ts === 'number' && Number.isFinite(l.ts) && !!l.tracks &&
+          typeof l.tracks === 'object';
+      })
+      .sort((a, b) => b[1].ts - a[1].ts)
+      .slice(0, MAX_LOGGERS);
+
+    for (const [id, logger] of loggers) {
+      const tracks: Record<string, TrackCourseOverrides> = {};
+      for (const [key, value] of Object.entries(logger.tracks).slice(0, MAX_TRACKS)) {
+        if (isOverrides(value)) tracks[key] = { include: value.include, exclude: value.exclude };
+      }
+      out[id] = { ts: logger.ts, tracks };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function readStore(): CourseOverrideStore {
+  try {
+    return parseCourseOverrides(localStorage.getItem(KEY));
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: CourseOverrideStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store));
+  } catch {
+    /* storage unavailable — curation falls back to the default rule */
+  }
+}
+
+/** True when nothing is actually overridden — the default rule alone applies. */
+export function isEmptyOverrides(o: TrackCourseOverrides): boolean {
+  return o.include.length === 0 && o.exclude.length === 0;
+}
+
+/** The user's overrides for one track on one logger, or none. */
+export function loadTrackOverrides(
+  deviceName: string | null | undefined,
+  kind: TrackKind,
+  shortName: string,
+): TrackCourseOverrides {
+  const logger = readStore()[loggerOverrideKey(deviceName)];
+  return logger?.tracks[trackOverrideKey(kind, shortName)] ?? NO_OVERRIDES;
+}
+
+/**
+ * Record the user's overrides for one track on one logger.
+ *
+ * Empty overrides REMOVE the entry rather than storing an empty one, so
+ * "put this back the way it was" is representable and the store stays small.
+ */
+export function saveTrackOverrides(
+  deviceName: string | null | undefined,
+  kind: TrackKind,
+  shortName: string,
+  overrides: TrackCourseOverrides,
+): void {
+  const store = readStore();
+  const id = loggerOverrideKey(deviceName);
+  const trackKey = trackOverrideKey(kind, shortName);
+  const tracks = { ...(store[id]?.tracks ?? {}) };
+
+  if (isEmptyOverrides(overrides)) delete tracks[trackKey];
+  else tracks[trackKey] = { include: [...overrides.include], exclude: [...overrides.exclude] };
+
+  if (Object.keys(tracks).length === 0) delete store[id];
+  else store[id] = { ts: Date.now(), tracks };
+
+  writeStore(store);
+}
+
+/** Drop every stored override. Exposed for tests and a "reset" action. */
+export function clearCourseOverrides(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/lib/deviceCourseSelection.test.ts
+++ b/src/lib/deviceCourseSelection.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import {
+  NO_OVERRIDES,
+  keepsOnlyNewest,
+  newestCourseIndex,
+  overridesFromSelection,
+  resolveDeviceCourses,
+  selectedDeviceCourses,
+} from "./deviceCourseSelection";
+import type { Course } from "@/types/racing";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    name: "Full CW",
+    startFinishA: { lat: 35.4, lon: -97.3 },
+    startFinishB: { lat: 35.4001, lon: -97.3001 },
+    isUserDefined: true,
+    ...overrides,
+  };
+}
+
+function sprint(name: string, dateCreated?: string): Course {
+  return makeCourse({
+    name,
+    type: "sprint",
+    finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+    dateCreated,
+  });
+}
+
+const names = (courses: Course[]) => courses.map(c => c.name);
+
+// ─── newestCourseIndex ───────────────────────────────────────────────────────
+
+describe("newestCourseIndex", () => {
+  it("returns -1 for no courses", () => {
+    expect(newestCourseIndex([])).toBe(-1);
+  });
+
+  it("picks the highest stamp, not the last course", () => {
+    const courses = [
+      sprint("Jan", "2026-01-04T09:00"),
+      sprint("Aug", "2026-08-09T14:32"),
+      sprint("Mar", "2026-03-21T11:15"),
+    ];
+    expect(newestCourseIndex(courses)).toBe(1);
+  });
+
+  // The stamps are compared as plain strings, exactly as the firmware does, so
+  // the zero-padded ISO shape is load-bearing. A naive comparison would put
+  // "2026-1-4" after "2026-08-09"; the fixtures pin the padded form.
+  it("orders correctly across month and day boundaries", () => {
+    const courses = [
+      sprint("Sep", "2026-09-01T08:00"),
+      sprint("Oct", "2026-10-01T08:00"),
+    ];
+    expect(newestCourseIndex(courses)).toBe(1);
+  });
+
+  it("separates two courses walked on the same day by time", () => {
+    const courses = [
+      sprint("Morning", "2026-08-09T09:05"),
+      sprint("Afternoon", "2026-08-09T14:32"),
+    ];
+    expect(newestCourseIndex(courses)).toBe(1);
+  });
+
+  // A missing stamp predates the field. Treating it as newest would let an old
+  // import displace the course actually walked this morning.
+  it("sorts a course with no stamp as the oldest", () => {
+    const courses = [sprint("Stamped", "2026-08-09T14:32"), sprint("Bare")];
+    expect(newestCourseIndex(courses)).toBe(0);
+  });
+
+  it("still returns a course when none of them are stamped", () => {
+    const courses = [sprint("A"), sprint("B")];
+    expect(newestCourseIndex(courses)).toBe(1);
+  });
+
+  it("breaks an exact tie toward the most recently added", () => {
+    const courses = [
+      sprint("First", "2026-08-09T14:32"),
+      sprint("Second", "2026-08-09T14:32"),
+    ];
+    expect(newestCourseIndex(courses)).toBe(1);
+  });
+});
+
+// ─── keepsOnlyNewest ─────────────────────────────────────────────────────────
+
+describe("keepsOnlyNewest", () => {
+  it("is true for a sprint track, whose courses accumulate every event", () => {
+    expect(keepsOnlyNewest([sprint("Run 1"), sprint("Run 2")])).toBe(true);
+  });
+
+  it("is false for a circuit track, whose layouts are all still driven", () => {
+    expect(keepsOnlyNewest([makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })])).toBe(false);
+  });
+
+  it("is false for an empty track", () => {
+    expect(keepsOnlyNewest([])).toBe(false);
+  });
+});
+
+// ─── resolveDeviceCourses — the default rule ─────────────────────────────────
+
+describe("resolveDeviceCourses (default rule)", () => {
+  it("keeps every course of a circuit track", () => {
+    const courses = [makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })];
+    expect(names(selectedDeviceCourses(courses))).toEqual(["CW", "CCW"]);
+  });
+
+  it("keeps only the newest course of a sprint track", () => {
+    const courses = [
+      sprint("Jan", "2026-01-04T09:00"),
+      sprint("Aug", "2026-08-09T14:32"),
+      sprint("Mar", "2026-03-21T11:15"),
+    ];
+    expect(names(selectedDeviceCourses(courses))).toEqual(["Aug"]);
+  });
+
+  it("preserves the original order of the courses it reports on", () => {
+    const courses = [sprint("A", "2026-01-01T00:00"), sprint("B", "2026-02-01T00:00")];
+    expect(resolveDeviceCourses(courses).map(d => d.course.name)).toEqual(["A", "B"]);
+  });
+
+  it("marks default decisions as such", () => {
+    const courses = [sprint("Old", "2026-01-01T00:00"), sprint("New", "2026-02-01T00:00")];
+    expect(resolveDeviceCourses(courses).map(d => d.why)).toEqual(["default", "default"]);
+  });
+
+  it("handles an empty course list", () => {
+    expect(resolveDeviceCourses([])).toEqual([]);
+  });
+
+  // This is the property that lets the override store be device-local and
+  // unsynced: on a browser that has never seen this logger, the rule alone must
+  // produce a set the device can hold, so the sync flow settles instead of
+  // prompting on every connect.
+  it("needs no stored state to produce a device-sized set", () => {
+    const courses = Array.from({ length: 30 }, (_, i) =>
+      sprint(`Run ${i}`, `2026-08-${String(i + 1).padStart(2, "0")}T09:00`),
+    );
+    expect(selectedDeviceCourses(courses, NO_OVERRIDES)).toHaveLength(1);
+  });
+});
+
+// ─── resolveDeviceCourses — overrides ────────────────────────────────────────
+
+describe("resolveDeviceCourses (overrides)", () => {
+  const sprintCourses = () => [
+    sprint("Old", "2026-01-04T09:00"),
+    sprint("New", "2026-08-09T14:32"),
+  ];
+
+  it("an explicit include re-adds an older sprint course", () => {
+    const selected = selectedDeviceCourses(sprintCourses(), { include: ["Old"], exclude: [] });
+    expect(names(selected)).toEqual(["Old", "New"]);
+  });
+
+  it("an explicit exclude drops a course the rule would keep", () => {
+    const selected = selectedDeviceCourses(sprintCourses(), { include: [], exclude: ["New"] });
+    expect(names(selected)).toEqual([]);
+  });
+
+  it("an exclude drops a circuit course the rule keeps by default", () => {
+    const courses = [makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })];
+    const selected = selectedDeviceCourses(courses, { include: [], exclude: ["CCW"] });
+    expect(names(selected)).toEqual(["CW"]);
+  });
+
+  it("marks overridden decisions as user decisions", () => {
+    const decisions = resolveDeviceCourses(sprintCourses(), { include: ["Old"], exclude: [] });
+    expect(decisions.map(d => d.why)).toEqual(["user", "default"]);
+  });
+
+  // Exclude is the direction that keeps a file under the device's buffer, and
+  // the cost of getting it wrong is a track that stops being detected at all.
+  it("exclude wins when a course is named in both lists", () => {
+    const selected = selectedDeviceCourses(sprintCourses(), {
+      include: ["New"],
+      exclude: ["New"],
+    });
+    expect(names(selected)).toEqual([]);
+  });
+
+  it("ignores an override naming a course that no longer exists", () => {
+    const selected = selectedDeviceCourses(sprintCourses(), {
+      include: ["Deleted"],
+      exclude: ["Renamed"],
+    });
+    expect(names(selected)).toEqual(["New"]);
+  });
+});
+
+// ─── overridesFromSelection ──────────────────────────────────────────────────
+
+describe("overridesFromSelection", () => {
+  const sprintCourses = () => [
+    sprint("Old", "2026-01-04T09:00"),
+    sprint("New", "2026-08-09T14:32"),
+  ];
+
+  // A track the user never curated must stay on the default rule forever,
+  // rather than being frozen to whatever it looked like when they opened the
+  // picker and pressed OK.
+  it("records nothing when the selection matches the default rule", () => {
+    expect(overridesFromSelection(sprintCourses(), ["New"])).toEqual({
+      include: [],
+      exclude: [],
+    });
+  });
+
+  it("records only the genuine deviations", () => {
+    expect(overridesFromSelection(sprintCourses(), ["Old", "New"])).toEqual({
+      include: ["Old"],
+      exclude: [],
+    });
+  });
+
+  it("records an exclude when the user unchecks a default-on course", () => {
+    const courses = [makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })];
+    expect(overridesFromSelection(courses, ["CW"])).toEqual({
+      include: [],
+      exclude: ["CCW"],
+    });
+  });
+
+  it("round-trips through resolveDeviceCourses", () => {
+    const courses = sprintCourses();
+    const wanted = ["Old"];
+    const overrides = overridesFromSelection(courses, wanted);
+    expect(names(selectedDeviceCourses(courses, overrides))).toEqual(wanted);
+  });
+
+  it("round-trips an empty selection", () => {
+    const courses = sprintCourses();
+    const overrides = overridesFromSelection(courses, []);
+    expect(selectedDeviceCourses(courses, overrides)).toEqual([]);
+  });
+});

--- a/src/lib/deviceCourseSelection.ts
+++ b/src/lib/deviceCourseSelection.ts
@@ -1,0 +1,139 @@
+/**
+ * Which of a track's courses belong on the device (plan 0017).
+ *
+ * The device holds a subset; the app holds everything. This module is the ONLY
+ * place that decides which subset, so the sync plan, the upload writers, the
+ * "is it synced?" check and the picker UI can never disagree about it — a
+ * disagreement between any two of them is a track that re-prompts on every
+ * connect, which is exactly the trap plan 0016 was written to close.
+ */
+
+import { Course, isSprintCourse } from '@/types/racing';
+
+/**
+ * A user's explicit deviations from the default rule, per track.
+ *
+ * Names, not indices: courses are reordered and re-saved, and an index would
+ * silently retarget. Absent from both lists means "no opinion" — the default
+ * rule decides, which is what makes an empty store a working configuration
+ * rather than a broken one.
+ */
+export interface TrackCourseOverrides {
+  /** Course names forced ON the device, past what the default rule picks. */
+  include: string[];
+  /** Course names forced OFF the device, against what the default rule picks. */
+  exclude: string[];
+}
+
+export interface CourseDecision {
+  course: Course;
+  included: boolean;
+  /** `user` when an override decided this, `default` when the rule did. */
+  why: 'default' | 'user';
+}
+
+/** An empty set of overrides — the state every logger starts in. */
+export const NO_OVERRIDES: TrackCourseOverrides = { include: [], exclude: [] };
+
+/**
+ * The newest sprint course, by `dateCreated`.
+ *
+ * `dateCreated` is a zero-padded `YYYY-MM-DDTHH:MM` stamp compared as a plain
+ * string — the same comparison the firmware does, deliberately. A course with
+ * no stamp sorts oldest: it predates the field, and treating a missing value as
+ * "newest" would let it displace the course actually walked this morning.
+ *
+ * Returns -1 for an empty list. Ties resolve to the LAST such course, matching
+ * "most recently added" when two were stamped in the same minute.
+ */
+export function newestCourseIndex(courses: readonly Course[]): number {
+  let best = -1;
+  let bestStamp = '';
+  for (let i = 0; i < courses.length; i++) {
+    const stamp = courses[i].dateCreated ?? '';
+    if (best === -1 || stamp >= bestStamp) {
+      best = i;
+      bestStamp = stamp;
+    }
+  }
+  return best;
+}
+
+/**
+ * True when this track's courses accumulate — i.e. the default rule should keep
+ * only the newest rather than all of them.
+ *
+ * A sprint venue re-lays its cones every event and the on-device creator mints
+ * a dated course each time, so the file grows without bound. Circuit courses
+ * are layouts of a fixed track: there are a handful, they don't accumulate, and
+ * dropping one would take a layout the driver still runs off the device.
+ */
+export function keepsOnlyNewest(courses: readonly Course[]): boolean {
+  return courses.some(isSprintCourse);
+}
+
+/**
+ * Decide, for every course, whether it belongs on the device.
+ *
+ * Default rule first, then the user's explicit overrides on top. Order is
+ * preserved so a caller can render decisions against the list it already has.
+ *
+ * An override naming a course that isn't here is ignored rather than an error —
+ * courses get renamed and deleted in the app, and a stale name should decay to
+ * the default, not break the sync.
+ */
+export function resolveDeviceCourses(
+  courses: readonly Course[],
+  overrides: TrackCourseOverrides = NO_OVERRIDES,
+): CourseDecision[] {
+  const newest = keepsOnlyNewest(courses) ? newestCourseIndex(courses) : -1;
+  const included = new Set(overrides.include);
+  const excluded = new Set(overrides.exclude);
+
+  return courses.map((course, i) => {
+    const byDefault = newest === -1 ? true : i === newest;
+
+    // An explicit exclude wins over an explicit include: it is the one that
+    // keeps a file under the device's buffer, and the cost of getting it wrong
+    // is a track that stops being detected at the venue.
+    if (excluded.has(course.name)) return { course, included: false, why: 'user' };
+    if (included.has(course.name)) return { course, included: true, why: 'user' };
+    return { course, included: byDefault, why: 'default' };
+  });
+}
+
+/** The courses that belong on the device, in their original order. */
+export function selectedDeviceCourses(
+  courses: readonly Course[],
+  overrides: TrackCourseOverrides = NO_OVERRIDES,
+): Course[] {
+  return resolveDeviceCourses(courses, overrides)
+    .filter(d => d.included)
+    .map(d => d.course);
+}
+
+/**
+ * Fold a user's checkbox state back into overrides.
+ *
+ * Only genuine deviations are stored: a choice that matches what the default
+ * rule would do anyway records nothing. That keeps the store small, and it
+ * means a track the user never curated stays on the default forever rather
+ * than being frozen to whatever it happened to look like the day they opened
+ * the picker.
+ */
+export function overridesFromSelection(
+  courses: readonly Course[],
+  selectedNames: readonly string[],
+): TrackCourseOverrides {
+  const wanted = new Set(selectedNames);
+  const include: string[] = [];
+  const exclude: string[] = [];
+
+  for (const { course, included } of resolveDeviceCourses(courses)) {
+    const want = wanted.has(course.name);
+    if (want === included) continue;
+    if (want) include.push(course.name);
+    else exclude.push(course.name);
+  }
+  return { include, exclude };
+}

--- a/src/lib/deviceTrackBudget.test.ts
+++ b/src/lib/deviceTrackBudget.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEVICE_TRACK_BYTES_LARGE,
+  DEVICE_TRACK_BYTES_SMALL,
+  bytesOverBudget,
+  deviceTrackBudget,
+  fitsDeviceBudget,
+  projectDeviceTrackBytes,
+} from "./deviceTrackBudget";
+import { buildTrackJsonForUpload } from "./deviceTrackSync";
+import type { Course, Track } from "@/types/racing";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    name: "Full CW",
+    startFinishA: { lat: 35.4123456, lon: -97.3123456 },
+    startFinishB: { lat: 35.4124567, lon: -97.3124567 },
+    isUserDefined: true,
+    ...overrides,
+  };
+}
+
+/** A sprint course carrying a finish line and two splits — the heaviest shape. */
+function fatSprint(name: string): Course {
+  return makeCourse({
+    name,
+    type: "sprint",
+    dateCreated: "2026-08-09T14:32",
+    finish: {
+      a: { lat: 35.4198765, lon: -97.3198765 },
+      b: { lat: 35.4199876, lon: -97.3199876 },
+    },
+    sectors: [
+      {
+        major: true,
+        line: {
+          a: { lat: 35.4150001, lon: -97.3150001 },
+          b: { lat: 35.4151112, lon: -97.3151112 },
+        },
+      },
+      {
+        major: true,
+        line: {
+          a: { lat: 35.4170002, lon: -97.3170002 },
+          b: { lat: 35.4171113, lon: -97.3171113 },
+        },
+      },
+    ],
+  });
+}
+
+function makeTrack(courses: Course[]): Track {
+  return { name: "Orlando Kart Center", shortName: "OKC", courses, isUserDefined: true };
+}
+
+// ─── deviceTrackBudget ───────────────────────────────────────────────────────
+
+describe("deviceTrackBudget", () => {
+  it("gives the large buffer to firmware that has it", () => {
+    expect(deviceTrackBudget(true)).toBe(DEVICE_TRACK_BYTES_LARGE);
+  });
+
+  it("gives the small buffer to firmware that does not", () => {
+    expect(deviceTrackBudget(false)).toBe(DEVICE_TRACK_BYTES_SMALL);
+  });
+
+  // Guessing high overfills the card and takes the track out of detection at
+  // the venue; guessing low costs the user one course they could have kept.
+  // The asymmetry decides the default.
+  it("assumes the small buffer when the capability is unknown", () => {
+    expect(deviceTrackBudget(undefined)).toBe(DEVICE_TRACK_BYTES_SMALL);
+  });
+
+  it("the large buffer really is larger", () => {
+    expect(DEVICE_TRACK_BYTES_LARGE).toBeGreaterThan(DEVICE_TRACK_BYTES_SMALL);
+  });
+});
+
+// ─── projectDeviceTrackBytes ─────────────────────────────────────────────────
+
+describe("projectDeviceTrackBytes", () => {
+  // The whole point of the module: the number shown to the user as the reason
+  // they must drop a course has to be the number the device is handed.
+  it("equals the encoded length of what the upload writer emits", () => {
+    const track = makeTrack([makeCourse(), makeCourse({ name: "CCW" })]);
+    const written = new TextEncoder().encode(buildTrackJsonForUpload(track)).length;
+    expect(projectDeviceTrackBytes(track, track.courses)).toBe(written);
+  });
+
+  it("measures the courses it is given, not the ones on the track", () => {
+    const all = [makeCourse({ name: "A" }), makeCourse({ name: "B" }), makeCourse({ name: "C" })];
+    const track = makeTrack(all);
+    const one = projectDeviceTrackBytes(track, [all[0]]);
+    const three = projectDeviceTrackBytes(track, all);
+    expect(one).toBeLessThan(three);
+  });
+
+  it("does not mutate the track it was handed", () => {
+    const track = makeTrack([makeCourse({ name: "A" }), makeCourse({ name: "B" })]);
+    projectDeviceTrackBytes(track, [track.courses[0]]);
+    expect(track.courses).toHaveLength(2);
+  });
+
+  it("handles a track with no courses at all", () => {
+    const track = makeTrack([]);
+    expect(projectDeviceTrackBytes(track, [])).toBeGreaterThan(0);
+  });
+
+  it("counts bytes rather than characters for non-ASCII names", () => {
+    const ascii = makeTrack([makeCourse({ name: "Circuit" })]);
+    const accented = makeTrack([makeCourse({ name: "Cïrcüït" })]);
+    expect(projectDeviceTrackBytes(accented, accented.courses)).toBeGreaterThan(
+      projectDeviceTrackBytes(ascii, ascii.courses),
+    );
+  });
+
+  // Sanity-check against the firmware's own measurements: it put a sprint
+  // course with a finish and two splits at ~528 B in the shape its writer
+  // emits. If this drifts far, the app's writer and the device's reader have
+  // diverged and the projection is measuring the wrong thing.
+  it("lands in the right order of magnitude per sprint course", () => {
+    const track = makeTrack([fatSprint("Run 1"), fatSprint("Run 2")]);
+    const one = projectDeviceTrackBytes(track, [track.courses[0]]);
+    const two = projectDeviceTrackBytes(track, track.courses);
+    const perCourse = two - one;
+    expect(perCourse).toBeGreaterThan(200);
+    expect(perCourse).toBeLessThan(900);
+  });
+
+  // The failure this plan exists to prevent: enough dated sprint courses and
+  // the file no longer fits the smaller buffer.
+  it("shows a season of sprint courses overflowing the small buffer", () => {
+    const courses = Array.from({ length: 20 }, (_, i) => fatSprint(`Run ${i + 1}`));
+    const track = makeTrack(courses);
+    expect(projectDeviceTrackBytes(track, courses)).toBeGreaterThan(DEVICE_TRACK_BYTES_SMALL);
+  });
+});
+
+// ─── fitsDeviceBudget / bytesOverBudget ──────────────────────────────────────
+
+describe("fitsDeviceBudget", () => {
+  it("accepts a small track", () => {
+    const track = makeTrack([makeCourse()]);
+    expect(fitsDeviceBudget(track, track.courses, DEVICE_TRACK_BYTES_SMALL)).toBe(true);
+  });
+
+  it("rejects a track past the budget", () => {
+    const courses = Array.from({ length: 20 }, (_, i) => fatSprint(`Run ${i + 1}`));
+    const track = makeTrack(courses);
+    expect(fitsDeviceBudget(track, courses, DEVICE_TRACK_BYTES_SMALL)).toBe(false);
+  });
+
+  it("treats exactly the budget as fitting", () => {
+    const track = makeTrack([makeCourse()]);
+    const exact = projectDeviceTrackBytes(track, track.courses);
+    expect(fitsDeviceBudget(track, track.courses, exact)).toBe(true);
+    expect(fitsDeviceBudget(track, track.courses, exact - 1)).toBe(false);
+  });
+
+  it("a track too big for the small buffer can still fit the large one", () => {
+    const courses = Array.from({ length: 9 }, (_, i) => fatSprint(`Run ${i + 1}`));
+    const track = makeTrack(courses);
+    expect(fitsDeviceBudget(track, courses, DEVICE_TRACK_BYTES_SMALL)).toBe(false);
+    expect(fitsDeviceBudget(track, courses, DEVICE_TRACK_BYTES_LARGE)).toBe(true);
+  });
+});
+
+describe("bytesOverBudget", () => {
+  it("is 0 when the track fits", () => {
+    const track = makeTrack([makeCourse()]);
+    expect(bytesOverBudget(track, track.courses, DEVICE_TRACK_BYTES_SMALL)).toBe(0);
+  });
+
+  it("reports the overshoot when it does not", () => {
+    const courses = Array.from({ length: 20 }, (_, i) => fatSprint(`Run ${i + 1}`));
+    const track = makeTrack(courses);
+    const over = bytesOverBudget(track, courses, DEVICE_TRACK_BYTES_SMALL);
+    expect(over).toBe(projectDeviceTrackBytes(track, courses) - DEVICE_TRACK_BYTES_SMALL);
+    expect(over).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/deviceTrackBudget.ts
+++ b/src/lib/deviceTrackBudget.ts
@@ -1,0 +1,71 @@
+/**
+ * How many bytes of track file the logger can actually hold (plan 0017).
+ *
+ * The device reads a whole track file into a fixed buffer and parses it there.
+ * One byte past that buffer and the read is cut mid-JSON: `deserializeJson`
+ * fails, `buildTrackList()` adds no manifest entry, and **the track stops being
+ * detected at the venue entirely** rather than merely losing its tail. So this
+ * is a hard wall, and the cost of misjudging it is losing timing for the day.
+ */
+
+import { Course, Track } from '@/types/racing';
+import { buildTrackJsonForUpload } from '@/lib/deviceTrackSync';
+
+/**
+ * `JSON_BUFFER_SIZE` on firmware from the release that raised it.
+ * Clears the 10-course `MAX_LAYOUTS` cap for every course shape.
+ */
+export const DEVICE_TRACK_BYTES_LARGE = 8192;
+
+/**
+ * `JSON_BUFFER_SIZE` on earlier firmware.
+ *
+ * The firmware's own measurements put a sprint course with a finish line and
+ * two splits at ~528 B, so a sprint track hits this wall at about SEVEN
+ * courses — below the 10-course cap, which is why the cap alone never caught
+ * it.
+ */
+export const DEVICE_TRACK_BYTES_SMALL = 4096;
+
+/**
+ * The byte budget for a device.
+ *
+ * Takes the capability boolean rather than a version, so nothing downstream of
+ * `DeviceDetails` ever compares versions.
+ */
+export function deviceTrackBudget(supportsLargeTrackBuffer: boolean | undefined): number {
+  return supportsLargeTrackBuffer ? DEVICE_TRACK_BYTES_LARGE : DEVICE_TRACK_BYTES_SMALL;
+}
+
+/**
+ * Bytes the device would store for `track` carrying exactly `courses`.
+ *
+ * Measured, never estimated: this runs the real upload writer and the real
+ * `TextEncoder`, which is what `putTrack` is handed. A per-course byte table
+ * would drift the first time the writer changed, and the number this returns is
+ * shown to the user as the reason they have to drop a course — it has to be the
+ * number actually written.
+ */
+export function projectDeviceTrackBytes(track: Track, courses: readonly Course[]): number {
+  return new TextEncoder().encode(
+    buildTrackJsonForUpload({ ...track, courses: [...courses] }),
+  ).length;
+}
+
+/** True when `courses` fit the device's buffer. */
+export function fitsDeviceBudget(
+  track: Track,
+  courses: readonly Course[],
+  budget: number,
+): boolean {
+  return projectDeviceTrackBytes(track, courses) <= budget;
+}
+
+/** Bytes over the budget, or 0 when it fits. For "drop N more" messaging. */
+export function bytesOverBudget(
+  track: Track,
+  courses: readonly Course[],
+  budget: number,
+): number {
+  return Math.max(0, projectDeviceTrackBytes(track, courses) - budget);
+}


### PR DESCRIPTION
## Summary

Second PR of plan 0017, stacked on #393. **Pure logic only — nothing imports
these yet.** The wiring, the capability gate and the picker UI follow. Splitting
it this way keeps the part that decides what ends up on a track day reviewable
as maths rather than as UI.

Three modules:

### `deviceCourseSelection` — the single resolver

Every consumer calls this, so the sync plan, the upload writers, the "is it
synced?" check and the picker can never disagree about the subset. A
disagreement between any two of them is a track that re-prompts on every
connect — the trap plan 0016 was written to close.

- **Circuit tracks keep every course.** Those are layouts of a fixed track and
  the driver still runs them; dropping one takes a layout off the device.
- **Sprint tracks keep only the newest by `dateCreated`.** A sprint venue
  re-lays its cones every event and the on-device creator mints a dated course
  each time, so the file grows without bound.
- Stamps compare **as plain strings**, the same comparison the firmware makes.
  A course with **no** stamp sorts *oldest*, not newest — otherwise an old
  import displaces the course actually walked this morning.
- Overrides are by **name, not index** (courses get reordered and re-saved), and
  **only genuine deviations are recorded**, so a track the user never curated
  follows the rule forever rather than being frozen to whatever it looked like
  when they last opened the picker.
- **Exclude beats include** when a course is in both lists: exclude is the
  direction that keeps a file under the buffer.

### `deviceTrackBudget` — measured, not estimated

Runs the **real upload writer and the real `TextEncoder`**, because the number
shown to the user as the reason to drop a course has to be the number actually
written. A per-course byte table would drift the first time the writer changed.

An **unknown capability assumes the small buffer**. The asymmetry decides it:
guessing high overfills the card and takes the track out of detection at the
venue; guessing low costs the user one course they could have kept.

### `deviceCourseOverrides` — device-local, on purpose

Modelled on `firmwareUpdateReminder`, with two deliberate differences:

- **Not a synced doc store.** It describes one physical SD card. Pushing one
  card's contents onto every logger the user owns is exactly how a file ends up
  over the buffer. The courses themselves already ride cloud sync with the
  garage, so nothing is lost by keeping this local.
- **No time expiry.** An expiring curation silently re-adds courses to a card
  that was deliberately trimmed, and the user finds out at the venue when the
  track stops registering. A stale entry costs a few bytes; a lapsed one costs a
  track day. Growth is bounded by count instead, evicting least-recently-written.

## Related Issues

Stacked on #393. Part of plan 0017; see `docs/plans/0017-device-course-curation.md`.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2804 tests, 193 files — 67 new)
- [x] `bun run build` succeeds
- [x] Feature works **offline** (no network involved)
- [x] Docs updated — plan 0017 already describes these; no user-visible change yet, so no `CHANGELOG.md` entry
- [ ] For a new parser: n/a

## Notes for Reviewers

**The test worth reading first** is the last one in
`deviceCourseOverrides.test.ts`: *"a never-seen logger still gets a single
sprint course"*. The whole design rests on it. Because the override store is
device-local, a new browser has nothing stored — so the default rule alone has
to produce a set the device can hold, or the sync flow would prompt on every
connect and we'd have reintroduced the 0016 bug through the back door.

**A corroboration, not a coincidence:** `deviceTrackBudget.test.ts` has a case
where nine sprint courses (finish line + two splits) fit the 8 KB buffer but not
the 4 KB one. That falls out of measuring the real writer, and it lines up with
the firmware's own measurement of ~528 B for that course shape — which is what
made a sprint track overflow at about seven courses, below the 10-course cap
that was supposed to catch it.

**No user-visible change in this PR.** Nothing calls any of it yet; that's the
next one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_