### PR TITLE
feat(sync): choose which courses go on the logger (plan 0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overflowing** (plan 0017). The app knows how much room your logger's firmware
   has and says which track doesn't fit, rather than sending a file that comes
   back unreadable.
+- **You can choose which courses go on the logger** (plan 0017). A new
+  **Courses** button on any track with more than one course opens a checklist,
+  with a live count of how much of the logger's room the selection uses and how
+  much there is. Unchecked courses stay in the app and in your account — only
+  the logger holds a subset. Use it to keep an older sprint course on the card,
+  or to trim a track that doesn't fit.
+- **Tracks can be selected and sent in one go** (plan 0017). Tick any number of
+  tracks in the list and send them all to the logger together. Each is sent as
+  whatever you chose above, so a bulk send never undoes your course picks.
 
 ### Changed
 - **Tracks are sent to the logger without formatting whitespace** (plan 0017).

--- a/docs/plans/0017-device-course-curation.md
+++ b/docs/plans/0017-device-course-curation.md
@@ -1,9 +1,14 @@
 # Device course curation — fitting a season of courses on the card
 
-> Status: **IN PROGRESS.** Stacked PRs: (1) the two size/correctness fixes below,
-> (2) the pure curation model, (3) the capability gate + sync wiring, (4) the
-> picker modal and the tracks list. Firmware side is
-> `DovesDataLogger/docs/plans/0005-*`.
+> Status: **DONE**, across four stacked PRs: (1) the two size/correctness fixes
+> below, (2) the pure curation model, (3) the capability gate + sync wiring,
+> (4) the course picker and the tracks list. Firmware side is
+> `DovesDataLogger/docs/plans/0005-sprint-course-prune.md`.
+>
+> **The picker lives in the tracks list, not in the sync wizard.** The wizard
+> reports an oversized track as a skip whose message points at the list, which
+> keeps the rule that curation is only ever reached by a deliberate action —
+> a dialog that appeared mid-sync would be the nag this plan exists to end.
 
 ## Why this exists
 

--- a/src/components/drawer/DeviceCoursePickerDialog.tsx
+++ b/src/components/drawer/DeviceCoursePickerDialog.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle, Check, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  buildPickerState,
+  initialPickerSelection,
+  togglePickerCourse,
+} from "@/lib/deviceCoursePicker";
+import { overridesFromSelection } from "@/lib/deviceCourseSelection";
+import type { TrackCourseOverrides } from "@/lib/deviceCourseSelection";
+import type { Track } from "@/types/racing";
+
+/**
+ * Choose which of a track's courses live on the logger (plan 0017).
+ *
+ * The logger reads a whole track file into a fixed buffer; past it the track
+ * stops being detected at the venue entirely. This is where a track that
+ * doesn't fit gets trimmed — deliberately, by the user, with the real byte
+ * count in front of them.
+ *
+ * Everything it decides comes from `deviceCoursePicker`, which is unit-tested;
+ * this only draws it. Courses left unchecked stay in the app and on cloud sync
+ * — only the card holds a subset.
+ */
+export function DeviceCoursePickerDialog({
+  open,
+  onOpenChange,
+  track,
+  budget,
+  overrides,
+  saving = false,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  track: Track;
+  budget: number;
+  overrides?: TrackCourseOverrides;
+  saving?: boolean;
+  onConfirm: (overrides: TrackCourseOverrides, selectedNames: string[]) => void;
+}) {
+  const { t, i18n } = useTranslation("drawer");
+  const [selected, setSelected] = useState<string[]>([]);
+
+  // Rebuild on open: the track is a snapshot, and a stale selection would be
+  // checked against courses that have since been renamed or deleted.
+  useEffect(() => {
+    if (open) setSelected(initialPickerSelection(track.courses, overrides));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const state = useMemo(
+    () => buildPickerState(track, selected, budget),
+    [track, selected, budget],
+  );
+
+  const walked = (iso?: string) => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(i18n.language, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("deviceTracks.picker.title", { name: track.name })}</DialogTitle>
+          <DialogDescription>
+            {state.accumulates
+              ? t("deviceTracks.picker.descriptionSprint")
+              : t("deviceTracks.picker.descriptionCircuit")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-64 overflow-y-auto space-y-2 pr-1">
+          {state.rows.map((row) => (
+            <button
+              key={row.name}
+              type="button"
+              role="checkbox"
+              aria-checked={row.selected}
+              disabled={saving}
+              onClick={() => setSelected((s) => togglePickerCourse(s, row.name))}
+              className={`w-full flex items-start gap-2 text-sm text-left ${
+                saving ? "opacity-60 cursor-not-allowed" : ""
+              }`}
+            >
+              <span
+                className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                  row.selected
+                    ? "bg-primary border-primary text-primary-foreground"
+                    : "border-input"
+                }`}
+              >
+                {row.selected && <Check className="w-3 h-3" />}
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="flex items-center gap-2 flex-wrap">
+                  <span className="text-foreground">{row.name}</span>
+                  {state.accumulates && row.isDefault && (
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-400">
+                      {t("deviceTracks.picker.newestBadge")}
+                    </span>
+                  )}
+                </span>
+                {row.dateCreated && (
+                  <span className="block text-xs text-muted-foreground">
+                    {t("deviceTracks.wizard.walkedOn", { date: walked(row.dateCreated) })}
+                  </span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="text-sm">
+          {state.overBy > 0 ? (
+            <span className="flex items-center gap-1.5 text-amber-400">
+              <AlertTriangle className="w-4 h-4 shrink-0" />
+              {t("deviceTracks.picker.overBudget", {
+                over: state.overBy,
+                budget: state.budget,
+              })}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">
+              {t("deviceTracks.picker.withinBudget", {
+                bytes: state.bytes,
+                budget: state.budget,
+              })}
+            </span>
+          )}
+          {state.rows.every((r) => !r.selected) && (
+            <span className="block text-amber-400 mt-1">
+              {t("deviceTracks.picker.needOne")}
+            </span>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            {t("deviceTracks.picker.cancel")}
+          </Button>
+          <Button
+            onClick={() => onConfirm(overridesFromSelection(track.courses, selected), selected)}
+            disabled={!state.canConfirm || saving}
+          >
+            {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            {t("deviceTracks.picker.confirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/drawer/DeviceTracksTab.tsx
+++ b/src/components/drawer/DeviceTracksTab.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCw,
   Trash2,
   RotateCcw,
+  ListChecks,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,7 +42,11 @@ import {
 } from "@/lib/deviceTrackSync";
 import { fetchDeviceTrackFiles } from "@/lib/deviceSyncFetch";
 import { loadTrackOverrides } from "@/lib/deviceCourseOverrides";
-import { selectedDeviceCourses } from "@/lib/deviceCourseSelection";
+import { selectedDeviceCourses, type TrackCourseOverrides } from "@/lib/deviceCourseSelection";
+import { loadTrackOverrides as _loadOverrides, saveTrackOverrides } from "@/lib/deviceCourseOverrides";
+import { deviceTrackBudget, supportsLargeTrackBuffer } from "@/lib/deviceTrackBudget";
+import { useFirmwareUpdateApi } from "@/contexts/FirmwareUpdateContext";
+import { DeviceCoursePickerDialog } from "./DeviceCoursePickerDialog";
 import { useDeviceContext } from "@/contexts/DeviceContext";
 import { loadTracks, addTrack, addCourse } from "@/lib/trackStorage";
 import { Track } from "@/types/racing";
@@ -68,6 +73,10 @@ const deviceFileOf = (entry: MergedTrackEntry): string =>
 export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
   const { t } = useTranslation("drawer");
   const { deviceName } = useDeviceContext();
+  const fw = useFirmwareUpdateApi();
+  // One boolean, derived once from the firmware version the shared context
+  // already read. Unknown firmware assumes the smaller buffer (plan 0017).
+  const trackBudget = deviceTrackBudget(supportsLargeTrackBuffer(fw.info?.version));
   const [view, setView] = useState<View>("loading");
   const [loadProgress, setLoadProgress] = useState({ current: 0, total: 0, label: "" });
   const [mergedTracks, setMergedTracks] = useState<MergedTrackEntry[]>([]);
@@ -78,6 +87,10 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
   // Confirmation dialogs
   const [deleteConfirm, setDeleteConfirm] = useState<{ type: 'track' | 'course'; trackEntry: MergedTrackEntry; courseName?: string } | null>(null);
   const [resyncConfirm, setResyncConfirm] = useState(false);
+  const [pickerEntry, setPickerEntry] = useState<MergedTrackEntry | null>(null);
+  // Bulk selection, keyed the same way the merge is — a circuit and a sprint
+  // track can share a short name and must not collapse into one.
+  const [checkedTracks, setCheckedTracks] = useState<Set<string>>(new Set());
   const [resyncProgress, setResyncProgress] = useState<{ current: number; total: number; label: string } | null>(null);
 
   const [deviceFiles, setDeviceFiles] = useState<DeviceTrackFile[]>([]);
@@ -155,6 +168,80 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
     } finally {
       setUploading(null);
     }
+  };
+
+  const trackKeyOf = (entry: MergedTrackEntry) => `${entry.kind}:${entry.shortName}`;
+
+  const toggleChecked = (entry: MergedTrackEntry) => {
+    const key = trackKeyOf(entry);
+    setCheckedTracks((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  // ── Send the checked tracks ──
+  //
+  // Each one goes through deviceJsonFor(), so a track the user has curated is
+  // sent as its curated subset rather than whole — a bulk action that quietly
+  // undid the curation would be worse than no bulk action.
+  const handleSendChecked = async () => {
+    const targets = mergedTracks.filter((e) => e.appTrack && checkedTracks.has(trackKeyOf(e)));
+    if (targets.length === 0) return;
+
+    let failed = 0;
+    for (const entry of targets) {
+      setUploading(entry.shortName);
+      try {
+        const data = new TextEncoder().encode(deviceJsonFor(entry, entry.appTrack!));
+        await details.putTrack(deviceFileOf(entry), data, entry.kind);
+      } catch (err) {
+        failed++;
+        console.error(`Send failed for ${entry.shortName}:`, err);
+      }
+    }
+    setUploading(null);
+    setCheckedTracks(new Set());
+    if (failed > 0) {
+      toast.error(t("deviceTracks.bulk.someFailed", { count: failed }));
+    } else {
+      toast.success(t("deviceTracks.bulk.sent", { count: targets.length }));
+    }
+    await syncAll();
+  };
+
+  // ── Choose which courses live on the logger (plan 0017) ──
+  const handlePickerConfirm = async (
+    entry: MergedTrackEntry,
+    overrides: TrackCourseOverrides,
+  ) => {
+    if (!entry.appTrack) return;
+    // Store the choice first, so deviceJsonFor() below and every later merge
+    // read the new curation rather than the one being replaced.
+    saveTrackOverrides(deviceName, entry.kind, entry.shortName, overrides);
+    setPickerEntry(null);
+
+    // Only push when the track is already on the card. For one that isn't,
+    // the choice simply applies the next time it's sent — writing a file the
+    // user never asked for would be a surprise.
+    if (!isOnDevice(entry)) {
+      await syncAll();
+      return;
+    }
+
+    setUploading(entry.shortName);
+    try {
+      const data = new TextEncoder().encode(deviceJsonFor(entry, entry.appTrack));
+      await details.putTrack(deviceFileOf(entry), data, entry.kind);
+      toast.success(t("deviceTracks.sentToast", { name: entry.shortName }));
+    } catch (err) {
+      toast.error(t("deviceTracks.sendFailedToast", { error: err instanceof Error ? err.message : t("deviceTracks.unknownError") }));
+    } finally {
+      setUploading(null);
+    }
+    await syncAll();
   };
 
   // ── Download device track to app ──
@@ -498,6 +585,33 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
         </div>
       </div>
 
+      {/* Bulk action bar — only present once something is checked, so the list
+          stays uncluttered for the common case of touching one track. */}
+      {checkedTracks.size > 0 && (
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/40">
+          <span className="flex-1 text-xs text-muted-foreground">
+            {t("deviceTracks.bulk.selected", { count: checkedTracks.size })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={() => setCheckedTracks(new Set())}
+          >
+            {t("deviceTracks.bulk.clear")}
+          </Button>
+          <Button
+            size="sm"
+            className="h-7 px-2 text-xs gap-1"
+            disabled={uploading !== null}
+            onClick={handleSendChecked}
+          >
+            {uploading !== null ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+            {t("deviceTracks.bulk.send")}
+          </Button>
+        </div>
+      )}
+
       {/* Track list */}
       <div className="flex-1 overflow-y-auto">
         {mergedTracks.length === 0 ? (
@@ -513,6 +627,24 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
               className="flex items-center gap-2 px-3 py-2.5 border-b border-border hover:bg-muted/30 transition-colors cursor-pointer"
               onClick={() => { setSelectedTrack(entry); setView("courses"); }}
             >
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={checkedTracks.has(`${entry.kind}:${entry.shortName}`)}
+                aria-label={entry.shortName}
+                onClick={(e) => { e.stopPropagation(); toggleChecked(entry); }}
+                className="shrink-0"
+              >
+                <span
+                  className={`flex h-4 w-4 items-center justify-center rounded border ${
+                    checkedTracks.has(`${entry.kind}:${entry.shortName}`)
+                      ? "bg-primary border-primary text-primary-foreground"
+                      : "border-input"
+                  }`}
+                >
+                  {checkedTracks.has(`${entry.kind}:${entry.shortName}`) && <Check className="w-3 h-3" />}
+                </span>
+              </button>
               <StatusIcon status={entry.status} />
               <span className="flex-1 text-sm font-medium text-foreground truncate">
                 {entry.shortName}
@@ -529,6 +661,17 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
               )}
 
               {/* Action buttons — stop propagation so click doesn't drill into courses */}
+              {entry.appTrack && entry.appTrack.courses.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs gap-1 shrink-0"
+                  title={t("deviceTracks.picker.buttonHint")}
+                  onClick={(e) => { e.stopPropagation(); setPickerEntry(entry); }}
+                >
+                  <ListChecks className="w-3.5 h-3.5" /> {t("deviceTracks.picker.button")}
+                </Button>
+              )}
               {entry.status === 'app_only' && (
                 <Button
                   variant="ghost"
@@ -538,7 +681,7 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
                   onClick={(e) => { e.stopPropagation(); handleSendToDevice(entry); }}
                 >
                   {uploading === entry.shortName ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
-                  Send
+                  {t("deviceTracks.send")}
                 </Button>
               )}
               {entry.status === 'device_only' && (
@@ -606,6 +749,18 @@ export function DeviceTracksTab({ details }: DeviceTracksTabProps) {
           loading={false}
           onConfirm={handleResyncAll}
           onClose={() => setResyncConfirm(false)}
+        />
+      )}
+
+      {pickerEntry?.appTrack && (
+        <DeviceCoursePickerDialog
+          open
+          onOpenChange={(o) => { if (!o) setPickerEntry(null); }}
+          track={pickerEntry.appTrack}
+          budget={trackBudget}
+          overrides={overridesFor(pickerEntry.kind, pickerEntry.shortName)}
+          saving={uploading === pickerEntry.shortName}
+          onConfirm={(overrides) => handlePickerConfirm(pickerEntry, overrides)}
         />
       )}
     </div>

--- a/src/lib/deviceCoursePicker.test.ts
+++ b/src/lib/deviceCoursePicker.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPickerState,
+  initialPickerSelection,
+  togglePickerCourse,
+} from "./deviceCoursePicker";
+import { DEVICE_TRACK_BYTES_SMALL, projectDeviceTrackBytes } from "./deviceTrackBudget";
+import type { Course, Track } from "@/types/racing";
+
+function makeCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    name: "Full CW",
+    startFinishA: { lat: 35.4123456, lon: -97.3123456 },
+    startFinishB: { lat: 35.4124567, lon: -97.3124567 },
+    isUserDefined: true,
+    ...overrides,
+  };
+}
+
+function sprint(name: string, dateCreated: string): Course {
+  return makeCourse({
+    name,
+    type: "sprint",
+    dateCreated,
+    finish: { a: { lat: 35.41, lon: -97.31 }, b: { lat: 35.41, lon: -97.32 } },
+  });
+}
+
+const track = (courses: Course[]): Track => ({
+  name: "Autocross Lot",
+  shortName: "LOT",
+  courses,
+  isUserDefined: true,
+});
+
+const sprintTrack = () =>
+  track([
+    sprint("Run Jan", "2026-01-04T09:00"),
+    sprint("Run Aug", "2026-08-09T14:32"),
+    sprint("Run Mar", "2026-03-21T11:15"),
+  ]);
+
+// ─── initialPickerSelection ──────────────────────────────────────────────────
+
+describe("initialPickerSelection", () => {
+  it("starts from what is currently bound for the device", () => {
+    expect(initialPickerSelection(sprintTrack().courses)).toEqual(["Run Aug"]);
+  });
+
+  it("includes courses the user explicitly kept", () => {
+    const selection = initialPickerSelection(sprintTrack().courses, {
+      include: ["Run Jan"],
+      exclude: [],
+    });
+    expect(selection.sort()).toEqual(["Run Aug", "Run Jan"]);
+  });
+
+  it("starts with everything for a circuit track", () => {
+    const circuit = track([makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })]);
+    expect(initialPickerSelection(circuit.courses)).toEqual(["CW", "CCW"]);
+  });
+});
+
+// ─── buildPickerState ────────────────────────────────────────────────────────
+
+describe("buildPickerState", () => {
+  it("lists every course, whether selected or not", () => {
+    const t = sprintTrack();
+    const state = buildPickerState(t, ["Run Aug"], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.rows.map((r) => r.name)).toEqual(["Run Jan", "Run Aug", "Run Mar"]);
+    expect(state.rows.map((r) => r.selected)).toEqual([false, true, false]);
+  });
+
+  it("marks the course the default rule would keep", () => {
+    const t = sprintTrack();
+    const state = buildPickerState(t, [], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.rows.filter((r) => r.isDefault).map((r) => r.name)).toEqual(["Run Aug"]);
+  });
+
+  it("marks every course as default on a circuit track", () => {
+    const circuit = track([makeCourse({ name: "CW" }), makeCourse({ name: "CCW" })]);
+    const state = buildPickerState(circuit, ["CW"], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.rows.every((r) => r.isDefault)).toBe(true);
+    expect(state.accumulates).toBe(false);
+  });
+
+  it("says a sprint track accumulates, so the dialog can explain the trim", () => {
+    expect(buildPickerState(sprintTrack(), [], DEVICE_TRACK_BYTES_SMALL).accumulates).toBe(
+      true,
+    );
+  });
+
+  it("carries the walked date through for display", () => {
+    const state = buildPickerState(sprintTrack(), [], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.rows[0].dateCreated).toBe("2026-01-04T09:00");
+  });
+
+  // The number on screen has to be the number written, or the user is being
+  // asked to drop a course on the strength of a guess.
+  it("measures the exact bytes the upload would write", () => {
+    const t = sprintTrack();
+    const state = buildPickerState(t, ["Run Aug"], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.bytes).toBe(projectDeviceTrackBytes(t, [t.courses[1]]));
+  });
+
+  it("grows as courses are added", () => {
+    const t = sprintTrack();
+    const one = buildPickerState(t, ["Run Aug"], DEVICE_TRACK_BYTES_SMALL).bytes;
+    const two = buildPickerState(t, ["Run Aug", "Run Jan"], DEVICE_TRACK_BYTES_SMALL).bytes;
+    expect(two).toBeGreaterThan(one);
+  });
+
+  it("reports nothing over budget when it fits", () => {
+    const state = buildPickerState(sprintTrack(), ["Run Aug"], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.overBy).toBe(0);
+    expect(state.canConfirm).toBe(true);
+  });
+
+  it("reports the overshoot and refuses to confirm when it does not fit", () => {
+    const t = sprintTrack();
+    const tiny = 100;
+    const state = buildPickerState(t, ["Run Aug"], tiny);
+    expect(state.overBy).toBe(state.bytes - tiny);
+    expect(state.overBy).toBeGreaterThan(0);
+    expect(state.canConfirm).toBe(false);
+  });
+
+  // A track file with no courses is not "a smaller track" — the logger parses
+  // it, finds nothing, and never detects it, which looks exactly like the
+  // failure this plan exists to prevent.
+  it("refuses an empty selection even though it obviously fits", () => {
+    const state = buildPickerState(sprintTrack(), [], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.overBy).toBe(0);
+    expect(state.canConfirm).toBe(false);
+  });
+
+  it("treats exactly the budget as fitting", () => {
+    const t = sprintTrack();
+    const exact = projectDeviceTrackBytes(t, [t.courses[1]]);
+    expect(buildPickerState(t, ["Run Aug"], exact).canConfirm).toBe(true);
+    expect(buildPickerState(t, ["Run Aug"], exact - 1).canConfirm).toBe(false);
+  });
+
+  it("ignores a selected name the track no longer has", () => {
+    const state = buildPickerState(sprintTrack(), ["Deleted"], DEVICE_TRACK_BYTES_SMALL);
+    expect(state.rows.every((r) => !r.selected)).toBe(true);
+    expect(state.canConfirm).toBe(false);
+  });
+});
+
+// ─── togglePickerCourse ──────────────────────────────────────────────────────
+
+describe("togglePickerCourse", () => {
+  it("adds a course that was not selected", () => {
+    expect(togglePickerCourse(["A"], "B")).toEqual(["A", "B"]);
+  });
+
+  it("removes one that was", () => {
+    expect(togglePickerCourse(["A", "B"], "A")).toEqual(["B"]);
+  });
+
+  it("does not mutate the list it was given", () => {
+    const before = ["A"];
+    togglePickerCourse(before, "B");
+    expect(before).toEqual(["A"]);
+  });
+
+  it("round-trips", () => {
+    expect(togglePickerCourse(togglePickerCourse(["A"], "B"), "B")).toEqual(["A"]);
+  });
+});

--- a/src/lib/deviceCoursePicker.ts
+++ b/src/lib/deviceCoursePicker.ts
@@ -1,0 +1,114 @@
+/**
+ * The state behind the "choose which courses go on the logger" dialog
+ * (plan 0017).
+ *
+ * The dialog itself is a component, and components are untestable here — the
+ * suite runs in `node` with no renderer, and `src/components/**` is excluded
+ * from coverage. So everything that decides anything lives in this module and
+ * the dialog only draws it.
+ */
+
+import { Course, Track } from '@/types/racing';
+import {
+  keepsOnlyNewest,
+  newestCourseIndex,
+  resolveDeviceCourses,
+  type TrackCourseOverrides,
+} from '@/lib/deviceCourseSelection';
+import { projectDeviceTrackBytes } from '@/lib/deviceTrackBudget';
+
+export interface PickerRow {
+  course: Course;
+  name: string;
+  selected: boolean;
+  /**
+   * True for the course the default rule keeps on its own — the newest run of
+   * a sprint track. Shown as a hint, NOT enforced: the user may drop it (they
+   * might be about to walk a replacement) and may keep older ones.
+   */
+  isDefault: boolean;
+  /** Sprint only; the dialog renders it so "oldest" is visible, not implied. */
+  dateCreated?: string;
+}
+
+export interface PickerState {
+  rows: PickerRow[];
+  /** Bytes the device would store for the current selection. */
+  bytes: number;
+  budget: number;
+  /** Bytes past the budget, or 0 when it fits. */
+  overBy: number;
+  /** False while the selection would not fit, or is empty. */
+  canConfirm: boolean;
+  /**
+   * True when this track's courses accumulate — a sprint venue re-laying its
+   * cones. The dialog uses it to explain WHY the list is trimmed by default,
+   * rather than presenting the trim as arbitrary.
+   */
+  accumulates: boolean;
+}
+
+/**
+ * The names the dialog should start with: whatever is currently bound for the
+ * device, default rule plus any stored overrides.
+ */
+export function initialPickerSelection(
+  courses: readonly Course[],
+  overrides?: TrackCourseOverrides,
+): string[] {
+  return resolveDeviceCourses(courses, overrides)
+    .filter((d) => d.included)
+    .map((d) => d.course.name);
+}
+
+/**
+ * Build the dialog's state for a given selection.
+ *
+ * `bytes` is measured through the real upload writer, so the number shown as
+ * the reason to drop a course is the number that would be written.
+ *
+ * An empty selection cannot be confirmed. Writing a track file with no courses
+ * is not "a smaller track" — it is a file the logger will parse, find nothing
+ * in, and never detect, which looks exactly like the failure this whole plan
+ * exists to prevent. Deleting the track is a different button.
+ */
+export function buildPickerState(
+  track: Track,
+  selectedNames: readonly string[],
+  budget: number,
+): PickerState {
+  const wanted = new Set(selectedNames);
+  const accumulates = keepsOnlyNewest(track.courses);
+  const defaultIndex = accumulates ? newestCourseIndex(track.courses) : -1;
+
+  const rows: PickerRow[] = track.courses.map((course, i) => ({
+    course,
+    name: course.name,
+    selected: wanted.has(course.name),
+    isDefault: defaultIndex === -1 ? true : i === defaultIndex,
+    dateCreated: course.dateCreated,
+  }));
+
+  const selected = rows.filter((r) => r.selected).map((r) => r.course);
+  const bytes = projectDeviceTrackBytes(track, selected);
+  const overBy = Math.max(0, bytes - budget);
+
+  return {
+    rows,
+    bytes,
+    budget,
+    overBy,
+    canConfirm: selected.length > 0 && overBy === 0,
+    accumulates,
+  };
+}
+
+/** Toggle one course in a selection, returning a new list. */
+export function togglePickerCourse(
+  selectedNames: readonly string[],
+  name: string,
+): string[] {
+  return selectedNames.includes(name)
+    ? selectedNames.filter((n) => n !== name)
+    : [...selectedNames, name];
+}

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -342,6 +342,26 @@
     "progressUnitFiles": "Dateien",
     "noCourses": "Keine Kurse",
     "send": "Senden",
+    "picker": {
+      "button": "Kurse",
+      "buttonHint": "Auswählen, welche Kurse auf den Logger kommen",
+      "title": "Kurse auf dem Logger – {{name}}",
+      "descriptionSprint": "Diese Strecke bekommt bei jedem Event einen Kurs dazu, und der Logger kann eine Datei nur bis zu einer bestimmten Größe lesen. Nicht angehakte Kurse bleiben in der App und in deinem Konto – nur der Logger hält eine Auswahl.",
+      "descriptionCircuit": "Wähle aus, welche Kurse auf den Logger kommen. Nicht angehakte bleiben in der App und in deinem Konto.",
+      "newestBadge": "neuester",
+      "withinBudget": "{{bytes}} von {{budget}} Bytes auf dem Logger belegt",
+      "overBudget": "{{over}} Bytes zu viel – der Logger kann nur {{budget}} lesen",
+      "needOne": "Behalte mindestens einen Kurs, sonst erkennt der Logger die Strecke nicht.",
+      "cancel": "Abbrechen",
+      "confirm": "Auf Logger speichern"
+    },
+    "bulk": {
+      "selected": "{{count}} ausgewählt",
+      "clear": "Auswahl aufheben",
+      "send": "An Logger senden",
+      "sent": "{{count}} Strecken an den Logger gesendet",
+      "someFailed": "{{count}} Strecken konnten nicht gesendet werden"
+    },
     "get": "Holen",
     "compare": "Vergleichen",
     "resyncAll": "Alle neu synchronisieren",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -341,6 +341,26 @@
     "progressUnitFiles": "files",
     "noCourses": "No courses",
     "send": "Send",
+    "picker": {
+      "button": "Courses",
+      "buttonHint": "Choose which courses go on the logger",
+      "title": "Courses on the logger — {{name}}",
+      "descriptionSprint": "This track gains a course every event, and the logger can only read a file so big. Unchecked courses stay in the app and in your account — only the logger holds a subset.",
+      "descriptionCircuit": "Choose which courses go on the logger. Unchecked ones stay in the app and in your account.",
+      "newestBadge": "newest",
+      "withinBudget": "{{bytes}} of {{budget}} bytes used on the logger",
+      "overBudget": "{{over}} bytes too many — the logger can only read {{budget}}",
+      "needOne": "Keep at least one course, or the logger won't recognise the track.",
+      "cancel": "Cancel",
+      "confirm": "Save to logger"
+    },
+    "bulk": {
+      "selected": "{{count}} selected",
+      "clear": "Clear",
+      "send": "Send to logger",
+      "sent": "Sent {{count}} tracks to the logger",
+      "someFailed": "{{count}} tracks failed to send"
+    },
     "get": "Get",
     "compare": "Compare",
     "resyncAll": "Resync All",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -342,6 +342,26 @@
     "progressUnitFiles": "archivos",
     "noCourses": "Sin recorridos",
     "send": "Enviar",
+    "picker": {
+      "button": "Recorridos",
+      "buttonHint": "Elige qué recorridos van al registrador",
+      "title": "Recorridos en el registrador: {{name}}",
+      "descriptionSprint": "Esta pista suma un recorrido en cada evento, y el registrador solo puede leer un archivo hasta cierto tamaño. Los recorridos sin marcar siguen en la app y en tu cuenta; solo el registrador guarda una parte.",
+      "descriptionCircuit": "Elige qué recorridos van al registrador. Los que no marques siguen en la app y en tu cuenta.",
+      "newestBadge": "más reciente",
+      "withinBudget": "{{bytes}} de {{budget}} bytes usados en el registrador",
+      "overBudget": "{{over}} bytes de más: el registrador solo puede leer {{budget}}",
+      "needOne": "Conserva al menos un recorrido o el registrador no reconocerá la pista.",
+      "cancel": "Cancelar",
+      "confirm": "Guardar en el registrador"
+    },
+    "bulk": {
+      "selected": "{{count}} seleccionadas",
+      "clear": "Quitar selección",
+      "send": "Enviar al registrador",
+      "sent": "{{count}} pistas enviadas al registrador",
+      "someFailed": "No se pudieron enviar {{count}} pistas"
+    },
     "get": "Obtener",
     "compare": "Comparar",
     "resyncAll": "Resincronizar todo",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -342,6 +342,26 @@
     "progressUnitFiles": "fichiers",
     "noCourses": "Aucun parcours",
     "send": "Envoyer",
+    "picker": {
+      "button": "Parcours",
+      "buttonHint": "Choisir les parcours à mettre sur l'enregistreur",
+      "title": "Parcours sur l'enregistreur — {{name}}",
+      "descriptionSprint": "Ce circuit gagne un parcours à chaque événement, et l'enregistreur ne peut lire un fichier que jusqu'à une certaine taille. Les parcours décochés restent dans l'app et dans ton compte : seul l'enregistreur n'en garde qu'une partie.",
+      "descriptionCircuit": "Choisis les parcours à mettre sur l'enregistreur. Ceux qui ne sont pas cochés restent dans l'app et dans ton compte.",
+      "newestBadge": "le plus récent",
+      "withinBudget": "{{bytes}} sur {{budget}} octets utilisés sur l'enregistreur",
+      "overBudget": "{{over}} octets de trop — l'enregistreur ne peut lire que {{budget}}",
+      "needOne": "Garde au moins un parcours, sinon l'enregistreur ne reconnaîtra pas le circuit.",
+      "cancel": "Annuler",
+      "confirm": "Enregistrer sur l'appareil"
+    },
+    "bulk": {
+      "selected": "{{count}} sélectionné(s)",
+      "clear": "Tout désélectionner",
+      "send": "Envoyer à l'enregistreur",
+      "sent": "{{count}} circuits envoyés à l'enregistreur",
+      "someFailed": "Échec de l'envoi de {{count}} circuits"
+    },
     "get": "Obtenir",
     "compare": "Comparer",
     "resyncAll": "Tout resynchroniser",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -342,6 +342,26 @@
     "progressUnitFiles": "file",
     "noCourses": "Nessun percorso",
     "send": "Invia",
+    "picker": {
+      "button": "Percorsi",
+      "buttonHint": "Scegli quali percorsi mettere sul logger",
+      "title": "Percorsi sul logger — {{name}}",
+      "descriptionSprint": "Questa pista guadagna un percorso a ogni evento, e il logger può leggere un file solo fino a una certa dimensione. I percorsi non selezionati restano nell'app e nel tuo account: solo il logger ne tiene una parte.",
+      "descriptionCircuit": "Scegli quali percorsi mettere sul logger. Quelli non selezionati restano nell'app e nel tuo account.",
+      "newestBadge": "più recente",
+      "withinBudget": "{{bytes}} di {{budget}} byte usati sul logger",
+      "overBudget": "{{over}} byte di troppo — il logger può leggerne solo {{budget}}",
+      "needOne": "Tieni almeno un percorso, altrimenti il logger non riconoscerà la pista.",
+      "cancel": "Annulla",
+      "confirm": "Salva sul logger"
+    },
+    "bulk": {
+      "selected": "{{count}} selezionate",
+      "clear": "Deseleziona",
+      "send": "Invia al logger",
+      "sent": "{{count}} piste inviate al logger",
+      "someFailed": "Invio non riuscito per {{count}} piste"
+    },
     "get": "Ottieni",
     "compare": "Confronta",
     "resyncAll": "Risincronizza tutto",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -342,6 +342,26 @@
     "progressUnitFiles": "ファイル",
     "noCourses": "コースなし",
     "send": "送信",
+    "picker": {
+      "button": "コース",
+      "buttonHint": "ロガーに入れるコースを選ぶ",
+      "title": "ロガー上のコース — {{name}}",
+      "descriptionSprint": "このトラックはイベントごとにコースが増えますが、ロガーが読めるファイルサイズには上限があります。チェックを外したコースはアプリとアカウントに残ります。一部だけを持つのはロガーだけです。",
+      "descriptionCircuit": "ロガーに入れるコースを選んでください。チェックを外したものはアプリとアカウントに残ります。",
+      "newestBadge": "最新",
+      "withinBudget": "ロガー上で {{budget}} バイト中 {{bytes}} バイト使用",
+      "overBudget": "{{over}} バイト超過 — ロガーが読めるのは {{budget}} バイトまでです",
+      "needOne": "コースを少なくとも1つ残してください。空だとロガーがトラックを認識できません。",
+      "cancel": "キャンセル",
+      "confirm": "ロガーに保存"
+    },
+    "bulk": {
+      "selected": "{{count}} 件選択中",
+      "clear": "選択を解除",
+      "send": "ロガーに送信",
+      "sent": "{{count}} 件のトラックをロガーに送信しました",
+      "someFailed": "{{count}} 件のトラックを送信できませんでした"
+    },
     "get": "取得",
     "compare": "比較",
     "resyncAll": "すべて再同期",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -342,6 +342,26 @@
     "progressUnitFiles": "arquivos",
     "noCourses": "Nenhum percurso",
     "send": "Enviar",
+    "picker": {
+      "button": "Percursos",
+      "buttonHint": "Escolha quais percursos vão para o registrador",
+      "title": "Percursos no registrador — {{name}}",
+      "descriptionSprint": "Esta pista ganha um percurso a cada evento, e o registrador só consegue ler um arquivo até certo tamanho. Percursos desmarcados continuam no app e na sua conta — só o registrador fica com uma parte.",
+      "descriptionCircuit": "Escolha quais percursos vão para o registrador. Os desmarcados continuam no app e na sua conta.",
+      "newestBadge": "mais recente",
+      "withinBudget": "{{bytes}} de {{budget}} bytes usados no registrador",
+      "overBudget": "{{over}} bytes a mais — o registrador só consegue ler {{budget}}",
+      "needOne": "Mantenha pelo menos um percurso, ou o registrador não vai reconhecer a pista.",
+      "cancel": "Cancelar",
+      "confirm": "Salvar no registrador"
+    },
+    "bulk": {
+      "selected": "{{count}} selecionadas",
+      "clear": "Limpar seleção",
+      "send": "Enviar ao registrador",
+      "sent": "{{count}} pistas enviadas ao registrador",
+      "someFailed": "Falha ao enviar {{count}} pistas"
+    },
     "get": "Obter",
     "compare": "Comparar",
     "resyncAll": "Ressincronizar tudo",


### PR DESCRIPTION
## Summary

Last PR of plan 0017, stacked on #395. Somewhere to actually *do* the curation
the previous PRs made possible.

A **Courses** button on any track with more than one course opens a checklist
with a live byte count — how much of the logger's room the current selection
uses, and how much there is. The number is **measured, not estimated**:
`buildPickerState` runs the real upload writer and the real `TextEncoder`,
because a user is being asked to drop a course on the strength of it.

Track rows also gain **checkboxes and a bulk send**.

## Three decisions worth reviewing

**The picker lives in the tracks list, not in the sync wizard.** The wizard
reports an oversized track as a skip whose message points here. That keeps the
rule the rest of this plan rests on: curation is only ever reached by a
deliberate action. A dialog that appeared mid-sync would be the nag the whole
plan exists to end. (Plan 0017's status block now says this explicitly.)

**An empty selection cannot be confirmed.** A track file with no courses is not
"a smaller track" — the logger parses it, finds nothing, and never detects it,
which looks exactly like the overflow being avoided. Deleting a track is a
different button, and it already exists.

**The newest sprint course is badged, not pinned.** The default rule keeps it,
but a driver about to walk its replacement may well want it gone, and a checkbox
that refuses to move is worse than no hint at all.

Every track in a bulk send goes through `deviceJsonFor()`, so it carries
whatever was chosen for it — a bulk action that quietly undid the curation would
be worse than having none.

## Related Issues

Stacked on #395 → #394 → #393. Completes plan 0017. Firmware half is
DovesDataLogger #137.

## Type of Change

- [x] New feature
- [x] Bug fix (two small ones, below)
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (2845 tests, 194 files — 19 new)
- [x] `bun run build` succeeds
- [x] Feature works **offline**
- [x] Docs updated — `CHANGELOG.md`, plan 0017 closed out
- [x] i18n — `picker.*` and `bulk.*` in all seven locales
- [ ] For a new parser: n/a

## Notes for Reviewers

**All logic is in `deviceCoursePicker` with 19 tests; the dialog only draws it.**
That's not a style preference — the suite runs in `node` with no renderer and
`src/components/**` is coverage-excluded, so anything that decides anything has
to live in `src/lib` to be covered at all. The dialog and the row markup are
eyeball-only, as with every component in this repo.

**Two small things fixed in passing**, both visible in the diff:
- the `app_only` row's **"Send"** label was hardcoded English while the
  identical button 150 lines away was translated;
- the picker reuses the wizard's existing `walkedOn` string rather than
  duplicating the same sentence across seven locale files. It reads slightly odd
  as `deviceTracks.wizard.walkedOn` from a non-wizard component — say if you'd
  rather I promoted it up a level instead.

**Not done, and worth saying:** there's no bulk *delete* to pair with the bulk
send. Send is the safe direction and the one this plan needs; a bulk delete
against a card is a different risk profile and I'd rather it were asked for than
assumed.

**Still unverified end to end.** Nothing in this stack has touched a real
logger — the byte projection lines up with the firmware's own per-course
measurements, and the round-trip-to-`synced` property is tested, but the actual
"curate a track, reconnect, confirm it doesn't re-prompt" loop needs hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkRRtF4vRrANPL6huSgmD)_