### PR TITLE
plan 0024 follow-up: save to gallery + the remembered video in the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.2.0] - unreleased
 
 ### Added
+- **Save to Gallery (Android app).** *Save to device* now lands the export in
+  your phone's gallery under *Movies/LapWing* — previously it quietly went
+  nowhere inside the app, because it used the browser's download path. The
+  file is written straight from the native pipeline, so nothing large passes
+  through the app's web layer.
+- **The app remembers your video.** Load a video for a session once in the
+  Android app and it comes back the next time you open that session, exactly
+  like the web version does with Chrome's file handles — the app keeps its own
+  copy in app storage and plays it from there. Exports of a remembered video
+  are faster too: the app already has the file, so there's nothing to upload
+  to the pipeline first.
 - **Hardware-speed export in the Android app.** Inside the LapWing shell,
   *Export with overlays* now hands the whole job to the phone's hardware:
   the shell transcodes with the platform codecs and composites the overlays

--- a/docs/plans/0024-native-export-bridge.md
+++ b/docs/plans/0024-native-export-bridge.md
@@ -1,6 +1,6 @@
 # Native export bridge — hardware-speed overlay video in the shell
 
-> Status: **LANDED** (bridge + renderer memoization). Companion: LapWing's
+> Status: **LANDED** (bridge + renderer memoization; follow-up: gallery save + remembered video). Companion: LapWing's
 > `tauri-plugin-videopipe` + `video_export_*` IPC (its `docs/video-pipeline.md`
 > is the contract; LapWing plan 0001, Phase 2).
 
@@ -64,3 +64,28 @@ and native layer generation alike — the draws' output is bit-identical.
   layout — expect seconds, not minutes; check overlay parity against the
   paused preview, audio presence, A/V sync at the trim boundaries, and that
   cancelling mid-export leaves no stale job (next export begins clean).
+
+## Follow-up (landed): save to gallery + the remembered video
+
+Two gaps the first on-device run exposed:
+
+- **"Save to device" saved nowhere.** It fell into `downloadBlob()` — an
+  `<a download href="blob:…">` click — which the Android WebView has no
+  download handler for. On native, `destination: "device"` now means the
+  **gallery**: the bridge calls `video_export_save(jobId, fileName)` and the
+  shell copies the finished MP4 straight out of its job dir into MediaStore
+  `Movies/LapWing` (the file never round-trips through the WebView); the
+  dialog's button reads *Save to Gallery* on native and `VideoPlayer` toasts
+  `export.savedToGallery`. New `ExportCallbacks.onSavedToDevice`; the web
+  path is untouched.
+- **The video was forgotten on reopen.** The web remembers it via a
+  `FileSystemFileHandle` (Chrome desktop only). `src/lib/nativeVideoStore.ts`
+  is the shell's equivalent: `useVideoSync.loadRecording` copies a
+  single-file recording into the shell's store in the background (8 MB
+  raw-body chunks; the blob URL keeps playing meanwhile), and the restore
+  effect tries `getNativeStoredVideo` before the IndexedDB fallback — the
+  `<video>` then streams from app storage over the asset protocol. The
+  store key rides `VideoSyncState.nativeStoredKey`, and the export bridge
+  passes it as `sourceKey` so an export of a remembered video **skips the
+  source upload entirely** (a stale key silently falls back to uploading).
+  Multi-file recordings keep today's behavior (no store, v1).

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -20,6 +20,7 @@ import { VideoExportDialog, ExportOptions } from "@/components/video-overlays/Vi
 import { OverlayCanvas } from "@/components/video-overlays/OverlayCanvas";
 import { startVideoExport, downloadBlob, ExportContext, ExportSource } from "@/lib/videoExport";
 import { startNativeVideoExport } from "@/lib/nativeVideoExport";
