### PR TITLE
feat(sync): apply the course curation, and gate on the device's real budget (plan 0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     hand-edited settings file — is shown as-is rather than silently displayed
     as one of the choices it does know.
 
+### Added
+- **Sprint tracks now send only their newest course to the logger** (plan 0017).
+  A sprint venue re-lays its course every event, so the courses pile up in one
+  track file — and once that file is bigger than the logger can read, the track
+  isn't recognised at the venue at all. Only the most recently walked course is
+  written to the logger now. **Every course stays in the app and in your
+  account**; only what lives on the card is trimmed. Circuit tracks are
+  unaffected — those layouts are all still driven, so they all stay on.
+- **A track too big for the logger is now reported instead of silently
+  overflowing** (plan 0017). The app knows how much room your logger's firmware
+  has and says which track doesn't fit, rather than sending a file that comes
+  back unreadable.
+
 ### Changed
 - **Tracks are sent to the logger without formatting whitespace** (plan 0017).
   The logger reads a whole track file into a fixed buffer and parses it there;
@@ -42,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bites. Nothing changes on your logger or in your own track files.
 
 ### Fixed
+- **A logger holding fewer courses than the app no longer asks to sync on every
+  connect** (plan 0017). The check treated any course in the app but not on the
+  logger as work outstanding, so once a track carried a subset — which is now
+  the normal state for sprint tracks — it could never read as synced and the
+  prompt returned every single time you connected.
 - **"Resync All" no longer leaves a duplicate track on the logger** (plan 0017).
   For a course you created on the logger itself, the track's short name and its
   filename are different — so Resync All deleted nothing and wrote a *second*

