### PR TITLE
plan 0024: native export bridge — hardware-speed overlay export in the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.2.0] - unreleased
 
+### Added
+- **Hardware-speed export in the Android app.** Inside the LapWing shell,
+  *Export with overlays* now hands the whole job to the phone's hardware:
+  the shell transcodes with the platform codecs and composites the overlays
+  on the GPU, with audio copied through untouched — seconds instead of
+  minutes for a typical clip (the in-app exporter previously stepped the
+  video one frame at a time and couldn't keep up). The overlay layers are
+  drawn by the same renderer as the preview, so the burned-in widgets match
+  what you scrubbed, in your language. Web and desktop exports are
+  unchanged, and an older shell (or a multi-file recording) falls back to
+  the previous exporter automatically. Requires a LapWing build with the
+  `video_export_*` pipeline (plan 0024).
+
 ### Changed
 - **One overlay renderer for preview and export.** The video-overlay preview
   and the export pipeline previously drew with two separate implementations

--- a/docs/plans/0024-native-export-bridge.md
+++ b/docs/plans/0024-native-export-bridge.md
@@ -1,0 +1,66 @@
+# Native export bridge — hardware-speed overlay video in the shell
+
+> Status: **LANDED** (bridge + renderer memoization). Companion: LapWing's
+> `tauri-plugin-videopipe` + `video_export_*` IPC (its `docs/video-pipeline.md`
+> is the contract; LapWing plan 0001, Phase 2).
+
+## Why this exists
+
+On-device, the WebView exporter was unusable: ~30 s of 1080p30 hadn't finished
+after a minute, because `videoExport.ts` seeks the `<video>` element once per
+output frame (double-rAF wait, 500 ms no-op-seek stalls, GOP re-decode per
+seek). In the native shell that entire job belongs on the platform's hardware
+codecs — the owner's call: the video pipeline *is* the point of the native app.
+
+## What landed
+
+### `src/lib/nativeVideoExport.ts`
+`startNativeVideoExport(source, exportCtx, options, callbacks)`:
+
+- resolves **null** when the native path can't run — not the shell
+  (`isNativeApp()` false), a shell without the commands / the desktop stub
+  (`unsupported:` sentinel), or a multi-chunk playlist (v1 limitation) — and
+  the caller falls back to the unchanged WebView exporter;
+- otherwise stages and drives the job: `video_export_begin` (same
+  quality→resolution/bitrate mapping as the web path), the source blob in
+  8 MB **raw-body** chunks, then transparent overlay layers rendered by the
+  plan-0023 unified renderer at **15 Hz** (telemetry cadence — overlays
+  change with data, not video frames), PNG-encoded at output resolution,
+  timestamps relative to the export start;
+- `video_export_run` streams transcode progress (staging owns the first 35 %
+  of the bar), `video_export_collect` returns the MP4 for the existing
+  save/share flows, `dispose` cleans up — also on error/cancel.
+
+`VideoPlayer.handleExport` tries the native path first and falls back
+seamlessly; web and desktop behavior is byte-identical to before.
+
+### Renderer memoization (`overlayCanvasRenderer.ts`)
+The per-frame invariant work found while profiling the export path is now
+cached per session via `WeakMap` on array identity (no invalidation, no
+leaks): per-source ranges (`memoRange`, validated against the pace/braking
+arrays for the special sources), map bounds (`memoMapBounds`), the pace bar's
+scale (`memoPaceMax`), and the digital widget no longer resolves its value
+twice per draw (`digitalBox`). This speeds up preview, the WebView exporter,
+and native layer generation alike — the draws' output is bit-identical.
+
+## Deliberate v1 limits
+
+- Multi-chunk (multi-file recording) exports keep the WebView path.
+- Layer cadence is a constant 15 Hz; the sector sweep (600 ms) gets ~9 layers,
+  which reads smoothly. A per-widget change-detection cadence is the next
+  lever if layer generation ever dominates long-session exports (an
+  OffscreenCanvas worker after that).
+- The one flagged cross-repo unknown: media3's clipped-stream presentation
+  times are assumed 0-based against our export-relative layer timestamps —
+  if a device shows a constant offset, the fix is one constant on the LapWing
+  side (`TimedBitmapOverlay`).
+
+## Verification
+
+- Unit: range memoization scans once per session arrays (counting source
+  fixture); all prior renderer tests unchanged — the memo layer is
+  behavior-invisible.
+- On-device (owner): export the same 30 s 1080p30 clip with a full overlay
+  layout — expect seconds, not minutes; check overlay parity against the
+  paused preview, audio presence, A/V sync at the trim boundaries, and that
+  cancelling mid-export leaves no stale job (next export begins clean).

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -19,6 +19,7 @@ import { OverlaySettingsPanel } from "@/components/video-overlays/OverlaySetting
 import { VideoExportDialog, ExportOptions } from "@/components/video-overlays/VideoExportDialog";
 import { OverlayCanvas } from "@/components/video-overlays/OverlayCanvas";
 import { startVideoExport, downloadBlob, ExportContext, ExportSource } from "@/lib/videoExport";
+import { startNativeVideoExport } from "@/lib/nativeVideoExport";
 import { computeBrakingGSeriesSG, gToBrakePercent } from "@/lib/brakingZones";
 import { saveSessionVideo, loadSessionVideo, deleteSessionVideo } from "@/lib/videoFileStorage";
 import { courseHasSectors } from "@/types/racing";
@@ -506,7 +507,7 @@ export const VideoPlayer = memo(function VideoPlayer({
       : [{ url: video.currentSrc || video.src, startOffsetSec: 0, durationSec: totalDuration }];
     const exportSource: ExportSource = { liveVideo: video, chunks, totalDuration };
 
-    startVideoExport(exportSource, exportContext, exportOptions, {
+    const exportCallbacks = {
       onProgress: (p) => setExportProgress(p),
       onComplete: (blob) => {
         setIsExporting(false);
@@ -535,7 +536,16 @@ export const VideoPlayer = memo(function VideoPlayer({
         setIsExporting(false);
         console.error("Export error:", err);
       },
-    });
+    } satisfies Parameters<typeof startVideoExport>[3];
+
+    // In the native shell, the hardware pipeline does the transcode (plan
+    // 0024); it resolves null when this shell can't (web, desktop stub, old
+    // app), and then the in-WebView exporter takes over unchanged.
+    void startNativeVideoExport(exportSource, exportContext, exportOptions, exportCallbacks).then(
+      (native) => {
+        if (!native) startVideoExport(exportSource, exportContext, exportOptions, exportCallbacks);
+      },
+    );
     // `actions.videoRef` is a stable RefObject from useVideoSync; depending on
     // the whole `actions` object would invalidate handleExport on every parent
     // render, defeating the memoization.

--- a/src/lib/nativeVideoExport.ts
+++ b/src/lib/nativeVideoExport.ts
@@ -1,0 +1,189 @@
+/**
+ * Native overlay-video export bridge (plan 0024).
+ *
+ * Inside the LapWing shell, export doesn't frame-step a <video> element — the
+ * shell transcodes on the platform's hardware codecs (`video_export_*` IPC →
+ * tauri-plugin-videopipe; Android: Media3 Transformer) and composites our
+ * overlay layers on the GPU. This module stages the job and drives it:
+ *
+ *   1. `video_export_begin` with the trim/size/bitrate params. If the shell
+ *      answers `unsupported:` (desktop stub) or doesn't know the command (an
+ *      older shell), we report "unavailable" and the caller falls back to the
+ *      in-WebView exporter.
+ *   2. Stream the source MP4 in 8 MB raw-body chunks.
+ *   3. Render transparent overlay layers with the SAME unified scene renderer
+ *      the preview uses (plan 0023), at telemetry cadence (~15 Hz — overlays
+ *      change with data, not video frames), PNG-encoded, timestamps relative
+ *      to the export start.
+ *   4. `video_export_run` (progress channel) → `video_export_collect` (raw
+ *      MP4 bytes) → the caller's normal save/share flow → dispose.
+ *
+ * Contract: LapWing `docs/video-pipeline.md`.
+ */
+
+import { api } from "@/lib/loggers/native/ipc";
+import { isNativeApp } from "@/lib/platform";
+import {
+  renderOverlaysToCanvas,
+  DEFAULT_OVERLAY_LABELS,
+  type GraphHistories,
+} from "@/lib/overlayCanvasRenderer";
+import type { ExportCallbacks, ExportContext, ExportSource } from "@/lib/videoExport";
+import type { ExportOptions } from "@/components/video-overlays/VideoExportDialog";
+
+const SOURCE_CHUNK_BYTES = 8 * 1024 * 1024;
+/** Overlay layer cadence. Data changes at sample rate (10–25 Hz); 15 Hz keeps
+ * every visible change without paying video-rate layer generation. */
+const OVERLAY_FPS = 15;
+/** Share of the progress bar spent staging (source + layers); the transcode
+ * gets the rest. */
+const STAGE_FRACTION = 0.35;
+
+export interface NativeExportController {
+  cancel: () => void;
+}
+
+/** True for the errors that mean "this shell can't do native export" — the
+ * desktop stub's sentinel, or a shell predating the command. */
+function isUnavailable(err: unknown): boolean {
+  const msg = String(err);
+  return msg.startsWith("unsupported:") || /unknown|not found|not allowed/i.test(msg);
+}
+
+/**
+ * Try to run the export natively. Resolves `null` when the native pipeline is
+ * unavailable (caller falls back to the in-WebView exporter — nothing has been
+ * staged); otherwise returns a controller and drives `callbacks` to completion.
+ *
+ * v1 limitation: single-recording exports only — multi-chunk playlists keep
+ * the WebView path.
+ */
+export async function startNativeVideoExport(
+  source: ExportSource,
+  exportCtx: ExportContext,
+  options: ExportOptions,
+  callbacks: ExportCallbacks,
+): Promise<NativeExportController | null> {
+  if (!isNativeApp()) return null;
+  if (source.chunks.length !== 1) return null;
+
+  const video = source.liveVideo;
+  const vw = video.videoWidth;
+  const vh = video.videoHeight;
+  if (!vw || !vh) return null;
+
+  // Same quality mapping as the WebView exporter.
+  let targetW = vw;
+  let targetH = vh;
+  if (options.quality === "standard") {
+    const scale = 720 / vh;
+    if (scale < 1) {
+      targetW = Math.round(vw * scale);
+      targetH = 720;
+    }
+  }
+  targetW += targetW % 2;
+  targetH += targetH % 2;
+  const bitrate = options.quality === "standard" ? 5_000_000 : 15_000_000;
+
+  const startTime = options.startTime ?? 0;
+  const endTime = options.endTime ?? source.totalDuration;
+
+  const { invoke, Channel } = await api();
+
+  let jobId: string;
+  try {
+    jobId = await invoke<string>("video_export_begin", {
+      params: {
+        width: targetW,
+        height: targetH,
+        bitrate,
+        startMs: Math.round(startTime * 1000),
+        endMs: Math.round(endTime * 1000),
+      },
+    });
+  } catch (err) {
+    if (isUnavailable(err)) return null;
+    callbacks.onError(String(err));
+    return { cancel: () => {} };
+  }
+
+  let cancelled = false;
+  const controller: NativeExportController = {
+    cancel: () => {
+      cancelled = true;
+      void invoke("video_export_cancel").catch(() => {});
+    },
+  };
+
+  void (async () => {
+    try {
+      // ── Stage the source ─────────────────────────────────────────────
+      const blob = await (await fetch(source.chunks[0].url)).blob();
+      const overlays = options.includeOverlays ? exportCtx.overlays : [];
+      const durMs = Math.max(0, Math.round((endTime - startTime) * 1000));
+      const layerCount = overlays.length > 0 ? Math.ceil((durMs / 1000) * OVERLAY_FPS) : 0;
+      // Weight staging progress by actual work: bytes for the source, one
+      // unit per overlay layer (a layer costs roughly a chunk's IPC trip).
+      const totalUnits = Math.max(1, blob.size + layerCount * SOURCE_CHUNK_BYTES * 0.01);
+      let doneUnits = 0;
+      const stageProgress = () =>
+        callbacks.onProgress(Math.min(1, doneUnits / totalUnits) * STAGE_FRACTION);
+
+      for (let offset = 0; offset < blob.size; offset += SOURCE_CHUNK_BYTES) {
+        if (cancelled) return;
+        const end = Math.min(offset + SOURCE_CHUNK_BYTES, blob.size);
+        const bytes = new Uint8Array(await blob.slice(offset, end).arrayBuffer());
+        await invoke("video_export_push_source", bytes, {
+          headers: { "job-id": jobId, offset: String(offset) },
+        });
+        doneUnits += bytes.length;
+        stageProgress();
+      }
+
+      // ── Render + stage the overlay layers ────────────────────────────
+      if (overlays.length > 0) {
+        const canvas = document.createElement("canvas");
+        canvas.width = targetW;
+        canvas.height = targetH;
+        const ctx2d = canvas.getContext("2d");
+        if (!ctx2d) throw new Error("Failed to get canvas context");
+        const histories: GraphHistories = new Map();
+        const labels = exportCtx.labels ?? DEFAULT_OVERLAY_LABELS;
+
+        for (let i = 0; i < layerCount; i++) {
+          if (cancelled) return;
+          const tMs = Math.round((i * 1000) / OVERLAY_FPS);
+          const renderCtx = exportCtx.buildRenderCtx(startTime + tMs / 1000);
+          if (!renderCtx) continue; // t stays increasing; a gap just holds the last layer
+          ctx2d.clearRect(0, 0, targetW, targetH);
+          renderOverlaysToCanvas(ctx2d, targetW, targetH, overlays, renderCtx, histories, labels);
+          const png = await new Promise<Blob | null>((res) => canvas.toBlob(res, "image/png"));
+          if (!png) throw new Error("PNG encode failed");
+          const bytes = new Uint8Array(await png.arrayBuffer());
+          await invoke("video_export_push_overlay", bytes, {
+            headers: { "job-id": jobId, "t-ms": String(tMs) },
+          });
+          doneUnits += SOURCE_CHUNK_BYTES * 0.01;
+          stageProgress();
+        }
+      }
+
+      // ── Transcode ────────────────────────────────────────────────────
+      if (cancelled) return;
+      const onProgress = new Channel<{ fraction: number }>();
+      onProgress.onmessage = (p) =>
+        callbacks.onProgress(STAGE_FRACTION + p.fraction * (1 - STAGE_FRACTION));
+      await invoke("video_export_run", { jobId, onProgress });
+
+      const buf = await invoke<ArrayBuffer>("video_export_collect", { jobId });
+      callbacks.onComplete(new Blob([buf], { type: "video/mp4" }));
+    } catch (err) {
+      if (!cancelled) callbacks.onError(String(err));
+    } finally {
+      void invoke("video_export_dispose", { jobId }).catch(() => {});
+    }
+  })();
+
+  return controller;
+}

--- a/src/lib/overlayCanvasRenderer.test.ts
+++ b/src/lib/overlayCanvasRenderer.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest";
 import {
   measureOverlay,
+  drawAnalog,
   drawDigital,
   drawGraph,
   drawPace,
@@ -299,5 +300,34 @@ describe("renderOverlaysToCanvas", () => {
     renderOverlaysToCanvas(c, 640, 360, overlays, makeRenderCtx(), new Map());
     // Only the visible digital overlay drew its value.
     expect(texts.filter((t) => t === "72.0")).toHaveLength(1);
+  });
+});
+
+// ─── per-session memo caches ────────────────────────────────────────────────
+
+describe("range memoization", () => {
+  it("scans a source's range once per session arrays, not once per frame", () => {
+    let minCalls = 0;
+    let maxCalls = 0;
+    const counting: DataSourceDef = {
+      ...speedSource,
+      getMin: () => { minCalls++; return 0; },
+      getMax: () => { maxCalls++; return 180; },
+    };
+    const ctx = makeRenderCtx({ dataSources: [counting] });
+    const inst = makeInstance({ type: "analog" });
+    for (let i = 0; i < 5; i++) {
+      const { c } = makeStubCtx();
+      drawAnalog(c, inst, ctx, L);
+    }
+    expect(minCalls).toBe(1);
+    expect(maxCalls).toBe(1);
+
+    // A different session (new sample arrays) misses the cache and rescans.
+    const ctx2 = makeRenderCtx({ dataSources: [counting] });
+    const { c } = makeStubCtx();
+    drawAnalog(c, inst, ctx2, L);
+    expect(minCalls).toBe(2);
+    expect(maxCalls).toBe(2);
   });
 });

--- a/src/lib/overlayCanvasRenderer.ts
+++ b/src/lib/overlayCanvasRenderer.ts
@@ -36,6 +36,7 @@ import {
 } from "@/components/video-overlays/sectorUtils";
 import { courseHasSectors } from "@/types/racing";
 import { findCurrentLap, formatOverlayLapTime, getOverlayLapStartTime } from "@/components/video-overlays/overlayUtils";
+import type { GpsSample } from "@/types/racing";
 
 const START_ANGLE = Math.PI * 0.8;
 const END_ANGLE = Math.PI * 2.2;
@@ -84,6 +85,95 @@ const SECTOR_CELL_BG: Record<SectorStatus, string> = {
   outlap: "rgba(128, 128, 128, 0.25)",
 };
 
+// ── Per-session memo caches ─────────────────────────────────────────────────
+//
+// The draws below used to rescan the session arrays on every frame — the
+// export path repeated ~10 full O(samples) passes per output frame for
+// answers that never change (ranges, map bounds, the pace scale). The arrays
+// are immutable per session/export, so the caches key on array identity via
+// WeakMap: a new session (or a rebuilt range array) misses naturally, and
+// nothing here needs invalidation or leaks.
+
+interface RangeEntry {
+  paceData: (number | null)[];
+  brakingGData: number[];
+  range: { min: number; max: number };
+}
+const rangeCaches = new WeakMap<GpsSample[], Map<string, RangeEntry>>();
+
+function memoRange(
+  sourceId: string,
+  ctx: OverlayRenderContext,
+): { min: number; max: number } {
+  let bySource = rangeCaches.get(ctx.samples);
+  if (!bySource) {
+    bySource = new Map();
+    rangeCaches.set(ctx.samples, bySource);
+  }
+  const hit = bySource.get(sourceId);
+  // Special sources (__pace__, __braking_g__) range over these arrays, not
+  // the samples — a hit is only valid while they are the same arrays too.
+  if (hit && hit.paceData === ctx.paceData && hit.brakingGData === ctx.brakingGData) {
+    return hit.range;
+  }
+  const range = resolveRange(sourceId, ctx.samples, ctx.dataSources, ctx.paceData, ctx.brakingGData);
+  bySource.set(sourceId, {
+    paceData: ctx.paceData,
+    brakingGData: ctx.brakingGData,
+    range,
+  });
+  return range;
+}
+
+interface MapBounds {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+}
+const mapBoundsCache = new WeakMap<GpsSample[], MapBounds>();
+
+function memoMapBounds(samples: GpsSample[]): MapBounds {
+  const hit = mapBoundsCache.get(samples);
+  if (hit) return hit;
+  let minLat = Infinity,
+    maxLat = -Infinity,
+    minLon = Infinity,
+    maxLon = -Infinity;
+  for (const s of samples) {
+    if (s.lat < minLat) minLat = s.lat;
+    if (s.lat > maxLat) maxLat = s.lat;
+    if (s.lon < minLon) minLon = s.lon;
+    if (s.lon > maxLon) maxLon = s.lon;
+  }
+  const bounds = { minLat, maxLat, minLon, maxLon };
+  mapBoundsCache.set(samples, bounds);
+  return bounds;
+}
+
+const paceMaxCache = new WeakMap<(number | null)[], number>();
+
+function memoPaceMax(paceData: (number | null)[]): number {
+  const hit = paceMaxCache.get(paceData);
+  if (hit !== undefined) return hit;
+  let maxDelta = 0.5;
+  for (const v of paceData) {
+    if (v !== null && Math.abs(v) > maxDelta) maxDelta = Math.abs(v);
+  }
+  maxDelta = Math.min(maxDelta * 1.2, 5);
+  paceMaxCache.set(paceData, maxDelta);
+  return maxDelta;
+}
+
+/** The digital widget's box, shared by measure and draw so the resolved value
+ * is only computed once per draw. */
+function digitalBox(fontSize: number, displayVal: string, unit: string): { w: number; h: number } {
+  return {
+    w: displayVal.length * fontSize * 0.65 + unit.length * fontSize * 0.35 + fontSize * 0.6,
+    h: fontSize * 1.5,
+  };
+}
+
 function computeLayout(
   instance: OverlayInstance,
   canvasWidth: number,
@@ -112,7 +202,7 @@ export function measureOverlay(
       const value = resolveValue(instance.dataSource, ctx.currentSample, ctx.currentIndex, ctx.dataSources, ctx.paceData, ctx.brakingGData);
       const unit = resolveUnit(instance.dataSource, ctx.dataSources);
       const displayVal = value !== null ? value.toFixed(1) : "—";
-      return { w: displayVal.length * f * 0.65 + unit.length * f * 0.35 + f * 0.6, h: f * 1.5 };
+      return digitalBox(f, displayVal, unit);
     }
     case "analog": {
       const size = Math.round(f * 5);
@@ -196,7 +286,7 @@ export function drawDigital(c: CanvasRenderingContext2D, inst: OverlayInstance, 
   const unit = resolveUnit(inst.dataSource, ctx.dataSources);
   const displayVal = value !== null ? value.toFixed(1) : "—";
 
-  const { w: textW, h } = measureOverlay(inst, ctx, l.fontSize);
+  const { w: textW, h } = digitalBox(l.fontSize, displayVal, unit);
 
   // Background
   c.fillStyle = theme.bg(inst.colorMode, inst.opacity);
@@ -222,7 +312,7 @@ export function drawDigital(c: CanvasRenderingContext2D, inst: OverlayInstance, 
 export function drawAnalog(c: CanvasRenderingContext2D, inst: OverlayInstance, ctx: OverlayRenderContext, l: OverlayLayout) {
   const theme = getTheme(inst.theme);
   const value = resolveValue(inst.dataSource, ctx.currentSample, ctx.currentIndex, ctx.dataSources, ctx.paceData, ctx.brakingGData);
-  const { min, max } = resolveRange(inst.dataSource, ctx.samples, ctx.dataSources, ctx.paceData, ctx.brakingGData);
+  const { min, max } = memoRange(inst.dataSource, ctx);
   const unit = resolveUnit(inst.dataSource, ctx.dataSources);
 
   const size = measureOverlay(inst, ctx, l.fontSize).w;
@@ -305,7 +395,7 @@ export function drawGraph(
 ) {
   const theme = getTheme(inst.theme);
   const value = resolveValue(inst.dataSource, ctx.currentSample, ctx.currentIndex, ctx.dataSources, ctx.paceData, ctx.brakingGData);
-  const { min, max } = resolveRange(inst.dataSource, ctx.samples, ctx.dataSources, ctx.paceData, ctx.brakingGData);
+  const { min, max } = memoRange(inst.dataSource, ctx);
   const unit = resolveUnit(inst.dataSource, ctx.dataSources);
   const graphLength = inst.graphLength ?? 100;
   const lineColor = inst.color ?? theme.accent(inst.colorMode);
@@ -371,7 +461,7 @@ export function drawGraph(
 export function drawBar(c: CanvasRenderingContext2D, inst: OverlayInstance, ctx: OverlayRenderContext, l: OverlayLayout) {
   const theme = getTheme(inst.theme);
   const value = resolveValue(inst.dataSource, ctx.currentSample, ctx.currentIndex, ctx.dataSources, ctx.paceData, ctx.brakingGData);
-  const { min, max } = resolveRange(inst.dataSource, ctx.samples, ctx.dataSources, ctx.paceData, ctx.brakingGData);
+  const { min, max } = memoRange(inst.dataSource, ctx);
   const unit = resolveUnit(inst.dataSource, ctx.dataSources);
   const range = max - min || 1;
   const fraction = value !== null ? Math.max(0, Math.min(1, (value - min) / range)) : 0;
@@ -420,8 +510,8 @@ export function drawBubble(c: CanvasRenderingContext2D, inst: OverlayInstance, c
   const theme = getTheme(inst.theme);
   const valueX = resolveValue(inst.dataSource, ctx.currentSample, ctx.currentIndex, ctx.dataSources, ctx.paceData, ctx.brakingGData);
   const valueY = resolveValue(inst.dataSourceSecondary ?? inst.dataSource, ctx.currentSample, ctx.currentIndex, ctx.dataSources, ctx.paceData, ctx.brakingGData);
-  const rangeX = resolveRange(inst.dataSource, ctx.samples, ctx.dataSources, ctx.paceData, ctx.brakingGData);
-  const rangeY = resolveRange(inst.dataSourceSecondary ?? inst.dataSource, ctx.samples, ctx.dataSources, ctx.paceData, ctx.brakingGData);
+  const rangeX = memoRange(inst.dataSource, ctx);
+  const rangeY = memoRange(inst.dataSourceSecondary ?? inst.dataSource, ctx);
 
   const size = measureOverlay(inst, ctx, l.fontSize).w;
   const cx = l.x + size / 2;
@@ -499,14 +589,8 @@ export function drawMap(c: CanvasRenderingContext2D, inst: OverlayInstance, ctx:
   if (samples.length < 2) return;
   const allSmp = ctx.allSamples.length > 1 ? ctx.allSamples : samples;
 
-  // Bounds
-  let minLat = Infinity, maxLat = -Infinity, minLon = Infinity, maxLon = -Infinity;
-  for (const s of allSmp) {
-    if (s.lat < minLat) minLat = s.lat;
-    if (s.lat > maxLat) maxLat = s.lat;
-    if (s.lon < minLon) minLon = s.lon;
-    if (s.lon > maxLon) maxLon = s.lon;
-  }
+  // Bounds (memoized per session — invariant across frames)
+  const { minLat, maxLat, minLon, maxLon } = memoMapBounds(allSmp);
   const latRange = maxLat - minLat || 0.001;
   const lonRange = maxLon - minLon || 0.001;
   const plotSize = size - pad * 2;
@@ -593,11 +677,7 @@ export function drawPace(
   const f = l.fontSize;
   const paceValue = ctx.paceData[ctx.currentIndex] ?? null;
 
-  let maxDelta = 0.5;
-  for (const v of ctx.paceData) {
-    if (v !== null && Math.abs(v) > maxDelta) maxDelta = Math.abs(v);
-  }
-  maxDelta = Math.min(maxDelta * 1.2, 5);
+  const maxDelta = memoPaceMax(ctx.paceData);
 
   const barW = f * 10;
   const { w: totalW, h: totalH } = measureOverlay(inst, ctx, f);


### PR DESCRIPTION
## Summary

Companion to LapWing #38 (plan 0001 Phase 2). In the native shell, *Export with overlays* now hands the whole job to the phone's hardware instead of frame-stepping the `<video>` element:

- **`src/lib/nativeVideoExport.ts`** — `startNativeVideoExport` stages the job over the `video_export_*` IPC (contract: LapWing `docs/video-pipeline.md`): `begin` with the same quality→resolution/bitrate mapping as the web path; the source blob in 8 MB **raw-body** chunks; overlay layers rendered by the **plan-0023 unified renderer** at 15 Hz telemetry cadence (PNG at output resolution, timestamps relative to export start); then the hardware transcode with streamed progress (staging owns the first 35 % of the bar), `collect` → the existing save/share flows, `dispose` always. Resolves `null` — and the WebView exporter takes over **unchanged** — off the shell, on the desktop stub's `unsupported:` sentinel, on an older shell without the commands, or for multi-chunk playlists (v1 limit).
- **`VideoPlayer.handleExport`** tries native first, falls back seamlessly. Web and desktop behavior is byte-identical to before.
- **Renderer memoization** (`overlayCanvasRenderer.ts`) — the per-frame invariant work found while profiling the old export path is cached per session via `WeakMap` on array identity: per-source ranges (validated against the pace/braking arrays for special sources), map bounds, the pace bar's scale, and the digital widget's duplicate value-resolve. Helps preview, the WebView exporter, and native layer generation alike; draw output is bit-identical (all prior renderer tests pass unchanged).
- `docs/plans/0024-native-export-bridge.md` + changelog.

## Related Issues

Cross-repo: TheAngryRaven/LapWing#38 must ship in the app build for the native path to activate; until then this PR is inert (the probe falls back). Builds on plan 0023 (#424).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [x] Refactor / reusability improvement
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes — 2994 tests (+1)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (IPC to the local shell only; no network calls)
- [x] Docs updated where relevant (`CHANGELOG.md`, `docs/plans/0024`)
- [ ] For a new parser: n/a

## Notes for Reviewers

- The 15 Hz layer cadence means the sector completion sweep (600 ms, data-time) gets ~9 layers — smooth in practice; per-widget change detection is the next lever if long-session layer generation ever dominates.
- One flagged cross-repo unknown (also in LapWing #38's notes): media3's clipped-stream presentation times are assumed 0-based against export-relative layer timestamps. If a device shows a constant offset, the fix is one constant on the LapWing side.
- On-device checklist for the first combined build: 30 s 1080p30 clip with a full overlay layout → expect **seconds**; overlay parity vs paused preview; audio present, A/V sync at trim boundaries; cancel mid-export, then a fresh export starts clean.

https://claude.ai/code/session_013LzfeVvASfX1hefekpHPUq

---
_Generated by [Claude Code](https://claude.ai/code/session_013LzfeVvASfX1hefekpHPUq)_