### PR TITLE
device settings: Cylinders is the engine's count, not the pickup's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implements them, so the seam forwards the track kind straight through and
   the native path reaches parity with Web Bluetooth.
 
+### Changed
+- **The Cylinders setting means your engine's cylinders again.** It was
+  labelled "cylinders the pickup SEES", which asked a V8 owner to type `1` in a
+  field called Cylinders — and anyone who read it literally and typed `8` got an
+  eighth of their real RPM, because the logger divided by it. The next firmware
+  drops that division: the pickup is one clamp on one plug wire, so **Spark
+  Mode** alone converts pulses to RPM. Enter what the engine has. Above one
+  cylinder the field now shows a notice that crank RPM is *inferred* from that
+  one wire's ignition pulses — between firings it is an estimate, and a cylinder
+  that stops firing reads as a stopped engine, which is normal for any clamp-on
+  tach. Needs the matching firmware; on older firmware the divider is still
+  there.
+- **Spark Mode says what it is for** — it is now labelled as the only setting
+  that scales RPM, and its options name the ignition types ("Wasted spark /
+  2-stroke", "Single fire / magneto") rather than just the ratio.
+
 ### Fixed
 - **No "which logger?" prompt when one is already connected** — pressing
   *Download from logger* while the garage holds a live connection now opens that

--- a/src/components/drawer/DeviceSettingsTab.tsx
+++ b/src/components/drawer/DeviceSettingsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Save, AlertCircle, RefreshCw, RotateCcw, UserRound, ChevronDown, SlidersHorizontal, Lightbulb } from "lucide-react";
+import { Loader2, Save, AlertCircle, AlertTriangle, RefreshCw, RotateCcw, UserRound, ChevronDown, SlidersHorizontal, Lightbulb } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -18,6 +18,7 @@ import {
   DEVICE_SETTINGS_SCHEMA,
   getSettingDef,
   groupSettingRows,
+  settingNotice,
   validateSettingValue,
   type DeviceSettingGroupId,
 } from "@/lib/deviceSettingsSchema";
@@ -191,6 +192,9 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
   const renderRow = (row: SettingRow) => {
     const def = getSettingDef(row.key);
     const isDirty = row.value !== row.originalValue;
+    // Follows the edited value, not the saved one, so the consequence of
+    // typing 8 is visible before the save rather than after it.
+    const notice = settingNotice(row.key, row.value);
     return (
       <div key={row.key} className="space-y-1">
         <div className="flex items-center gap-2">
@@ -261,6 +265,16 @@ export function DeviceSettingsTab({ details, bleConnection, onResetComplete }: D
         )}
         {row.error && (
           <p className="text-xs text-destructive">{row.error}</p>
+        )}
+        {/* Advisory, not a rejection: the value is fine, but it changes what
+            the reading MEANS (see settingNotice). Rendered under the field so
+            it lands next to the number that caused it, and only while that
+            value is set. */}
+        {!row.error && notice && (
+          <p className="flex items-start gap-1.5 text-xs text-warning">
+            <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+            <span>{notice}</span>
+          </p>
         )}
       </div>
     );

--- a/src/lib/deviceSettingsSchema.test.ts
+++ b/src/lib/deviceSettingsSchema.test.ts
@@ -8,6 +8,7 @@ import {
   isAdvancedSetting,
   validateSettingValue,
   settingDisplayValue,
+  settingNotice,
 } from "./deviceSettingsSchema";
 
 // ─── schema shape ─────────────────────────────────────────────────────────────