--- a/src/components/DeviceConnectFlow.tsx
+++ b/src/components/DeviceConnectFlow.tsx
@@ -98,7 +98,10 @@ export function DeviceConnectFlow() {
     (async () => {
       try {
         const tracks = await loadTracks();
-        const next = await buildDeviceSyncSnapshot(details, tracks);
+        const next = await buildDeviceSyncSnapshot(details, tracks, undefined, {
+          deviceName,
+          firmwareVersion: fw.info?.version,
+        });
         if (cancelled) return;
         // Only interrupt when there is something to do. A prompt that appears
         // on every connect to say "nothing to sync" is worse than silence.
@@ -116,7 +119,7 @@ export function DeviceConnectFlow() {
     return () => {
       cancelled = true;
     };
-  }, [phase, details]);
+  }, [phase, details, deviceName, fw.info?.version]);
 
   const handleAccept = useCallback(() => {
     setPromptOpen(false);

--- a/src/components/drawer/DeviceSyncWizard.tsx
+++ b/src/components/drawer/DeviceSyncWizard.tsx
@@ -18,6 +18,8 @@ import { parseDeviceGeneratedName } from "@/lib/deviceGeneratedNames";
 import type { NameProblem } from "@/lib/deviceSyncNames";
 import type { SkipReason, SyncDirection, SyncPlan } from "@/lib/deviceSyncPlan";
 import { planOperations } from "@/lib/deviceSyncOps";
+import { loadTrackOverrides } from "@/lib/deviceCourseOverrides";
+import { useDeviceContext } from "@/contexts/DeviceContext";
 import { runSyncOperations, type SyncExecutors } from "@/lib/deviceSyncRunner";
 import {
   canAdvance,
@@ -77,6 +79,7 @@ export function DeviceSyncWizard({
   onDone?: () => void;
 }) {
   const { t, i18n } = useTranslation("drawer");
+  const { deviceName } = useDeviceContext();
   const [state, setState] = useState(() => initWizard(plan, reserved));
   const [running, setRunning] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -128,6 +131,8 @@ export function DeviceSyncWizard({
           return t("deviceTracks.wizard.skippedMixedKind", { name });
         case "too_many_courses":
           return t("deviceTracks.wizard.skippedTooManyCourses", { name });
+        case "too_many_bytes":
+          return t("deviceTracks.wizard.skippedTooManyBytes", { name });
         case "sprint_unsupported":
           return t("deviceTracks.wizard.skippedSprintUnsupported", { name });
       }
@@ -136,7 +141,12 @@ export function DeviceSyncWizard({
   );
 
   const handleSave = async () => {
-    const operations = planOperations(resolutions(state));
+    // The device gets the curated subset; the app keeps every course. Without
+    // this lookup, accepting the wizard would write them all back and undo the
+    // curation the user did in the tracks list (plan 0017).
+    const operations = planOperations(resolutions(state), (kind, shortName) =>
+      loadTrackOverrides(deviceName, kind, shortName),
+    );
     const executors: SyncExecutors = {
       devicePut: (folder, fileName, data) => details.putTrack(fileName, data, folder),
       deviceDelete: (folder, fileName) => details.deleteTrack(fileName, folder),

--- a/src/components/drawer/DeviceTracksTab.tsx
+++ b/src/components/drawer/DeviceTracksTab.tsx
@@ -24,6 +24,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import type { DeviceDetails } from "@/lib/loggers";
+import type { TrackKind } from "@/lib/ble/trackOpcodes";
 import {
   DeviceCourseJson,
   DeviceTrackFile,
@@ -39,6 +40,9 @@ import {
   startADistance,
 } from "@/lib/deviceTrackSync";
 import { fetchDeviceTrackFiles } from "@/lib/deviceSyncFetch";
+import { loadTrackOverrides } from "@/lib/deviceCourseOverrides";
+import { selectedDeviceCourses } from "@/lib/deviceCourseSelection";
+import { useDeviceContext } from "@/contexts/DeviceContext";
 import { loadTracks, addTrack, addCourse } from "@/lib/trackStorage";
 import { Track } from "@/types/racing";
 import { toast } from "sonner";
@@ -63,6 +67,7 @@ const deviceFileOf = (entry: MergedTrackEntry): string =>
 
 export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
   const { t } = useTranslation("drawer");
+  const { deviceName } = useDeviceContext();
   const [view, setView] = useState<View>("loading");
   const [loadProgress, setLoadProgress] = useState({ current: 0, total: 0, label: "" });
   const [mergedTracks, setMergedTracks] = useState<MergedTrackEntry[]>([]);
@@ -77,6 +82,27 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
 
   const [deviceFiles, setDeviceFiles] = useState<DeviceTrackFile[]>([]);
   const [appTracks, setAppTracks] = useState<Track[]>([]);
+
+  // The user's curation for THIS logger. Every merge goes through it, so a
+  // course deliberately kept off the card reads as settled rather than as work
+  // outstanding — otherwise the track sits at `mismatch` and re-prompts on
+  // every connect (plan 0017).
+  const overridesFor = useCallback(
+    (kind: TrackKind, shortName: string) => loadTrackOverrides(deviceName, kind, shortName),
+    [deviceName],
+  );
+
+  // What we actually write for a track: the app's copy, carrying only the
+  // courses bound for the card. The app keeps the rest — they are already
+  // cloud-synced, so nothing is lost by the device holding a subset.
+  const deviceJsonFor = useCallback(
+    (entry: MergedTrackEntry, track: Track) =>
+      buildTrackJsonForUpload({
+        ...track,
+        courses: selectedDeviceCourses(track.courses, overridesFor(entry.kind, entry.shortName)),
+      }),
+    [overridesFor],
+  );
 
   const syncAll = useCallback(async () => {
     setView("loading");
@@ -94,14 +120,14 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
       setDeviceFiles(files);
       const tracks = await loadTracks();
       setAppTracks(tracks);
-      setMergedTracks(buildMergedTrackList(tracks, files));
+      setMergedTracks(buildMergedTrackList(tracks, files, overridesFor));
       setView("tracks");
     } catch (err) {
       console.error("Track sync failed:", err);
       toast.error(t("deviceTracks.syncFailedToast"));
       setView("tracks");
     }
-  }, [details, t]);
+  }, [details, t, overridesFor]);
 
   useEffect(() => {
     syncAll();
@@ -119,7 +145,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
     if (!entry.appTrack) return;
     setUploading(entry.shortName);
     try {
-      const json = buildTrackJsonForUpload(entry.appTrack);
+      const json = deviceJsonFor(entry, entry.appTrack);
       const data = new TextEncoder().encode(json);
       await details.putTrack(deviceFileOf(entry), data, entry.kind);
       toast.success(t("deviceTracks.sentToast", { name: entry.shortName }));
@@ -150,7 +176,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
       toast.success(t("deviceTracks.downloadedToast", { name: trackName }));
       const tracks = await loadTracks();
       setAppTracks(tracks);
-      setMergedTracks(buildMergedTrackList(tracks, deviceFiles));
+      setMergedTracks(buildMergedTrackList(tracks, deviceFiles, overridesFor));
     } catch (err) {
       toast.error(t("deviceTracks.downloadFailedToast", { error: err instanceof Error ? err.message : t("deviceTracks.unknownError") }));
     }
@@ -243,9 +269,9 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
       setDiffCourse(null);
       const tracks = await loadTracks();
       setAppTracks(tracks);
-      setMergedTracks(buildMergedTrackList(tracks, deviceFiles));
+      setMergedTracks(buildMergedTrackList(tracks, deviceFiles, overridesFor));
       // Match on kind too: a circuit and a sprint track can share a short name.
-      const updated = buildMergedTrackList(tracks, deviceFiles)
+      const updated = buildMergedTrackList(tracks, deviceFiles, overridesFor)
         .find(t => t.shortName === trackEntry.shortName && t.kind === trackEntry.kind);
       if (updated) setSelectedTrack(updated);
     } catch (err) {
@@ -275,7 +301,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
           await details.deleteTrack(deviceFileOf(entry), entry.kind);
         }
         // Upload from app
-        const json = buildTrackJsonForUpload(entry.appTrack!);
+        const json = deviceJsonFor(entry, entry.appTrack!);
         const data = new TextEncoder().encode(json);
         await details.putTrack(deviceFileOf(entry), data, entry.kind);
       } catch (err) {

--- a/src/lib/deviceSyncFetch.ts
+++ b/src/lib/deviceSyncFetch.ts
@@ -18,6 +18,8 @@ import {
 } from '@/lib/deviceTrackSync';
 import { buildSyncPlan, type SyncPlan } from '@/lib/deviceSyncPlan';
 import type { ReservedShortName } from '@/lib/deviceSyncWizard';
+import { loadTrackOverrides } from '@/lib/deviceCourseOverrides';
+import { deviceTrackBudget, supportsLargeTrackBuffer } from '@/lib/deviceTrackBudget';
 
 export interface FetchProgress {
   current: number;
@@ -80,16 +82,37 @@ export interface DeviceSyncSnapshot {
   files: DeviceTrackFile[];
 }
 
+/**
+ * What this particular logger is, for the parts of the plan that depend on it
+ * (plan 0017).
+ *
+ * Both fields are optional and both degrade safely: an unknown logger reads no
+ * curation and gets the default rule, and an unknown firmware is assumed to
+ * have the SMALLER track buffer — see `supportsLargeTrackBuffer` for why
+ * conservative is the right direction when the cost of guessing high is a track
+ * that stops being detected at the venue.
+ */
+export interface DeviceSyncContext {
+  /** BLE device name — keys the per-logger curation store. */
+  deviceName?: string | null;
+  /** Firmware version as reported over DIS. */
+  firmwareVersion?: string | null;
+}
+
 /** Read the device and work out what a sync would do, in one call. */
 export async function buildDeviceSyncSnapshot(
   details: DeviceDetails,
   appTracks: Track[],
   onProgress?: (p: FetchProgress) => void,
+  context: DeviceSyncContext = {},
 ): Promise<DeviceSyncSnapshot> {
   const files = await fetchDeviceTrackFiles(details, onProgress);
-  const merged = buildMergedTrackList(appTracks, files);
+  const merged = buildMergedTrackList(appTracks, files, (kind, shortName) =>
+    loadTrackOverrides(context.deviceName, kind, shortName),
+  );
   const plan = buildSyncPlan(merged, {
     supportsSprintTracks: details.supportsSprintTracks,
+    trackBudgetBytes: deviceTrackBudget(supportsLargeTrackBuffer(context.firmwareVersion)),
   });
 
   const inPlan = new Set(plan.rows.map((r) => r.key));

--- a/src/lib/deviceSyncOps.test.ts
+++ b/src/lib/deviceSyncOps.test.ts
@@ -261,3 +261,111 @@ describe("planOperations settles the sync", () => {
     expect(merged[0].status).toBe("synced");
   });
 });
+
+// ─── Curation survives the sync (plan 0017) ──────────────────────────────────
+
+describe("planOperations — device subset", () => {
+  function sprintCourse(name: string, dateCreated: string): Course {
+    return makeCourse({
+      name,
+      type: "sprint",
+      dateCreated,
+      finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+    });
+  }
+
+  const appTrack = (): Track => ({
+    name: "Autocross Lot",
+    shortName: "LOT",
+    courses: [
+      sprintCourse("Run Jan", "2026-01-04T09:00"),
+      sprintCourse("Run Aug", "2026-08-09T14:32"),
+    ],
+    isUserDefined: true,
+  });
+
+  function sprintResolution(): SyncResolution {
+    return resolve({
+      row: row({
+        kind: "sprint",
+        key: "sprint:LOT",
+        shortName: "LOT",
+        name: "Autocross Lot",
+        needsRename: false,
+        deviceFileName: "LOT.json",
+        deviceOnlyCourses: [],
+        appTrack: appTrack(),
+      }),
+      name: "Autocross Lot",
+      shortName: "LOT",
+    });
+  }
+
+  // The failure this closes: accepting the wizard re-uploaded every course and
+  // silently undid the curation, putting the file straight back over the
+  // firmware's parse buffer.
+  it("writes only the newest sprint course to the device", () => {
+    const ops = planOperations([sprintResolution()]);
+    const written: DeviceTrackFileJson = JSON.parse(put(ops).json);
+    expect(written.courses.map((c) => c.name)).toEqual(["Run Aug"]);
+  });
+
+  // ...while the app keeps everything. Nothing is lost; only the card holds a
+  // subset. These are deliberately two different lists.
+  it("keeps every course in the app", () => {
+    const ops = planOperations([sprintResolution()]);
+    expect(appPut(ops).track.courses.map((c) => c.name)).toEqual(["Run Jan", "Run Aug"]);
+  });
+
+  it("names a default course the device actually has", () => {
+    const ops = planOperations([sprintResolution()]);
+    const written: DeviceTrackFileJson = JSON.parse(put(ops).json);
+    expect(written.defaultCourse).toBe("Run Aug");
+  });
+
+  it("honours an explicit include, writing the older course too", () => {
+    const ops = planOperations([sprintResolution()], () => ({
+      include: ["Run Jan"],
+      exclude: [],
+    }));
+    const written: DeviceTrackFileJson = JSON.parse(put(ops).json);
+    expect(written.courses.map((c) => c.name)).toEqual(["Run Jan", "Run Aug"]);
+  });
+
+  it("leaves circuit tracks carrying every course", () => {
+    const circuit: Track = {
+      name: "Orlando Kart Center",
+      shortName: "OKC",
+      courses: [makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })],
+      isUserDefined: true,
+    };
+    const ops = planOperations([
+      resolve({
+        row: row({
+          kind: "circuit",
+          key: "circuit:OKC",
+          shortName: "OKC",
+          name: "Orlando Kart Center",
+          needsRename: false,
+          deviceFileName: "OKC.json",
+          deviceOnlyCourses: [],
+          appTrack: circuit,
+        }),
+        name: "Orlando Kart Center",
+        shortName: "OKC",
+      }),
+    ]);
+    const written: DeviceTrackFileJson = JSON.parse(put(ops).json);
+    expect(written.courses.map((c) => c.name)).toEqual(["CW", "CCW"]);
+  });
+
+  // The property that has to hold end to end: write the subset, read it back,
+  // and the merge must say `synced` rather than re-offering the work.
+  it("round-trips to 'synced' with the subset on the card", () => {
+    const ops = planOperations([sprintResolution()]);
+    const written = put(ops);
+    const onDevice = deviceTrackFileFrom(written.fileName, written.json, "sprint");
+    const merged = buildMergedTrackList([appPut(ops).track], [onDevice]);
+    expect(merged[0].status).toBe("synced");
+  });
+});

--- a/src/lib/deviceSyncOps.ts
+++ b/src/lib/deviceSyncOps.ts
@@ -16,6 +16,11 @@ import {
   type DeviceCourseJson,
 } from '@/lib/deviceTrackSync';
 import type { SyncTrackRow } from '@/lib/deviceSyncPlan';
+import {
+  NO_OVERRIDES,
+  selectedDeviceCourses,
+  type TrackCourseOverrides,
+} from '@/lib/deviceCourseSelection';
 
 /** A track row plus the names the user settled on for it. */
 export interface SyncResolution {
@@ -94,7 +99,11 @@ function deviceCoursesFor(courses: Course[]): DeviceCourseJson[] {
  *   renamed app track next to its old device file, and the user sees the same
  *   track twice.
  */
-export function planOperations(resolutions: SyncResolution[]): SyncOperation[] {
+export function planOperations(
+  resolutions: SyncResolution[],
+  overridesFor: (kind: TrackKind, shortName: string) => TrackCourseOverrides =
+    () => NO_OVERRIDES,
+): SyncOperation[] {
   const ops: SyncOperation[] = [];
 
   for (const resolution of resolutions) {
@@ -103,6 +112,16 @@ export function planOperations(resolutions: SyncResolution[]): SyncOperation[] {
     const shortName = resolution.shortName.trim();
     const courses = finalCourses(resolution);
     const fileName = `${shortName}.json`;
+
+    // The app keeps every course; the DEVICE gets the subset (plan 0017). Two
+    // deliberately different lists — writing `courses` to the card is what made
+    // accepting the wizard silently undo the user's curation and put the file
+    // straight back over the firmware's parse buffer.
+    //
+    // A renamed track or course falls back to the default rule, since the
+    // overrides are keyed by names it no longer has. That is the safe
+    // direction: the default keeps a sprint track's newest course only.
+    const deviceCourses = selectedDeviceCourses(courses, overridesFor(row.kind, shortName));
 
     ops.push({
       type: 'device_put',
@@ -113,8 +132,8 @@ export function planOperations(resolutions: SyncResolution[]): SyncOperation[] {
         longName: name,
         shortName,
         type: row.kind,
-        defaultCourse: courses[0]?.name ?? '',
-        courses: deviceCoursesFor(courses),
+        defaultCourse: deviceCourses[0]?.name ?? '',
+        courses: deviceCoursesFor(deviceCourses),
       }),
     });
 

--- a/src/lib/deviceSyncPlan.test.ts
+++ b/src/lib/deviceSyncPlan.test.ts
@@ -244,6 +244,142 @@ describe("buildSyncPlan skips what can never converge", () => {
     expect(plan.skipped).toEqual([]);
   });
 
+  // Curation shrinks what actually gets written, so the count guard has to
+  // measure the planned set. Counting every app course skipped an eleven-course
+  // sprint venue outright, when only one of them was ever going on the card.
+  it("counts only the courses actually bound for the device", () => {
+    const eleven = Array.from({ length: 11 }, (_, i) => makeCourse({ name: `C${i}` }));
+    const entry = makeEntry({
+      status: "mismatch",
+      appTrack: appTrack(eleven),
+      appCourses: eleven,
+      // Everything but the last is deliberately kept off the device.
+      mergedCourses: eleven.map((c, i) => ({
+        name: c.name,
+        status: "app_only" as const,
+        appCourse: c,
+        plannedOnDevice: i === 10,
+      })),
+    });
+    const plan = buildSyncPlan([entry]);
+    expect(plan.skipped).toEqual([]);
+    expect(plan.rows).toHaveLength(1);
+  });
+
+  it("still skips when the planned set alone is over the course limit", () => {
+    const eleven = Array.from({ length: 11 }, (_, i) => makeCourse({ name: `C${i}` }));
+    const entry = makeEntry({
+      status: "mismatch",
+      appTrack: appTrack(eleven),
+      appCourses: eleven,
+      mergedCourses: eleven.map((c) => ({
+        name: c.name,
+        status: "app_only" as const,
+        appCourse: c,
+        plannedOnDevice: true,
+      })),
+    });
+    expect(buildSyncPlan([entry]).skipped[0].reason).toBe("too_many_courses");
+  });
+});
+
+// ─── The byte budget ─────────────────────────────────────────────────────────
+
+describe("buildSyncPlan — track size", () => {
+  /** A sprint course with a finish line and two splits: the heaviest shape. */
+  function fatSprint(name: string): Course {
+    return makeCourse({
+      name,
+      type: "sprint",
+      dateCreated: "2026-08-09T14:32",
+      finish: {
+        a: { lat: 35.4198765, lon: -97.3198765 },
+        b: { lat: 35.4199876, lon: -97.3199876 },
+      },
+      sectors: [
+        {
+          major: true,
+          line: {
+            a: { lat: 35.4150001, lon: -97.3150001 },
+            b: { lat: 35.4151112, lon: -97.3151112 },
+          },
+        },
+        {
+          major: true,
+          line: {
+            a: { lat: 35.4170002, lon: -97.3170002 },
+            b: { lat: 35.4171113, lon: -97.3171113 },
+          },
+        },
+      ],
+    });
+  }
+
+  function sprintEntry(count: number) {
+    const courses = Array.from({ length: count }, (_, i) => fatSprint(`Run ${i + 1}`));
+    return makeEntry({
+      status: "app_only",
+      kind: "sprint",
+      appTrack: appTrack(courses),
+      appCourses: courses,
+      mergedCourses: courses.map((c) => ({
+        name: c.name,
+        status: "app_only" as const,
+        appCourse: c,
+        plannedOnDevice: true,
+      })),
+    });
+  }
+
+  // Nine of these fit the 10-course cap but not the smaller parse buffer. This
+  // is the gap the count guard could never see, and it is the live bug: a sprint
+  // track overflowed at about SEVEN courses.
+  it("skips a track that fits the course cap but not the byte budget", () => {
+    const plan = buildSyncPlan([sprintEntry(9)], { trackBudgetBytes: 4096 });
+    expect(plan.skipped[0].reason).toBe("too_many_bytes");
+  });
+
+  it("accepts that same track on firmware with the larger buffer", () => {
+    const plan = buildSyncPlan([sprintEntry(9)], { trackBudgetBytes: 8192 });
+    expect(plan.skipped).toEqual([]);
+    expect(plan.rows).toHaveLength(1);
+  });
+
+  // A caller that doesn't know the firmware must not invent a limit and start
+  // skipping tracks that were fine before.
+  it("does not check size at all when no budget is given", () => {
+    const plan = buildSyncPlan([sprintEntry(9)]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  it("accepts a small track well inside the budget", () => {
+    const plan = buildSyncPlan([sprintEntry(1)], { trackBudgetBytes: 4096 });
+    expect(plan.skipped).toEqual([]);
+  });
+
+  // Curation is what rescues the track: the same nine courses fit once only the
+  // newest is bound for the card.
+  it("fits once the older courses are kept off the device", () => {
+    const courses = Array.from({ length: 9 }, (_, i) => fatSprint(`Run ${i + 1}`));
+    const entry = makeEntry({
+      status: "app_only",
+      kind: "sprint",
+      appTrack: appTrack(courses),
+      appCourses: courses,
+      mergedCourses: courses.map((c, i) => ({
+        name: c.name,
+        status: "app_only" as const,
+        appCourse: c,
+        plannedOnDevice: i === 8,
+      })),
+    });
+    const plan = buildSyncPlan([entry], { trackBudgetBytes: 4096 });
+    expect(plan.skipped).toEqual([]);
+    expect(plan.rows).toHaveLength(1);
+  });
+});
+
+describe("buildSyncPlan — transports", () => {
   // The native IPC drops the `kind` argument, so a sprint write lands among the
   // circuit tracks. Better to say we can't than to corrupt the card.
   it("skips sprint tracks on a transport that can't reach the sprint folder", () => {

--- a/src/lib/deviceSyncPlan.ts
+++ b/src/lib/deviceSyncPlan.ts
@@ -12,10 +12,12 @@ import type { TrackKind } from '@/lib/ble/trackOpcodes';
 import type { Course, Track } from '@/types/racing';
 import { isSprintCourse } from '@/types/racing';
 import {
+  deviceCourseToAppCourse,
   isMixedKindTrack,
   type DeviceCourseJson,
   type MergedTrackEntry,
 } from '@/lib/deviceTrackSync';
+import { fitsDeviceBudget } from '@/lib/deviceTrackBudget';
 import { isDeviceGeneratedName, isDeviceGeneratedShortName } from '@/lib/deviceGeneratedNames';
 
 /**
@@ -38,6 +40,20 @@ export type SkipReason =
   | 'mixed_kind'
   /** More courses than the firmware will read back. */
   | 'too_many_courses'
+  /**
+   * The file would be bigger than the firmware's parse buffer, even after the
+   * curation rule has had its say (plan 0017).
+   *
+   * Distinct from `too_many_courses` because neither guard subsumes the other:
+   * on the larger buffer the course cap binds first, and on the smaller one a
+   * sprint track overflows at about SEVEN courses — under the cap, which is why
+   * the cap alone never caught it.
+   *
+   * Reported, never prompted. On a browser with nothing stored the default rule
+   * alone has to settle, so a track that still doesn't fit is surfaced here to
+   * be curated deliberately rather than raised as a dialog on every connect.
+   */
+  | 'too_many_bytes'
   /** A sprint track on a transport that can't reach the sprint folder. */
   | 'sprint_unsupported';
 
@@ -96,6 +112,15 @@ export interface SyncPlanOptions {
    * would silently land among the circuit tracks.
    */
   supportsSprintTracks?: boolean;
+  /**
+   * Bytes one track file may occupy on this device — `deviceTrackBudget()` of
+   * the firmware's capability (plan 0017).
+   *
+   * Omitted means "don't check", so a caller that doesn't know the firmware
+   * keeps the pre-curation behaviour rather than guessing a limit and skipping
+   * tracks that were fine.
+   */
+  trackBudgetBytes?: number;
 }
 
 /** The display name for an entry, preferring whichever side actually has one. */
@@ -164,14 +189,38 @@ export function buildSyncPlan(
       continue;
     }
 
-    // Count what the file would end up holding, not just what one side has.
+    // Count what the file would end up holding, not just what one side has —
+    // and only the courses actually bound for the device. A sprint track keeps
+    // its newest course by default, so counting every app course skipped an
+    // eleven-course venue that would have fitted comfortably.
     const deviceOnlyCourses = entry.mergedCourses
       .filter((mc) => mc.status === 'device_only' && mc.deviceCourse)
       .map((mc) => mc.deviceCourse!);
-    const resultingCourseCount = entry.appCourses.length + deviceOnlyCourses.length;
+    // Read the curation off the merge, but count `appCourses` — an `app_only`
+    // entry carries no merged courses at all, and deriving the list from the
+    // merge would silently count it as empty and wave through a track that
+    // cannot fit. Anything the merge has no opinion on stays planned.
+    const plannedByName = new Map(
+      entry.mergedCourses
+        .filter((mc) => mc.appCourse)
+        .map((mc) => [mc.name, mc.plannedOnDevice ?? true] as const),
+    );
+    const plannedAppCourses = entry.appCourses.filter((c) => plannedByName.get(c.name) ?? true);
+    const resultingCourseCount = plannedAppCourses.length + deviceOnlyCourses.length;
     if (resultingCourseCount > DEVICE_MAX_COURSES) {
       skip('too_many_courses');
       continue;
+    }
+
+    // Then the wall the count guard never saw: on the smaller buffer a sprint
+    // track overflows below the course cap. Measured through the real writer,
+    // over the courses the file would actually end up with.
+    if (options.trackBudgetBytes != null && entry.appTrack) {
+      const resulting = [...plannedAppCourses, ...deviceOnlyCourses.map(deviceCourseToAppCourse)];
+      if (!fitsDeviceBudget(entry.appTrack, resulting, options.trackBudgetBytes)) {
+        skip('too_many_bytes');
+        continue;
+      }
     }
 
     // The app's own reference tracks are not "unknown tracks the device is

--- a/src/lib/deviceTrackBudget.test.ts
+++ b/src/lib/deviceTrackBudget.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   DEVICE_TRACK_BYTES_LARGE,
   DEVICE_TRACK_BYTES_SMALL,
+  TRACK_BUFFER_MIN_VERSION,
   bytesOverBudget,
   deviceTrackBudget,
   fitsDeviceBudget,
   projectDeviceTrackBytes,
+  supportsLargeTrackBuffer,
 } from "./deviceTrackBudget";
 import { buildTrackJsonForUpload } from "./deviceTrackSync";
 import type { Course, Track } from "@/types/racing";
@@ -75,6 +77,47 @@ describe("deviceTrackBudget", () => {
 
   it("the large buffer really is larger", () => {
     expect(DEVICE_TRACK_BYTES_LARGE).toBeGreaterThan(DEVICE_TRACK_BYTES_SMALL);
+  });
+});
+
+// ─── supportsLargeTrackBuffer ────────────────────────────────────────────────
+
+describe("supportsLargeTrackBuffer", () => {
+  it("is true at and above the release that raised the buffer", () => {
+    expect(supportsLargeTrackBuffer(TRACK_BUFFER_MIN_VERSION)).toBe(true);
+    expect(supportsLargeTrackBuffer("3.2.1")).toBe(true);
+    expect(supportsLargeTrackBuffer("4.0.0")).toBe(true);
+  });
+
+  it("is false below it", () => {
+    expect(supportsLargeTrackBuffer("3.1.0")).toBe(false);
+    expect(supportsLargeTrackBuffer("3.0.1")).toBe(false);
+    expect(supportsLargeTrackBuffer("2.9.9")).toBe(false);
+  });
+
+  // A track file past the buffer isn't a degraded track — it fails to parse and
+  // stops being detected at the venue. So not knowing has to mean "assume the
+  // small buffer", which is the opposite of how needsOtaLayoutUpgrade treats an
+  // unknown version.
+  it("assumes the small buffer when the version is unknown", () => {
+    expect(supportsLargeTrackBuffer(null)).toBe(false);
+    expect(supportsLargeTrackBuffer(undefined)).toBe(false);
+    expect(supportsLargeTrackBuffer("")).toBe(false);
+  });
+
+  // The beta channel stamps `<base>-beta.<gitsha>`, and compareVersions reads
+  // the numeric core only. A beta of the capable release is capable.
+  it("reads a beta build of a capable release as capable", () => {
+    expect(supportsLargeTrackBuffer("3.2.0-beta.abc1234")).toBe(true);
+  });
+
+  it("reads a beta build of an older release as not capable", () => {
+    expect(supportsLargeTrackBuffer("3.1.0-beta.abc1234")).toBe(false);
+  });
+
+  it("feeds the budget directly", () => {
+    expect(deviceTrackBudget(supportsLargeTrackBuffer("3.2.0"))).toBe(DEVICE_TRACK_BYTES_LARGE);
+    expect(deviceTrackBudget(supportsLargeTrackBuffer("3.1.0"))).toBe(DEVICE_TRACK_BYTES_SMALL);
   });
 });
 

--- a/src/lib/deviceTrackBudget.ts
+++ b/src/lib/deviceTrackBudget.ts
@@ -10,6 +10,36 @@
 
 import { Course, Track } from '@/types/racing';
 import { buildTrackJsonForUpload } from '@/lib/deviceTrackSync';
+import { compareVersions } from '@/lib/ble/dfu/firmwareManifest';
+
+/**
+ * First firmware release whose track JSON buffer is
+ * {@link DEVICE_TRACK_BYTES_LARGE}. Everything at or below `3.1.0` — the last
+ * release before this one — parses tracks in half that.
+ */
+export const TRACK_BUFFER_MIN_VERSION = '3.2.0';
+
+/**
+ * Whether this firmware has the larger track buffer.
+ *
+ * The ONE place a firmware version is turned into this capability; everything
+ * downstream takes the boolean. Mirrors `needsOtaLayoutUpgrade`.
+ *
+ * **An unknown version returns `false`, which is the opposite of what
+ * `needsOtaLayoutUpgrade` does with one — deliberately.** That function must
+ * never nag a user without certainty, so uncertainty means "don't". Here
+ * uncertainty must never overfill a card, because a track file past the buffer
+ * is not a degraded track: it fails to parse, gets no manifest entry, and
+ * stops being detected at the venue. So uncertainty means "assume the smaller
+ * buffer" — at worst the user keeps one course fewer than they could have.
+ *
+ * `compareVersions` ignores prerelease suffixes, so a beta build stamped
+ * `3.2.0-beta.<sha>` counts as `3.2.0` and reads as capable.
+ */
+export function supportsLargeTrackBuffer(version: string | null | undefined): boolean {
+  if (!version) return false;
+  return compareVersions(version, TRACK_BUFFER_MIN_VERSION) >= 0;
+}
 
 /**
  * `JSON_BUFFER_SIZE` on firmware from the release that raised it.

--- a/src/lib/deviceTrackSync.test.ts
+++ b/src/lib/deviceTrackSync.test.ts
@@ -394,6 +394,103 @@ describe("device round trip", () => {
     expect(merged[0].status).toBe("synced");
   });
 
+  // Curation reopens the same trap from a new direction: the device now holds a
+  // SUBSET on purpose, and comparing against every app course would leave the
+  // track at `mismatch` forever — prompting on every single connect.
+  it("settles to 'synced' when a sprint track keeps only its newest course", () => {
+    const sprintCourse = (name: string, dateCreated: string): Course =>
+      makeAppCourse({
+        name,
+        type: "sprint",
+        dateCreated,
+        finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      });
+
+    const track: Track = {
+      name: "Autocross Lot",
+      shortName: "LOT",
+      courses: [
+        sprintCourse("Run Jan", "2026-01-04T09:00"),
+        sprintCourse("Run Aug", "2026-08-09T14:32"),
+      ],
+      isUserDefined: true,
+    };
+
+    // The device carries only the newest, which is exactly what we upload.
+    const onDevice = deviceTrackFileFrom(
+      "LOT.json",
+      buildTrackJsonForUpload({ ...track, courses: [track.courses[1]] }),
+      "sprint",
+    );
+
+    const merged = buildMergedTrackList([track], [onDevice]);
+    expect(merged[0].status).toBe("synced");
+  });
+
+  it("still reports a mismatch when the course that IS wanted is missing", () => {
+    const sprintCourse = (name: string, dateCreated: string): Course =>
+      makeAppCourse({
+        name,
+        type: "sprint",
+        dateCreated,
+        finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      });
+
+    const track: Track = {
+      name: "Autocross Lot",
+      shortName: "LOT",
+      courses: [
+        sprintCourse("Run Jan", "2026-01-04T09:00"),
+        sprintCourse("Run Aug", "2026-08-09T14:32"),
+      ],
+      isUserDefined: true,
+    };
+
+    // The device has the OLD course; the newest one is the one that belongs.
+    const onDevice = deviceTrackFileFrom(
+      "LOT.json",
+      buildTrackJsonForUpload({ ...track, courses: [track.courses[0]] }),
+      "sprint",
+    );
+
+    expect(buildMergedTrackList([track], [onDevice])[0].status).toBe("mismatch");
+  });
+
+  it("settles when the user has explicitly kept an older sprint course too", () => {
+    const sprintCourse = (name: string, dateCreated: string): Course =>
+      makeAppCourse({
+        name,
+        type: "sprint",
+        dateCreated,
+        finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+      });
+
+    const track: Track = {
+      name: "Autocross Lot",
+      shortName: "LOT",
+      courses: [
+        sprintCourse("Run Jan", "2026-01-04T09:00"),
+        sprintCourse("Run Aug", "2026-08-09T14:32"),
+      ],
+      isUserDefined: true,
+    };
+    const onDevice = deviceTrackFileFrom(
+      "LOT.json",
+      buildTrackJsonForUpload(track),
+      "sprint",
+    );
+
+    // Default rule alone: the device has one course too many.
+    expect(buildMergedTrackList([track], [onDevice])[0].status).toBe("mismatch");
+
+    // With the user's explicit include, both belong and it settles.
+    const merged = buildMergedTrackList([track], [onDevice], () => ({
+      include: ["Run Jan"],
+      exclude: [],
+    }));
+    expect(merged[0].status).toBe("synced");
+  });
+
   // The rename case: the file moves from N260803_1432.json to SUNSET.json, and
   // the app track carries name "Sunset Park" / shortName "SUNSET".
   it("settles to 'synced' after a device-authored track is renamed", () => {

--- a/src/lib/deviceTrackSync.ts
+++ b/src/lib/deviceTrackSync.ts
@@ -9,6 +9,11 @@ import type { TrackKind } from '@/lib/ble/trackOpcodes';
 import { haversineDistance } from '@/lib/parserUtils';
 import { legacyMirror, majorSectorLines, normalizeCourseSectors } from '@/lib/courseSectors';
 import { deriveShortName } from '@/lib/trackUtils';
+import {
+  NO_OVERRIDES,
+  selectedDeviceCourses,
+  type TrackCourseOverrides,
+} from '@/lib/deviceCourseSelection';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -96,6 +101,35 @@ export interface MergedCourseEntry {
   status: CourseSyncStatus;
   appCourse?: Course;
   deviceCourse?: DeviceCourseJson;
+  /**
+   * Whether this course is MEANT to be on the device (plan 0017).
+   *
+   * The device holds a subset — a sprint track keeps only its newest course
+   * unless the user says otherwise — so "in the app but not on the device" is
+   * often the correct state rather than work outstanding. Absent means "yes",
+   * so a caller that predates curation behaves exactly as it did.
+   *
+   * Only meaningful for courses the app knows about; a `device_only` course is
+   * never planned, because the selection can only speak about courses it has.
+   */
+  plannedOnDevice?: boolean;
+}
+
+/**
+ * True when a course needs nothing done to it.
+ *
+ * Not the same as `status === 'synced'`: a course deliberately kept OFF the
+ * device is settled precisely by being absent from it, and one the user
+ * excluded that is still ON the device is unsettled until it's removed. Getting
+ * this wrong in the "not settled" direction is what makes a track sit at
+ * `mismatch` forever and re-prompt on every connect.
+ */
+export function courseIsSettled(entry: MergedCourseEntry): boolean {
+  // A course only the device has is always outstanding — it wants importing or
+  // renaming, which is what the sync wizard is for.
+  if (!entry.appCourse) return false;
+  const planned = entry.plannedOnDevice ?? true;
+  return planned ? entry.status === 'synced' : entry.status === 'app_only';
 }
 
 export interface MergedTrackEntry {
@@ -482,15 +516,18 @@ export function isMixedKindTrack(track: Pick<Track, 'courses'>): boolean {
 /** Build merged course list for a single track. */
 function buildMergedCourses(
   appCourses: Course[],
-  deviceCourses: DeviceCourseJson[]
+  deviceCourses: DeviceCourseJson[],
+  overrides: TrackCourseOverrides = NO_OVERRIDES,
 ): MergedCourseEntry[] {
   const entries: MergedCourseEntry[] = [];
   const deviceByName = new Map(deviceCourses.map(dc => [dc.name, dc]));
   const seenDeviceNames = new Set<string>();
+  const planned = new Set(selectedDeviceCourses(appCourses, overrides).map(c => c.name));
 
   // Process app courses first
   for (const ac of appCourses) {
     const dc = deviceByName.get(ac.name);
+    const plannedOnDevice = planned.has(ac.name);
     if (dc) {
       seenDeviceNames.add(ac.name);
       entries.push({
@@ -498,26 +535,36 @@ function buildMergedCourses(
         status: coursesMatch(ac, dc) ? 'synced' : 'mismatch',
         appCourse: ac,
         deviceCourse: dc,
+        plannedOnDevice,
       });
     } else {
-      entries.push({ name: ac.name, status: 'app_only', appCourse: ac });
+      entries.push({ name: ac.name, status: 'app_only', appCourse: ac, plannedOnDevice });
     }
   }
 
   // Device-only courses
   for (const dc of deviceCourses) {
     if (!seenDeviceNames.has(dc.name)) {
-      entries.push({ name: dc.name, status: 'device_only', deviceCourse: dc });
+      entries.push({ name: dc.name, status: 'device_only', deviceCourse: dc, plannedOnDevice: false });
     }
   }
 
   return entries;
 }
 
-/** Build merged track list from app tracks and device files. */
+/**
+ * Build merged track list from app tracks and device files.
+ *
+ * `overridesFor` supplies the user's per-track curation (plan 0017). It is a
+ * lookup rather than a value so this stays pure and the caller owns the
+ * storage. Omitting it means "no overrides", which is the default rule — the
+ * behaviour every caller had before curation existed.
+ */
 export function buildMergedTrackList(
   appTracks: Track[],
-  deviceFiles: DeviceTrackFile[]
+  deviceFiles: DeviceTrackFile[],
+  overridesFor: (kind: TrackKind, shortName: string) => TrackCourseOverrides =
+    () => NO_OVERRIDES,
 ): MergedTrackEntry[] {
   const entries: MergedTrackEntry[] = [];
   // Keyed on (kind, shortName): the device keeps circuit and sprint tracks in
@@ -537,8 +584,11 @@ export function buildMergedTrackList(
     const df = deviceByKey.get(key(kind, sn));
     if (df) {
       seenDeviceKeys.add(key(kind, sn));
-      const mergedCourses = buildMergedCourses(track.courses, df.courses);
-      const allSynced = mergedCourses.every(c => c.status === 'synced');
+      const mergedCourses = buildMergedCourses(track.courses, df.courses, overridesFor(kind, sn));
+      // Settled, not "synced": a course deliberately kept off the device is
+      // settled by being absent. Comparing against every app course is what
+      // made a curated track sit at `mismatch` and re-prompt on every connect.
+      const allSynced = mergedCourses.every(courseIsSettled);
       entries.push({
         shortName: sn,
         kind,

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -393,6 +393,7 @@
       "skippedTitle": "Nicht synchronisiert",
       "skippedMixedKind": "{{name}} mischt Rundkurs- und Sprint-Kurse, die der Logger getrennt speichert.",
       "skippedTooManyCourses": "{{name}} hat mehr Kurse, als der Logger zurücklesen kann.",
+      "skippedTooManyBytes": "{{name}} ist zu groß, als dass der Logger es lesen könnte – selbst wenn nur der neueste Kurs behalten wird. Öffne die Strecke in der Streckenliste, um auszuwählen, welche Kurse bleiben.",
       "skippedSprintUnsupported": "{{name}} ist eine Sprint-Strecke, die über diese Verbindung nicht erreichbar ist.",
       "problemRequired": "Namen eingeben",
       "problemStillGenerated": "Gib dem einen echten Namen",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -392,6 +392,7 @@
       "skippedTitle": "Not synced",
       "skippedMixedKind": "{{name}} mixes circuit and sprint courses, which the logger stores separately.",
       "skippedTooManyCourses": "{{name}} has more courses than the logger can read back.",
+      "skippedTooManyBytes": "{{name}} is too large for the logger to read, even keeping only its newest course. Open it in the tracks list to choose which courses to keep.",
       "skippedSprintUnsupported": "{{name}} is a sprint track, which this connection cannot reach.",
       "problemRequired": "Enter a name",
       "problemStillGenerated": "Give this a real name",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -393,6 +393,7 @@
       "skippedTitle": "Sin sincronizar",
       "skippedMixedKind": "{{name}} mezcla recorridos de circuito y de sprint, que el registrador guarda por separado.",
       "skippedTooManyCourses": "{{name}} tiene más recorridos de los que el registrador puede releer.",
+      "skippedTooManyBytes": "{{name}} es demasiado grande para que el registrador lo lea, incluso conservando solo su recorrido más reciente. Ábrelo en la lista de pistas para elegir qué recorridos conservar.",
       "skippedSprintUnsupported": "{{name}} es una pista de sprint, a la que esta conexión no puede acceder.",
       "problemRequired": "Introduce un nombre",
       "problemStillGenerated": "Dale un nombre real",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -393,6 +393,7 @@
       "skippedTitle": "Non synchronisé",
       "skippedMixedKind": "{{name}} mélange des parcours circuit et sprint, que l'enregistreur stocke séparément.",
       "skippedTooManyCourses": "{{name}} a plus de parcours que l'enregistreur ne peut relire.",
+      "skippedTooManyBytes": "{{name}} est trop volumineux pour que l'enregistreur le lise, même en ne gardant que son parcours le plus récent. Ouvre-le dans la liste des circuits pour choisir les parcours à conserver.",
       "skippedSprintUnsupported": "{{name}} est un circuit sprint, inaccessible via cette connexion.",
       "problemRequired": "Saisissez un nom",
       "problemStillGenerated": "Donnez-lui un vrai nom",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -393,6 +393,7 @@
       "skippedTitle": "Non sincronizzato",
       "skippedMixedKind": "{{name}} mescola percorsi da circuito e sprint, che il logger memorizza separatamente.",
       "skippedTooManyCourses": "{{name}} ha più percorsi di quanti il logger possa rileggere.",
+      "skippedTooManyBytes": "{{name}} è troppo grande perché il logger possa leggerlo, anche tenendo solo il percorso più recente. Aprilo nell'elenco delle piste per scegliere quali percorsi mantenere.",
       "skippedSprintUnsupported": "{{name}} è una pista sprint, non raggiungibile con questa connessione.",
       "problemRequired": "Inserisci un nome",
       "problemStillGenerated": "Dagli un nome vero",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -393,6 +393,7 @@
       "skippedTitle": "同期しません",
       "skippedMixedKind": "{{name}} にはサーキットとスプリントのコースが混在しています。ロガーはこれらを別々に保存します。",
       "skippedTooManyCourses": "{{name}} のコース数が、ロガーが読み戻せる上限を超えています。",
+      "skippedTooManyBytes": "{{name}} は、最新のコースだけを残してもロガーが読み込めないほど大きくなっています。トラック一覧で開き、残すコースを選んでください。",
       "skippedSprintUnsupported": "{{name}} はスプリントのトラックで、この接続からはアクセスできません。",
       "problemRequired": "名前を入力してください",
       "problemStillGenerated": "正式な名前を付けてください",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -393,6 +393,7 @@
       "skippedTitle": "Não sincronizado",
       "skippedMixedKind": "{{name}} mistura percursos de circuito e de sprint, que o registrador guarda separadamente.",
       "skippedTooManyCourses": "{{name}} tem mais percursos do que o registrador consegue reler.",
+      "skippedTooManyBytes": "{{name}} é grande demais para o registrador ler, mesmo mantendo apenas o percurso mais recente. Abra na lista de pistas para escolher quais percursos manter.",
       "skippedSprintUnsupported": "{{name}} é uma pista de sprint, inacessível por esta conexão.",
       "problemRequired": "Digite um nome",
       "problemStillGenerated": "Dê um nome de verdade",


### PR DESCRIPTION
## Summary

Third PR of plan 0017, stacked on #394. Wires the model from that PR into the
three places a curated device set was broken, and adds the one firmware
capability it needs. **This is the PR where behaviour changes.**

### The nag — the one that matters

`allSynced` compared *every* app course against the device, so a track holding a
deliberate subset read `mismatch` forever and the on-connect prompt fired every
single time you plugged in. That's the same never-reaches-`synced` trap plan 0016
was written to close, reopened from a new direction by curation.

The merge now carries `plannedOnDevice` per course and settles on
`courseIsSettled`, which is deliberately **not** `status === 'synced'`:

| | settled when |
|---|---|
| course planned for the device | it's there and matches |
| course deliberately kept off | it's **absent** |
| course the user excluded, still on the card | never — it wants removing |
| `device_only` course | never — it wants importing (unchanged) |

### The guards — both of them stay

The count guard now measures the **planned** set, so an eleven-course sprint
venue is no longer skipped outright when only one course was ever going on the
card. It reads the curation off the merge but still counts `appCourses`, because
an `app_only` entry carries no merged courses at all — deriving the list from the
merge would count it as empty and wave through a track that cannot fit.

Alongside it, a **byte guard**. On the smaller buffer a sprint track overflows at
about seven courses — *under* the ten-course cap, which is exactly why the cap
alone never caught it. Neither guard subsumes the other. A caller that passes no
budget gets no size check rather than a guessed one.

### The upload

`planOperations` writes the subset to the device while the app keeps every
course — two deliberately different lists. Writing `courses` to both is what made
accepting the wizard silently undo the curation and put the file straight back
over the buffer. The two manual upload paths in the tracks tab go through the
same subset.

### The capability

`supportsLargeTrackBuffer` mirrors `needsOtaLayoutUpgrade` over the existing
`compareVersions`, and is the only place a firmware version becomes this boolean.
It **inverts that function's handling of an unknown version, on purpose**: that
one must never nag without certainty; this one must never overfill a card,
because a file past the buffer doesn't degrade a track — it takes it out of
detection at the venue. The version comes from the shared firmware context, which
already owns the one DIS read, so there's no second GATT read.

`TRACK_BUFFER_MIN_VERSION` is `3.2.0` — the next release. The latest published
firmware is `v3.1.0`, which parses tracks in 4 KB.

## Related Issues

Stacked on #394 → #393. Part of plan 0017.
Needs the matching firmware PR to ship as `3.2.0` or above, or beta units report
`3.0.1` and get handed the smaller budget they don't have.

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2826 tests, 193 files)
- [x] `bun run build` succeeds
- [x] Feature works **offline**
- [x] Docs updated — `CHANGELOG.md`; plan 0017 already covers the design
- [x] i18n — `skippedTooManyBytes` added to all seven locales
- [ ] For a new parser: n/a

## Notes for Reviewers

**Every new parameter is optional and defaults to the old behaviour**, which is
why the existing 2700-odd tests pass untouched. `buildMergedTrackList`,
`buildSyncPlan` and `planOperations` all behave exactly as before when called
without curation or a budget. Worth checking that claim — it's what makes this
reviewable.

**The test to read first** is *"still reports a mismatch when the course that IS
wanted is missing"* in `deviceTrackSync.test.ts`. The risk in loosening
`allSynced` is loosening it into always-true; that test pins the other side, and
the one below it pins that an explicit include settles too.

**One judgement call worth flagging.** When the firmware version is unknown, the
byte gate applies the *small* budget rather than skipping the check. It means a
user on unknown firmware may be asked to curate a track that would have fitted.
I took that over the alternative because the failure modes aren't symmetric: the
cost of guessing low is one course fewer on the card, and the cost of guessing
high is a track that silently stops being detected at the venue. Say if you'd
rather it skipped the check instead — it's a one-line change in
`buildDeviceSyncSnapshot`.

**Not covered by tests:** the four component call sites (`DeviceTracksTab`,
`DeviceSyncWizard`, `DeviceConnectFlow`). `src/components/**/*.tsx` is
coverage-excluded and the suite runs in `node` with no renderer. Everything they
call is pure and tested; the wiring itself is eyeball-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_