### PR TITLE
feat(native): route sprint tracks through the native IPC bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
+## [Unreleased]
+
+### Added
+- **Sprint tracks in the native app** — the Android/native Device tab can now
+  list, download, upload and delete **sprint** courses, not just circuit ones.
+  It previously showed an empty sprint list and said the transport couldn't
+  reach that folder, because the native bridge had no `TS*` verbs; LapWing now
+  implements them, so the seam forwards the track kind straight through and
+  the native path reaches parity with Web Bluetooth.
+
 ## [4.0.1] - 2026-08-15
 
 ### Changed

--- a/docs/plans/0015-sprint-mode.md
+++ b/docs/plans/0015-sprint-mode.md
@@ -1,8 +1,9 @@
 # Sprint Mode (Autocross / Point-to-Point) — DataViewer Side
 
-> Status: **DONE** (bar the end-of-project Android IPC follow-up below) — the
-> logger and the timing library already shipped sprint support; this plan was
-> the app catching up. Phase 3 of the cross-repo effort recorded in
+> Status: **DONE** — including the end-of-project Android IPC follow-up, now
+> that LapWing implements the `TS*` verbs. The logger and the timing library
+> already shipped sprint support; this plan was the app catching up. Phase 3 of
+> the cross-repo effort recorded in
 > `DovesDataLogger/docs/plans/0002-sprint-mode.md`.
 
 ## Why this exists
@@ -165,18 +166,21 @@ testable (Golden Rule 3).
   implementation reports no sprint tracks until it is updated, which is honest
   (it genuinely cannot fetch them) rather than a silent failure.
 
-### Android IPC — end-of-project follow-up
+### ~~Android IPC — end-of-project follow-up~~ — **Done.**
 
-When the native app ships, `dovesloggerConnection.ts` and its Android bridge
-need the `TS*` verbs to reach parity with Web Bluetooth:
+LapWing now implements the `TS*` verbs behind its `logger_*_track` commands
+(`TrackKind` + a single opcode table in `loggers/doveslogger/tracks.rs`,
+mirroring `trackOpcodes.ts`), so the seam reaches parity with Web Bluetooth:
 
 - `listTracks(kind)` / `getTrack(name, kind)` / `putTrack(name, data, kind)` /
