### PR TITLE
Release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [4.1.0] - unreleased
+## [4.0.1] - 2026-08-15
 
 ### Changed
 - **One Profile button** — the header's Sign-in button is gone: everyone gets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.1.0] - unreleased
 
 ### Changed
+- **One Profile button** — the header's Sign-in button is gone: everyone gets
+  the same Profile button, which opens the garage's Profile tab where signing
+  in (or creating an account) is offered instead of forced. The side panel is
+  now titled **Garage** throughout, no matter which tab is open.
 - **Tidier Device Settings** — the garage's device settings panel now tucks
   its expert knobs (lap/waypoint detection distances, waypoint speed, debug
   pages, the legacy CSV switch) under a collapsed **Advanced** section, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [4.1.0] - unreleased
+
+### Changed
+- **Tidier Device Settings** — the garage's device settings panel now tucks
+  its expert knobs (lap/waypoint detection distances, waypoint speed, debug
+  pages, the legacy CSV switch) under a collapsed **Advanced** section, so
+  the everyday settings — names, display, RPM setup — stand alone up top.
+  New settings appear in the main list unless deliberately marked advanced.
+
 ## [4.0.0] - 2026-08-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/components/FileManagerDrawer.tsx
+++ b/src/components/FileManagerDrawer.tsx
@@ -185,8 +185,10 @@ export function FileManagerDrawer({
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
           <div className="flex items-center gap-2">
-            {topTab === "garage" ? <Gauge className="w-5 h-5 text-primary" /> : topTab === "profile" ? <User className="w-5 h-5 text-primary" /> : <Cpu className="w-5 h-5 text-primary" />}
-            <h2 className="font-semibold text-foreground">{topTab === "garage" ? t("shell.tabs.garage") : topTab === "profile" ? t("shell.tabs.profile") : t("shell.tabs.device")}</h2>
+            {/* The whole panel is "the garage" — the title stays put while the
+                tabs below (Garage / Profile / Device) switch its contents. */}
+            <Gauge className="w-5 h-5 text-primary" />
+            <h2 className="font-semibold text-foreground">{t("shell.tabs.garage")}</h2>
             {topTab === "device" && device.deviceName && (
               <span className="text-xs text-muted-foreground truncate max-w-[120px]">— {device.deviceName}</span>
             )}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode } from "react";
-import { Heart, LogIn, User } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Heart, User } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { BrandLogo } from "@/components/BrandLogo";
 import { Button } from "@/components/ui/button";