+import { toast } from "@/hooks/use-toast";
 import { computeBrakingGSeriesSG, gToBrakePercent } from "@/lib/brakingZones";
 import { saveSessionVideo, loadSessionVideo, deleteSessionVideo } from "@/lib/videoFileStorage";
 import { courseHasSectors } from "@/types/racing";
@@ -505,7 +506,15 @@ export const VideoPlayer = memo(function VideoPlayer({
     const chunks = state.exportChunks.length > 0
       ? state.exportChunks
       : [{ url: video.currentSrc || video.src, startOffsetSec: 0, durationSec: totalDuration }];
-    const exportSource: ExportSource = { liveVideo: video, chunks, totalDuration };
+    const exportSource: ExportSource = {
+      liveVideo: video,
+      chunks,
+      totalDuration,
+      fileName: state.videoFileName ?? undefined,
+      // The shell's remembered copy is only the source for single-file
+      // recordings — the store holds one video per session.
+      nativeSourceKey: chunks.length === 1 ? (state.nativeStoredKey ?? undefined) : undefined,
+    };
 
     const exportCallbacks = {
       onProgress: (p) => setExportProgress(p),
@@ -536,6 +545,13 @@ export const VideoPlayer = memo(function VideoPlayer({
         setIsExporting(false);
         console.error("Export error:", err);
       },
+      // Native shell: "Save to device" wrote straight into the gallery.
+      onSavedToDevice: (uri) => {
+        setIsExporting(false);
+        setShowExportDialog(false);
+        console.log("Video saved to gallery:", uri);
+        toast({ title: t("export.savedToGallery") });
+      },
     } satisfies Parameters<typeof startVideoExport>[3];
 
     // In the native shell, the hardware pipeline does the transcode (plan
@@ -550,7 +566,7 @@ export const VideoPlayer = memo(function VideoPlayer({
     // the whole `actions` object would invalidate handleExport on every parent
     // render, defeating the memoization.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actions.videoRef, state.videoFileName, state.syncOffsetMs, state.videoDuration, state.exportChunks, overlays, buildExportRenderCtx, sessionFileName, selectedLapNumber, laps]);
+  }, [actions.videoRef, state.videoFileName, state.syncOffsetMs, state.videoDuration, state.exportChunks, state.nativeStoredKey, overlays, buildExportRenderCtx, sessionFileName, selectedLapNumber, laps, t]);
 
   // Download existing stored video
   const handleSaveExisting = useCallback(async () => {

--- a/src/components/video-overlays/VideoExportDialog.tsx
+++ b/src/components/video-overlays/VideoExportDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { isNativeApp } from "@/lib/platform";
 import { useTranslation, Trans } from "react-i18next";
 import type { TFunction } from "i18next";
 import { Download, Save, Loader2, HardDrive, Video, Trash2, AlertTriangle } from "lucide-react";
@@ -67,6 +68,9 @@ export function VideoExportDialog({
   const [quality, setQuality] = useState<"standard" | "high">("standard");
   const [range, setRange] = useState<"full" | "lap">("full");
   const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // In the native shell "device" means the phone's gallery, not a download.
+  const native = isNativeApp();
 
   const handleExport = useCallback((destination: "device" | "app") => {
     onExport({ includeOverlays, quality, range, destination });
@@ -224,10 +228,10 @@ export function VideoExportDialog({
               className="flex-1 gap-2"
               onClick={() => handleExport("device")}
               disabled={isExporting}
-              title={t("export.saveToDeviceTitle")}
+              title={native ? t("export.saveToGalleryTitle") : t("export.saveToDeviceTitle")}
             >
               <HardDrive className="w-4 h-4" />
-              {t("export.saveToDevice")}
+              {native ? t("export.saveToGallery") : t("export.saveToDevice")}
             </Button>
           </div>
 

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -2,6 +2,8 @@ import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { GpsSample } from "@/types/racing";
 import { saveVideoSync, loadVideoSync, VideoSyncRecord, VideoSyncChunk } from "@/lib/videoStorage";
 import { loadSessionVideo, hasSessionVideo, deleteSessionVideo, getSessionVideoMeta, type StoredVideoMeta } from "@/lib/videoFileStorage";
+import { getNativeStoredVideo, storeNativeVideo } from "@/lib/nativeVideoStore";
+import { isNativeApp } from "@/lib/platform";
 import type { OverlaySettings } from "@/components/video-overlays/types";
 import { DEFAULT_OVERLAY_SETTINGS } from "@/components/video-overlays/types";
 import { findNearestIndex } from "@/components/video-overlays/overlayUtils";
@@ -50,6 +52,12 @@ export interface VideoSyncState {
   overlaySettings: OverlaySettings;
   hasStoredVideo: boolean;
   storedVideoMeta: StoredVideoMeta | null;
+  /**
+   * Native shell: the key of this session's remembered video in the shell's
+   * store (null on the web, or until the copy finishes). The native export
+   * uses it as its source and skips the source upload.
+   */
+  nativeStoredKey: string | null;
   /**
    * When a selection holds several distinct recordings, the choices to prompt
    * the user with (null = no prompt pending). Each is one recording's display
@@ -165,6 +173,7 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const [isOutOfRange, setIsOutOfRange] = useState(false);
   const [coverage, setCoverage] = useState<VideoCoverage>('covered');
   const [fileHandle, setFileHandle] = useState<FileSystemFileHandle | null>(null);
+  const [nativeStoredKey, setNativeStoredKey] = useState<string | null>(null);
   const [overlaySettings, setOverlaySettings] = useState<OverlaySettings>(DEFAULT_OVERLAY_SETTINGS);
   const [storedVideoAvailable, setStoredVideoAvailable] = useState(false);
   const [storedVideoMeta, setStoredVideoMeta] = useState<StoredVideoMeta | null>(null);
@@ -247,9 +256,12 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     hasSessionVideo(sessionFileName).then(has => setStoredVideoAvailable(has));
     getSessionVideoMeta(sessionFileName).then(meta => setStoredVideoMeta(meta)).catch(() => {});
 
+    setNativeStoredKey(null);
     loadVideoSync(sessionFileName).then(async (record) => {
       if (!record) {
-        // No sync record, but check for stored video anyway
+        // No sync record — the shell may still remember the video, else
+        // check for an app-stored (exported) video.
+        if (await tryLoadNativeStored(sessionFileName)) return;
         await tryLoadStoredVideo(sessionFileName);
         return;
       }
@@ -288,6 +300,11 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
         } catch { /* File System Access query failed; fall through to IDB stored video */ }
       }
 
+      // Native shell: the session's remembered video, streamed from app storage.
+      if (!loaded) {
+        loaded = await tryLoadNativeStored(sessionFileName);
+      }
+
       // Fallback: load from IndexedDB stored video
       if (!loaded) {
         await tryLoadStoredVideo(sessionFileName);
@@ -316,6 +333,18 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     }
     revokeAllUrls();
     await applyPlaylist(entries);
+    return true;
+  }, [revokeAllUrls, applyPlaylist]);
+
+  // Native shell: the session's remembered video (see nativeVideoStore.ts).
+  // Plays over the asset protocol straight from app storage — no blob, no
+  // copy into memory.
+  const tryLoadNativeStored = useCallback(async (fileName: string): Promise<boolean> => {
+    const stored = await getNativeStoredVideo(fileName);
+    if (!stored) return false;
+    revokeAllUrls();
+    await applyPlaylist([{ name: stored.fileName, url: stored.url }]);
+    setNativeStoredKey(stored.key);
     return true;
   }, [revokeAllUrls, applyPlaylist]);
 
@@ -384,7 +413,18 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
       handle: e.handle,
     })));
     persistSync(syncOffsetMsRef.current);
-  }, [revokeAllUrls, applyPlaylist, persistSync]);
+
+    // Native shell: remember the video for this session by copying it into
+    // the shell's store in the background (single-file recordings only). The
+    // blob URL keeps playing meanwhile; once stored, exports use the copy.
+    setNativeStoredKey(null);
+    if (isNativeApp() && sessionFileName && recording.files.length === 1) {
+      const file = recording.files[0].file;
+      void storeNativeVideo(sessionFileName, file)
+        .then((stored) => { if (stored) setNativeStoredKey(stored.key); })
+        .catch((e) => console.warn("Native video store failed:", e));
+    }
+  }, [revokeAllUrls, applyPlaylist, persistSync, sessionFileName]);
 
   // Group a fresh selection into recordings: load straight away when there's
   // exactly one, otherwise stash them and prompt the user to pick.
@@ -842,12 +882,13 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     videoUrl, preloadUrl, videoFileName, isLocked, isPlaying, syncOffsetMs, syncRate, rateAnchorCount, fps,
     videoDuration, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, coverage, overlaySettings,
     hasStoredVideo: storedVideoAvailable,
+    nativeStoredKey,
     storedVideoMeta,
     pendingRecordings,
   }), [
     videoUrl, preloadUrl, videoFileName, isLocked, isPlaying, syncOffsetMs, syncRate, rateAnchorCount, fps,
     videoDuration, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, coverage, overlaySettings,
-    storedVideoAvailable, storedVideoMeta, pendingRecordings,
+    storedVideoAvailable, nativeStoredKey, storedVideoMeta, pendingRecordings,
   ]);
 
   const actions: VideoSyncActions = useMemo(() => ({

--- a/src/lib/nativeVideoExport.ts
+++ b/src/lib/nativeVideoExport.ts
@@ -91,17 +91,28 @@ export async function startNativeVideoExport(
 
   const { invoke, Channel } = await api();
 
+  const baseParams = {
+    width: targetW,
+    height: targetH,
+    bitrate,
+    startMs: Math.round(startTime * 1000),
+    endMs: Math.round(endTime * 1000),
+  };
+
+  // Prefer the session's stored copy as the source (no upload at all); a
+  // stale key just means we upload the blob like any other export.
+  let useStoredSource = !!source.nativeSourceKey;
   let jobId: string;
   try {
-    jobId = await invoke<string>("video_export_begin", {
-      params: {
-        width: targetW,
-        height: targetH,
-        bitrate,
-        startMs: Math.round(startTime * 1000),
-        endMs: Math.round(endTime * 1000),
-      },
-    });
+    try {
+      jobId = await invoke<string>("video_export_begin", {
+        params: useStoredSource ? { ...baseParams, sourceKey: source.nativeSourceKey } : baseParams,
+      });
+    } catch (err) {
+      if (!useStoredSource || isUnavailable(err)) throw err;
+      useStoredSource = false;
+      jobId = await invoke<string>("video_export_begin", { params: baseParams });
+    }
   } catch (err) {
     if (isUnavailable(err)) return null;
     callbacks.onError(String(err));
@@ -118,19 +129,20 @@ export async function startNativeVideoExport(
 
   void (async () => {
     try {
-      // ── Stage the source ─────────────────────────────────────────────
-      const blob = await (await fetch(source.chunks[0].url)).blob();
+      // ── Stage the source (unless the shell already holds it) ─────────
+      const blob = useStoredSource ? null : await (await fetch(source.chunks[0].url)).blob();
+      const sourceBytes = blob?.size ?? 0;
       const overlays = options.includeOverlays ? exportCtx.overlays : [];
       const durMs = Math.max(0, Math.round((endTime - startTime) * 1000));
       const layerCount = overlays.length > 0 ? Math.ceil((durMs / 1000) * OVERLAY_FPS) : 0;
       // Weight staging progress by actual work: bytes for the source, one
       // unit per overlay layer (a layer costs roughly a chunk's IPC trip).
-      const totalUnits = Math.max(1, blob.size + layerCount * SOURCE_CHUNK_BYTES * 0.01);
+      const totalUnits = Math.max(1, sourceBytes + layerCount * SOURCE_CHUNK_BYTES * 0.01);
       let doneUnits = 0;
       const stageProgress = () =>
         callbacks.onProgress(Math.min(1, doneUnits / totalUnits) * STAGE_FRACTION);
 
-      for (let offset = 0; offset < blob.size; offset += SOURCE_CHUNK_BYTES) {
+      for (let offset = 0; blob && offset < blob.size; offset += SOURCE_CHUNK_BYTES) {
         if (cancelled) return;
         const end = Math.min(offset + SOURCE_CHUNK_BYTES, blob.size);
         const bytes = new Uint8Array(await blob.slice(offset, end).arrayBuffer());
@@ -176,8 +188,20 @@ export async function startNativeVideoExport(
         callbacks.onProgress(STAGE_FRACTION + p.fraction * (1 - STAGE_FRACTION));
       await invoke("video_export_run", { jobId, onProgress });
 
-      const buf = await invoke<ArrayBuffer>("video_export_collect", { jobId });
-      callbacks.onComplete(new Blob([buf], { type: "video/mp4" }));
+      // "Save to device" on native means the gallery: the shell copies the
+      // finished MP4 straight out of its job dir — nothing comes back through
+      // the WebView. "Save to app" (and callers without the hook) collect it.
+      if (options.destination === "device" && callbacks.onSavedToDevice) {
+        const base = (source.fileName ?? "export").replace(/\.[^.]+$/, "");
+        const uri = await invoke<string>("video_export_save", {
+          jobId,
+          fileName: `${base}-overlay.mp4`,
+        });
+        callbacks.onSavedToDevice(uri);
+      } else {
+        const buf = await invoke<ArrayBuffer>("video_export_collect", { jobId });
+        callbacks.onComplete(new Blob([buf], { type: "video/mp4" }));
+      }
     } catch (err) {
       if (!cancelled) callbacks.onError(String(err));
     } finally {

--- a/src/lib/nativeVideoStore.ts
+++ b/src/lib/nativeVideoStore.ts
@@ -1,0 +1,102 @@
+/**
+ * Native video store bridge (plan 0024 follow-up).
+ *
+ * On the web, a session remembers its video through a `FileSystemFileHandle`
+ * in the sync record — Chrome desktop only. The Android WebView has no such
+ * thing, so the LapWing shell keeps a copy of the video in app data instead
+ * (`video_store_*` IPC; contract in LapWing `docs/video-pipeline.md`):
+ *
+ *   - `storeNativeVideo` copies the picked File across once (8 MB raw-body
+ *     chunks) and seals it under the session's store key;
+ *   - `getNativeStoredVideo` finds it again on the next open and returns a
+ *     playable URL over the asset protocol — the <video> streams from disk;
+ *   - the export bridge names the stored copy as its source (`sourceKey`) and
+ *     skips the source copy entirely.
+ *
+ * Every function is a no-op (`null`) off the native shell or on a shell that
+ * predates the store, so callers can call them unconditionally.
+ */
+
+import { api } from "@/lib/loggers/native/ipc";
+import { isNativeApp } from "@/lib/platform";
+
+const CHUNK_BYTES = 8 * 1024 * 1024;
+
+export interface NativeStoredVideo {
+  key: string;
+  fileName: string;
+  size: number;
+  /** Absolute path on the device (the export bridge passes the key, not this). */
+  path: string;
+  /** Playable URL over the asset protocol. */
+  url: string;
+}
+
+interface StoredVideoInfo {
+  key: string;
+  fileName: string;
+  size: number;
+  path: string;
+}
+
+/** The desktop stub's sentinel, or a shell predating the store commands. */
+function isUnavailable(err: unknown): boolean {
+  const msg = String(err);
+  return msg.startsWith("unsupported:") || /unknown|not found|not allowed/i.test(msg);
+}
+
+/** The session's remembered video, if the shell has one. */
+export async function getNativeStoredVideo(sessionFileName: string): Promise<NativeStoredVideo | null> {
+  if (!isNativeApp()) return null;
+  try {
+    const { invoke, convertFileSrc } = await api();
+    const info = await invoke<StoredVideoInfo | null>("video_store_get", { sessionFileName });
+    if (!info) return null;
+    return { ...info, url: convertFileSrc(info.path) };
+  } catch (err) {
+    if (!isUnavailable(err)) console.warn("Native video store lookup failed:", err);
+    return null;
+  }
+}
+
+/**
+ * Copy `file` into the shell's store for `sessionFileName`, replacing any
+ * previous video for that session. Resolves `null` when the shell can't
+ * store (web, desktop stub, old shell) — the caller just keeps its blob URL.
+ */
+export async function storeNativeVideo(
+  sessionFileName: string,
+  file: File,
+  onProgress?: (fraction: number) => void,
+): Promise<NativeStoredVideo | null> {
+  if (!isNativeApp() || file.size === 0) return null;
+  const { invoke, convertFileSrc } = await api();
+  let key: string;
+  try {
+    key = await invoke<string>("video_store_begin", { sessionFileName, fileName: file.name });
+  } catch (err) {
+    if (isUnavailable(err)) return null;
+    throw err;
+  }
+  for (let offset = 0; offset < file.size; offset += CHUNK_BYTES) {
+    const end = Math.min(offset + CHUNK_BYTES, file.size);
+    const bytes = new Uint8Array(await file.slice(offset, end).arrayBuffer());
+    await invoke("video_store_push", bytes, {
+      headers: { "store-key": key, offset: String(offset) },
+    });
+    onProgress?.(end / file.size);
+  }
+  const info = await invoke<StoredVideoInfo>("video_store_finish", { key });
+  return { ...info, url: convertFileSrc(info.path) };
+}
+
+/** Forget the session's stored video (best effort). */
+export async function deleteNativeStoredVideo(sessionFileName: string): Promise<void> {
+  if (!isNativeApp()) return;
+  try {
+    const { invoke } = await api();
+    await invoke("video_store_delete", { sessionFileName });
+  } catch {
+    // Best effort — an old shell or the desktop stub simply has nothing to delete.
+  }
+}

--- a/src/lib/videoExport.ts
+++ b/src/lib/videoExport.ts
@@ -50,6 +50,12 @@ export interface ExportCallbacks {
   onProgress: (fraction: number) => void;
   onComplete: (blob: Blob) => void;
   onError: (error: string) => void;
+  /**
+   * Native shell only: the export was written straight into the device's
+   * gallery and no Blob comes back. When absent, the native bridge collects
+   * the MP4 and calls `onComplete` instead.
+   */
+  onSavedToDevice?: (uri: string) => void;
 }
 
 export interface ExportContext {
@@ -76,6 +82,13 @@ export interface ExportSource {
   liveVideo: HTMLVideoElement;
   chunks: ExportChunk[];
   totalDuration: number;
+  /** The video's display file name — output naming on the native path. */
+  fileName?: string;
+  /**
+   * Native shell: the session's remembered-video key. The native export uses
+   * the stored copy as its source and skips the source upload entirely.
+   */
+  nativeSourceKey?: string;
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/locales/de/video.json
+++ b/src/locales/de/video.json
@@ -55,6 +55,9 @@
     "saveToAppTitle": "Exportiertes Video zum automatischen Laden in der App speichern",
     "saveToDevice": "Auf Gerät speichern",
     "saveToDeviceTitle": "Exportierte Videodatei herunterladen",
+    "saveToGallery": "In Galerie speichern",
+    "saveToGalleryTitle": "Exportiertes Video in der Galerie des Telefons speichern (Movies/LapWing)",
+    "savedToGallery": "In der Galerie gespeichert (Movies/LapWing)",
     "info": "Der Export spielt das Video in Echtzeit ab, um jedes Bild mit Overlays aufzunehmen. \"In App speichern\" legt das Video für das automatische Laden in der nächsten Session ab."
   },
   "settings": {

--- a/src/locales/en/video.json
+++ b/src/locales/en/video.json
@@ -54,6 +54,9 @@
     "saveToAppTitle": "Save exported video to the app for auto-loading",
     "saveToDevice": "Save to Device",
     "saveToDeviceTitle": "Download exported video file",
+    "saveToGallery": "Save to Gallery",
+    "saveToGalleryTitle": "Save the exported video to your phone's gallery (Movies/LapWing)",
+    "savedToGallery": "Saved to your gallery (Movies/LapWing)",
     "info": "Video export plays through the video in real-time to capture each frame with overlays. \"Save to App\" stores the video for auto-loading next session."
   },
   "settings": {

--- a/src/locales/es/video.json
+++ b/src/locales/es/video.json
@@ -55,6 +55,9 @@
     "saveToAppTitle": "Guardar el vídeo exportado en la app para carga automática",
     "saveToDevice": "Guardar en el dispositivo",
     "saveToDeviceTitle": "Descargar el archivo de vídeo exportado",
+    "saveToGallery": "Guardar en la galería",
+    "saveToGalleryTitle": "Guardar el vídeo exportado en la galería del teléfono (Movies/LapWing)",
+    "savedToGallery": "Guardado en tu galería (Movies/LapWing)",
     "info": "La exportación reproduce el vídeo en tiempo real para capturar cada fotograma con las superposiciones. \"Guardar en la app\" almacena el vídeo para cargarlo automáticamente la próxima sesión."
   },
   "settings": {

--- a/src/locales/fr/video.json
+++ b/src/locales/fr/video.json
@@ -55,6 +55,9 @@
     "saveToAppTitle": "Enregistrer la vidéo exportée dans l'app pour un chargement automatique",
     "saveToDevice": "Enregistrer sur l'appareil",
     "saveToDeviceTitle": "Télécharger le fichier vidéo exporté",
+    "saveToGallery": "Enregistrer dans la galerie",
+    "saveToGalleryTitle": "Enregistrer la vidéo exportée dans la galerie du téléphone (Movies/LapWing)",
+    "savedToGallery": "Enregistré dans votre galerie (Movies/LapWing)",
     "info": "L'export lit la vidéo en temps réel pour capturer chaque image avec les superpositions. \"Enregistrer dans l'app\" stocke la vidéo pour la charger automatiquement à la prochaine session."
   },
   "settings": {

--- a/src/locales/it/video.json
+++ b/src/locales/it/video.json
@@ -55,6 +55,9 @@
     "saveToAppTitle": "Salva il video esportato nell'app per il caricamento automatico",
     "saveToDevice": "Salva sul dispositivo",
     "saveToDeviceTitle": "Scarica il file video esportato",
+    "saveToGallery": "Salva nella galleria",
+    "saveToGalleryTitle": "Salva il video esportato nella galleria del telefono (Movies/LapWing)",
+    "savedToGallery": "Salvato nella galleria (Movies/LapWing)",
     "info": "L'esportazione riproduce il video in tempo reale per catturare ogni fotogramma con le sovrapposizioni. \"Salva nell'app\" memorizza il video per caricarlo automaticamente alla prossima sessione."
   },
   "settings": {

--- a/src/locales/ja/video.json
+++ b/src/locales/ja/video.json
@@ -55,6 +55,9 @@
     "saveToAppTitle": "書き出した動画を自動読み込み用にアプリへ保存",
     "saveToDevice": "デバイスに保存",
     "saveToDeviceTitle": "書き出した動画ファイルをダウンロード",
+    "saveToGallery": "ギャラリーに保存",
+    "saveToGalleryTitle": "書き出した動画をスマートフォンのギャラリーに保存します（Movies/LapWing）",
+    "savedToGallery": "ギャラリーに保存しました（Movies/LapWing）",
     "info": "書き出しは動画をリアルタイムで再生し、各フレームをオーバーレイ付きで取り込みます。「アプリに保存」すると、次回セッションで自動読み込みされるよう動画が保存されます。"
   },
   "settings": {

--- a/src/locales/pt-BR/video.json
+++ b/src/locales/pt-BR/video.json
@@ -55,6 +55,9 @@
     "saveToAppTitle": "Salvar o vídeo exportado no app para carregamento automático",
     "saveToDevice": "Salvar no dispositivo",
     "saveToDeviceTitle": "Baixar o arquivo de vídeo exportado",
+    "saveToGallery": "Salvar na galeria",
+    "saveToGalleryTitle": "Salvar o vídeo exportado na galeria do celular (Movies/LapWing)",
+    "savedToGallery": "Salvo na sua galeria (Movies/LapWing)",
     "info": "A exportação reproduz o vídeo em tempo real para capturar cada quadro com as sobreposições. \"Salvar no app\" armazena o vídeo para carregá-lo automaticamente na próxima sessão."
   },
   "settings": {


### PR DESCRIPTION
## Summary

Companion to LapWing #40. Two gaps from the first on-device run of the native export:

- **"Save to device" saved nowhere.** Inside the shell it fell into `downloadBlob()` — an `<a download href="blob:…">` click the Android WebView has no download handler for — so the export completed and the file vanished. On native, `destination: "device"` now means the **gallery**: the bridge calls `video_export_save` and the shell copies the finished MP4 straight from its job dir into MediaStore `Movies/LapWing` (nothing round-trips through the WebView). The dialog's button reads **Save to Gallery** on native, `VideoPlayer` toasts `export.savedToGallery`. New optional `ExportCallbacks.onSavedToDevice`; the web path is byte-identical.
- **The video was forgotten on reopen.** The web remembers a session's video through a Chrome-desktop-only `FileSystemFileHandle`; the shell had nothing. `src/lib/nativeVideoStore.ts` is its equivalent over the shell's `video_store_*` IPC: `loadRecording` copies a single-file recording into the shell's store **in the background** (8 MB raw-body chunks; the blob URL keeps playing meanwhile), and the restore effect tries `getNativeStoredVideo` before the IndexedDB fallback — the `<video>` then streams from app storage over the asset protocol. The key rides `VideoSyncState.nativeStoredKey`, and the export bridge passes it as `sourceKey` so **exporting a remembered video skips the source upload entirely** (a stale key silently falls back to uploading).
- i18n keys (`export.saveToGallery`, `saveToGalleryTitle`, `savedToGallery`) in all seven locales; plan 0024 doc + changelog updated.

Every new call is a no-op off the native shell or on an older shell, so web/desktop behavior is unchanged.

## Related Issues

TheAngryRaven/LapWing#40 (must ship in the app build for the gallery save + store to activate; until then the bridge falls back exactly as before). Builds on #425.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes — 2994 tests
- [x] `npm run build` succeeds
- [x] Feature works **offline** (IPC to the local shell only)
- [x] Docs updated where relevant (`CHANGELOG.md`, `docs/plans/0024`)
- [ ] For a new parser: n/a

## Notes for Reviewers

- v1 stores **single-file recordings only**; multi-chunk (chaptered GoPro) recordings keep today's behavior — flagged in the plan doc.
- The background copy is fire-and-forget on load; until it finishes, an export just uploads the blob as before, so there's no window where export breaks.
- On-device checks: load a video → kill the app → reopen the session (video should be back, playing from storage); export with *Save to Gallery* → check Photos/Files under Movies/LapWing; export a remembered video and notice the upload phase is gone from the progress bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LzfeVvASfX1hefekpHPUq

---
_Generated by [Claude Code](https://claude.ai/code/session_013LzfeVvASfX1hefekpHPUq)_