### PR TITLE
feat(settings): expose the logger's debug-pages setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Debug Pages** — a new logger setting controlling the two diagnostic pages
+  at the front of the race rotation (GPS/RF counters and the stats page). The
+  firmware now hides them by default so a driver only sees speed, RPM and lap
+  pages; flip this to Shown for development or tuning. Appears once your
+  logger has the firmware that supports it.
 - **Display Colours** — a new logger setting that inverts the screen, so it
   shows black on a lit background instead of white on black. Easier to read in
   direct sun. Appears once your logger has the firmware that supports it; the

--- a/src/lib/deviceSettingsSchema.test.ts
+++ b/src/lib/deviceSettingsSchema.test.ts
@@ -169,6 +169,8 @@ describe("validateSettingValue — enum fields", () => {
   it("accepts every declared option", () => {
     expect(validateSettingValue("display_invert", "normal")).toBeNull();
     expect(validateSettingValue("display_invert", "inverted")).toBeNull();
+    expect(validateSettingValue("debug_pages", "hide")).toBeNull();
+    expect(validateSettingValue("debug_pages", "show")).toBeNull();
     expect(validateSettingValue("race_mode", "circuit")).toBeNull();
     expect(validateSettingValue("race_mode", "sprint")).toBeNull();
     expect(validateSettingValue("spark_mode", "wasted")).toBeNull();
@@ -259,5 +261,20 @@ describe("display_invert", () => {
 
   it("labels the stored values for display", () => {
     expect(settingDisplayValue("display_invert", "inverted")).toBe("Inverted (black on white)");
+  });
+});
+
+describe("debug_pages", () => {
+  // The firmware shows the diagnostic pages only on an exact "show" — any
+  // other value silently means hidden, so near misses must be rejected here.
+  it("rejects near misses the firmware would ignore", () => {
+    expect(validateSettingValue("debug_pages", "Show")).not.toBeNull();
+    expect(validateSettingValue("debug_pages", "hidden")).not.toBeNull();
+    expect(validateSettingValue("debug_pages", "1")).not.toBeNull();
+  });
+
+  it("labels the stored values for display", () => {
+    expect(settingDisplayValue("debug_pages", "hide")).toBe("Hidden (racing pages only)");
+    expect(settingDisplayValue("debug_pages", "show")).toBe("Shown (GPS/RF diagnostics first)");
   });
 });

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -111,6 +111,17 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     description: "Inverting can be easier to read in direct sun. Normal is how the logger has always looked",
   },
   {
+    key: 'debug_pages',
+    label: 'Debug Pages',
+    type: 'enum',
+    options: [
+      { value: 'hide', label: 'Hidden (racing pages only)' },
+      { value: 'show', label: 'Shown (GPS/RF diagnostics first)' },
+    ],
+    description:
+      'The two diagnostic pages at the front of the race rotation. Hidden is the factory default — show them for development or tuning',
+  },
+  {
     key: 'spark_mode',
     label: 'Spark Mode',
     type: 'enum',


### PR DESCRIPTION
## Summary

The firmware (DovesDataLogger BETA, release-prep branch) now hides the two diagnostic pages at the front of the race rotation behind a `debug_pages` setting, defaulting to `hide` so end users get a clean rotation (speed / RPM / lap pages only). This adds the matching schema entry so the setting renders as a proper dropdown in the Device Settings tab — the firmware only shows the pages on an exact `show`, so free-text entry with a typo would read as the setting silently not working. Follows the `display_invert` pattern from #392 exactly.

## Related Issues

None — part of the first-unit release-prep pass alongside the firmware change.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (2738 tests)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (no new network calls — schema entry only)
- [x] Docs updated where relevant (`CHANGELOG.md`)
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table (n/a)

## Notes for Reviewers

Three files, purely additive: one `DEVICE_SETTINGS_SCHEMA` entry (positioned right after `display_invert`), tests (option acceptance, near-miss rejection, display labels), and a CHANGELOG bullet. The row only appears in the UI once a connected logger actually reports the `debug_pages` key, so it is invisible against current-release firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDNr2DbMapSHHyieJigF3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDNr2DbMapSHHyieJigF3s)_