@@ -13,7 +12,7 @@ interface SiteHeaderProps {
   /** The settings modal (trigger + dialog), rendered just left of the account button. */
   settingsButton: ReactNode;
   enableCloud: boolean;
-  /** Opens the Profile (account) surface. */
+  /** Opens the garage panel on its Profile (account) tab. */
   onOpenProfile: () => void;
   /** Show the "Supported files" reference dialog button (default true). */
   showSupportedFiles?: boolean;
@@ -37,7 +36,6 @@ export function SiteHeader({
   showAbout = true,
   children,
 }: SiteHeaderProps) {
-  const navigate = useNavigate();
   const { user } = useAuth();
   const { t } = useTranslation(["common"]);
   const native = isNativeApp();
@@ -67,18 +65,13 @@ export function SiteHeader({
           {showSupportedFiles && <SupportedFilesDialog />}
           {showAbout && <AboutDialog />}
           {settingsButton}
+          {/* One profile button for everyone — it opens the garage's Profile
+              tab, which offers sign-in when signed out (no forced /login). */}
           {enableCloud && (
-            user ? (
-              <Button size="sm" className="gap-2" onClick={onOpenProfile} title={user.email ?? undefined}>
-                <User className="w-4 h-4" />
-                <span className="hidden sm:inline">{t("common:actions.profile")}</span>
-              </Button>
-            ) : (
-              <Button size="sm" className="gap-2" onClick={() => navigate('/login')}>
-                <LogIn className="w-4 h-4" />
-                <span className="hidden sm:inline">{t("common:actions.signIn")}</span>
-              </Button>
-            )
+            <Button size="sm" className="gap-2" onClick={onOpenProfile} title={user?.email ?? undefined}>
+              <User className="w-4 h-4" />
+              <span className="hidden sm:inline">{t("common:actions.profile")}</span>
+            </Button>
           )}
         </div>
       </div>

--- a/src/components/drawer/DeviceSettingsTab.tsx
+++ b/src/components/drawer/DeviceSettingsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Save, AlertCircle, RefreshCw, RotateCcw, UserRound } from "lucide-react";
+import { Loader2, Save, AlertCircle, RefreshCw, RotateCcw, UserRound, ChevronDown, SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -10,12 +10,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { toast } from "sonner";
 import { type BleConnection } from "@/lib/bleDatalogger";
 import type { DeviceDetails } from "@/lib/loggers";
 import {
   DEVICE_SETTINGS_SCHEMA,
   getSettingDef,
+  isAdvancedSetting,
   validateSettingValue,
 } from "@/lib/deviceSettingsSchema";
 import { useAuth } from "@/contexts/AuthContext";
@@ -53,6 +55,7 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [resetting, setResetting] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
   // The signed-in user's account name, used by the "use profile name" shortcut
   // on the Device Name field. Loaded lazily so the Supabase client never lands
   // on the offline-first eager graph; null when signed out or unavailable.
@@ -113,35 +116,35 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
     fetchSettings();
   }, [fetchSettings]);
 
-  const handleChange = (index: number, newValue: string) => {
+  const handleChange = (key: string, newValue: string) => {
     setRows((prev) =>
-      prev.map((r, i) =>
-        i === index
+      prev.map((r) =>
+        r.key === key
           ? { ...r, value: newValue, error: validateSettingValue(r.key, newValue) }
           : r
       )
     );
   };
 
-  const handleSave = async (index: number) => {
-    const row = rows[index];
-    if (row.error || row.value === row.originalValue) return;
+  const handleSave = async (key: string) => {
+    const row = rows.find((r) => r.key === key);
+    if (!row || row.error || row.value === row.originalValue) return;
 
     setRows((prev) =>
-      prev.map((r, i) => (i === index ? { ...r, saving: true } : r))
+      prev.map((r) => (r.key === key ? { ...r, saving: true } : r))
     );
 
     try {
       await details.setSetting(row.key, row.value);
       setRows((prev) =>
-        prev.map((r, i) =>
-          i === index ? { ...r, originalValue: r.value, saving: false } : r
+        prev.map((r) =>
+          r.key === key ? { ...r, originalValue: r.value, saving: false } : r
         )
       );
       toast.success(t("device.toastSaved", { name: getSettingDef(row.key)?.label ?? row.key }));
     } catch (err) {
       setRows((prev) =>
-        prev.map((r, i) => (i === index ? { ...r, saving: false } : r))
+        prev.map((r) => (r.key === key ? { ...r, saving: false } : r))
       );
       toast.error(t("device.toastSaveFailed", { error: err instanceof Error ? err.message : t("device.unknownError") }));
     }
@@ -164,6 +167,85 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
     }
   };
 
+  // Advanced settings (detection thresholds, debug toggles) live under a
+  // collapsed section; anything unflagged — including unknown keys from a
+  // newer firmware — stays in the main list.
+  const normalRows = rows.filter((r) => !isAdvancedSetting(r.key));
+  const advancedRows = rows.filter((r) => isAdvancedSetting(r.key));
+
+  const renderRow = (row: SettingRow) => {
+    const def = getSettingDef(row.key);
+    const isDirty = row.value !== row.originalValue;
+    return (
+      <div key={row.key} className="space-y-1">
+        <div className="flex items-center gap-2">
+          <div className="flex-1 min-w-0">
+            <label className="text-sm font-medium text-foreground">
+              {def?.label ?? row.key}
+            </label>
+            {def?.description && (
+              <p className="text-xs text-muted-foreground">{def.description}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {def?.type === "enum" && def.options?.length ? (
+            <Select value={row.value} onValueChange={(v) => handleChange(row.key, v)}>
+              <SelectTrigger className="h-9 flex-1 text-sm">
+                {/* A device can hold a value this build doesn't know — an
+                    older or newer firmware, or a hand-edited SETTINGS.json.
+                    Show it verbatim rather than an empty box. */}
+                <SelectValue placeholder={row.value || undefined} />
+              </SelectTrigger>
+              <SelectContent>
+                {def.options.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              value={row.value}
+              onChange={(e) => handleChange(row.key, e.target.value)}
+              className="h-9 text-sm flex-1"
+              type={def?.type === "number" ? "number" : "text"}
+              maxLength={def?.maxLength}
+            />
+          )}
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            disabled={!isDirty || !!row.error || row.saving}
+            onClick={() => handleSave(row.key)}
+          >
+            {row.saving ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Save className="w-4 h-4" />
+            )}
+          </Button>
+        </div>
+        {row.key === DEVICE_NAME_KEY && profileName && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+            onClick={() => handleChange(row.key, profileName.slice(0, def?.maxLength ?? profileName.length))}
+          >
+            <UserRound className="w-3.5 h-3.5" />
+            {t("device.useProfileName")}
+          </Button>
+        )}
+        {row.error && (
+          <p className="text-xs text-destructive">{row.error}</p>
+        )}
+      </div>
+    );
+  };
+
   const settingsBody = loading ? (
     <div className="flex items-center justify-center py-8">
       <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
@@ -182,78 +264,23 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
       {rows.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">{t("device.noSettings")}</p>
       )}
-      {rows.map((row, i) => {
-        const def = getSettingDef(row.key);
-        const isDirty = row.value !== row.originalValue;
-        return (
-          <div key={row.key} className="space-y-1">
-            <div className="flex items-center gap-2">
-              <div className="flex-1 min-w-0">
-                <label className="text-sm font-medium text-foreground">
-                  {def?.label ?? row.key}
-                </label>
-                {def?.description && (
-                  <p className="text-xs text-muted-foreground">{def.description}</p>
-                )}
-              </div>
+      {normalRows.map(renderRow)}
+      {advancedRows.length > 0 && (
+        <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced} className="border border-border rounded-md">
+          <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 hover:bg-muted/40 transition-colors">
+            <SlidersHorizontal className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide flex-1 text-left">
+              {t("device.advanced")}
+            </span>
+            <ChevronDown className={`w-4 h-4 text-muted-foreground shrink-0 transition-transform ${showAdvanced ? "rotate-180" : ""}`} />
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="px-3 pb-3 pt-1 space-y-3">
+              {advancedRows.map(renderRow)}
             </div>
-            <div className="flex items-center gap-2">
-              {def?.type === "enum" && def.options?.length ? (
-                <Select value={row.value} onValueChange={(v) => handleChange(i, v)}>
-                  <SelectTrigger className="h-9 flex-1 text-sm">
-                    {/* A device can hold a value this build doesn't know — an
-                        older or newer firmware, or a hand-edited SETTINGS.json.
-                        Show it verbatim rather than an empty box. */}
-                    <SelectValue placeholder={row.value || undefined} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {def.options.map((o) => (
-                      <SelectItem key={o.value} value={o.value}>
-                        {o.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Input
-                  value={row.value}
-                  onChange={(e) => handleChange(i, e.target.value)}
-                  className="h-9 text-sm flex-1"
-                  type={def?.type === "number" ? "number" : "text"}
-                  maxLength={def?.maxLength}
-                />
-              )}
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-9 w-9 shrink-0"
-                disabled={!isDirty || !!row.error || row.saving}
-                onClick={() => handleSave(i)}
-              >
-                {row.saving ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  <Save className="w-4 h-4" />
-                )}
-              </Button>
-            </div>
-            {row.key === DEVICE_NAME_KEY && profileName && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
-                onClick={() => handleChange(i, profileName.slice(0, def?.maxLength ?? profileName.length))}
-              >
-                <UserRound className="w-3.5 h-3.5" />
-                {t("device.useProfileName")}
-              </Button>
-            )}
-            {row.error && (
-              <p className="text-xs text-destructive">{row.error}</p>
-            )}
-          </div>
-        );
-      })}
+          </CollapsibleContent>
+        </Collapsible>
+      )}
       {rows.length > 0 && (
         <div className="pt-4 border-t border-border">
           <Button

--- a/src/lib/deviceSettingsSchema.test.ts
+++ b/src/lib/deviceSettingsSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   DEVICE_SETTINGS_SCHEMA,
   getSettingDef,
+  isAdvancedSetting,
   validateSettingValue,
   settingDisplayValue,
 } from "./deviceSettingsSchema";
@@ -211,6 +212,36 @@ describe("enum schema entries", () => {
       const values = def.options!.map((o) => o.value);
       expect(new Set(values).size, `${def.key} has duplicate values`).toBe(values.length);
     }
+  });
+});
+
+// ─── isAdvancedSetting ────────────────────────────────────────────────────────
+
+describe("isAdvancedSetting", () => {
+  it("flags detection thresholds, debug pages and the legacy-CSV switch", () => {
+    expect(isAdvancedSetting("lap_detection_distance")).toBe(true);
+    expect(isAdvancedSetting("waypoint_detection_distance")).toBe(true);
+    expect(isAdvancedSetting("waypoint_speed")).toBe(true);
+    expect(isAdvancedSetting("debug_pages")).toBe(true);
+    expect(isAdvancedSetting("use_legacy_csv")).toBe(true);
+  });
+
+  it("keeps everyday settings in the normal list", () => {
+    expect(isAdvancedSetting("device_name")).toBe(false);
+    expect(isAdvancedSetting("bluetooth_name")).toBe(false);
+    expect(isAdvancedSetting("bluetooth_pin")).toBe(false);
+    expect(isAdvancedSetting("driver_name")).toBe(false);
+    expect(isAdvancedSetting("race_mode")).toBe(false);
+    expect(isAdvancedSetting("display_invert")).toBe(false);
+    expect(isAdvancedSetting("spark_mode")).toBe(false);
+    expect(isAdvancedSetting("cylinder_count")).toBe(false);
+  });
+
+  // A newer firmware can send keys this build has no schema for. The default is
+  // "normal unless flagged", so an unknown key must stay visible in the main
+  // list, not vanish into a collapsed section.
+  it("treats unknown keys as normal", () => {
+    expect(isAdvancedSetting("some_future_setting")).toBe(false);
   });
 });
 

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -22,6 +22,12 @@ export interface DeviceSettingDef {
    */
   options?: DeviceSettingOption[];
   description?: string;
+  /**
+   * Tucks the setting under the collapsed "Advanced" section of the Device
+   * Settings tab (detection thresholds, debug toggles, legacy switches).
+   * Absent = normal: a new setting shows in the main list unless flagged.
+   */
+  advanced?: boolean;
 }
 
 export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
@@ -62,6 +68,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     min: 1,
     max: 50,
     description: 'Start/finish crossing threshold in meters',
+    advanced: true,
   },
   {
     key: 'waypoint_detection_distance',
@@ -70,6 +77,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     min: 5,
     max: 100,
     description: 'Waypoint / course detector proximity zone in meters',
+    advanced: true,
   },
   {
     key: 'waypoint_speed',
@@ -78,6 +86,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     min: 5,
     max: 100,
     description: 'Minimum speed (MPH) to activate lap/waypoint detection',
+    advanced: true,
   },
   {
     key: 'use_legacy_csv',
@@ -86,6 +95,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     min: 0,
     max: 1,
     description: 'Save as .dove instead of .dovex (0 = off, 1 = on)',
+    advanced: true,
   },
   {
     // Exists on the device already, but was never in this schema — so it showed
@@ -120,6 +130,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     ],
     description:
       'The two diagnostic pages at the front of the race rotation. Hidden is the factory default — show them for development or tuning',
+    advanced: true,
   },
   {
     key: 'spark_mode',
@@ -146,6 +157,15 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
 /** Look up schema definition for a key, or return null for unknown keys */
 export function getSettingDef(key: string): DeviceSettingDef | null {
   return DEVICE_SETTINGS_SCHEMA.find((s) => s.key === key) ?? null;
+}
+
+/**
+ * Whether a setting belongs under the collapsed "Advanced" section. Unknown
+ * keys (newer firmware than this build) count as normal — same default as an
+ * unflagged schema entry — so they stay visible rather than tucked away.
+ */
+export function isAdvancedSetting(key: string): boolean {
+  return getSettingDef(key)?.advanced === true;
 }
 
 /** Validate a value against its schema definition. Returns error string or null if valid. */

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Anmelden",
     "signOut": "Abmelden",
     "profile": "Profil",
     "sponsor": "Unterstützen",

--- a/src/locales/de/drawer.json
+++ b/src/locales/de/drawer.json
@@ -266,6 +266,7 @@
     "readingSettings": "Einstellungen werden gelesen…",
     "retry": "Erneut versuchen",
     "noSettings": "Keine Einstellungen auf dem Gerät gefunden.",
+    "advanced": "Erweitert",
     "useProfileName": "Profilnamen verwenden",
     "reset": "Einstellungen auf Standard zurücksetzen",
     "resetConfirm": "Zurücksetzen bestätigen — Gerät startet neu",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,7 +1,6 @@
 {
   "appName": "LapWing",
   "actions": {
-    "signIn": "Sign in",
     "signOut": "Sign out",
     "profile": "Profile",
     "backToHome": "Back to home",

--- a/src/locales/en/drawer.json
+++ b/src/locales/en/drawer.json
@@ -265,6 +265,7 @@
     "readingSettings": "Reading settings…",
     "retry": "Retry",
     "noSettings": "No settings found on device.",
+    "advanced": "Advanced",
     "useProfileName": "Use profile name",
     "reset": "Reset Settings to Default",
     "resetConfirm": "Confirm Reset — Device Will Reboot",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Iniciar sesión",
     "signOut": "Cerrar sesión",
     "profile": "Perfil",
     "sponsor": "Patrocinar",

--- a/src/locales/es/drawer.json
+++ b/src/locales/es/drawer.json
@@ -266,6 +266,7 @@
     "readingSettings": "Leyendo ajustes…",
     "retry": "Reintentar",
     "noSettings": "No se encontraron ajustes en el dispositivo.",
+    "advanced": "Avanzado",
     "useProfileName": "Usar nombre de perfil",
     "reset": "Restablecer ajustes predeterminados",
     "resetConfirm": "Confirmar restablecimiento: el dispositivo se reiniciará",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Se connecter",
     "signOut": "Se déconnecter",
     "profile": "Profil",
     "sponsor": "Soutenir",

--- a/src/locales/fr/drawer.json
+++ b/src/locales/fr/drawer.json
@@ -266,6 +266,7 @@
     "readingSettings": "Lecture des réglages…",
     "retry": "Réessayer",
     "noSettings": "Aucun réglage trouvé sur l'appareil.",
+    "advanced": "Avancé",
     "useProfileName": "Utiliser le nom du profil",
     "reset": "Réinitialiser les réglages par défaut",
     "resetConfirm": "Confirmer la réinitialisation — l'appareil va redémarrer",

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Accedi",
     "signOut": "Esci",
     "profile": "Profilo",
     "sponsor": "Sostieni",

--- a/src/locales/it/drawer.json
+++ b/src/locales/it/drawer.json
@@ -266,6 +266,7 @@
     "readingSettings": "Lettura impostazioni…",
     "retry": "Riprova",
     "noSettings": "Nessuna impostazione trovata sul dispositivo.",
+    "advanced": "Avanzate",
     "useProfileName": "Usa il nome del profilo",
     "reset": "Ripristina impostazioni predefinite",
     "resetConfirm": "Conferma ripristino — il dispositivo si riavvierà",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "ログイン",
     "signOut": "ログアウト",
     "profile": "プロフィール",
     "sponsor": "支援する",

--- a/src/locales/ja/drawer.json
+++ b/src/locales/ja/drawer.json
@@ -266,6 +266,7 @@
     "readingSettings": "設定を読み込み中…",
     "retry": "再試行",
     "noSettings": "デバイスに設定が見つかりません。",
+    "advanced": "詳細設定",
     "useProfileName": "プロフィール名を使う",
     "reset": "設定を既定値に戻す",
     "resetConfirm": "リセットを確定 — デバイスが再起動します",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -2,7 +2,6 @@
   "_machine": true,
   "appName": "LapWing",
   "actions": {
-    "signIn": "Entrar",
     "signOut": "Sair",
     "profile": "Perfil",
     "sponsor": "Apoiar",

--- a/src/locales/pt-BR/drawer.json
+++ b/src/locales/pt-BR/drawer.json
@@ -266,6 +266,7 @@
     "readingSettings": "Lendo configurações…",
     "retry": "Tentar novamente",
     "noSettings": "Nenhuma configuração encontrada no dispositivo.",
+    "advanced": "Avançado",
     "useProfileName": "Usar nome do perfil",
     "reset": "Restaurar configurações padrão",
     "resetConfirm": "Confirmar restauração — o dispositivo vai reiniciar",


### PR DESCRIPTION
## v4.0.1 — 2026-08-15

A small quality-of-life patch on top of 4.0.0. No new capabilities, no data or format changes — two bits of UI polish in the header and the garage.

### Changed
- **One Profile button** — the header's Sign-in button is gone: everyone gets
  the same Profile button, which opens the garage's Profile tab where signing
  in (or creating an account) is offered instead of forced. The side panel is
  now titled **Garage** throughout, no matter which tab is open.
- **Tidier Device Settings** — the garage's device settings panel now tucks
  its expert knobs (lap/waypoint detection distances, waypoint speed, debug
  pages, the legacy CSV switch) under a collapsed **Advanced** section, so
  the everyday settings — names, display, RPM setup — stand alone up top.
  New settings appear in the main list unless deliberately marked advanced.

**Full changelog:** https://github.com/TheAngryRaven/DovesDataViewer/compare/v4.0.0...main

---
_Generated by [Claude Code](https://claude.ai/code/session_014KJWfEZ24zNkkedw6MQ634)_