@@ -308,14 +309,50 @@ describe("cylinder_count", () => {
   it("accepts a plausible cylinder count", () => {
     expect(validateSettingValue("cylinder_count", "1")).toBeNull();
     expect(validateSettingValue("cylinder_count", "2")).toBeNull();
+    // A V8 is entered as a V8 (logger plan 0012). Before it, the field meant
+    // "cylinders the pickup sees" and this user was told to type 1.
+    expect(validateSettingValue("cylinder_count", "8")).toBeNull();
   });
 
-  it("rejects zero — it would divide RPM by nothing", () => {
+  it("rejects zero — not a describable engine", () => {
     expect(validateSettingValue("cylinder_count", "0")).toBe("Minimum value is 1");
   });
 
   it("rejects a fractional count", () => {
     expect(validateSettingValue("cylinder_count", "1.5")).toBe("Must be a whole number");
+  });
+
+  it("no longer claims to scale RPM — spark_mode is the only thing that does", () => {
+    // Guards the copy, because the wrong copy here IS the bug: it is what sent
+    // a V8 owner to type 1 in a field labelled Cylinders.
+    expect(getSettingDef("cylinder_count")?.description).not.toMatch(/pickup sees/i);
+    expect(getSettingDef("spark_mode")?.description).toMatch(/only setting that scales RPM/i);
+  });
+});
+
+describe("settingNotice", () => {
+  it("warns that multi-cylinder RPM is inferred from ignition pulses", () => {
+    const notice = settingNotice("cylinder_count", "8");
+    expect(notice).toMatch(/8 cylinders/);
+    expect(notice).toMatch(/inferred/i);
+  });
+
+  it("says nothing on a single — its every firing IS the crank turning", () => {
+    expect(settingNotice("cylinder_count", "1")).toBeNull();
+  });
+
+  it("says nothing for a value it cannot read, rather than guessing", () => {
+    expect(settingNotice("cylinder_count", "")).toBeNull();
+    expect(settingNotice("cylinder_count", "  ")).toBeNull();
+    expect(settingNotice("cylinder_count", "eight")).toBeNull();
+    expect(settingNotice("cylinder_count", "2.5")).toBeNull();
+    expect(settingNotice("cylinder_count", "0")).toBeNull();
+  });
+
+  it("has nothing to say about any other key", () => {
+    expect(settingNotice("spark_mode", "single")).toBeNull();
+    expect(settingNotice("rev_limit", "15000")).toBeNull();
+    expect(settingNotice("not_a_real_key", "8")).toBeNull();
   });
 });
 

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -126,24 +126,32 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     description: "Inverting can be easier to read in direct sun. Normal is how the logger has always looked",
   },
   {
+    // The ONLY setting that scales RPM (logger plan 0012). The pickup is one
+    // clamp on one plug wire, so how often THAT plug fires is the whole
+    // conversion; the engine's cylinder count is not a term.
     key: 'spark_mode',
     label: 'Spark Mode',
     type: 'enum',
     options: [
-      { value: 'wasted', label: 'Wasted spark (1 per rev)' },
-      { value: 'single', label: 'Single fire (1 per 2 revs)' },
+      { value: 'wasted', label: 'Wasted spark / 2-stroke (1 per rev)' },
+      { value: 'single', label: 'Single fire / magneto (1 per 2 revs)' },
     ],
     description:
-      'How often the ignition fires per revolution. 2-stroke and wasted-spark 4-stroke fire every rev',
+      'How often the plug on the clamped wire fires. 2-stroke and wasted-spark 4-stroke fire every revolution; a traditional distributor or magneto fires every other one. This is the only setting that scales RPM',
   },
   {
+    // Descriptive since logger plan 0012 — it does NOT scale RPM. It used to,
+    // which meant a V8 entered honestly as 8 read an eighth of its real crank
+    // speed, and the fix at the time was to redefine the field as "cylinders
+    // the pickup sees" and tell V8 owners to enter 1. Enter what the engine
+    // has; the notice below says what that costs.
     key: 'cylinder_count',
     label: 'Cylinders',
     type: 'number',
     min: 1,
     max: 16,
     description:
-      'Cylinders the pickup SEES — a clamp around one plug wire of a twin sees one, so leave it at 1',
+      "The engine's actual cylinder count — enter 8 for a V8. It does not scale RPM: the pickup clamps one plug wire, so Spark Mode above does that on its own",
   },
   {
     // Minutes east of UTC. Presentation only: logged timestamps are UTC by
@@ -363,6 +371,27 @@ export function validateSettingValue(key: string, value: string): string | null 
   }
 
   return null;
+}
+
+/**
+ * A non-blocking notice about the value a setting currently holds — shown
+ * alongside the field, unlike `validateSettingValue`, which rejects.
+ *
+ * Today there is exactly one: above a single cylinder, crank RPM is INFERRED
+ * from one cylinder's ignition pulses, because there is one sense wire and one
+ * clamp. Between firings the reading is an assumption, and a cylinder that
+ * drops out reads as a stopped engine. That is how every clamp-on inductive
+ * tach behaves — known and accepted, not a fault — but a driver who sees it in
+ * a trace and hasn't been told will file it as one.
+ *
+ * Returns null when there is nothing to say (unknown key, unparseable value,
+ * or a value with no notice attached).
+ */
+export function settingNotice(key: string, value: string): string | null {
+  if (key !== 'cylinder_count') return null;
+  const num = Number(value);
+  if (value.trim() === '' || !Number.isInteger(num) || num <= 1) return null;
+  return `With ${num} cylinders, RPM is inferred from the ignition pulses on the one plug wire the pickup clamps. Between firings it is an estimate, and a cylinder that stops firing reads as a stopped engine — normal for any clamp-on tach.`;
 }
 
 /**


### PR DESCRIPTION
## Summary

The **Cylinders** field was described as *"Cylinders the pickup SEES — a clamp around one plug wire of a twin sees one, so leave it at 1"*.

That copy existed because the firmware computed `pulses_per_rev = cylinder_count × spark_factor`, which only holds for a clamp on a shared coil / distributor king lead. On the real hardware — one sense wire, one clamp, one plug wire — it **divided RPM by the count**. So a V8 owner who read the label literally and typed `8` got an eighth of their crank speed, and the documented workaround was to type `1` into a field labelled Cylinders.

The firmware drops the divider (logger plan 0012, companion PR below). This drops the mind game:

- **Cylinders** is the engine's actual count — enter 8 for a V8 — and says plainly that it does not scale RPM.
- **Spark Mode** is labelled as the only setting that does, and its options name the ignition types (`Wasted spark / 2-stroke`, `Single fire / magneto`) rather than just the ratio.
- New `settingNotice(key, value)`: a **non-blocking, value-dependent advisory** rendered next to a field, distinct from `validateSettingValue`'s rejection. Its one case today is `cylinder_count > 1` — crank RPM is *inferred* from one wire's ignition pulses, an estimate between firings, and a dropped cylinder reads as a stopped engine. Normal for any clamp-on tach, but a driver who meets that in a trace without being told files it as a bug. It follows the **edited** value, so typing `8` shows the consequence before the save, and it hides while the field is in an error state.

Styled with the `text-warning` semantic token per `CLAUDE.md`, not a raw amber.

Companion: **TheAngryRaven/DovesDataLogger#154** (`claude/tach-rpm-cylinder-config-c1e4ht` → `BETA`). They should land together — this PR's copy is only true once that firmware ships. On older firmware the divider is still there.

## Related Issues

<!-- none filed -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (196 files / 2894 tests; 8 new cases covering the notice and the corrected copy)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (no new network calls)
- [x] Docs updated where relevant (`CHANGELOG.md` under `[Unreleased]` → Changed)
- [ ] For a new parser: n/a

## Notes for Reviewers

- The notice text lives in the schema module, untranslated, matching the existing treatment of `description` on this surface (the tab's own comment: *"Section titles are chrome, so they translate; the schema's own labels don't"*). Say the word if you'd rather it move into `locales/en` and I'll thread it through i18next.
- A test now guards the copy itself (`description` must not say "pickup sees"), because the wrong copy here *is* the bug — it's what sent a V8 owner to type 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQvwnqBUZaJTPFkJZAFgKm)_