-  `deleteTrack(name, kind)` must route to `TSLIST` / `TSGET:` / `TSPUT:` /
-  `TSDEL:` when `kind === 'sprint'`.
-- Until then the native path returns an empty sprint list. **This is deliberate
-  and must be revisited here, not patched over at a call site** — the seam is
-  the single place the two transports are supposed to agree.
-- Sequenced at the END of this plan on purpose: it is gated on another
+  `deleteTrack(name, kind)` now forward `kind` straight through to the bridge,
+  which routes to `TSLIST` / `TSGET:` / `TSPUT:` / `TSDEL:` for `'sprint'`.
+  `supportsSprintTracks` is `true`.
+- Fixed **in the seam**, as this section required — not patched at a call site.
+  `dovesloggerConnection.ts` is still the single place the two transports agree.
+- The `kind` argument is optional on LapWing's side of the IPC (it defaults to
+  circuit), but this repo always sends it explicitly.
+- Sequenced at the END of this plan on purpose: it was gated on another
   product's release, not on anything in this repo, and blocking sprint mode on
   it would have stalled work that is otherwise finished.
 - ~~**PR 5 — reading runs back.**~~ **Done.** (Was PR 4; renumbered when the

--- a/src/lib/loggers/doveslogger/dovesloggerConnection.test.ts
+++ b/src/lib/loggers/doveslogger/dovesloggerConnection.test.ts
@@ -78,23 +78,41 @@ describe("createDovesloggerConnection", () => {
 describe("native device details — sprint tracks", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("declares that it cannot reach the sprint folder", () => {
-    // The tab reads this to say so plainly, instead of rendering an empty
-    // sprint list that looks like "no sprint tracks on the device".
-    expect(createDovesloggerConnection(info()).details!.supportsSprintTracks).toBe(false);
+  it("declares that it can reach the sprint folder", () => {
+    // The native bridge implements the TS* verbs, so the tab shows the sprint
+    // list for real rather than explaining that this transport can't fetch it.
+    expect(createDovesloggerConnection(info()).details!.supportsSprintTracks).toBe(true);
   });
 
-  it("returns an empty sprint list without touching the bridge", async () => {
+  it("lists sprint tracks through the bridge", async () => {
+    vi.mocked(ipc.loggerListTracks).mockResolvedValue(["autocross.json"]);
     const details = createDovesloggerConnection(info()).details!;
-    await expect(details.listTracks("sprint")).resolves.toEqual([]);
-    expect(ipc.loggerListTracks).not.toHaveBeenCalled();
+    await expect(details.listTracks("sprint")).resolves.toEqual(["autocross.json"]);
+    expect(ipc.loggerListTracks).toHaveBeenCalledWith("sprint");
   });
 
-  it("still lists circuit tracks through the bridge", async () => {
+  it("lists circuit tracks through the bridge", async () => {
     vi.mocked(ipc.loggerListTracks).mockResolvedValue(["OKC.json"]);
     const details = createDovesloggerConnection(info()).details!;
     await expect(details.listTracks("circuit")).resolves.toEqual(["OKC.json"]);
     await expect(details.listTracks()).resolves.toEqual(["OKC.json"]);
     expect(ipc.loggerListTracks).toHaveBeenCalledTimes(2);
+  });
+
+  // Every verb has to carry the kind, not just the listing: a sprint upload
+  // that silently landed in /TRACKS would be the worst kind of wrong.
+  it("forwards the kind on get / put / delete", async () => {
+    const details = createDovesloggerConnection(info()).details!;
+    const data = new Uint8Array([1, 2]);
+
+    vi.mocked(ipc.loggerDownloadTrack).mockResolvedValue(data);
+    await details.getTrack("autocross.json", "sprint");
+    expect(ipc.loggerDownloadTrack).toHaveBeenCalledWith("autocross.json", "sprint");
+
+    await details.putTrack("autocross.json", data, "sprint");
+    expect(ipc.loggerUploadTrack).toHaveBeenCalledWith("autocross.json", data, "sprint");
+
+    await details.deleteTrack("autocross.json", "sprint");
+    expect(ipc.loggerDeleteTrack).toHaveBeenCalledWith("autocross.json", "sprint");
   });
 });

--- a/src/lib/loggers/doveslogger/dovesloggerConnection.ts
+++ b/src/lib/loggers/doveslogger/dovesloggerConnection.ts
@@ -38,20 +38,16 @@ export function createNativeDeviceDetails(): DeviceDetails {
     listSettings: () => loggerListSettings(),
     setSetting: (key, value) => loggerSetSetting(key, value),
     resetSettings: () => loggerResetSettings(),
-    // Sprint tracks live in a separate folder reached by the TS* BLE verbs,
-    // which the native bridge does not implement yet. Report nothing rather
-    // than throwing: it genuinely cannot fetch them, and the tab says so
-    // explicitly via supportsSprintTracks rather than showing an empty list
-    // that reads as "no sprint tracks on the device".
-    //
-    // Scheduled for the end of plan 0015 — it is gated on the native app's
-    // release, not on anything in this repo. See
-    // docs/plans/0015-sprint-mode.md, "Android IPC — end-of-project follow-up".
-    listTracks: (kind) => (kind === 'sprint' ? Promise.resolve([]) : loggerListTracks()),
-    getTrack: (name) => loggerDownloadTrack(name),
-    putTrack: (name, data) => loggerUploadTrack(name, data),
-    deleteTrack: (name) => loggerDeleteTrack(name),
-    supportsSprintTracks: false,
+    // Both track folders route through the native bridge: `kind` picks the T*
+    // (circuit, /TRACKS) or TS* (sprint, /TRACKS/SPRINT) BLE verbs backend-side.
+    // This closes plan 0015's "Android IPC — end-of-project follow-up", which
+    // had this adapter reporting an empty sprint list while the native app
+    // lacked the TS* verbs.
+    listTracks: (kind) => loggerListTracks(kind),
+    getTrack: (name, kind) => loggerDownloadTrack(name, kind),
+    putTrack: (name, data, kind) => loggerUploadTrack(name, data, kind),
+    deleteTrack: (name, kind) => loggerDeleteTrack(name, kind),
+    supportsSprintTracks: true,
   };
 }
 

--- a/src/lib/loggers/doveslogger/ipc.test.ts
+++ b/src/lib/loggers/doveslogger/ipc.test.ts
@@ -123,10 +123,10 @@ describe("doveslogger device-tab ipc", () => {
     expect(invoke).toHaveBeenCalledWith("logger_reset_settings");
   });
 
-  it("lists tracks", async () => {
+  it("lists tracks, defaulting to the circuit folder", async () => {
     invoke.mockResolvedValue(["t.json"]);
     await expect(loggerListTracks()).resolves.toEqual(["t.json"]);
-    expect(invoke).toHaveBeenCalledWith("logger_list_tracks");
+    expect(invoke).toHaveBeenCalledWith("logger_list_tracks", { kind: "circuit" });
   });
 
   it("downloads a track through a progress channel and returns bytes", async () => {
@@ -134,6 +134,7 @@ describe("doveslogger device-tab ipc", () => {
     await expect(loggerDownloadTrack("t.json")).resolves.toEqual(new Uint8Array([123, 125]));
     expect(invoke).toHaveBeenCalledWith("logger_download_track", {
       name: "t.json",
+      kind: "circuit",
       onProgress: expect.any(ChannelMock),
     });
   });
@@ -142,12 +143,50 @@ describe("doveslogger device-tab ipc", () => {
     invoke.mockResolvedValue(undefined);
     const data = new Uint8Array([1, 2]);
     await loggerUploadTrack("t.json", data);
-    expect(invoke).toHaveBeenCalledWith("logger_upload_track", { name: "t.json", data });
+    expect(invoke).toHaveBeenCalledWith("logger_upload_track", {
+      name: "t.json",
+      data,
+      kind: "circuit",
+    });
   });
 
   it("deletes a track", async () => {
     invoke.mockResolvedValue(undefined);
     await loggerDeleteTrack("t.json");
-    expect(invoke).toHaveBeenCalledWith("logger_delete_track", { name: "t.json" });
+    expect(invoke).toHaveBeenCalledWith("logger_delete_track", {
+      name: "t.json",
+      kind: "circuit",
+    });
+  });
+
+  // The sprint folder is reached by the backend's TS* verbs, selected by this
+  // `kind` — never by a path in the filename (the firmware rejects `/` and `..`).
+  it("forwards the sprint kind on every track command", async () => {
+    invoke.mockResolvedValue(["a.json"]);
+    await loggerListTracks("sprint");
+    expect(invoke).toHaveBeenCalledWith("logger_list_tracks", { kind: "sprint" });
+
+    invoke.mockResolvedValue(new Uint8Array([1]).buffer);
+    await loggerDownloadTrack("a.json", "sprint");
+    expect(invoke).toHaveBeenCalledWith("logger_download_track", {
+      name: "a.json",
+      kind: "sprint",
+      onProgress: expect.any(ChannelMock),
+    });
+
+    invoke.mockResolvedValue(undefined);
+    const data = new Uint8Array([1, 2]);
+    await loggerUploadTrack("a.json", data, "sprint");
+    expect(invoke).toHaveBeenCalledWith("logger_upload_track", {
+      name: "a.json",
+      data,
+      kind: "sprint",
+    });
+
+    await loggerDeleteTrack("a.json", "sprint");
+    expect(invoke).toHaveBeenCalledWith("logger_delete_track", {
+      name: "a.json",
+      kind: "sprint",
+    });
   });
 });

--- a/src/lib/loggers/doveslogger/ipc.ts
+++ b/src/lib/loggers/doveslogger/ipc.ts
@@ -17,6 +17,7 @@
  */
 
 import { api, type DownloadProgress, type LoggerDeviceInfo } from "../native/ipc";
+import type { TrackKind } from "@/lib/ble/trackOpcodes";
 
 // Re-export the shared native surface so DovesLogger callers import it all from here.
 export {
@@ -121,32 +122,53 @@ export async function loggerResetSettings(): Promise<void> {
   await invoke("logger_reset_settings");
 }
 
-/** List the track files stored on the device. */
-export async function loggerListTracks(): Promise<string[]> {
+// The four track commands take a `kind` selecting the on-device folder:
+// "circuit" (/TRACKS) or "sprint" (/TRACKS/SPRINT). The backend routes to the
+// T* or TS* BLE verbs accordingly — the folder is never encoded in the
+// filename, because the firmware's filename validator rejects `/` and `..`.
+//
+// `kind` is optional on the wire (the backend defaults it to circuit), but we
+// always send it: an explicit value costs nothing and makes the intent legible
+// in the IPC log.
+
+/** List the track files stored on the device, in the folder `kind` selects. */
+export async function loggerListTracks(kind: TrackKind = "circuit"): Promise<string[]> {
   const { invoke } = await api();
-  return invoke<string[]>("logger_list_tracks");
+  return invoke<string[]>("logger_list_tracks", { kind });
 }
 
 /** Download one track file, streaming progress like `loggerDownloadFile`. */
 export async function loggerDownloadTrack(
   name: string,
+  kind: TrackKind = "circuit",
   onProgress?: (p: DownloadProgress) => void,
 ): Promise<Uint8Array> {
   const { invoke, Channel } = await api();
   const channel = new Channel<DownloadProgress>();
   channel.onmessage = onProgress ?? (() => {});
-  const buf = await invoke<ArrayBuffer>("logger_download_track", { name, onProgress: channel });
+  const buf = await invoke<ArrayBuffer>("logger_download_track", {
+    name,
+    kind,
+    onProgress: channel,
+  });
   return new Uint8Array(buf);
 }
 
 /** Upload a track file (small JSON documents — plain byte array over IPC). */
-export async function loggerUploadTrack(name: string, data: Uint8Array): Promise<void> {
+export async function loggerUploadTrack(
+  name: string,
+  data: Uint8Array,
+  kind: TrackKind = "circuit",
+): Promise<void> {
   const { invoke } = await api();
-  await invoke("logger_upload_track", { name, data });
+  await invoke("logger_upload_track", { name, data, kind });
 }
 
-/** Delete a track file by name. */
-export async function loggerDeleteTrack(name: string): Promise<void> {
+/** Delete a track file by name from the folder `kind` selects. */
+export async function loggerDeleteTrack(
+  name: string,
+  kind: TrackKind = "circuit",
+): Promise<void> {
   const { invoke } = await api();
-  await invoke("logger_delete_track", { name });
+  await invoke("logger_delete_track", { name, kind });
 }

--- a/src/lib/loggers/types.ts
+++ b/src/lib/loggers/types.ts
@@ -67,10 +67,11 @@ export interface DeviceDetails {
    * (`/TRACKS/SPRINT`). Omitted means circuit, which is what every caller
    * meant before sprint mode existed.
    *
-   * A transport that cannot reach the sprint folder returns an empty list for
-   * `'sprint'` rather than throwing — see `docs/plans/0015-sprint-mode.md`
-   * ("Android IPC — end-of-project follow-up"). Reporting nothing is honest:
-   * it genuinely cannot fetch them.
+   * Both shipped transports reach both folders: Web Bluetooth via `bleDetails`
+   * and the native bridge via the `logger_*_track` IPC. A transport that
+   * cannot reach the sprint folder must return an empty list for `'sprint'`
+   * rather than throwing, and flag `supportsSprintTracks: false` so the tab
+   * says so plainly — reporting nothing is honest, but only if it's labelled.
    */
   listTracks(kind?: TrackKind): Promise<string[]>;
   /** Download one track file from the folder `kind` selects. */


### PR DESCRIPTION
## Summary

Closes plan 0015's **"Android IPC — end-of-project follow-up"**.

That section deferred the native side of sprint mode because it was gated on LapWing's release, and left `createNativeDeviceDetails()` reporting `supportsSprintTracks: false` with an empty sprint list — honest, but a dead end for anyone on the native app. LapWing now implements the `TS*` verbs behind its `logger_*_track` commands (a `TrackKind` plus a single opcode table in `loggers/doveslogger/tracks.rs`, mirroring `trackOpcodes.ts` here), so the bridge can reach `/TRACKS/SPRINT`.

- **`ipc.ts`** — the four track commands take a `kind` and put it on the wire. It's *optional* on LapWing's side (defaulting to circuit, so a build of this app predating sprint mode keeps working), but we always send it explicitly: it costs nothing and makes the IPC log legible.
- **`dovesloggerConnection.ts`** — the seam forwards `kind` on all four verbs and flips `supportsSprintTracks` to `true`. Fixed **in the seam**, as 0015 required, rather than patched at a call site — this is still the one place the two transports are supposed to agree.
- **`types.ts`** — the `listTracks` doc no longer points at the deferred follow-up. `supportsSprintTracks` **stays** in the interface: it's generic, and `deviceSyncPlan` / `deviceSyncFetch` still skip sprint entries for a transport that lacks the folder.

Tests cover the kind reaching the wire on all four commands, and the seam forwarding it on get/put/delete — not just the listing. A sprint upload that silently landed in `/TRACKS` would be the worst failure mode here, so it's asserted directly.

## Related Issues

Companion PR: **TheAngryRaven/LapWing#33**, which adds the `TS*` verbs this depends on.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes — 2852 tests, 194 files
- [x] `npm run build` succeeds
- [x] Feature works **offline** (no new required network calls, except weather / map tiles / admin)
- [x] Docs updated where relevant (`README.md`, `CLAUDE.md`, Credits, `CHANGELOG.md`) — plus `docs/plans/0015-sprint-mode.md`, whose follow-up section this closes
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table — n/a

## Notes for Reviewers

**Merge ordering matters here.** This PR makes the app send `kind: "sprint"`. A native shell without LapWing#33 would ignore the unknown argument and operate on the **circuit** folder instead — so `listTracks("sprint")` would return circuit tracks, and worse, `putTrack(…, "sprint")` would write a sprint course into `/TRACKS`. That's a silent wrong-folder write, not a clean failure.

I checked before relying on it: **LapWing has no releases and no tags** — it has never shipped — so there is no native build in the wild that this can desync from, which matches 0015's own note that "the native app is not live yet". The two PRs just need to land before LapWing's first release, and shouldn't be split across it.

If you'd rather not depend on that ordering, the alternative is a capability probe or a version handshake over IPC before enabling sprint. I didn't build one, since the risk window is currently zero and it'd be real complexity for a case that can't happen yet — but it's the natural hedge if native release timing gets less certain.

One thing I deliberately did **not** change: `supportsSprintTracks` is still on the `DeviceDetails` interface even though both shipped transports now return `true`. `deviceSyncPlan` and `deviceSyncFetch` genuinely branch on it, and a future transport could lack the folder — removing it would be a bigger refactor than this PR warrants.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdbzoPPBA6kaFfhTKgZEzg)_