### PR TITLE
Release prep v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set to Off, Target RPM, Target Speed, GPS Status, Camera Sync, Last Lap, Last
   Sector or EGT, with a **help button** next to each that explains what every
   colour means. EGT is only offered on loggers built with SensorEgg support,
-  since elsewhere it just renders as a dark LED. Requires logger firmware 4.2.
+  since elsewhere it just renders as a dark LED. Requires logger firmware 4.1.0.
 - **Target Speed** — the ceiling for the LED bar on a session with no
   tachometer, so the strip does something useful before the first lap lands.
 - **Target Speed and EGT Alert follow your units** — both are stored on the
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Rev Limit is now Target RPM.** It always was the shift point — Over-rev
-  Limit is the real limit — and logger firmware 4.2 renames the underlying
+  Limit is the real limit — and logger firmware 4.1.0 renames the underlying
   setting to match. Loggers on older firmware still show a properly labelled
   Target RPM field, so nothing changes for them.
 - **The Cylinders setting means your engine's cylinders again.** It was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > from git history and grouped by theme rather than exhaustive per-commit
 > detail.
 
-## [Unreleased]
+## [4.1.0] - 2026-08-24
 
 ### Added
 - **Choose what each status LED shows** — the strip's two end LEDs can each be

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -324,8 +324,8 @@ and expect the link to drop. Timeout ~10 s. Errors as `SERR:<reason>`.
 | `utc_offset_min` | number | −840…840 | Minutes east of UTC, presentation only |
 | `led_status_left` | enum | `off` \| `rpm` \| `speed` \| `gps` \| `camera` \| `lap` \| `sector` \| `egt` | What the left status LED shows |
 | `led_status_right` | enum | same as above | What the right status LED shows |
-| `target_rpm` | number | 1000–20000 | Shift point: LED rev-bar top + rev flasher. Was `rev_limit` before logger 4.2 |
-| `rev_limit` | number | 1000–20000 | The pre-4.2 name for `target_rpm` |
+| `target_rpm` | number | 1000–20000 | Shift point: LED rev-bar top + rev flasher. Was `rev_limit` before logger 4.1.0 |
+| `rev_limit` | number | 1000–20000 | The pre-4.1.0 name for `target_rpm` |
 | `target_speed_mph` | number | 5–250 (**MPH**) | LED bar ceiling on a tach-less session + speed flasher |
 | `overrev_limit` | number | **0 or** 1000–20000 | Whole-strip red flash; 0 disables |
 | `temp1_alert_c` | number | 50–1200 (**°C**) | EGT alert threshold. SensorEgg firmware only |
@@ -339,7 +339,7 @@ Three things this table does not show but a client must handle:
   compiled-in default for anything out of band.
 - **Not every key exists on every device.** Feature flags differ by firmware
   channel: `temp1_alert_c` ships only where the SensorEgg probe is compiled in,
-  and a device on pre-4.2 firmware reports `rev_limit` instead of `target_rpm`.
+  and a device on pre-4.1.0 firmware reports `rev_limit` instead of `target_rpm`.
   Enumerate what `SLIST` actually returns rather than assuming this list.
 - **`overrev_limit`'s range has a hole in it.** 0 means disabled and the working
   band starts at 1000; the firmware discards anything between.

--- a/docs/plans/0020-led-status-modes.md
+++ b/docs/plans/0020-led-status-modes.md
@@ -41,7 +41,7 @@ Only three things travelled.
 
 `rev_limit` stays alongside `target_rpm` with the **same** `'Target RPM'`
 label. The tab renders only keys the device reports, so exactly one of the two
