### PR TITLE
Release prep v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [4.1.0] - unreleased
+## [4.0.1] - 2026-08-15
 
 ### Changed
 - **One Profile button** — the header's Sign-in button is gone: everyone gets

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",


### PR DESCRIPTION
## Summary

Prepares `BETA` for a **v4.0.1** patch release. Two QOL changes have landed since `v4.0.0` (PRs #402 and #403), both UI polish with no new capability, so this cuts them as a patch rather than the minor version the changelog heading was holding.

- `package.json` `4.0.0` → `4.0.1` — the only version string to edit; the footer/build stamp is baked from here in `vite.config.ts`.
- `CHANGELOG.md` — retitled the topmost unreleased heading `## [4.1.0] - unreleased` → `## [4.0.1] - 2026-08-15`. Content is unchanged and already covered both merged PRs; no older heading was touched, and no new `[Unreleased]` block was added (that gets started after this release ships).

**No coach flip was needed this cycle.** `@perchwerks/eye-in-the-sky` is already the published production package at `0.5.0` in both `package.json` and `vite.config.ts` — identical to `main` — so there is no BETA git-dependency to revert, and no follow-up "flip coach back to BETA" PR is required.

**No tag was created.** Tagging is manual, after the BETA → main merge.

## Related Issues

Ships #402 and #403.

## Type of Change

- [x] Other: release prep (version + changelog only, no source changes)

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes (194 files, 2850 tests)
- [x] `bun run build` succeeds
- [x] Feature works **offline** (no functional change)
- [x] Docs updated where relevant (`CHANGELOG.md`)
- [x] For a new parser: n/a

## Notes for Reviewers

The diff is two lines. The judgement call worth checking is **4.0.1 vs 4.0.0's changelog heading of 4.1.0** — the unified Profile button does change header behaviour for signed-out users, so if you'd rather ship that as a minor, say so and I'll move both the heading and the version back to `4.1.0`.

Companion release PR into `main`: see the linked `Release v4.0.1` PR, whose body is copy-paste-ready release notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KJWfEZ24zNkkedw6MQ634)_