### PR TITLE
plan 0024 follow-up 2: base64 chunk bridge (Android has no raw bodies) + visible export failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and your chosen distance is remembered per file and switchable from the
   session header.
 
+### Fixed
+- **Save to Gallery / export in the Android app did nothing.** Every export
+  (and the app's background copy of your video) failed on its very first
+  chunk: the way the app handed video bytes to the shell doesn't exist on
+  Android's WebView, and the failure was only logged to the console — the
+  dialog just went idle after a one-second stutter. Video and overlay data
+  now cross the bridge in a form Android supports, and an export that fails
+  says so with the reason instead of silently stopping. Requires the matching
+  LapWing build.
+
 ## [4.1.0] - 2026-08-24
 
 ### Added

--- a/docs/plans/0024-native-export-bridge.md
+++ b/docs/plans/0024-native-export-bridge.md
@@ -1,6 +1,6 @@
 # Native export bridge — hardware-speed overlay video in the shell
 
-> Status: **LANDED** (bridge + renderer memoization; follow-up: gallery save + remembered video). Companion: LapWing's
+> Status: **LANDED** (bridge + renderer memoization; follow-ups: gallery save + remembered video; the Android bridge fix). Companion: LapWing's
 > `tauri-plugin-videopipe` + `video_export_*` IPC (its `docs/video-pipeline.md`
 > is the contract; LapWing plan 0001, Phase 2).
 
@@ -23,7 +23,7 @@ codecs — the owner's call: the video pipeline *is* the point of the native app
   the caller falls back to the unchanged WebView exporter;
 - otherwise stages and drives the job: `video_export_begin` (same
   quality→resolution/bitrate mapping as the web path), the source blob in
-  8 MB **raw-body** chunks, then transparent overlay layers rendered by the
+  4 MB **base64** chunks (see follow-up 2), then transparent overlay layers rendered by the
   plan-0023 unified renderer at **15 Hz** (telemetry cadence — overlays
   change with data, not video frames), PNG-encoded at output resolution,
   timestamps relative to the export start;
@@ -89,3 +89,34 @@ Two gaps the first on-device run exposed:
   passes it as `sourceKey` so an export of a remembered video **skips the
   source upload entirely** (a stale key silently falls back to uploading).
   Multi-file recordings keep today's behavior (no store, v1).
+
+## Follow-up 2 (landed): the Android bridge has no raw bodies
+
+The first on-device run of "Save to Gallery" stuttered for a second and went
+idle — no file, no message. Root cause, in LapWing's IPC layer: the upload
+commands took **raw invoke bodies** (`invoke(cmd, bytes, { headers })` →
+`tauri::ipc::Request`), and Tauri never uses that IPC on Android — the
+WebView cannot hand the app a request body, so Tauri falls back to
+`window.ipc.postMessage` and serializes a `Uint8Array` payload as a JSON
+*array of numbers*, which a raw-body command rejects. The very first chunk
+of every export (and of every video-store copy) failed; `onError` only
+logged to the console, so the dialog just returned to idle. The stutter was
+the WebView turning 8 MB of bytes into ~30 MB of JSON text.
+
+What changed:
+
+- `src/lib/nativeBytes.ts`: bulk bytes now cross the bridge as **base64
+  strings in ordinary JSON args**, in 4 MB chunks (`blobToBase64` via
+  `FileReader.readAsDataURL` — native, off the main thread). LapWing decodes
+  in one pass (`video::job::decode_chunk`). `nativeVideoExport.ts` and
+  `nativeVideoStore.ts` use it; the shell's push commands take
+  `{ jobId, offset | tMs, data }` / `{ key, offset, data }`.
+- Export failures are now **visible**: `VideoPlayer.onError` toasts
+  `export.failed` with the shell's message (destructive variant) instead of
+  only `console.error`. The WebView exporter's errors get the same toast.
+- Staging progress weights one overlay layer like one chunk push (render +
+  PNG encode + bridge trip), which is what it costs.
+
+Requires the matching LapWing shell (base64 push commands); an older shell
+rejects the new args and the toast says so.
+

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -544,6 +544,8 @@ export const VideoPlayer = memo(function VideoPlayer({
       onError: (err) => {
         setIsExporting(false);
         console.error("Export error:", err);
+        // Say so — a silent return to idle reads as "nothing happened".
+        toast({ title: t("export.failed"), description: String(err), variant: "destructive" });
       },
       // Native shell: "Save to device" wrote straight into the gallery.
       onSavedToDevice: (uri) => {

--- a/src/lib/nativeBytes.test.ts
+++ b/src/lib/nativeBytes.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { blobToBase64, bytesToBase64, NATIVE_CHUNK_BYTES } from "./nativeBytes";
+
+/** Naive reference encoder. */
+function referenceBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function pattern(n: number, mul = 1): Uint8Array {
+  const bytes = new Uint8Array(n);
+  for (let i = 0; i < n; i++) bytes[i] = (i * mul) % 256;
+  return bytes;
+}
+
+/**
+ * A stand-in for the browser's FileReader: `readAsDataURL` produces the same
+ * `data:<mime>;base64,<payload>` shape, asynchronously, from the Blob's bytes.
+ */
+class FakeFileReader {
+  result: string | null = null;
+  error: Error | null = null;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  static failNext = false;
+  readAsDataURL(blob: Blob) {
+    void blob.arrayBuffer().then((buf) => {
+      if (FakeFileReader.failNext) {
+        FakeFileReader.failNext = false;
+        this.error = new Error("NotReadableError");
+        this.onerror?.();
+        return;
+      }
+      const mime = blob.type || "application/octet-stream";
+      this.result = `data:${mime};base64,${referenceBase64(new Uint8Array(buf))}`;
+      this.onload?.();
+    });
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("bytesToBase64", () => {
+  it("matches a reference encoder across the 32 KB step boundary", () => {
+    const bytes = pattern(100_003, 7);
+    const b64 = bytesToBase64(bytes);
+    expect(b64).toBe(referenceBase64(bytes));
+    // Round-trips byte-for-byte.
+    expect(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))).toEqual(bytes);
+  });
+
+  it("encodes the empty input as the empty string", () => {
+    expect(bytesToBase64(new Uint8Array(0))).toBe("");
+  });
+});
+
+describe("blobToBase64", () => {
+  it("falls back to the pure encoder where there is no FileReader (this test runtime)", async () => {
+    expect(typeof FileReader).toBe("undefined");
+    const bytes = pattern(1000);
+    expect(await blobToBase64(new Blob([bytes]))).toBe(referenceBase64(bytes));
+    expect(await blobToBase64(new Blob([]))).toBe("");
+  });
+
+  it("uses FileReader.readAsDataURL and strips the prefix regardless of the blob's mime type", async () => {
+    vi.stubGlobal("FileReader", FakeFileReader);
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const expected = referenceBase64(png);
+    expect(await blobToBase64(new Blob([png], { type: "image/png" }))).toBe(expected);
+    expect(await blobToBase64(new Blob([png], { type: "video/mp4" }))).toBe(expected);
+    expect(await blobToBase64(new Blob([png]))).toBe(expected);
+    expect(await blobToBase64(new Blob([]))).toBe("");
+  });
+
+  it("encodes a slice of a larger blob independently", async () => {
+    vi.stubGlobal("FileReader", FakeFileReader);
+    const bytes = pattern(3000, 7);
+    const chunk = await blobToBase64(new Blob([bytes]).slice(1000, 2000));
+    expect(chunk).toBe(referenceBase64(bytes.subarray(1000, 2000)));
+  });
+
+  it("rejects with the reader's error", async () => {
+    vi.stubGlobal("FileReader", FakeFileReader);
+    FakeFileReader.failNext = true;
+    await expect(blobToBase64(new Blob([1, 2, 3].map(String)))).rejects.toThrow("NotReadableError");
+  });
+});
+
+describe("NATIVE_CHUNK_BYTES", () => {
+  it("keeps one base64 message in the single-digit megabytes", () => {
+    // Each chunk is decoded on its own (padding per chunk is fine), so the
+    // only constraint is the per-message size.
+    expect(NATIVE_CHUNK_BYTES).toBeGreaterThanOrEqual(1024 * 1024);
+    expect((NATIVE_CHUNK_BYTES * 4) / 3).toBeLessThan(8 * 1024 * 1024);
+  });
+});

--- a/src/lib/nativeBytes.ts
+++ b/src/lib/nativeBytes.ts
@@ -1,0 +1,61 @@
+/**
+ * Bytes across the native (Tauri) bridge, WebView → shell direction.
+ *
+ * Tauri's raw-body IPC (`invoke(cmd, bytes, { headers })`) only exists where
+ * the WebView can hand the shell a request body, and Android's WebView
+ * cannot: there Tauri falls back to `window.ipc.postMessage`, which
+ * serializes a `Uint8Array` payload as a JSON *array of numbers* (~4× the
+ * text, one heap value per byte on the Rust side) — and a raw-body command
+ * rejects it outright. That is how the first on-device export and video-store
+ * uploads failed on their very first chunk.
+ *
+ * So bulk uploads go as base64 strings in ordinary JSON args, in chunks; the
+ * shell decodes each in one pass (LapWing `video::job::decode_chunk`). The
+ * encoding is `FileReader.readAsDataURL`, which the browser does natively off
+ * the main thread — no per-byte JavaScript. Bytes coming *back* (raw
+ * `tauri::ipc::Response`) are unaffected; those work everywhere.
+ */
+
+/**
+ * Upload chunk size. Base64 inflates 4/3, so ~5.3 MB of text per message —
+ * big enough that the per-call bridge overhead is noise, small enough that
+ * the transient copies (JS string, Java string, Rust string, decoded bytes)
+ * stay modest on a phone.
+ */
+export const NATIVE_CHUNK_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Base64 (standard alphabet, padded) of raw bytes — pure JS, in 32 KB steps
+ * so `btoa` never sees a call-argument list the engine would refuse. The
+ * fallback for `blobToBase64` where there is no `FileReader`.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  const STEP = 0x8000;
+  let bin = "";
+  for (let i = 0; i < bytes.length; i += STEP) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + STEP));
+  }
+  return btoa(bin);
+}
+
+/** Base64 (standard alphabet, padded) of a Blob's bytes — no data-URL prefix. */
+export async function blobToBase64(blob: Blob): Promise<string> {
+  if (typeof FileReader === "undefined") {
+    return bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read bytes"));
+    reader.onload = () => {
+      const url = reader.result;
+      if (typeof url !== "string") {
+        reject(new Error("Failed to read bytes"));
+        return;
+      }
+      // "data:<mime>;base64,<payload>" — the mime varies with the Blob's type.
+      const comma = url.indexOf(",");
+      resolve(comma >= 0 ? url.slice(comma + 1) : "");
+    };
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/lib/nativeVideoExport.ts
+++ b/src/lib/nativeVideoExport.ts
@@ -10,7 +10,8 @@
  *      answers `unsupported:` (desktop stub) or doesn't know the command (an
  *      older shell), we report "unavailable" and the caller falls back to the
  *      in-WebView exporter.
- *   2. Stream the source MP4 in 8 MB raw-body chunks.
+ *   2. Stream the source MP4 in base64 chunks (`nativeBytes.ts` — Android's
+ *      bridge has no raw request bodies).
  *   3. Render transparent overlay layers with the SAME unified scene renderer
  *      the preview uses (plan 0023), at telemetry cadence (~15 Hz — overlays
  *      change with data, not video frames), PNG-encoded, timestamps relative
@@ -22,6 +23,7 @@
  */
 
 import { api } from "@/lib/loggers/native/ipc";
+import { blobToBase64, NATIVE_CHUNK_BYTES } from "@/lib/nativeBytes";
 import { isNativeApp } from "@/lib/platform";
 import {
   renderOverlaysToCanvas,
@@ -31,13 +33,15 @@ import {
 import type { ExportCallbacks, ExportContext, ExportSource } from "@/lib/videoExport";
 import type { ExportOptions } from "@/components/video-overlays/VideoExportDialog";
 
-const SOURCE_CHUNK_BYTES = 8 * 1024 * 1024;
 /** Overlay layer cadence. Data changes at sample rate (10–25 Hz); 15 Hz keeps
  * every visible change without paying video-rate layer generation. */
 const OVERLAY_FPS = 15;
 /** Share of the progress bar spent staging (source + layers); the transcode
  * gets the rest. */
 const STAGE_FRACTION = 0.35;
+/** Staging-progress weight of one overlay layer, in source bytes: rendering,
+ * PNG-encoding and shipping a 1080p layer costs about one chunk push. */
+const LAYER_UNITS = NATIVE_CHUNK_BYTES;
 
 export interface NativeExportController {
   cancel: () => void;
@@ -136,20 +140,18 @@ export async function startNativeVideoExport(
       const durMs = Math.max(0, Math.round((endTime - startTime) * 1000));
       const layerCount = overlays.length > 0 ? Math.ceil((durMs / 1000) * OVERLAY_FPS) : 0;
       // Weight staging progress by actual work: bytes for the source, one
-      // unit per overlay layer (a layer costs roughly a chunk's IPC trip).
-      const totalUnits = Math.max(1, sourceBytes + layerCount * SOURCE_CHUNK_BYTES * 0.01);
+      // chunk's worth per overlay layer.
+      const totalUnits = Math.max(1, sourceBytes + layerCount * LAYER_UNITS);
       let doneUnits = 0;
       const stageProgress = () =>
         callbacks.onProgress(Math.min(1, doneUnits / totalUnits) * STAGE_FRACTION);
 
-      for (let offset = 0; blob && offset < blob.size; offset += SOURCE_CHUNK_BYTES) {
+      for (let offset = 0; blob && offset < blob.size; offset += NATIVE_CHUNK_BYTES) {
         if (cancelled) return;
-        const end = Math.min(offset + SOURCE_CHUNK_BYTES, blob.size);
-        const bytes = new Uint8Array(await blob.slice(offset, end).arrayBuffer());
-        await invoke("video_export_push_source", bytes, {
-          headers: { "job-id": jobId, offset: String(offset) },
-        });
-        doneUnits += bytes.length;
+        const end = Math.min(offset + NATIVE_CHUNK_BYTES, blob.size);
+        const data = await blobToBase64(blob.slice(offset, end));
+        await invoke("video_export_push_source", { jobId, offset, data });
+        doneUnits += end - offset;
         stageProgress();
       }
 
@@ -172,11 +174,9 @@ export async function startNativeVideoExport(
           renderOverlaysToCanvas(ctx2d, targetW, targetH, overlays, renderCtx, histories, labels);
           const png = await new Promise<Blob | null>((res) => canvas.toBlob(res, "image/png"));
           if (!png) throw new Error("PNG encode failed");
-          const bytes = new Uint8Array(await png.arrayBuffer());
-          await invoke("video_export_push_overlay", bytes, {
-            headers: { "job-id": jobId, "t-ms": String(tMs) },
-          });
-          doneUnits += SOURCE_CHUNK_BYTES * 0.01;
+          const data = await blobToBase64(png);
+          await invoke("video_export_push_overlay", { jobId, tMs, data });
+          doneUnits += LAYER_UNITS;
           stageProgress();
         }
       }

--- a/src/lib/nativeVideoStore.ts
+++ b/src/lib/nativeVideoStore.ts
@@ -6,8 +6,8 @@
  * thing, so the LapWing shell keeps a copy of the video in app data instead
  * (`video_store_*` IPC; contract in LapWing `docs/video-pipeline.md`):
  *
- *   - `storeNativeVideo` copies the picked File across once (8 MB raw-body
- *     chunks) and seals it under the session's store key;
+ *   - `storeNativeVideo` copies the picked File across once (base64 chunks —
+ *     `nativeBytes.ts`) and seals it under the session's store key;
  *   - `getNativeStoredVideo` finds it again on the next open and returns a
  *     playable URL over the asset protocol — the <video> streams from disk;
  *   - the export bridge names the stored copy as its source (`sourceKey`) and
@@ -18,9 +18,8 @@
  */
 
 import { api } from "@/lib/loggers/native/ipc";
+import { blobToBase64, NATIVE_CHUNK_BYTES } from "@/lib/nativeBytes";
 import { isNativeApp } from "@/lib/platform";
-
-const CHUNK_BYTES = 8 * 1024 * 1024;
 
 export interface NativeStoredVideo {
   key: string;
@@ -78,12 +77,10 @@ export async function storeNativeVideo(
     if (isUnavailable(err)) return null;
     throw err;
   }
-  for (let offset = 0; offset < file.size; offset += CHUNK_BYTES) {
-    const end = Math.min(offset + CHUNK_BYTES, file.size);
-    const bytes = new Uint8Array(await file.slice(offset, end).arrayBuffer());
-    await invoke("video_store_push", bytes, {
-      headers: { "store-key": key, offset: String(offset) },
-    });
+  for (let offset = 0; offset < file.size; offset += NATIVE_CHUNK_BYTES) {
+    const end = Math.min(offset + NATIVE_CHUNK_BYTES, file.size);
+    const data = await blobToBase64(file.slice(offset, end));
+    await invoke("video_store_push", { key, offset, data });
     onProgress?.(end / file.size);
   }
   const info = await invoke<StoredVideoInfo>("video_store_finish", { key });

--- a/src/locales/de/video.json
+++ b/src/locales/de/video.json
@@ -58,6 +58,7 @@
     "saveToGallery": "In Galerie speichern",
     "saveToGalleryTitle": "Exportiertes Video in der Galerie des Telefons speichern (Movies/LapWing)",
     "savedToGallery": "In der Galerie gespeichert (Movies/LapWing)",
+    "failed": "Export fehlgeschlagen",
     "info": "Der Export spielt das Video in Echtzeit ab, um jedes Bild mit Overlays aufzunehmen. \"In App speichern\" legt das Video für das automatische Laden in der nächsten Session ab."
   },
   "settings": {

--- a/src/locales/en/video.json
+++ b/src/locales/en/video.json
@@ -57,6 +57,7 @@
     "saveToGallery": "Save to Gallery",
     "saveToGalleryTitle": "Save the exported video to your phone's gallery (Movies/LapWing)",
     "savedToGallery": "Saved to your gallery (Movies/LapWing)",
+    "failed": "Export failed",
     "info": "Video export plays through the video in real-time to capture each frame with overlays. \"Save to App\" stores the video for auto-loading next session."
   },
   "settings": {

--- a/src/locales/es/video.json
+++ b/src/locales/es/video.json
@@ -58,6 +58,7 @@
     "saveToGallery": "Guardar en la galería",
     "saveToGalleryTitle": "Guardar el vídeo exportado en la galería del teléfono (Movies/LapWing)",
     "savedToGallery": "Guardado en tu galería (Movies/LapWing)",
+    "failed": "Error al exportar",
     "info": "La exportación reproduce el vídeo en tiempo real para capturar cada fotograma con las superposiciones. \"Guardar en la app\" almacena el vídeo para cargarlo automáticamente la próxima sesión."
   },
   "settings": {

--- a/src/locales/fr/video.json
+++ b/src/locales/fr/video.json
@@ -58,6 +58,7 @@
     "saveToGallery": "Enregistrer dans la galerie",
     "saveToGalleryTitle": "Enregistrer la vidéo exportée dans la galerie du téléphone (Movies/LapWing)",
     "savedToGallery": "Enregistré dans votre galerie (Movies/LapWing)",
+    "failed": "Échec de l'exportation",
     "info": "L'export lit la vidéo en temps réel pour capturer chaque image avec les superpositions. \"Enregistrer dans l'app\" stocke la vidéo pour la charger automatiquement à la prochaine session."
   },
   "settings": {

--- a/src/locales/it/video.json
+++ b/src/locales/it/video.json
@@ -58,6 +58,7 @@
     "saveToGallery": "Salva nella galleria",
     "saveToGalleryTitle": "Salva il video esportato nella galleria del telefono (Movies/LapWing)",
     "savedToGallery": "Salvato nella galleria (Movies/LapWing)",
+    "failed": "Esportazione non riuscita",
     "info": "L'esportazione riproduce il video in tempo reale per catturare ogni fotogramma con le sovrapposizioni. \"Salva nell'app\" memorizza il video per caricarlo automaticamente alla prossima sessione."
   },
   "settings": {

--- a/src/locales/ja/video.json
+++ b/src/locales/ja/video.json
@@ -58,6 +58,7 @@
     "saveToGallery": "ギャラリーに保存",
     "saveToGalleryTitle": "書き出した動画をスマートフォンのギャラリーに保存します（Movies/LapWing）",
     "savedToGallery": "ギャラリーに保存しました（Movies/LapWing）",
+    "failed": "エクスポートに失敗しました",
     "info": "書き出しは動画をリアルタイムで再生し、各フレームをオーバーレイ付きで取り込みます。「アプリに保存」すると、次回セッションで自動読み込みされるよう動画が保存されます。"
   },
   "settings": {

--- a/src/locales/pt-BR/video.json
+++ b/src/locales/pt-BR/video.json
@@ -58,6 +58,7 @@
     "saveToGallery": "Salvar na galeria",
     "saveToGalleryTitle": "Salvar o vídeo exportado na galeria do celular (Movies/LapWing)",
     "savedToGallery": "Salvo na sua galeria (Movies/LapWing)",
+    "failed": "Falha na exportação",
     "info": "A exportação reproduz o vídeo em tempo real para capturar cada quadro com as sobreposições. \"Salvar no app\" armazena o vídeo para carregá-lo automaticamente na próxima sessão."
   },
   "settings": {


### PR DESCRIPTION
## Summary

Fixes the on-device report: **"I hit Save to Gallery, the app stutters for a second, nothing appears to happen."**

Root cause is in how bytes were handed to the shell. The upload commands took **raw invoke bodies** (`invoke(cmd, bytes, { headers })`), and Tauri never uses that IPC on Android — the WebView cannot expose a request body, so Tauri falls back to `window.ipc.postMessage` and serializes a `Uint8Array` payload as a JSON *array of numbers*, which the shell's raw-body commands rejected. The **first chunk of every export failed** (and every background copy into the shell's video store, so the remembered-video feature never engaged either). `VideoPlayer.onError` only logged to the console, so the dialog just went idle. The stutter was the WebView turning 8 MB of bytes into ~30 MB of JSON text.

What this PR changes:

- **`src/lib/nativeBytes.ts`** — bulk bytes now cross the bridge as **base64 strings in ordinary JSON args**, in 4 MB chunks: `blobToBase64` via `FileReader.readAsDataURL` (native, off the main thread), with a pure chunked-`btoa` fallback (`bytesToBase64`). Unit-tested, including the FileReader path through a stubbed reader.
- **`nativeVideoExport.ts` / `nativeVideoStore.ts`** send `{ jobId, offset | tMs, data }` / `{ key, offset, data }` to the matching LapWing shell (LapWing PR #41). Staging progress now weights one overlay layer like one chunk push, which is what it costs.
- **Export failures are visible**: `onError` toasts `export.failed` (7 locales) with the shell's message (destructive variant). The WebView exporter's errors get the same toast — no more silent return to idle.
- Plan 0024 doc gains a "follow-up 2" section; CHANGELOG under 4.2.0 → Fixed.

Web and desktop behaviour: unchanged apart from the new failure toast (the native bridge is only entered inside the shell).

## Related Issues

Companion to LapWing #41 (shell side: base64 push commands, gallery copy off the main thread, logcat logging under `LapWingVideo`). Requires that shell — an older one rejects the new args and the toast says so.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (3002 tests, +7)
- [x] `npm run build` succeeds (built as the LapWing submodule via `bun run tauri build --no-bundle --debug`)
- [x] Feature works **offline** (no new required network calls, except weather / map tiles / admin)
- [x] Docs updated where relevant (`README.md`, `CLAUDE.md`, Credits, `CHANGELOG.md`)
- [ ] For a new parser: registered in `datalogParser.ts`, added tests, updated the formats table — n/a

## Notes for Reviewers

On-device, with the LapWing #41 APK: load a video, wait a few seconds (the background copy into the store now actually completes), export with **Save to Gallery** — the progress bar should now walk through staging and transcode, then toast "Saved to your gallery" and the file appears under Movies/LapWing. If anything fails, the toast now carries the shell's reason, and `adb logcat -s LapWingVideo` has the native side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LzfeVvASfX1hefekpHPUq

---
_Generated by [Claude Code](https://claude.ai/code/session_013LzfeVvASfX1hefekpHPUq)_