-ever appears — a 4.1.x logger sends `rev_limit`, a 4.2+ one `target_rpm` — and
+ever appears — a pre-4.1.0 logger sends `rev_limit`, a 4.1.0+ one `target_rpm` — and
 either way the field reads the same.
 
 **`requiresKey` on an option**, with `availableOptions()`. EGT is compiled out

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doves-dataviewer",
   "private": true,
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Open-source, offline-first motorsport telemetry viewer (Dove's DataViewer / LapWing).",
   "license": "GPL-3.0-or-later",
   "author": "TheAngryRaven",

--- a/src/lib/deviceSettingsSchema.ts
+++ b/src/lib/deviceSettingsSchema.ts
@@ -290,7 +290,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     group: 'leds',
   },
   {
-    // The pre-4.2 name for target_rpm. Kept so a logger on older firmware
+    // The pre-4.1.0 name for target_rpm. Kept so a logger on older firmware
     // still gets a labelled field rather than the raw-key fallback — the tab
     // renders only keys the device actually reports, so exactly one of the two
     // ever appears.
@@ -300,7 +300,7 @@ export const DEVICE_SETTINGS_SCHEMA: DeviceSettingDef[] = [
     min: 1000,
     max: 20000,
     description:
-      'Your shift point — the top of the LED rev bar, and where the strip starts flashing. Renamed to Target RPM on logger firmware 4.2 and later',
+      'Your shift point — the top of the LED rev bar, and where the strip starts flashing. Renamed to Target RPM on logger firmware 4.1.0 and later',
     group: 'leds',
   },
   {


### PR DESCRIPTION
## Summary

Prep for **v4.1.0**, mirroring what #407 did for v4.0.1. Two commits:

**1. `fix:` the status-LED settings ship in logger 4.1.0, not 4.2.** #417 was merged at its first commit, so this correction didn't come across. I'd written "firmware 4.2" throughout on the assumption plan 0012 would land in the logger's release-after-next — it ships in **4.1.0**, since the logger re-cut that version to absorb everything on its BETA. Left alone this ships wrong version numbers in user-facing text: a CHANGELOG line reading *"Requires logger firmware 4.2"*, the `rev_limit` description users read in the settings panel, and three rows of `docs/ble-protocol.md`.

**2. `chore(release):` the prep itself** — the same two files #407 touched, nothing else:
- `package.json` 4.0.1 → 4.1.0. The only version literal; the footer stamp is baked from it plus git in `vite.config.ts`.
- `CHANGELOG.md`: retitle the topmost `## [Unreleased]` to `## [4.1.0] - 2026-08-24`, per CLAUDE.md rule 4 (retitle and date, don't replace with a new block).

### Why MINOR

Four new capabilities since 4.0.1 — the timezone picker, the LED Strip section, the status-LED modes, and sprint tracks over the native bridge — plus the support track attachment. Nothing changes what the app reads or writes, so no MAJOR.

It pairs with **logger firmware 4.1.0**, which is what makes this a real minor release rather than housekeeping: that firmware reports `led_status_left`, `led_status_right`, `target_speed_mph` and the renamed `target_rpm`, and this is the release that knows what they are. Shipping the firmware without this app release is what produced the unlabelled-text-box report earlier today.

### Coach dependency

No flip needed. Both `BETA` and `main` already pin the published `@perchwerks/eye-in-the-sky` 0.5.0 in `package.json` and `vite.config.ts` rather than the `github:…#BETA` git dep — same situation as at v4.0.1, so the ⚠️ product-cut dance in CLAUDE.md doesn't apply and there's nothing to flip back afterwards.

## Type of Change

- [x] Other: release prep

## Checklist

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test:run` passes — 2925 tests / 197 files
- [x] `bun run build` succeeds
- [x] `bun install --frozen-lockfile` clean — no `bun.lock` drift from the version bump
- [x] Feature works offline — n/a
- [x] Docs updated — the CHANGELOG *is* the change

## Notes for Reviewers

After this merges, the promotion is a `BETA` → `main` PR titled "Release v4.1.0" (mirroring #408), then tag `v4.1.0` on `main`. I've verified `git merge-tree` reports **no conflicts** for that promotion — #416 cleared the divergence my earlier mis-targeted PR had created.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYeq2pZonbkPtEGsFUVbJE)_