### PR TITLE
One Profile button in the header; garage panel titled "Garage"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.1.0] - unreleased
 
 ### Changed
+- **One Profile button** — the header's Sign-in button is gone: everyone gets
+  the same Profile button, which opens the garage's Profile tab where signing
+  in (or creating an account) is offered instead of forced. The side panel is
+  now titled **Garage** throughout, no matter which tab is open.
 - **Tidier Device Settings** — the garage's device settings panel now tucks
   its expert knobs (lap/waypoint detection distances, waypoint speed, debug
   pages, the legacy CSV switch) under a collapsed **Advanced** section, so

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -185,8 +185,10 @@ export function FileManagerDrawer({
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
           <div className="flex items-center gap-2">
-            {topTab === "garage" ? <Gauge className="w-5 h-5 text-primary" /> : topTab === "profile" ? <User className="w-5 h-5 text-primary" /> : <Cpu className="w-5 h-5 text-primary" />}
-            <h2 className="font-semibold text-foreground">{topTab === "garage" ? t("shell.tabs.garage") : topTab === "profile" ? t("shell.tabs.profile") : t("shell.tabs.device")}</h2>
+            {/* The whole panel is "the garage" — the title stays put while the
+                tabs below (Garage / Profile / Device) switch its contents. */}
+            <Gauge className="w-5 h-5 text-primary" />
+            <h2 className="font-semibold text-foreground">{t("shell.tabs.garage")}</h2>
             {topTab === "device" && device.deviceName && (
               <span className="text-xs text-muted-foreground truncate max-w-[120px]">— {device.deviceName}</span>
             )}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode } from "react";
-import { Heart, LogIn, User } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Heart, User } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { BrandLogo } from "@/components/BrandLogo";
 import { Button } from "@/components/ui/button";
@@ -13,7 +12,7 @@ interface SiteHeaderProps {
   /** The settings modal (trigger + dialog), rendered just left of the account button. */
   settingsButton: ReactNode;
   enableCloud: boolean;
-  /** Opens the Profile (account) surface. */
+  /** Opens the garage panel on its Profile (account) tab. */
   onOpenProfile: () => void;
   /** Show the "Supported files" reference dialog button (default true). */
   showSupportedFiles?: boolean;
@@ -37,7 +36,6 @@ export function SiteHeader({
   showAbout = true,
   children,
 }: SiteHeaderProps) {
-  const navigate = useNavigate();
   const { user } = useAuth();
   const { t } = useTranslation(["common"]);
   const native = isNativeApp();
@@ -67,18 +65,13 @@ export function SiteHeader({
           {showSupportedFiles && <SupportedFilesDialog />}
           {showAbout && <AboutDialog />}
           {settingsButton}
+          {/* One profile button for everyone — it opens the garage's Profile
+              tab, which offers sign-in when signed out (no forced /login). */}
           {enableCloud && (
-            user ? (
-              <Button size="sm" className="gap-2" onClick={onOpenProfile} title={user.email ?? undefined}>
-                <User className="w-4 h-4" />
-                <span className="hidden sm:inline">{t("common:actions.profile")}</span>
-              </Button>
-            ) : (
-              <Button size="sm" className="gap-2" onClick={() => navigate('/login')}>
-                <LogIn className="w-4 h-4" />
-                <span className="hidden sm:inline">{t("common:actions.signIn")}</span>
-              </Button>
-            )
+            <Button size="sm" className="gap-2" onClick={onOpenProfile} title={user?.email ?? undefined}>
+              <User className="w-4 h-4" />
+              <span className="hidden sm:inline">{t("common:actions.profile")}</span>
+            </Button>
           )}
         </div>
       </div>

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Anmelden",
     "signOut": "Abmelden",
     "profile": "Profil",
     "sponsor": "Unterstützen",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,7 +1,6 @@
 {
   "appName": "LapWing",
   "actions": {
-    "signIn": "Sign in",
     "signOut": "Sign out",
     "profile": "Profile",
     "backToHome": "Back to home",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Iniciar sesión",
     "signOut": "Cerrar sesión",
     "profile": "Perfil",
     "sponsor": "Patrocinar",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Se connecter",
     "signOut": "Se déconnecter",
     "profile": "Profil",
     "sponsor": "Soutenir",

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Accedi",
     "signOut": "Esci",
     "profile": "Profilo",
     "sponsor": "Sostieni",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "ログイン",
     "signOut": "ログアウト",
     "profile": "プロフィール",
     "sponsor": "支援する",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Entrar",
     "signOut": "Sair",
     "profile": "Perfil",
     "sponsor": "Apoiar",


### PR DESCRIPTION
## Summary

Makes the upper-right header uniform and drops the forced sign-in:

- **`SiteHeader`**: the conditional Sign-in (→ `/login`) / Profile button pair is replaced by a single Profile button for everyone. It opens the garage panel on its Profile tab via the existing `onOpenProfile` wiring (works from Leaderboards/Simulator/Updates/DriverProfile too, via the `openProfile` navigation state). Signed-out users see the Profile tab's existing sign-in / create-account offer (`StoragePanel`'s `SignInPrompt`), so login is available but never forced. The signed-in email tooltip is kept.
- **`FileManagerDrawer`**: the panel title is now a static **"Garage"** (Gauge icon) instead of retitling itself Profile/Device with the active tab — the whole side panel is "the garage"; the tabs below switch its contents. Reuses the existing `shell.tabs.garage` translation, so no new i18n keys.
- Removed the now-unused `common:actions.signIn` key from all seven locales.
- CHANGELOG entry under `[4.1.0] - unreleased`.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [x] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (194 files, 2850 tests)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (no new network calls; the Profile tab's sign-in remains cloud-gated as before)
- [x] Docs updated where relevant (`CHANGELOG.md`; no README/CLAUDE.md impact)
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table

## Notes for Reviewers

The header button stays gated on `enableCloud` — a cloud-off build has no Profile tab, so it shows no account button, same as before. `/login` still exists for direct links and the in-panel sign-in buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENY1w5WJMSEbtRUvxFP51F

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENY1w5WJMSEbtRUvxFP51F)_