### PR TITLE
plan 0025: stream an Insta360 camera recording into the player (native)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.2.0] - unreleased
 
 ### Added
+- **Stream video straight from an Insta360 camera (Android app).** *From
+  Insta360 camera* in the video panel joins the camera's Wi-Fi, lists its
+  recordings and plays one without downloading it — the app's native player
+  streams the file off the camera, and overlays, sync lock and scrubbing work
+  on it like any video. 360° recordings show as a flat view you point by
+  dragging the picture (compass button), then lock; a reset button returns
+  to straight ahead. Export isn't available for camera streams yet. Needs a
+  build of the app that bundles the Insta360 SDK; otherwise the button
+  doesn't appear. (Plan 0025; LapWing plan 0002.)
 - **Save to Gallery (Android app).** *Save to device* now lands the export in
   your phone's gallery under *Movies/LapWing* — previously it quietly went
   nowhere inside the app, because it used the browser's download path. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ src/
 │   ├── video-overlays/    # Video-export overlay system: registry + themes + per-widget *Overlay
 │   ├── RaceLineView.tsx   # Leaflet map: race line, speed heatmap, braking zones
 │   ├── TelemetryChart.tsx # Canvas speed/telemetry chart (simple mode)
-│   ├── VideoPlayer.tsx    # Synced video playback + overlay system (multi-chunk GoPro playlists via lib/videoPlaylist)
+│   ├── VideoPlayer.tsx    # Synced video playback + overlay system (multi-chunk GoPro playlists via lib/videoPlaylist); native: a camera stream renders as an <img> over lib/insta360's NativePlayerElement (plan 0025), with components/insta360/ (import dialog, 360° drag-to-point layer)
 │   └── …                  # FileImport, LoggerDownload (eager picker host) + LoggerPicker (image chooser) + DataloggerDownload (lazy web-BLE Fledgling flow) / DovesloggerDownload (lazy native-BLE Fledgling flow) / MyChronDownload (lazy native Wi-Fi flow), LapSnapshot*, …
 ├── hooks/                 # One concern each; Index.tsx orchestrates.
 │   ├── useSessionData     # Parses imported file → ParsedData
@@ -139,6 +139,7 @@ src/
 │   ├── loggers/           # ★ Generic LoggerConnection (listLogs/downloadLog/disconnect) + per-logger adapters — Fledgling=web BLE, mychron/=MyChron over native (Tauri) Wi-Fi IPC, doveslogger/=same Fledgling hardware over native (Tauri) BLE IPC (scan→connect→list→download), alfano/=Alfano over native (Tauri) Bluetooth-serial IPC (SKELETON: web-side seam only, Rust backend TBD — Bluetooth serial can't be reached in-browser so there's no web path); native/ipc.ts = shared kind-agnostic native IPC (all lazy; @tauri-apps/api dynamic-imported, native-only). progress.ts = transport-neutral formatters + computeProgress; errors.ts = pure error-prefix classifier + recovery-action table — every download flow renders classified, translated errors via the shared ErrorPanel, never raw backend strings. Native Fledgling firmware OTA (plan 0008): doveslogger/`loggerUpdateFirmware` + `firmwareInfo.ts` + `useNativeFirmwareUpdate`/`NativeFirmwarePanel`, reusing lib/ble/dfu; availability runtime-detected (→ docs/ble.md, docs/android.md)
 │   ├── speedHeatmap.ts / mapMarker.ts / brakingZones / gforceCalculation / …  # racing math
 │   ├── chartUtils / canvas2d / chartAxis / chartColors / videoExport / overlayCanvasRenderer  # charts/video
+│   ├── insta360/          # ★ Native-only Insta360 camera bridge (plan 0025): ipc (insta360_* over the lazy Tauri loader), nativePlayer (the camera stream as a <video>-shaped VideoSurface for useVideoSync), playerClock + pose (pure, tested)
 │   ├── videoPlaylist.ts   # ★ Pure GoPro chunked-video model: parse/order GH/GX/GP/GOPR chunk names, build a virtual timeline (cumulative offsets) + virtual↔local time mapping + planAudioSegments (export audio stitch). useVideoSync swaps the <video> src per chunk; a single file is a 1-chunk playlist
 │   ├── satelliteImagery.ts # ★ Esri Wayback parsing (online-only satellite imagery-date picker)
 │   ├── ble/               # Web Bluetooth DovesLapTimer protocol + firmware OTA (→ docs/ble.md)

--- a/docs/plans/0025-insta360-camera-preview.md
+++ b/docs/plans/0025-insta360-camera-preview.md
@@ -1,0 +1,82 @@
+# Insta360 camera preview — stream a recording off the camera into the player
+
+> Status: **LANDED (frontend), awaiting the shell's first SDK build.**
+> Companion: LapWing plan 0002 + `docs/insta360.md` (the `insta360_*` IPC
+> contract, the native plugin, and the build-with-SDK story). Native only —
+> the web app is untouched beyond a lazy chunk it never loads.
+
+## Why this exists
+
+The Android app is the place for camera integration (LapWing plan 0001).
+The first slice, by the owner's brief: connect to an Insta360 camera, get a
+recording into the player **without downloading it**, preview it with the
+overlays, and — for 360° footage — let the user point the view somewhere
+and lock it. Nothing fancier: no export, no GPS sync, no motion tracking.
+The constraint that shaped everything: reuse the existing video machinery.
+
+## What landed
+
+### `src/lib/insta360/`
+- `types.ts` — the IPC contract (`Insta360CameraFile`, `ViewPose`, player
+  request/info/events).
+- `ipc.ts` — thin wrappers over `insta360_*` through the shared lazy Tauri
+  loader; `insta360SdkInfo()` never throws and answers `available: false`
+  on the web, on the desktop stub, on an Android build without the SDK, and
+  on an older shell — the one gate the UI needs.
+- `pose.ts` — pure: yaw wrap / pitch+fov clamp, `dragToPose` (a full-width
+  drag sweeps the current horizontal FOV, scene follows the finger, vertical
+  FOV from the picture's aspect), `pinchToPose` (unused by the UI yet).
+- `playerClock.ts` — pure: the playhead the WebView reads synchronously,
+  extrapolated between the shell's ~10 Hz reports, snapped on seeks,
+  frozen on pause.
+- `nativePlayer.ts` — `NativePlayerElement`, the camera stream as a
+  `<video>`-shaped object: implements the `VideoSurface` subset
+  `useVideoSync` relies on (`currentTime`, `duration`, `paused`,
+  `play/pause`, `fastSeek`, the intrinsic size, `muted`, and the
+  `loadedmetadata`/`play`/`pause`/`seeked`/`ended`/`error` events) over
+  the IPC + a player-event channel. Seeks fire `seeked` when the shell
+  confirms or after a 600 ms watchdog, so the scrub pacer can't wedge.
+
+### `useVideoSync`
+- `videoRef` is now a `MutableRefObject<VideoSurface | null>` claimed by
+  whichever surface mounts — the `<video>` element (callback ref) or the
+  native player. The `requestVideoFrameCallback` paths became optional
+  (rAF fallback already existed). No sync/offset/scrub logic changed.
+- New `loadCameraRecording(file, size)`: opens the native player (waits for
+  a real duration if the shell didn't have one yet), builds a one-chunk
+  playlist on the MJPEG URL, clears export chunks and the store key (no file
+  behind a stream), remembers the sync record by file name. `unloadVideo()`
+  drops any source. `state.nativeSource` tells the player what it's showing.
+- Any source change (`revokeAllUrls`) closes the stream.
+
+### `VideoPlayer`
+- Empty state and toolbar get a *From Insta360 camera* button when the shell
+  reports the SDK; the lazy `Insta360ImportDialog` (Wi-Fi name prefix +
+  password — `88888888` is the factory default — connect, list newest first
+  with a 360° badge, Load; Disconnect ends a stream) sits next to the
+  recording picker.
+- A camera stream renders as an `<img>` where the `<video>` would be; the
+  overlay canvas, rect tracking and toolbar work unchanged. Export is
+  disabled for streams (no file to transcode yet); the mute toggle is
+  mirrored onto the native player.
+- 360° streams get two buttons: point (unlocks `Insta360ViewLayer`, a
+  drag surface under the overlays that turns finger deltas into absolute
+  poses, one in flight at a time, latest wins) / lock, and reset. Streams
+  start locked so a stray touch can't spin the view.
+
+## Deliberate limits
+
+- Preview only: no export, no download, no GPS sync; pose isn't persisted
+  and a stream isn't restored on reopen (the sync offset is, by file name).
+- No pinch/zoom in the UI yet (`pinchToPose` is ready).
+- Wi-Fi only; the SDK's USB/BLE transports are in the contract only.
+
+## Verification
+
+- Unit: `pose.test.ts`, `playerClock.test.ts`, `nativePlayer.test.ts`
+  (mocked bridge: request shape, play/pause clock, status resync, seek
+  hold-off + confirmation + watchdog, ended/error, muted, close-while-opening).
+  Full suite, `tsc -b`, eslint, `vite build` green.
+- On device (owner, with the SDK build): connect → list → load → overlays
+  on the stream → lock sync + offset → 360° point/lock/reset; see the
+  checklist in LapWing `docs/insta360.md`.

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,6 +1,6 @@
-import { memo, useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { memo, lazy, Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Play, Pause, Lock, Unlock, Plus, Minus, Video, Crosshair, Volume2, VolumeX, RefreshCw, Sliders, Move, Download } from "lucide-react";
+import { Play, Pause, Lock, Unlock, Plus, Minus, Video, Crosshair, Volume2, VolumeX, RefreshCw, Sliders, Move, Download, Camera, Compass, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -20,11 +20,33 @@ import { VideoExportDialog, ExportOptions } from "@/components/video-overlays/Vi
 import { OverlayCanvas } from "@/components/video-overlays/OverlayCanvas";
 import { startVideoExport, downloadBlob, ExportContext, ExportSource } from "@/lib/videoExport";
 import { startNativeVideoExport } from "@/lib/nativeVideoExport";
+import { isNativeApp } from "@/lib/platform";
+import { insta360SdkInfo } from "@/lib/insta360/ipc";
+import { NativePlayerElement } from "@/lib/insta360/nativePlayer";
+import { DEFAULT_VIEW_POSE } from "@/lib/insta360/types";
+import { Insta360ViewLayer } from "@/components/insta360/Insta360ViewLayer";
 import { toast } from "@/hooks/use-toast";
 import { computeBrakingGSeriesSG, gToBrakePercent } from "@/lib/brakingZones";
 import { saveSessionVideo, loadSessionVideo, deleteSessionVideo } from "@/lib/videoFileStorage";
 import { courseHasSectors } from "@/types/racing";
 import { findNearestIndex } from "@/components/video-overlays/overlayUtils";
+
+// Native-only camera import (plan 0025): lazy so the web bundle never carries it.
+const Insta360ImportDialog = lazy(() =>
+  import("@/components/insta360/Insta360ImportDialog").then((m) => ({ default: m.Insta360ImportDialog })),
+);
+
+/** Preview frame for a camera stream: the panel in device pixels, capped at 720p, even. */
+function previewSizeOf(el: HTMLElement | null): { width: number; height: number } {
+  const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+  let w = Math.round((el?.clientWidth ?? 0) * dpr);
+  let h = Math.round((el?.clientHeight ?? 0) * dpr);
+  if (w < 160 || h < 90) { w = 1280; h = 720; }
+  const scale = Math.min(1, 1280 / w, 720 / h);
+  w = Math.round(w * scale);
+  h = Math.round(h * scale);
+  return { width: w - (w % 2), height: h - (h % 2) };
+}
 
 interface VideoPlayerProps {
   state: VideoSyncState;
@@ -278,6 +300,55 @@ export const VideoPlayer = memo(function VideoPlayer({
   const [isExporting, setIsExporting] = useState(false);
   const [exportProgress, setExportProgress] = useState(0);
 
+  // Insta360 camera streaming (plan 0025) — offered only where the shell can
+  // do it; a 360° stream starts view-locked so a stray touch can't spin it.
+  const [insta360Available, setInsta360Available] = useState(false);
+  const [showCameraDialog, setShowCameraDialog] = useState(false);
+  const [viewLocked, setViewLocked] = useState(true);
+  const emptyStateRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isNativeApp()) return;
+    let alive = true;
+    void insta360SdkInfo().then((info) => { if (alive) setInsta360Available(info.available); });
+    return () => { alive = false; };
+  }, []);
+  const nativePlayer = state.nativeSource ? actions.videoRef.current : null;
+  const cameraPlayer = nativePlayer instanceof NativePlayerElement ? nativePlayer : null;
+  const is360Stream = !!state.nativeSource?.is360 && !!cameraPlayer;
+  useEffect(() => { setViewLocked(true); }, [state.nativeSource]);
+  // The <video> element's `muted` attribute has no equivalent on the stream;
+  // mirror the toggle onto the native player instead.
+  useEffect(() => { if (cameraPlayer) cameraPlayer.muted = isMuted; }, [cameraPlayer, isMuted]);
+  // A stream that dies (camera walked out of range) is reported, not silent.
+  useEffect(() => {
+    if (!cameraPlayer) return;
+    const onError = () => toast({ title: t("insta360.streamError"), description: cameraPlayer.lastError ?? undefined, variant: "destructive" });
+    cameraPlayer.addEventListener("error", onError);
+    return () => cameraPlayer.removeEventListener("error", onError);
+  }, [cameraPlayer, t]);
+  const handleCameraLoad = useCallback((file: Parameters<typeof actions.loadCameraRecording>[0]) => {
+    const size = previewSizeOf(videoAreaRef.current ?? emptyStateRef.current);
+    void actions.loadCameraRecording(file, size).catch((err) => {
+      toast({ title: t("insta360.openFailed"), description: String(err), variant: "destructive" });
+    });
+  }, [actions, t]);
+  const handleCameraDisconnected = useCallback(() => {
+    if (state.nativeSource) actions.unloadVideo();
+  }, [state.nativeSource, actions]);
+  const resetView = useCallback(() => {
+    void cameraPlayer?.setViewPose(DEFAULT_VIEW_POSE).catch(() => {});
+  }, [cameraPlayer]);
+  const cameraDialog = insta360Available ? (
+    <Suspense fallback={null}>
+      <Insta360ImportDialog
+        open={showCameraDialog}
+        onOpenChange={setShowCameraDialog}
+        onLoad={handleCameraLoad}
+        onDisconnected={handleCameraDisconnected}
+      />
+    </Suspense>
+  ) : null;
+
   // Keep refs for export context building
   const samplesRef = useRef(samples);
   samplesRef.current = samples;
@@ -462,7 +533,8 @@ export const VideoPlayer = memo(function VideoPlayer({
   // Export
   const handleExport = useCallback((options: ExportOptions) => {
     const video = actions.videoRef.current;
-    if (!video) return;
+    // Camera streams have no file behind them — nothing to transcode (v1).
+    if (!video || state.nativeSource || !(video instanceof HTMLVideoElement)) return;
     setIsExporting(true);
     setExportProgress(0);
 
@@ -568,7 +640,7 @@ export const VideoPlayer = memo(function VideoPlayer({
     // the whole `actions` object would invalidate handleExport on every parent
     // render, defeating the memoization.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actions.videoRef, state.videoFileName, state.syncOffsetMs, state.videoDuration, state.exportChunks, state.nativeStoredKey, overlays, buildExportRenderCtx, sessionFileName, selectedLapNumber, laps, t]);
+  }, [actions.videoRef, state.videoFileName, state.syncOffsetMs, state.videoDuration, state.exportChunks, state.nativeStoredKey, state.nativeSource, overlays, buildExportRenderCtx, sessionFileName, selectedLapNumber, laps, t]);
 
   // Download existing stored video
   const handleSaveExisting = useCallback(async () => {
@@ -590,18 +662,26 @@ export const VideoPlayer = memo(function VideoPlayer({
   // No video loaded
   if (!state.videoUrl) {
     return (
-      <div className="h-full flex flex-col items-center justify-center bg-muted/20 gap-4 px-6 text-center">
+      <div ref={emptyStateRef} className="h-full flex flex-col items-center justify-center bg-muted/20 gap-4 px-6 text-center">
         <Video className="w-12 h-12 text-muted-foreground/50" />
         <p className="text-muted-foreground text-sm">{t("player.noVideo")}</p>
         {state.videoFileName && (
           <p className="text-xs text-muted-foreground max-w-xs break-words">{t("player.lastUsed", { name: state.videoFileName })}</p>
         )}
-        <Button variant="outline" size="sm" onClick={actions.loadVideo} className="gap-2">
-          <Video className="w-4 h-4" /> {t("player.loadVideo")}
-        </Button>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button variant="outline" size="sm" onClick={actions.loadVideo} className="gap-2">
+            <Video className="w-4 h-4" /> {t("player.loadVideo")}
+          </Button>
+          {insta360Available && (
+            <Button variant="outline" size="sm" onClick={() => setShowCameraDialog(true)} className="gap-2">
+              <Camera className="w-4 h-4" /> {t("insta360.importButton")}
+            </Button>
+          )}
+        </div>
         <p className="text-xs text-muted-foreground/70 max-w-xs">{t("player.goproHint")}</p>
         <p className="text-xs text-muted-foreground/70 max-w-xs">{t("player.bulkSelectHint")}</p>
         <RecordingPicker state={state} actions={actions} />
+        {cameraDialog}
       </div>
     );
   }
@@ -610,15 +690,31 @@ export const VideoPlayer = memo(function VideoPlayer({
     <div className="h-full flex flex-col relative bg-black">
       {/* Video element + click target */}
       <div ref={videoAreaRef} className="flex-1 min-h-0 relative overflow-hidden" onClick={handleVideoClick}>
-        <video
-          ref={actions.videoRef}
-          src={state.videoUrl}
-          onLoadedMetadata={onLoadedMetadata}
-          className="w-full h-full object-contain"
-          playsInline
-          preload="auto"
-          muted={isMuted}
-        />
+        {state.nativeSource ? (
+          // A camera stream: the shell's player renders it and serves the
+          // frames as MJPEG; the surface object lives in actions.videoRef.
+          <img
+            src={state.videoUrl}
+            alt=""
+            draggable={false}
+            className="w-full h-full object-contain select-none"
+          />
+        ) : (
+          <video
+            ref={(el) => {
+              // Only a mounted element claims the surface; on unmount, release
+              // it only if it's still ours (a camera stream may have taken it).
+              if (el) actions.videoRef.current = el;
+              else if (actions.videoRef.current instanceof HTMLVideoElement) actions.videoRef.current = null;
+            }}
+            src={state.videoUrl}
+            onLoadedMetadata={onLoadedMetadata}
+            className="w-full h-full object-contain"
+            playsInline
+            preload="auto"
+            muted={isMuted}
+          />
+        )}
 
         {/* Hidden element that buffers the next chunk so the boundary swap is near-seamless. */}
         {state.preloadUrl && (
@@ -641,6 +737,13 @@ export const VideoPlayer = memo(function VideoPlayer({
                   ? t("player.videoEnded")
                   : t("player.noVideoForPortion")}
             </p>
+          </div>
+        )}
+
+        {/* 360° drag-to-point layer (camera streams), under the overlays */}
+        {is360Stream && cameraPlayer && videoRect && (
+          <div className="absolute" style={{ left: videoRect.left, top: videoRect.top, width: videoRect.width, height: videoRect.height }}>
+            <Insta360ViewLayer player={cameraPlayer} width={videoRect.width} height={videoRect.height} locked={viewLocked} />
           </div>
         )}
 
@@ -711,6 +814,7 @@ export const VideoPlayer = memo(function VideoPlayer({
 
       {/* Recording picker (multi-recording selection) */}
       <RecordingPicker state={state} actions={actions} />
+      {cameraDialog}
 
       {/* Unified bottom toolbar + progress bar */}
       <div
@@ -753,6 +857,23 @@ export const VideoPlayer = memo(function VideoPlayer({
             </>
           )}
 
+          {is360Stream && (
+            <>
+              <div className="w-px h-5 bg-white/20 mx-1" />
+              <Button
+                variant="ghost" size="icon"
+                className={`h-7 w-7 backdrop-blur-sm text-white ${!viewLocked ? "bg-amber-500/60 hover:bg-amber-500/40" : "bg-white/15 hover:bg-white/30"}`}
+                onClick={() => setViewLocked((v) => !v)}
+                title={viewLocked ? t("insta360.pointView") : t("insta360.lockView")}
+              >
+                {viewLocked ? <Compass className="w-3.5 h-3.5" /> : <Lock className="w-3.5 h-3.5" />}
+              </Button>
+              <Button variant="ghost" size="icon" className="h-7 w-7 bg-white/15 backdrop-blur-sm text-white hover:bg-white/30" onClick={resetView} title={t("insta360.resetView")}>
+                <RotateCcw className="w-3.5 h-3.5" />
+              </Button>
+            </>
+          )}
+
           <div className="flex-1" />
 
           {/* Overlay position lock */}
@@ -775,17 +896,16 @@ export const VideoPlayer = memo(function VideoPlayer({
             <Sliders className="w-3.5 h-3.5" />
           </Button>
 
-          {/* Export */}
-          {(
-            <Button
-              variant="ghost" size="icon"
-              className="h-7 w-7 bg-white/15 backdrop-blur-sm text-white hover:bg-white/30"
-              onClick={() => setShowExportDialog(true)}
-              title={t("player.exportVideo")}
-            >
-              <Download className="w-3.5 h-3.5" />
-            </Button>
-          )}
+          {/* Export (not for camera streams: there's no file to transcode yet) */}
+          <Button
+            variant="ghost" size="icon"
+            className="h-7 w-7 bg-white/15 backdrop-blur-sm text-white hover:bg-white/30 disabled:opacity-40"
+            onClick={() => setShowExportDialog(true)}
+            disabled={!!state.nativeSource}
+            title={state.nativeSource ? t("insta360.exportUnavailable") : t("player.exportVideo")}
+          >
+            <Download className="w-3.5 h-3.5" />
+          </Button>
         </div>
 
         {/* Progress bar row */}
@@ -814,6 +934,11 @@ export const VideoPlayer = memo(function VideoPlayer({
           <Button variant="ghost" size="icon" className="h-7 w-7 bg-white/15 backdrop-blur-sm text-white hover:bg-white/30" onClick={actions.loadVideo} title={t("player.replaceVideo")}>
             <RefreshCw className="w-3.5 h-3.5" />
           </Button>
+          {insta360Available && (
+            <Button variant="ghost" size="icon" className="h-7 w-7 bg-white/15 backdrop-blur-sm text-white hover:bg-white/30" onClick={() => setShowCameraDialog(true)} title={t("insta360.importButton")}>
+              <Camera className="w-3.5 h-3.5" />
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/insta360/Insta360ImportDialog.tsx
+++ b/src/components/insta360/Insta360ImportDialog.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Camera, Loader2, Unplug } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ErrorPanel } from "@/components/loggers/DownloadPanels";
+import { classifyLoggerError, loggerErrorKey } from "@/lib/loggers/errors";
+import {
+  insta360Connect,
+  insta360Disconnect,
+  insta360ListFiles,
+  insta360Status,
+} from "@/lib/insta360/ipc";
+import type { Insta360CameraFile, Insta360CameraInfo } from "@/lib/insta360/types";
+
+interface Insta360ImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Stream this recording into the player. */
+  onLoad: (file: Insta360CameraFile) => void;
+  /** The camera was disconnected on purpose — a stream from it is over. */
+  onDisconnected: () => void;
+}
+
+type Phase = "idle" | "connecting" | "listing" | "ready" | "error";
+
+/** Insta360 cameras ship with this hotspot password. */
+const DEFAULT_PASSPHRASE = "88888888";
+
+function formatDuration(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatWhen(file: Insta360CameraFile, locale: string): string | null {
+  const iso = file.recordedAt ?? (file.createdAtMs > 0 ? new Date(file.createdAtMs).toISOString() : null);
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" });
+}
+
+/**
+ * Connect to an Insta360 camera over its Wi-Fi hotspot and pick a recording
+ * to stream (plan 0025; LapWing `docs/insta360.md`). Native only — lazily
+ * loaded by VideoPlayer, never part of the web bundle's eager graph.
+ *
+ * Closing the dialog keeps the camera connected: the stream needs it. Only
+ * the explicit Disconnect button drops the camera (and the stream with it).
+ */
+export function Insta360ImportDialog({ open, onOpenChange, onLoad, onDisconnected }: Insta360ImportDialogProps) {
+  const { t, i18n } = useTranslation("video");
+  const { t: tLogger } = useTranslation("logger");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [camera, setCamera] = useState<Insta360CameraInfo | null>(null);
+  const [files, setFiles] = useState<Insta360CameraFile[]>([]);
+  const [error, setError] = useState<unknown>(null);
+  const [ssidPrefix, setSsidPrefix] = useState("");
+  const [passphrase, setPassphrase] = useState(DEFAULT_PASSPHRASE);
+
+  // Reopening the dialog while a camera is still connected (a stream is
+  // playing) resumes at the recording list.
+  useEffect(() => {
+    if (!open || phase !== "idle") return;
+    let alive = true;
+    void insta360Status()
+      .then(async (s) => {
+        if (!alive || !s.connected || !s.camera) return;
+        setCamera(s.camera);
+        setPhase("listing");
+        setFiles(await insta360ListFiles());
+        if (alive) setPhase("ready");
+      })
+      .catch(() => { /* not connected — stay idle */ });
+    return () => { alive = false; };
+  }, [open, phase]);
+
+  const connect = useCallback(async () => {
+    setError(null);
+    setPhase("connecting");
+    try {
+      const info = await insta360Connect("wifi", {
+        ssidPrefix: ssidPrefix.trim() || "*",
+        passphrase: passphrase || undefined,
+      });
+      setCamera(info);
+      setPhase("listing");
+      setFiles(await insta360ListFiles());
+      setPhase("ready");
+    } catch (err) {
+      setError(err);
+      setPhase("error");
+    }
+  }, [ssidPrefix, passphrase]);
+
+  const refresh = useCallback(async () => {
+    setPhase("listing");
+    try {
+      setFiles(await insta360ListFiles());
+      setPhase("ready");
+    } catch (err) {
+      setError(err);
+      setPhase("error");
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    await insta360Disconnect();
+    setCamera(null);
+    setFiles([]);
+    setPhase("idle");
+    onDisconnected();
+  }, [onDisconnected]);
+
+  const classified = error != null ? classifyLoggerError(error) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader className="flex-shrink-0">
+          <DialogTitle className="flex items-center gap-2">
+            <Camera className="w-5 h-5" />
+            {t("insta360.title")}
+          </DialogTitle>
+          <DialogDescription>{t("insta360.intro")}</DialogDescription>
+        </DialogHeader>
+
+        {phase === "idle" && (
+          <div className="flex flex-col gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="insta360-ssid">{t("insta360.ssidPrefix")}</Label>
+              <Input
+                id="insta360-ssid"
+                value={ssidPrefix}
+                onChange={(e) => setSsidPrefix(e.target.value)}
+                placeholder="X4"
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">{t("insta360.ssidPrefixHint")}</p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="insta360-pass">{t("insta360.passphrase")}</Label>
+              <Input
+                id="insta360-pass"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">{t("insta360.passphraseHint")}</p>
+            </div>
+            <Button onClick={() => void connect()} className="gap-2">
+              <Camera className="w-4 h-4" /> {t("insta360.connect")}
+            </Button>
+          </div>
+        )}
+
+        {(phase === "connecting" || phase === "listing") && (
+          <div className="flex flex-col items-center gap-3 py-6 text-sm text-muted-foreground">
+            <Loader2 className="w-6 h-6 animate-spin" />
+            {phase === "connecting" ? t("insta360.connecting") : t("insta360.listing")}
+          </div>
+        )}
+
+        {phase === "error" && classified && (
+          <ErrorPanel
+            message={tLogger(loggerErrorKey(classified.category))}
+            detail={classified.detail}
+            detailLabel={tLogger("errors.detailLabel")}
+            onCancel={() => { setError(null); setPhase("idle"); }}
+            cancelLabel={t("insta360.back")}
+            onAction={() => void connect()}
+            actionLabel={tLogger("errors.actionRetry")}
+          />
+        )}
+
+        {phase === "ready" && (
+          <div className="flex flex-col gap-3 min-h-0">
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="text-muted-foreground truncate">
+                {t("insta360.connected", { camera: camera?.cameraType ?? "Insta360" })}
+              </span>
+              <div className="flex gap-1 shrink-0">
+                <Button variant="ghost" size="sm" onClick={() => void refresh()}>{t("insta360.refresh")}</Button>
+                <Button variant="ghost" size="sm" onClick={() => void disconnect()} className="gap-1">
+                  <Unplug className="w-3.5 h-3.5" /> {t("insta360.disconnect")}
+                </Button>
+              </div>
+            </div>
+            {files.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">{t("insta360.noRecordings")}</p>
+            ) : (
+              <div className="flex-1 min-h-0 overflow-y-auto pr-1 scrollbar-thin flex flex-col gap-2">
+                {files.map((f) => {
+                  const when = formatWhen(f, i18n.language);
+                  return (
+                    <div key={f.id} className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium truncate">{f.name}</span>
+                          {f.is360 && (
+                            <span className="text-[10px] font-semibold rounded bg-primary/15 text-primary px-1.5 py-0.5">
+                              {t("insta360.badge360")}
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground font-mono">
+                          {when ? `${when} · ` : ""}{formatDuration(f.durationMs)}
+                          {f.width > 0 ? ` · ${f.width}×${f.height}` : ""}
+                          {f.segmentCount > 1 ? ` · ${t("insta360.segments", { count: f.segmentCount })}` : ""}
+                        </div>
+                      </div>
+                      <Button size="sm" onClick={() => { onLoad(f); onOpenChange(false); }}>
+                        {t("insta360.load")}
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/insta360/Insta360ViewLayer.tsx
+++ b/src/components/insta360/Insta360ViewLayer.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { NativePlayerElement } from "@/lib/insta360/nativePlayer";
+import { dragToPose } from "@/lib/insta360/pose";
+import { DEFAULT_VIEW_POSE, type ViewPose } from "@/lib/insta360/types";
+
+interface Insta360ViewLayerProps {
+  player: NativePlayerElement;
+  /** The on-screen picture size (CSS px) — drag distances are scaled to it. */
+  width: number;
+  height: number;
+  /** Locked: the layer is inert and touches fall through to the player UI. */
+  locked: boolean;
+}
+
+/**
+ * Drag-to-point for a 360° camera stream (plan 0025). The picture follows the
+ * finger the way every 360° player behaves; each move becomes an absolute
+ * pose the shell steers the native player to. Poses are sent one at a time —
+ * a drag that outruns the bridge collapses to the latest pose, never a
+ * queue. Pinch/zoom is deliberately not here yet.
+ */
+export function Insta360ViewLayer({ player, width, height, locked }: Insta360ViewLayerProps) {
+  const poseRef = useRef<ViewPose>(player.pose ?? DEFAULT_VIEW_POSE);
+  const lastRef = useRef<{ x: number; y: number } | null>(null);
+  const inflightRef = useRef(false);
+  const pendingRef = useRef<ViewPose | null>(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  const flush = useCallback(() => {
+    if (inflightRef.current) return;
+    const next = pendingRef.current;
+    if (!next) return;
+    pendingRef.current = null;
+    inflightRef.current = true;
+    void player
+      .setViewPose(next)
+      .then((reached) => { poseRef.current = reached; })
+      .catch(() => { /* the next drag re-sends; a closed player just ignores us */ })
+      .finally(() => {
+        inflightRef.current = false;
+        if (aliveRef.current) flush();
+      });
+  }, [player]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (locked) return;
+    e.preventDefault();
+    e.stopPropagation();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    lastRef.current = { x: e.clientX, y: e.clientY };
+    poseRef.current = player.pose ?? poseRef.current;
+  }, [locked, player]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const last = lastRef.current;
+    if (!last || locked) return;
+    const dx = e.clientX - last.x;
+    const dy = e.clientY - last.y;
+    lastRef.current = { x: e.clientX, y: e.clientY };
+    const next = dragToPose(pendingRef.current ?? poseRef.current, dx, dy, width, height);
+    pendingRef.current = next;
+    flush();
+  }, [locked, width, height, flush]);
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!lastRef.current) return;
+    lastRef.current = null;
+    e.stopPropagation();
+    flush();
+  }, [flush]);
+
+  if (locked) return null;
+  return (
+    <div
+      className="absolute inset-0 touch-none cursor-grab active:cursor-grabbing"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onClick={(e) => e.stopPropagation()}
+    />
+  );
+}

--- a/src/hooks/useVideoSync.ts
+++ b/src/hooks/useVideoSync.ts
@@ -3,6 +3,8 @@ import { GpsSample } from "@/types/racing";
 import { saveVideoSync, loadVideoSync, VideoSyncRecord, VideoSyncChunk } from "@/lib/videoStorage";
 import { loadSessionVideo, hasSessionVideo, deleteSessionVideo, getSessionVideoMeta, type StoredVideoMeta } from "@/lib/videoFileStorage";
 import { getNativeStoredVideo, storeNativeVideo } from "@/lib/nativeVideoStore";
+import { NativePlayerElement, type VideoSurface } from "@/lib/insta360/nativePlayer";
+import type { Insta360CameraFile } from "@/lib/insta360/types";
 import { isNativeApp } from "@/lib/platform";
 import type { OverlaySettings } from "@/components/video-overlays/types";
 import { DEFAULT_OVERLAY_SETTINGS } from "@/components/video-overlays/types";
@@ -22,6 +24,18 @@ interface UseVideoSyncOptions {
    * slave instead of being seek-scrubbed once per cursor tick (which stutters).
    */
   dataIsPlaying: boolean;
+}
+
+/**
+ * Native shell: a video streamed by the shell's own player (plan 0025 —
+ * Insta360 camera recordings) instead of a <video> element. The pixels are an
+ * MJPEG <img>; playback is driven through a NativePlayerElement that fills
+ * the same VideoSurface role as the element.
+ */
+export interface NativeVideoSource {
+  kind: "insta360";
+  file: Insta360CameraFile;
+  is360: boolean;
 }
 
 export interface VideoSyncState {
@@ -58,6 +72,8 @@ export interface VideoSyncState {
    * uses it as its source and skips the source upload.
    */
   nativeStoredKey: string | null;
+  /** The shell-streamed source behind `videoUrl`, or null for a file. */
+  nativeSource: NativeVideoSource | null;
   /**
    * When a selection holds several distinct recordings, the choices to prompt
    * the user with (null = no prompt pending). Each is one recording's display
@@ -68,6 +84,13 @@ export interface VideoSyncState {
 
 export interface VideoSyncActions {
   loadVideo: () => void;
+  /**
+   * Native shell: stream a recording straight off a connected Insta360
+   * camera (plan 0025). `size` is the preview frame in device pixels.
+   */
+  loadCameraRecording: (file: Insta360CameraFile, size: { width: number; height: number }) => Promise<void>;
+  /** Drop the current video (file or camera stream) without touching storage. */
+  unloadVideo: () => void;
   /** Load one of the prompted recordings; the others are dropped from memory. */
   chooseRecording: (key: string) => void;
   /** Dismiss the recording prompt without loading anything. */
@@ -84,7 +107,11 @@ export interface VideoSyncActions {
     updateOverlaySettings: (settings: OverlaySettings) => void;
     deleteStoredVideo: () => Promise<void>;
     refreshStoredMeta: () => Promise<void>;
-    videoRef: React.RefObject<HTMLVideoElement>;
+    /**
+     * The playback surface: the <video> element for files, the shell's
+     * NativePlayerElement for a camera stream. Assigned by whichever mounts.
+     */
+    videoRef: React.MutableRefObject<VideoSurface | null>;
     preloadVideoRef: React.RefObject<HTMLVideoElement>;
   }
 
@@ -108,10 +135,9 @@ interface ChunkEntry {
  * Seek a video element, preferring `fastSeek` (approximate seek, no decode
  * stall) when the browser supports it — smoother for scrub + drift correction.
  */
-function seekVideoElement(video: HTMLVideoElement, timeSec: number): void {
-  const fast = (video as HTMLVideoElement & { fastSeek?: (t: number) => void }).fastSeek;
+function seekVideoElement(video: VideoSurface, timeSec: number): void {
   try {
-    if (typeof fast === "function") fast.call(video, timeSec);
+    if (typeof video.fastSeek === "function") video.fastSeek(timeSec);
     else video.currentTime = timeSec;
   } catch { /* out-of-range time is clamped by the browser */ }
 }
@@ -140,8 +166,12 @@ function readVideoDuration(url: string): Promise<number> {
 }
 
 export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessionFileName, dataIsPlaying }: UseVideoSyncOptions) {
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<VideoSurface | null>(null);
   const preloadVideoRef = useRef<HTMLVideoElement>(null);
+  // The shell-streamed player behind a camera source (plan 0025); closed on
+  // every source change.
+  const nativePlayerRef = useRef<NativePlayerElement | null>(null);
+  const [nativeSource, setNativeSource] = useState<NativeVideoSource | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const onScrubRef = useRef(onScrub);
@@ -195,10 +225,17 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   const swapTokenRef = useRef(0);
   const pendingActionRef = useRef<{ seekLocalSec: number; play: boolean; token: number } | null>(null);
 
-  // Revoke every chunk URL and clear the playlist.
+  // Revoke every chunk URL, stop any camera stream, and clear the playlist.
   const revokeAllUrls = useCallback(() => {
     chunkUrlsRef.current.forEach((u) => { try { URL.revokeObjectURL(u); } catch { /* already revoked */ } });
     chunkUrlsRef.current = [];
+    const native = nativePlayerRef.current;
+    if (native) {
+      native.close();
+      nativePlayerRef.current = null;
+      if (videoRef.current === native) videoRef.current = null;
+    }
+    setNativeSource(null);
     setVideoUrl(null);
     setPreloadUrl(null);
   }, []);
@@ -426,6 +463,55 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     }
   }, [revokeAllUrls, applyPlaylist, persistSync, sessionFileName]);
 
+  // Native shell: stream a recording off a connected Insta360 camera. The
+  // shell's player streams the file over the camera's Wi-Fi and serves the
+  // pixels as MJPEG; NativePlayerElement stands in for the <video> so the
+  // sync machinery below is none the wiser. Camera streams are one chunk,
+  // aren't copied into the store, and can't be exported (v1).
+  const loadCameraRecording = useCallback(async (file: Insta360CameraFile, size: { width: number; height: number }) => {
+    revokeAllUrls();
+    const player = new NativePlayerElement(file, { width: size.width, height: size.height });
+    nativePlayerRef.current = player;
+    setNativeSource({ kind: "insta360", file, is360: file.is360 });
+    try {
+      const info = await player.open();
+      if (nativePlayerRef.current !== player) throw new Error("superseded");
+      // The playlist needs a real length; the shell knows it once the player
+      // is prepared, or reports it a moment later on `loadedmetadata`.
+      if (player.duration <= 0) {
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(done, 8000);
+          function done() { clearTimeout(timer); player.removeEventListener("loadedmetadata", done); resolve(); }
+          player.addEventListener("loadedmetadata", done);
+        });
+      }
+      if (nativePlayerRef.current !== player) throw new Error("superseded");
+      videoRef.current = player;
+      await applyPlaylist([{ name: file.name, url: info.streamUrl, durationSec: player.duration }]);
+      // No file behind the stream: nothing to export from, nothing to store.
+      setExportChunks([]);
+      setNativeStoredKey(null);
+      setFileHandle(null);
+      persistSync(syncOffsetMsRef.current, undefined, file.name);
+    } catch (e) {
+      player.close();
+      if (nativePlayerRef.current === player) {
+        nativePlayerRef.current = null;
+        setNativeSource(null);
+      }
+      if (!(e instanceof Error && e.message === "superseded")) throw e;
+    }
+  }, [revokeAllUrls, applyPlaylist, persistSync]);
+
+  const unloadVideo = useCallback(() => {
+    revokeAllUrls();
+    setVideoFileName(null);
+    setExportChunks([]);
+    playlistRef.current = null;
+    chunkHandlesRef.current = [];
+    chunkNamesRef.current = [];
+  }, [revokeAllUrls]);
+
   // Group a fresh selection into recordings: load straight away when there's
   // exactly one, otherwise stash them and prompt the user to pick.
   const handleSelectedFiles = useCallback(async (selected: SelectedVideoFile[]) => {
@@ -536,7 +622,8 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
   useEffect(() => {
     const video = videoRef.current;
     if (!video || !videoUrl) return;
-    if ("requestVideoFrameCallback" in video) {
+    const rvfc = video.requestVideoFrameCallback?.bind(video);
+    if (rvfc) {
       let lastTime = 0;
       let frameCount = 0;
       const frameTimes: number[] = [];
@@ -555,18 +642,18 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
           }
         }
         lastTime = metadata.mediaTime;
-        video.requestVideoFrameCallback(callback);
+        rvfc(callback);
       };
       const origPaused = video.paused;
       if (origPaused) {
         const onPlay = () => {
-          video.requestVideoFrameCallback(callback);
+          rvfc(callback);
           video.removeEventListener("play", onPlay);
         };
         video.addEventListener("play", onPlay);
         return () => video.removeEventListener("play", onPlay);
       } else {
-        video.requestVideoFrameCallback(callback);
+        rvfc(callback);
       }
     }
   }, [videoUrl]);
@@ -604,13 +691,14 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
         setIsOutOfRange(false);
       }
     };
-    if ("requestVideoFrameCallback" in video) {
+    const rvfc = video.requestVideoFrameCallback?.bind(video);
+    if (rvfc) {
       const callback = () => {
         if (!active) return;
         tick();
-        if (active) videoRef.current?.requestVideoFrameCallback(callback);
+        if (active) rvfc(callback);
       };
-      video.requestVideoFrameCallback(callback);
+      rvfc(callback);
     } else {
       let lastRaf = 0;
       const loop = (ts: number) => {
@@ -883,20 +971,21 @@ export function useVideoSync({ samples, allSamples, currentIndex, onScrub, sessi
     videoDuration, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, coverage, overlaySettings,
     hasStoredVideo: storedVideoAvailable,
     nativeStoredKey,
+    nativeSource,
     storedVideoMeta,
     pendingRecordings,
   }), [
     videoUrl, preloadUrl, videoFileName, isLocked, isPlaying, syncOffsetMs, syncRate, rateAnchorCount, fps,
     videoDuration, chunkCount, currentChunkIndex, exportChunks, isOutOfRange, coverage, overlaySettings,
-    storedVideoAvailable, nativeStoredKey, storedVideoMeta, pendingRecordings,
+    storedVideoAvailable, nativeStoredKey, nativeSource, storedVideoMeta, pendingRecordings,
   ]);
 
   const actions: VideoSyncActions = useMemo(() => ({
-    loadVideo, chooseRecording, cancelRecordingChoice, toggleLock, togglePlay, stepFrame, setSyncPoint,
+    loadVideo, loadCameraRecording, unloadVideo, chooseRecording, cancelRecordingChoice, toggleLock, togglePlay, stepFrame, setSyncPoint,
     addRateAnchor, clearRateAnchors,
     seekVideo, updateOverlaySettings, deleteStoredVideo: handleDeleteStoredVideo, refreshStoredMeta, videoRef, preloadVideoRef,
   }), [
-    loadVideo, chooseRecording, cancelRecordingChoice, toggleLock, togglePlay, stepFrame, setSyncPoint,
+    loadVideo, loadCameraRecording, unloadVideo, chooseRecording, cancelRecordingChoice, toggleLock, togglePlay, stepFrame, setSyncPoint,
     addRateAnchor, clearRateAnchors,
     seekVideo, updateOverlaySettings, handleDeleteStoredVideo, refreshStoredMeta,
   ]);

--- a/src/lib/insta360/ipc.ts
+++ b/src/lib/insta360/ipc.ts
@@ -1,0 +1,113 @@
+/**
+ * Insta360 IPC wrappers — native (Tauri) only, reached through the shared
+ * lazy loader in `loggers/native/ipc.ts` so `@tauri-apps/api` stays out of
+ * the web bundle. Errors are plain strings; an `unsupported:` prefix means
+ * this shell can't talk to a camera (desktop, or an Android build without
+ * the SDK) — `isInsta360Unavailable` folds a shell that predates these
+ * commands into the same answer.
+ */
+
+import { api } from "@/lib/loggers/native/ipc";
+import { isNativeApp } from "@/lib/platform";
+import type {
+  Insta360CameraFile,
+  Insta360CameraInfo,
+  Insta360CameraStatus,
+  Insta360ConnectType,
+  Insta360PlayerCommand,
+  Insta360PlayerEvent,
+  Insta360PlayerInfo,
+  Insta360PlayerRequest,
+  Insta360SdkInfo,
+  Insta360WifiJoin,
+  ViewPose,
+} from "./types";
+
+/** The stub sentinel, or a shell that doesn't know the command at all. */
+export function isInsta360Unavailable(err: unknown): boolean {
+  const msg = String(err);
+  return msg.startsWith("unsupported:") || /unknown|not found|not allowed/i.test(msg);
+}
+
+/**
+ * Whether this shell can talk to an Insta360 camera. Resolves `false` off
+ * native, on the stubs, and on a shell that predates the feature — never
+ * throws, so a UI can gate on it unconditionally.
+ */
+export async function insta360SdkInfo(): Promise<Insta360SdkInfo> {
+  if (!isNativeApp()) return { available: false, note: "not the native app" };
+  try {
+    const { invoke } = await api();
+    return await invoke<Insta360SdkInfo>("insta360_sdk_info");
+  } catch (err) {
+    return { available: false, note: String(err) };
+  }
+}
+
+export async function insta360Connect(
+  connectType: Insta360ConnectType,
+  wifi?: Insta360WifiJoin,
+): Promise<Insta360CameraInfo> {
+  const { invoke } = await api();
+  return invoke<Insta360CameraInfo>("insta360_connect", { connectType, wifi: wifi ?? null });
+}
+
+/** Best effort: never throws (already disconnected / old shell). */
+export async function insta360Disconnect(): Promise<void> {
+  try {
+    const { invoke } = await api();
+    await invoke("insta360_disconnect");
+  } catch {
+    // Nothing to tear down.
+  }
+}
+
+export async function insta360Status(): Promise<Insta360CameraStatus> {
+  const { invoke } = await api();
+  return invoke<Insta360CameraStatus>("insta360_status");
+}
+
+export async function insta360ListFiles(): Promise<Insta360CameraFile[]> {
+  const { invoke } = await api();
+  return invoke<Insta360CameraFile[]>("insta360_list_files");
+}
+
+/**
+ * Open the streaming player. Events keep arriving on `onEvent` until the
+ * player is closed; the returned info carries the MJPEG URL to show.
+ */
+export async function insta360OpenPlayer(
+  request: Insta360PlayerRequest,
+  onEvent: (e: Insta360PlayerEvent) => void,
+): Promise<Insta360PlayerInfo> {
+  const { invoke, Channel } = await api();
+  const channel = new Channel<Insta360PlayerEvent>();
+  channel.onmessage = onEvent;
+  return invoke<Insta360PlayerInfo>("insta360_player_open", { request, onEvent: channel });
+}
+
+export async function insta360PlayerControl(command: Insta360PlayerCommand): Promise<void> {
+  const { invoke } = await api();
+  await invoke("insta360_player_control", { command });
+}
+
+/** Point the 360° view; resolves to the pose the player actually reached. */
+export async function insta360SetView(pose: ViewPose): Promise<ViewPose> {
+  const { invoke } = await api();
+  return invoke<ViewPose>("insta360_player_set_view", { pose });
+}
+
+export async function insta360GetView(): Promise<ViewPose> {
+  const { invoke } = await api();
+  return invoke<ViewPose>("insta360_player_get_view");
+}
+
+/** Best effort: never throws. */
+export async function insta360ClosePlayer(): Promise<void> {
+  try {
+    const { invoke } = await api();
+    await invoke("insta360_player_close");
+  } catch {
+    // Already closed.
+  }
+}

--- a/src/lib/insta360/nativePlayer.test.ts
+++ b/src/lib/insta360/nativePlayer.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from "vitest";
+import { NativePlayerElement } from "./nativePlayer";
+import type { Insta360CameraFile, Insta360PlayerEvent, Insta360PlayerInfo } from "./types";
+
+const file: Insta360CameraFile = {
+  id: "abc",
+  name: "VID_20240315_101500_00_012",
+  urls: ["http://192.168.42.1/DCIM/Camera01/VID_20240315_101500_00_012.insv"],
+  lrvUrls: ["http://192.168.42.1/DCIM/Camera01/LRV_20240315_101500_01_012.lrv"],
+  is360: true,
+  durationMs: 30_000,
+  width: 5760,
+  height: 2880,
+  size: 1,
+  segmentCount: 1,
+  createdAtMs: 0,
+};
+
+function harness(overrides: Partial<Insta360PlayerInfo> = {}) {
+  let clock = 1000;
+  let emit: ((e: Insta360PlayerEvent) => void) | null = null;
+  const control = vi.fn(async () => {});
+  const close = vi.fn(async () => {});
+  const setView = vi.fn(async (p) => ({ ...p, yaw: p.yaw + 0.05 }));
+  const info: Insta360PlayerInfo = {
+    streamUrl: "http://127.0.0.1:4321/stream/tok",
+    width: 1280,
+    height: 720,
+    durationMs: 30_000,
+    is360: true,
+    ...overrides,
+  };
+  const open = vi.fn(async (_req, onEvent) => {
+    emit = onEvent;
+    return info;
+  });
+  const player = new NativePlayerElement(file, {
+    width: 1280,
+    height: 720,
+    now: () => clock,
+    open,
+    control,
+    close,
+    setView,
+  });
+  return {
+    player,
+    control,
+    close,
+    setView,
+    open,
+    tick: (ms: number) => {
+      clock += ms;
+    },
+    emit: (e: Insta360PlayerEvent) => emit?.(e),
+  };
+}
+
+describe("NativePlayerElement", () => {
+  it("opens with the request built from the file and reports metadata", async () => {
+    const h = harness();
+    const meta = vi.fn();
+    h.player.addEventListener("loadedmetadata", meta);
+    const info = await h.player.open();
+    expect(info.streamUrl).toContain("127.0.0.1");
+    expect(h.open).toHaveBeenCalledWith(
+      expect.objectContaining({ urls: file.urls, is360: true, preferProxy: true, width: 1280, height: 720, muted: true }),
+      expect.any(Function),
+    );
+    expect(meta).toHaveBeenCalledTimes(1);
+    expect(h.player.streamUrl).toBe(info.streamUrl);
+    expect(h.player.videoWidth).toBe(1280);
+    expect(h.player.duration).toBe(30);
+    expect(h.player.paused).toBe(true);
+    expect(h.player.is360).toBe(true);
+  });
+
+  it("play/pause drive the shell and the extrapolated clock", async () => {
+    const h = harness();
+    await h.player.open();
+    const events: string[] = [];
+    for (const t of ["play", "pause"]) h.player.addEventListener(t, () => events.push(t));
+    await h.player.play();
+    expect(h.control).toHaveBeenLastCalledWith({ action: "play" });
+    expect(h.player.paused).toBe(false);
+    h.tick(500);
+    expect(h.player.currentTime).toBeCloseTo(0.5, 6);
+    h.player.pause();
+    expect(h.control).toHaveBeenLastCalledWith({ action: "pause" });
+    h.tick(5000);
+    expect(h.player.currentTime).toBeCloseTo(0.5, 6);
+    expect(events).toEqual(["play", "pause"]);
+  });
+
+  it("native status reports resync the clock", async () => {
+    const h = harness();
+    await h.player.open();
+    await h.player.play();
+    h.tick(100);
+    h.emit({ kind: "status", positionMs: 4000, durationMs: 31_000, playing: true });
+    h.tick(250);
+    expect(h.player.currentTime).toBeCloseTo(4.25, 6);
+    expect(h.player.duration).toBe(31);
+  });
+
+  it("seeks snap the clock, hold off status reports, and fire seeked on confirmation", async () => {
+    const h = harness();
+    await h.player.open();
+    const seeked = vi.fn();
+    h.player.addEventListener("seeked", seeked);
+    h.player.currentTime = 12;
+    expect(h.control).toHaveBeenLastCalledWith({ action: "seek", positionMs: 12_000, precise: true });
+    expect(h.player.currentTime).toBe(12);
+    h.emit({ kind: "status", positionMs: 3000, durationMs: 30_000, playing: false });
+    expect(h.player.currentTime).toBe(12);
+    h.emit({ kind: "seeked", positionMs: 12_010, durationMs: 30_000, playing: false });
+    expect(seeked).toHaveBeenCalledTimes(1);
+    expect(h.player.currentTime).toBeCloseTo(12.01, 6);
+    h.player.fastSeek(3);
+    expect(h.control).toHaveBeenLastCalledWith({ action: "seek", positionMs: 3000, precise: false });
+  });
+
+  it("a seek the shell never confirms still settles via the watchdog", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = harness();
+      await h.player.open();
+      const seeked = vi.fn();
+      h.player.addEventListener("seeked", seeked);
+      h.player.currentTime = 1;
+      vi.advanceTimersByTime(700);
+      expect(seeked).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ended pauses and fires ended; error fires error", async () => {
+    const h = harness();
+    await h.player.open();
+    await h.player.play();
+    const seen: string[] = [];
+    for (const t of ["pause", "ended", "error"]) h.player.addEventListener(t, () => seen.push(t));
+    h.emit({ kind: "ended", positionMs: 30_000, durationMs: 30_000, playing: false });
+    expect(h.player.paused).toBe(true);
+    expect(h.player.currentTime).toBe(30);
+    h.emit({ kind: "error", positionMs: 0, durationMs: 0, playing: false, message: "boom" });
+    expect(seen).toEqual(["pause", "ended", "error"]);
+    expect(h.player.lastError).toBe("boom");
+  });
+
+  it("muted toggles reach the shell only after open, and only on change", async () => {
+    const h = harness();
+    h.player.muted = false;
+    expect(h.control).not.toHaveBeenCalled();
+    await h.player.open();
+    h.player.muted = false;
+    expect(h.control).not.toHaveBeenCalled();
+    h.player.muted = true;
+    expect(h.control).toHaveBeenLastCalledWith({ action: "setMuted", muted: true });
+  });
+
+  it("setViewPose records the pose the player reached", async () => {
+    const h = harness();
+    await h.player.open();
+    const reached = await h.player.setViewPose({ yaw: 10, pitch: 0, fov: 90 });
+    expect(reached.yaw).toBeCloseTo(10.05, 6);
+    expect(h.player.pose).toEqual(reached);
+  });
+
+  it("close releases the native player once and ignores later events", async () => {
+    const h = harness();
+    await h.player.open();
+    h.player.close();
+    h.player.close();
+    expect(h.close).toHaveBeenCalledTimes(1);
+    expect(h.player.streamUrl).toBeNull();
+    h.emit({ kind: "status", positionMs: 9000, durationMs: 30_000, playing: true });
+    expect(h.player.currentTime).toBe(0);
+    await h.player.play();
+    expect(h.control).not.toHaveBeenCalledWith({ action: "play" });
+  });
+
+  it("a player closed while opening releases the shell's player", async () => {
+    let resolveOpen: ((i: Insta360PlayerInfo) => void) | null = null;
+    const close = vi.fn(async () => {});
+    const player = new NativePlayerElement(file, {
+      width: 640,
+      height: 360,
+      open: () => new Promise((res) => { resolveOpen = res; }),
+      control: async () => {},
+      close,
+      setView: async (p) => p,
+    });
+    const opening = player.open();
+    player.close();
+    resolveOpen!({ streamUrl: "u", width: 640, height: 360, durationMs: 1, is360: false });
+    await expect(opening).rejects.toThrow(/closed/);
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/src/lib/insta360/nativePlayer.ts
+++ b/src/lib/insta360/nativePlayer.ts
@@ -1,0 +1,290 @@
+/**
+ * The camera stream as a `<video>`-shaped object (plan 0025).
+ *
+ * `useVideoSync` and `VideoPlayer` drive playback through the subset of the
+ * `HTMLVideoElement` API in [`VideoSurface`]: `currentTime`, `duration`,
+ * `paused`, `play()/pause()`, the intrinsic size, and the `loadedmetadata` /
+ * `play` / `pause` / `seeked` / `ended` events. A camera recording streamed
+ * by the shell's native player has no DOM element behind it — its pixels are
+ * an MJPEG `<img>` — so this adapter implements that same surface over the
+ * `insta360_*` IPC and a player-event channel, and the sync code stays
+ * source-agnostic.
+ *
+ * Time is served from a [`PlayerClock`] (extrapolated between native
+ * reports) so reads are synchronous; seeks fire `seeked` when native confirms
+ * or after a watchdog, so the scrub pacer can never wedge.
+ */
+
+import {
+  insta360ClosePlayer,
+  insta360OpenPlayer,
+  insta360PlayerControl,
+  insta360SetView,
+} from "./ipc";
+import { PlayerClock } from "./playerClock";
+import type {
+  Insta360CameraFile,
+  Insta360PlayerEvent,
+  Insta360PlayerInfo,
+  Insta360PlayerRequest,
+  ViewPose,
+} from "./types";
+
+/** The part of `HTMLVideoElement` the video-sync machinery relies on. */
+export interface VideoSurface {
+  currentTime: number;
+  readonly duration: number;
+  readonly paused: boolean;
+  readonly videoWidth: number;
+  readonly videoHeight: number;
+  muted: boolean;
+  play(): Promise<void>;
+  pause(): void;
+  fastSeek?(time: number): void;
+  requestVideoFrameCallback?(cb: (now: number, metadata: VideoFrameCallbackMetadata) => void): number;
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+export interface NativePlayerOptions {
+  /** Preview frame size — the WebView's panel size in device pixels. */
+  width: number;
+  height: number;
+  fps?: number;
+  quality?: number;
+  preferProxy?: boolean;
+  muted?: boolean;
+  /** Injectable for tests. */
+  now?: () => number;
+  open?: typeof insta360OpenPlayer;
+  control?: typeof insta360PlayerControl;
+  close?: typeof insta360ClosePlayer;
+  setView?: typeof insta360SetView;
+}
+
+const SEEK_WATCHDOG_MS = 600;
+
+/**
+ * One native player session over one camera recording. `open()` starts the
+ * stream; `close()` (or opening another) stops it. Extends `EventTarget` so
+ * the sync hook's `addEventListener` calls work unchanged.
+ */
+export class NativePlayerElement extends EventTarget implements VideoSurface {
+  readonly file: Insta360CameraFile;
+  private readonly opts: Required<Pick<NativePlayerOptions, "width" | "height" | "fps" | "quality" | "preferProxy" | "muted">>;
+  private readonly now: () => number;
+  private readonly ipc: {
+    open: typeof insta360OpenPlayer;
+    control: typeof insta360PlayerControl;
+    close: typeof insta360ClosePlayer;
+    setView: typeof insta360SetView;
+  };
+  private readonly clock = new PlayerClock();
+  private info: Insta360PlayerInfo | null = null;
+  private closed = false;
+  private mutedState: boolean;
+  private seekTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingSeek = false;
+  /** Last pose the player confirmed (360° only). */
+  pose: ViewPose | null = null;
+  /** The shell's message for the last `error` event. */
+  lastError: string | null = null;
+
+  constructor(file: Insta360CameraFile, options: NativePlayerOptions) {
+    super();
+    this.file = file;
+    this.opts = {
+      width: options.width,
+      height: options.height,
+      fps: options.fps ?? 20,
+      quality: options.quality ?? 70,
+      preferProxy: options.preferProxy ?? true,
+      muted: options.muted ?? true,
+    };
+    this.mutedState = this.opts.muted;
+    this.now = options.now ?? (() => performance.now());
+    this.ipc = {
+      open: options.open ?? insta360OpenPlayer,
+      control: options.control ?? insta360PlayerControl,
+      close: options.close ?? insta360ClosePlayer,
+      setView: options.setView ?? insta360SetView,
+    };
+    this.clock.setDuration(file.durationMs);
+  }
+
+  /** The MJPEG URL to show, once opened. */
+  get streamUrl(): string | null {
+    return this.info?.streamUrl ?? null;
+  }
+
+  get is360(): boolean {
+    return this.info?.is360 ?? this.file.is360;
+  }
+
+  // ── VideoSurface ────────────────────────────────────────────────────────
+
+  get currentTime(): number {
+    return this.clock.positionAt(this.now()) / 1000;
+  }
+
+  set currentTime(sec: number) {
+    this.seekTo(sec, true);
+  }
+
+  fastSeek(sec: number): void {
+    this.seekTo(sec, false);
+  }
+
+  get duration(): number {
+    return this.clock.duration / 1000;
+  }
+
+  get paused(): boolean {
+    return !this.clock.isPlaying;
+  }
+
+  get videoWidth(): number {
+    return this.info?.width ?? this.opts.width;
+  }
+
+  get videoHeight(): number {
+    return this.info?.height ?? this.opts.height;
+  }
+
+  get muted(): boolean {
+    return this.mutedState;
+  }
+
+  set muted(m: boolean) {
+    if (this.mutedState === m) return;
+    this.mutedState = m;
+    if (this.info) void this.ipc.control({ action: "setMuted", muted: m }).catch(() => {});
+  }
+
+  async play(): Promise<void> {
+    if (this.closed || !this.info) return;
+    this.clock.setPlaying(true, this.now());
+    this.dispatchEvent(new Event("play"));
+    await this.ipc.control({ action: "play" });
+  }
+
+  pause(): void {
+    if (this.closed || !this.info) return;
+    this.clock.setPlaying(false, this.now());
+    this.dispatchEvent(new Event("pause"));
+    void this.ipc.control({ action: "pause" }).catch(() => {});
+  }
+
+  // ── lifecycle ───────────────────────────────────────────────────────────
+
+  /** Start the stream. Resolves once the shell has the player prepared. */
+  async open(): Promise<Insta360PlayerInfo> {
+    const request: Insta360PlayerRequest = {
+      urls: this.file.urls,
+      is360: this.file.is360,
+      preferProxy: this.opts.preferProxy,
+      width: this.opts.width,
+      height: this.opts.height,
+      fps: this.opts.fps,
+      quality: this.opts.quality,
+      muted: this.opts.muted,
+    };
+    const info = await this.ipc.open(request, (e) => this.onEvent(e));
+    if (this.closed) {
+      void this.ipc.close();
+      throw new Error("player closed while opening");
+    }
+    this.info = info;
+    this.clock.setDuration(info.durationMs);
+    // Metadata is known as soon as the player is prepared; a later `opened`
+    // event may refine the duration (fired again then, harmlessly).
+    this.dispatchEvent(new Event("loadedmetadata"));
+    return info;
+  }
+
+  /** Stop the stream and release the native player (idempotent). */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.clearSeekTimer();
+    if (this.info) void this.ipc.close();
+    this.info = null;
+    this.clock.setPlaying(false, this.now());
+  }
+
+  /** Point the 360° view. Resolves to the pose the player reached. */
+  async setViewPose(pose: ViewPose): Promise<ViewPose> {
+    if (this.closed || !this.info) return pose;
+    const reached = await this.ipc.setView(pose);
+    this.pose = reached;
+    return reached;
+  }
+
+  // ── internals ───────────────────────────────────────────────────────────
+
+  private seekTo(sec: number, precise: boolean): void {
+    if (this.closed || !this.info) return;
+    const positionMs = Math.max(0, Math.round(sec * 1000));
+    this.clock.seek(positionMs, this.now());
+    this.pendingSeek = true;
+    this.armSeekWatchdog();
+    void this.ipc.control({ action: "seek", positionMs, precise }).catch(() => this.settleSeek());
+  }
+
+  private armSeekWatchdog(): void {
+    this.clearSeekTimer();
+    this.seekTimer = setTimeout(() => this.settleSeek(), SEEK_WATCHDOG_MS);
+  }
+
+  private clearSeekTimer(): void {
+    if (this.seekTimer) clearTimeout(this.seekTimer);
+    this.seekTimer = null;
+  }
+
+  private settleSeek(): void {
+    this.clearSeekTimer();
+    if (!this.pendingSeek) return;
+    this.pendingSeek = false;
+    this.dispatchEvent(new Event("seeked"));
+  }
+
+  private onEvent(e: Insta360PlayerEvent): void {
+    if (this.closed) return;
+    const now = this.now();
+    switch (e.kind) {
+      case "opened":
+        this.clock.report({ positionMs: e.positionMs, durationMs: e.durationMs, playing: e.playing }, now);
+        this.dispatchEvent(new Event("loadedmetadata"));
+        break;
+      case "status": {
+        // A seek in flight owns the position until it lands.
+        if (!this.pendingSeek) {
+          this.clock.report({ positionMs: e.positionMs, durationMs: e.durationMs, playing: e.playing }, now);
+        } else {
+          this.clock.setDuration(e.durationMs);
+        }
+        this.dispatchEvent(new Event("timeupdate"));
+        break;
+      }
+      case "seeked":
+        this.clock.report({ positionMs: e.positionMs, durationMs: e.durationMs, playing: e.playing }, now);
+        this.settleSeek();
+        break;
+      case "ended":
+        this.clock.report({ positionMs: e.positionMs, durationMs: e.durationMs, playing: false }, now);
+        this.dispatchEvent(new Event("pause"));
+        this.dispatchEvent(new Event("ended"));
+        break;
+      case "error":
+        this.clock.setPlaying(false, now);
+        this.lastError = e.message ?? "player error";
+        this.dispatchEvent(new Event("error"));
+        break;
+      case "closed":
+        this.closed = true;
+        this.info = null;
+        this.clearSeekTimer();
+        break;
+    }
+  }
+}

--- a/src/lib/insta360/playerClock.test.ts
+++ b/src/lib/insta360/playerClock.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { PlayerClock } from "./playerClock";
+
+describe("PlayerClock", () => {
+  it("holds the last report while paused", () => {
+    const c = new PlayerClock();
+    c.report({ positionMs: 5000, durationMs: 60000, playing: false }, 1000);
+    expect(c.positionAt(9000)).toBe(5000);
+    expect(c.duration).toBe(60000);
+    expect(c.isPlaying).toBe(false);
+  });
+
+  it("extrapolates while playing and clamps at the duration", () => {
+    const c = new PlayerClock();
+    c.report({ positionMs: 5000, durationMs: 6000, playing: true }, 1000);
+    expect(c.positionAt(1500)).toBe(5500);
+    expect(c.positionAt(9000)).toBe(6000);
+  });
+
+  it("never runs backwards on a stale clock", () => {
+    const c = new PlayerClock();
+    c.report({ positionMs: 5000, durationMs: 60000, playing: true }, 1000);
+    expect(c.positionAt(500)).toBe(5000);
+  });
+
+  it("snaps on seek and keeps a zero duration open-ended", () => {
+    const c = new PlayerClock();
+    c.report({ positionMs: 0, durationMs: 0, playing: true }, 0);
+    c.seek(20000, 100);
+    expect(c.positionAt(1100)).toBe(21000);
+    c.setDuration(20500);
+    expect(c.positionAt(2100)).toBe(20500);
+    c.seek(-5, 3000);
+    expect(c.positionAt(3000)).toBe(0);
+  });
+
+  it("freezes the extrapolated position when pausing", () => {
+    const c = new PlayerClock();
+    c.report({ positionMs: 1000, durationMs: 60000, playing: true }, 0);
+    c.setPlaying(false, 700);
+    expect(c.positionAt(5000)).toBe(1700);
+    c.setPlaying(true, 6000);
+    expect(c.positionAt(6250)).toBe(1950);
+  });
+
+  it("ignores a zero duration in a report but accepts a real one later", () => {
+    const c = new PlayerClock();
+    c.report({ positionMs: 10, durationMs: 0, playing: false }, 0);
+    expect(c.duration).toBe(0);
+    c.report({ positionMs: 10, durationMs: 42, playing: false }, 1);
+    expect(c.duration).toBe(42);
+    c.report({ positionMs: 12, durationMs: 0, playing: false }, 2);
+    expect(c.duration).toBe(42);
+  });
+});

--- a/src/lib/insta360/playerClock.ts
+++ b/src/lib/insta360/playerClock.ts
@@ -1,0 +1,63 @@
+/**
+ * A playhead the WebView can read synchronously — pure.
+ *
+ * The native player reports its position in bursts (~10 Hz while playing);
+ * everything in the video-sync machinery expects `currentTime` to be
+ * readable any time, like a `<video>`. The clock keeps the last report and
+ * extrapolates while playing, clamped to the duration, and snaps on seeks.
+ */
+
+export interface PlayerReport {
+  positionMs: number;
+  durationMs: number;
+  playing: boolean;
+}
+
+export class PlayerClock {
+  private positionMs = 0;
+  private durationMs = 0;
+  private playing = false;
+  private reportedAt = 0;
+
+  /** Fold in a native report taken at `nowMs` (monotonic, e.g. performance.now()). */
+  report(r: PlayerReport, nowMs: number): void {
+    this.positionMs = Math.max(0, r.positionMs);
+    if (r.durationMs > 0) this.durationMs = r.durationMs;
+    this.playing = r.playing;
+    this.reportedAt = nowMs;
+  }
+
+  /** The WebView asked for a seek; assume it lands until native says otherwise. */
+  seek(positionMs: number, nowMs: number): void {
+    this.positionMs = Math.max(0, positionMs);
+    if (this.durationMs > 0) this.positionMs = Math.min(this.positionMs, this.durationMs);
+    this.reportedAt = nowMs;
+  }
+
+  setPlaying(playing: boolean, nowMs: number): void {
+    // Freeze the extrapolated position at the transition so pausing doesn't
+    // jump back to the last report.
+    this.positionMs = this.positionAt(nowMs);
+    this.playing = playing;
+    this.reportedAt = nowMs;
+  }
+
+  setDuration(durationMs: number): void {
+    if (durationMs > 0) this.durationMs = durationMs;
+  }
+
+  get isPlaying(): boolean {
+    return this.playing;
+  }
+
+  get duration(): number {
+    return this.durationMs;
+  }
+
+  /** Extrapolated position at `nowMs`, ms. */
+  positionAt(nowMs: number): number {
+    if (!this.playing) return this.positionMs;
+    const p = this.positionMs + Math.max(0, nowMs - this.reportedAt);
+    return this.durationMs > 0 ? Math.min(p, this.durationMs) : p;
+  }
+}

--- a/src/lib/insta360/pose.test.ts
+++ b/src/lib/insta360/pose.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { dragToPose, normalizePose, pinchToPose, samePose, wrapYaw, FOV_MAX, FOV_MIN, PITCH_MAX } from "./pose";
+import { DEFAULT_VIEW_POSE } from "./types";
+
+describe("wrapYaw", () => {
+  it("wraps into [-180, 180)", () => {
+    expect(wrapYaw(0)).toBe(0);
+    expect(wrapYaw(180)).toBe(-180);
+    expect(wrapYaw(-180)).toBe(-180);
+    expect(wrapYaw(190)).toBe(-170);
+    expect(wrapYaw(-190)).toBe(170);
+    expect(wrapYaw(720)).toBe(0);
+  });
+});
+
+describe("normalizePose", () => {
+  it("clamps pitch and fov, wraps yaw", () => {
+    expect(normalizePose({ yaw: 370, pitch: 120, fov: 5 })).toEqual({ yaw: 10, pitch: PITCH_MAX, fov: FOV_MIN });
+    expect(normalizePose({ yaw: -190, pitch: -120, fov: 900 })).toEqual({ yaw: 170, pitch: -PITCH_MAX, fov: FOV_MAX });
+  });
+  it("falls back to the default for non-finite parts", () => {
+    expect(normalizePose({ yaw: NaN, pitch: Infinity, fov: -Infinity })).toEqual(DEFAULT_VIEW_POSE);
+  });
+  it("leaves an in-range pose alone", () => {
+    const p = { yaw: -45.5, pitch: 10.25, fov: 75 };
+    expect(normalizePose(p)).toEqual(p);
+  });
+});
+
+describe("dragToPose", () => {
+  const pose = { yaw: 0, pitch: 0, fov: 90 };
+  it("a full-width drag sweeps the field of view, scene following the finger", () => {
+    const p = dragToPose(pose, 1280, 0, 1280, 720);
+    expect(p.yaw).toBeCloseTo(-90, 5);
+    expect(p.pitch).toBe(0);
+  });
+  it("vertical drag uses the picture's aspect ratio", () => {
+    const p = dragToPose(pose, 0, 720, 1280, 720);
+    // vfov = 90 * 720/1280 = 50.625°, a full-height drag sweeps it.
+    expect(p.pitch).toBeCloseTo(50.625, 5);
+  });
+  it("scales with the current fov (zoomed in = finer)", () => {
+    const wide = dragToPose(pose, 100, 0, 1000, 500);
+    const narrow = dragToPose({ ...pose, fov: 45 }, 100, 0, 1000, 500);
+    expect(Math.abs(narrow.yaw)).toBeCloseTo(Math.abs(wide.yaw) / 2, 5);
+  });
+  it("wraps and clamps the result", () => {
+    const p = dragToPose({ yaw: -170, pitch: 80, fov: 90 }, -400, 400, 1000, 500);
+    expect(p.yaw).toBeCloseTo(-170 + 36 - 360 + 360, 5); // -134
+    expect(p.pitch).toBe(PITCH_MAX);
+  });
+  it("ignores a degenerate picture size", () => {
+    expect(dragToPose(pose, 50, 50, 0, 0)).toEqual(pose);
+  });
+});
+
+describe("pinchToPose", () => {
+  it("zooms in for scale > 1 and out for scale < 1, within limits", () => {
+    expect(pinchToPose({ yaw: 0, pitch: 0, fov: 90 }, 2).fov).toBe(45);
+    expect(pinchToPose({ yaw: 0, pitch: 0, fov: 90 }, 0.5).fov).toBe(FOV_MAX);
+    expect(pinchToPose({ yaw: 0, pitch: 0, fov: 40 }, 10).fov).toBe(FOV_MIN);
+  });
+  it("ignores a bad scale", () => {
+    const p = { yaw: 1, pitch: 2, fov: 60 };
+    expect(pinchToPose(p, 0)).toEqual(p);
+    expect(pinchToPose(p, NaN)).toEqual(p);
+  });
+});
+
+describe("samePose", () => {
+  it("treats yaw modulo 360 and sub-tenth-degree differences as equal", () => {
+    expect(samePose({ yaw: 179.95, pitch: 0, fov: 90 }, { yaw: -180, pitch: 0.05, fov: 90.05 })).toBe(true);
+    expect(samePose({ yaw: 0, pitch: 0, fov: 90 }, { yaw: 1, pitch: 0, fov: 90 })).toBe(false);
+  });
+});

--- a/src/lib/insta360/pose.ts
+++ b/src/lib/insta360/pose.ts
@@ -1,0 +1,68 @@
+/**
+ * 360° view-pose math — pure. The preview is a flat reframe of the sphere;
+ * the user points it by dragging the picture (like the Insta360 app), and
+ * the shell applies the resulting pose to the native player.
+ */
+
+import { DEFAULT_VIEW_POSE, type ViewPose } from "./types";
+
+export const FOV_MIN = 30;
+export const FOV_MAX = 150;
+export const PITCH_MAX = 90;
+
+/** Degrees into [-180, 180). */
+export function wrapYaw(deg: number): number {
+  let y = ((deg % 360) + 360) % 360;
+  if (y >= 180) y -= 360;
+  return y;
+}
+
+/** Yaw wrapped, pitch and fov clamped; non-finite parts fall back to default. */
+export function normalizePose(pose: ViewPose): ViewPose {
+  return {
+    yaw: Number.isFinite(pose.yaw) ? wrapYaw(pose.yaw) : DEFAULT_VIEW_POSE.yaw,
+    pitch: Number.isFinite(pose.pitch)
+      ? Math.max(-PITCH_MAX, Math.min(PITCH_MAX, pose.pitch))
+      : DEFAULT_VIEW_POSE.pitch,
+    fov: Number.isFinite(pose.fov) ? Math.max(FOV_MIN, Math.min(FOV_MAX, pose.fov)) : DEFAULT_VIEW_POSE.fov,
+  };
+}
+
+/**
+ * Turn a drag across the picture into a new pose. A drag of the picture's
+ * full width sweeps the current horizontal field of view, so the scene
+ * follows the finger 1:1 at any zoom — the convention every 360° player
+ * uses. Dragging right shows what's to the left (yaw decreases); dragging
+ * down shows what's above (pitch increases).
+ */
+export function dragToPose(
+  pose: ViewPose,
+  dxPx: number,
+  dyPx: number,
+  pictureWidthPx: number,
+  pictureHeightPx: number,
+): ViewPose {
+  if (pictureWidthPx <= 0 || pictureHeightPx <= 0) return normalizePose(pose);
+  const degPerPxX = pose.fov / pictureWidthPx;
+  // Vertical fov follows the aspect ratio of the flat picture.
+  const vFov = pose.fov * (pictureHeightPx / pictureWidthPx);
+  const degPerPxY = vFov / pictureHeightPx;
+  return normalizePose({
+    yaw: pose.yaw - dxPx * degPerPxX,
+    pitch: pose.pitch + dyPx * degPerPxY,
+    fov: pose.fov,
+  });
+}
+
+/** Pinch: scale > 1 zooms in (narrower fov). */
+export function pinchToPose(pose: ViewPose, scale: number): ViewPose {
+  if (!Number.isFinite(scale) || scale <= 0) return normalizePose(pose);
+  return normalizePose({ ...pose, fov: pose.fov / scale });
+}
+
+/** True when two poses are visually the same (sub-tenth-degree). */
+export function samePose(a: ViewPose, b: ViewPose): boolean {
+  return (
+    Math.abs(wrapYaw(a.yaw - b.yaw)) < 0.1 && Math.abs(a.pitch - b.pitch) < 0.1 && Math.abs(a.fov - b.fov) < 0.1
+  );
+}

--- a/src/lib/insta360/types.ts
+++ b/src/lib/insta360/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Insta360 camera bridge — the contract with the LapWing shell's `insta360_*`
+ * commands (LapWing `docs/insta360.md`, plan 0025 here). Native-only: the
+ * web build never imports the IPC module, only these types.
+ */
+
+export type Insta360ConnectType = "wifi" | "usb" | "ble";
+
+export interface Insta360SdkInfo {
+  /** False on the desktop stub and on Android builds made without the SDK. */
+  available: boolean;
+  cameraSdkVersion?: string;
+  mediaSdkVersion?: string;
+  note?: string;
+}
+
+export interface Insta360CameraInfo {
+  cameraType: string;
+  serial?: string;
+  firmware?: string;
+  connectType: Insta360ConnectType;
+  httpPrefix?: string;
+}
+
+export interface Insta360CameraStatus {
+  connected: boolean;
+  camera?: Insta360CameraInfo;
+  batteryPercent?: number;
+  charging?: boolean;
+  sdCard?: string;
+}
+
+/** One recording on the camera, as the shell lists it (newest first). */
+export interface Insta360CameraFile {
+  id: string;
+  name: string;
+  urls: string[];
+  lrvUrls: string[];
+  is360: boolean;
+  durationMs: number;
+  width: number;
+  height: number;
+  size: number;
+  segmentCount: number;
+  /** Camera-local wall clock, `YYYY-MM-DDTHH:MM:SS`, when known. */
+  recordedAt?: string;
+  createdAtMs: number;
+  cameraType?: string;
+}
+
+/** Wi-Fi join request forwarded to the shell's network binder. */
+export interface Insta360WifiJoin {
+  ssid?: string;
+  /** `"*"` = let the OS picker show every network. */
+  ssidPrefix?: string;
+  passphrase?: string;
+}
+
+export interface Insta360PlayerRequest {
+  urls: string[];
+  is360: boolean;
+  preferProxy: boolean;
+  width: number;
+  height: number;
+  fps: number;
+  quality: number;
+  muted: boolean;
+}
+
+export interface Insta360PlayerInfo {
+  /** Loopback MJPEG stream for an `<img>`. */
+  streamUrl: string;
+  width: number;
+  height: number;
+  durationMs: number;
+  is360: boolean;
+}
+
+export type Insta360PlayerCommand =
+  | { action: "play" }
+  | { action: "pause" }
+  | { action: "seek"; positionMs: number; precise: boolean }
+  | { action: "setMuted"; muted: boolean };
+
+/** Degrees. Yaw wraps in [-180, 180), pitch ±90, fov 30–150. */
+export interface ViewPose {
+  yaw: number;
+  pitch: number;
+  fov: number;
+}
+
+export const DEFAULT_VIEW_POSE: ViewPose = { yaw: 0, pitch: 0, fov: 90 };
+
+export type Insta360PlayerEventKind = "opened" | "status" | "seeked" | "ended" | "error" | "closed";
+
+export interface Insta360PlayerEvent {
+  kind: Insta360PlayerEventKind;
+  positionMs: number;
+  durationMs: number;
+  playing: boolean;
+  message?: string;
+}

--- a/src/locales/de/video.json
+++ b/src/locales/de/video.json
@@ -101,5 +101,31 @@
     "lapTime": "RUNDENZEIT",
     "delta": "DELTA",
     "best": "BESTE {{lap}}"
+  },
+  "insta360": {
+    "importButton": "Von Insta360-Kamera",
+    "title": "Insta360-Kamera",
+    "intro": "Mit dem WLAN der Kamera verbinden und eine Aufnahme direkt von der Kamera streamen – es wird nichts heruntergeladen.",
+    "ssidPrefix": "WLAN-Name der Kamera beginnt mit",
+    "ssidPrefixHint": "Leer lassen, um aus allen Netzwerken in Reichweite zu wählen.",
+    "passphrase": "WLAN-Passwort",
+    "passphraseHint": "Insta360-Kameras werden mit 88888888 ausgeliefert.",
+    "connect": "Verbinden",
+    "connecting": "Verbindung zur Kamera wird hergestellt…",
+    "listing": "Aufnahmen der Kamera werden gelesen…",
+    "connected": "Verbunden: {{camera}}",
+    "refresh": "Aktualisieren",
+    "disconnect": "Trennen",
+    "noRecordings": "Keine Videoaufnahmen auf der Kamera.",
+    "load": "Laden",
+    "badge360": "360°",
+    "segments": "{{count}} Segmente",
+    "back": "Zurück",
+    "pointView": "360°-Ansicht ausrichten – Bild ziehen",
+    "lockView": "360°-Ansicht sperren",
+    "resetView": "360°-Ansicht zurücksetzen",
+    "exportUnavailable": "Export ist für Kamera-Streams noch nicht verfügbar",
+    "openFailed": "Kamera-Stream konnte nicht gestartet werden",
+    "streamError": "Der Kamera-Stream wurde unterbrochen"
   }
 }

--- a/src/locales/en/video.json
+++ b/src/locales/en/video.json
@@ -100,5 +100,31 @@
     "lapTime": "LAP TIME",
     "delta": "DELTA",
     "best": "BEST {{lap}}"
+  },
+  "insta360": {
+    "importButton": "From Insta360 camera",
+    "title": "Insta360 camera",
+    "intro": "Join the camera's Wi-Fi and stream a recording straight from the camera — nothing is downloaded.",
+    "ssidPrefix": "Camera Wi-Fi name starts with",
+    "ssidPrefixHint": "Leave empty to pick from every network in range.",
+    "passphrase": "Wi-Fi password",
+    "passphraseHint": "Insta360 cameras ship with 88888888.",
+    "connect": "Connect",
+    "connecting": "Connecting to the camera…",
+    "listing": "Reading the camera's recordings…",
+    "connected": "Connected: {{camera}}",
+    "refresh": "Refresh",
+    "disconnect": "Disconnect",
+    "noRecordings": "No video recordings on the camera.",
+    "load": "Load",
+    "badge360": "360°",
+    "segments": "{{count}} segments",
+    "back": "Back",
+    "pointView": "Point the 360° view — drag the picture",
+    "lockView": "Lock the 360° view",
+    "resetView": "Reset the 360° view",
+    "exportUnavailable": "Export isn't available for camera streams yet",
+    "openFailed": "Couldn't start the camera stream",
+    "streamError": "The camera stream stopped"
   }
 }

--- a/src/locales/es/video.json
+++ b/src/locales/es/video.json
@@ -101,5 +101,31 @@
     "lapTime": "TIEMPO DE VUELTA",
     "delta": "DELTA",
     "best": "MEJOR {{lap}}"
+  },
+  "insta360": {
+    "importButton": "Desde cámara Insta360",
+    "title": "Cámara Insta360",
+    "intro": "Conéctate al Wi-Fi de la cámara y reproduce una grabación directamente desde ella; no se descarga nada.",
+    "ssidPrefix": "El nombre del Wi-Fi de la cámara empieza por",
+    "ssidPrefixHint": "Déjalo vacío para elegir entre todas las redes al alcance.",
+    "passphrase": "Contraseña del Wi-Fi",
+    "passphraseHint": "Las cámaras Insta360 vienen con 88888888.",
+    "connect": "Conectar",
+    "connecting": "Conectando con la cámara…",
+    "listing": "Leyendo las grabaciones de la cámara…",
+    "connected": "Conectado: {{camera}}",
+    "refresh": "Actualizar",
+    "disconnect": "Desconectar",
+    "noRecordings": "No hay grabaciones de vídeo en la cámara.",
+    "load": "Cargar",
+    "badge360": "360°",
+    "segments": "{{count}} segmentos",
+    "back": "Atrás",
+    "pointView": "Orientar la vista 360°: arrastra la imagen",
+    "lockView": "Bloquear la vista 360°",
+    "resetView": "Restablecer la vista 360°",
+    "exportUnavailable": "La exportación aún no está disponible para transmisiones de cámara",
+    "openFailed": "No se pudo iniciar la transmisión de la cámara",
+    "streamError": "La transmisión de la cámara se detuvo"
   }
 }

--- a/src/locales/fr/video.json
+++ b/src/locales/fr/video.json
@@ -101,5 +101,31 @@
     "lapTime": "TEMPS AU TOUR",
     "delta": "DELTA",
     "best": "MEILLEUR {{lap}}"
+  },
+  "insta360": {
+    "importButton": "Depuis une caméra Insta360",
+    "title": "Caméra Insta360",
+    "intro": "Rejoignez le Wi-Fi de la caméra et diffusez un enregistrement directement depuis celle-ci — rien n'est téléchargé.",
+    "ssidPrefix": "Le nom Wi-Fi de la caméra commence par",
+    "ssidPrefixHint": "Laissez vide pour choisir parmi tous les réseaux à portée.",
+    "passphrase": "Mot de passe Wi-Fi",
+    "passphraseHint": "Les caméras Insta360 sont livrées avec 88888888.",
+    "connect": "Connecter",
+    "connecting": "Connexion à la caméra…",
+    "listing": "Lecture des enregistrements de la caméra…",
+    "connected": "Connecté : {{camera}}",
+    "refresh": "Actualiser",
+    "disconnect": "Déconnecter",
+    "noRecordings": "Aucun enregistrement vidéo sur la caméra.",
+    "load": "Charger",
+    "badge360": "360°",
+    "segments": "{{count}} segments",
+    "back": "Retour",
+    "pointView": "Orienter la vue 360° — faites glisser l'image",
+    "lockView": "Verrouiller la vue 360°",
+    "resetView": "Réinitialiser la vue 360°",
+    "exportUnavailable": "L'export n'est pas encore disponible pour les flux caméra",
+    "openFailed": "Impossible de démarrer le flux de la caméra",
+    "streamError": "Le flux de la caméra s'est arrêté"
   }
 }

--- a/src/locales/it/video.json
+++ b/src/locales/it/video.json
@@ -101,5 +101,31 @@
     "lapTime": "TEMPO SUL GIRO",
     "delta": "DELTA",
     "best": "MIGLIORE {{lap}}"
+  },
+  "insta360": {
+    "importButton": "Da fotocamera Insta360",
+    "title": "Fotocamera Insta360",
+    "intro": "Collegati al Wi-Fi della fotocamera e riproduci una registrazione direttamente da essa: non viene scaricato nulla.",
+    "ssidPrefix": "Il nome Wi-Fi della fotocamera inizia con",
+    "ssidPrefixHint": "Lascia vuoto per scegliere tra tutte le reti nel raggio d'azione.",
+    "passphrase": "Password Wi-Fi",
+    "passphraseHint": "Le fotocamere Insta360 hanno di fabbrica 88888888.",
+    "connect": "Connetti",
+    "connecting": "Connessione alla fotocamera…",
+    "listing": "Lettura delle registrazioni della fotocamera…",
+    "connected": "Connesso: {{camera}}",
+    "refresh": "Aggiorna",
+    "disconnect": "Disconnetti",
+    "noRecordings": "Nessuna registrazione video sulla fotocamera.",
+    "load": "Carica",
+    "badge360": "360°",
+    "segments": "{{count}} segmenti",
+    "back": "Indietro",
+    "pointView": "Orienta la vista 360°: trascina l'immagine",
+    "lockView": "Blocca la vista 360°",
+    "resetView": "Reimposta la vista 360°",
+    "exportUnavailable": "L'esportazione non è ancora disponibile per gli stream della fotocamera",
+    "openFailed": "Impossibile avviare lo stream della fotocamera",
+    "streamError": "Lo stream della fotocamera si è interrotto"
   }
 }

--- a/src/locales/ja/video.json
+++ b/src/locales/ja/video.json
@@ -101,5 +101,31 @@
     "lapTime": "ラップタイム",
     "delta": "デルタ",
     "best": "ベスト {{lap}}"
+  },
+  "insta360": {
+    "importButton": "Insta360 カメラから",
+    "title": "Insta360 カメラ",
+    "intro": "カメラの Wi-Fi に接続し、録画をカメラから直接ストリーミングします。ダウンロードは行いません。",
+    "ssidPrefix": "カメラの Wi-Fi 名の先頭",
+    "ssidPrefixHint": "空欄にすると、範囲内のすべてのネットワークから選べます。",
+    "passphrase": "Wi-Fi パスワード",
+    "passphraseHint": "Insta360 カメラの初期値は 88888888 です。",
+    "connect": "接続",
+    "connecting": "カメラに接続中…",
+    "listing": "カメラの録画を読み込み中…",
+    "connected": "接続済み: {{camera}}",
+    "refresh": "更新",
+    "disconnect": "切断",
+    "noRecordings": "カメラに動画の録画がありません。",
+    "load": "読み込む",
+    "badge360": "360°",
+    "segments": "{{count}} セグメント",
+    "back": "戻る",
+    "pointView": "360° ビューの向きを変える — 画像をドラッグ",
+    "lockView": "360° ビューをロック",
+    "resetView": "360° ビューをリセット",
+    "exportUnavailable": "カメラストリームの書き出しはまだ利用できません",
+    "openFailed": "カメラストリームを開始できませんでした",
+    "streamError": "カメラストリームが停止しました"
   }
 }

--- a/src/locales/pt-BR/video.json
+++ b/src/locales/pt-BR/video.json
@@ -101,5 +101,31 @@
     "lapTime": "TEMPO DE VOLTA",
     "delta": "DELTA",
     "best": "MELHOR {{lap}}"
+  },
+  "insta360": {
+    "importButton": "Da câmera Insta360",
+    "title": "Câmera Insta360",
+    "intro": "Conecte-se ao Wi-Fi da câmera e transmita uma gravação direto da câmera — nada é baixado.",
+    "ssidPrefix": "O nome do Wi-Fi da câmera começa com",
+    "ssidPrefixHint": "Deixe em branco para escolher entre todas as redes ao alcance.",
+    "passphrase": "Senha do Wi-Fi",
+    "passphraseHint": "As câmeras Insta360 vêm de fábrica com 88888888.",
+    "connect": "Conectar",
+    "connecting": "Conectando à câmera…",
+    "listing": "Lendo as gravações da câmera…",
+    "connected": "Conectado: {{camera}}",
+    "refresh": "Atualizar",
+    "disconnect": "Desconectar",
+    "noRecordings": "Nenhuma gravação de vídeo na câmera.",
+    "load": "Carregar",
+    "badge360": "360°",
+    "segments": "{{count}} segmentos",
+    "back": "Voltar",
+    "pointView": "Apontar a visão 360° — arraste a imagem",
+    "lockView": "Travar a visão 360°",
+    "resetView": "Redefinir a visão 360°",
+    "exportUnavailable": "A exportação ainda não está disponível para transmissões da câmera",
+    "openFailed": "Não foi possível iniciar a transmissão da câmera",
+    "streamError": "A transmissão da câmera parou"
   }
 }


### PR DESCRIPTION
## Summary

Android app only: a **From Insta360 camera** button in the video panel joins the camera's Wi-Fi, lists its recordings and plays one **without downloading it** — the LapWing shell's native player streams the file off the camera and serves the frames as an MJPEG stream that the player shows in an `<img>`. Overlays, sync lock, offset tools and scrubbing work on the stream unchanged. 360° recordings get a drag-to-point layer with lock/reset. Export is disabled for streams (no file behind them yet).

How it stays source-agnostic: `NativePlayerElement` (`src/lib/insta360/nativePlayer.ts`) implements the `<video>` subset `useVideoSync` relies on (`currentTime`/`duration`/`paused`/`play`/`pause`/`fastSeek`, intrinsic size, `loadedmetadata`/`play`/`pause`/`seeked`/`ended`/`error`) over the shell's `insta360_*` IPC and a player-event channel — an extrapolated clock between the shell's ~10 Hz reports and a seek watchdog so the scrub pacer can't wedge. `videoRef` became a `MutableRefObject<VideoSurface | null>` claimed by whichever surface mounts; no sync/offset/scrub logic changed.

- `src/lib/insta360/`: `types`, `ipc` (over the shared lazy Tauri loader; `insta360SdkInfo()` never throws and gates the UI), `pose` + `playerClock` (pure, tested), `nativePlayer` (tested with a mocked bridge)
- `src/components/insta360/`: `Insta360ImportDialog` (Wi-Fi name prefix + password, connect, list newest-first with 360° badge, load, disconnect; lazy, native only), `Insta360ViewLayer` (drag → absolute pose, one in flight, latest wins)
- `useVideoSync`: `loadCameraRecording`, `unloadVideo`, `state.nativeSource`; `VideoPlayer`: `<img>` surface, camera buttons, 360° lock/reset, export disabled for streams, mute mirrored to the native player
- `video` namespace strings in all seven languages; `docs/plans/0025-insta360-camera-preview.md`; `CHANGELOG.md`; `CLAUDE.md` map

Companion: LapWing branch `claude/insta360-android-sdk-y79wvk` (plan 0002 — `tauri-plugin-insta360` + `docs/insta360.md`, the IPC contract). The web build is untouched beyond a lazy chunk it never loads.

## Related Issues

LapWing plan 0001 (Phase 3), LapWing plan 0002.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New file-format parser
- [ ] Refactor / reusability improvement
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (3029 tests)
- [x] `npm run build` succeeds
- [x] Feature works **offline** (talks only to the camera on its own hotspot)
- [x] Docs updated where relevant (`CLAUDE.md`, `CHANGELOG.md`, plan 0025)
- [ ] For a new parser: n/a

## Notes for Reviewers

- Needs the LapWing shell built **with** the Insta360 SDK to light up; on the web, the desktop shell, or an Android build without the SDK the button doesn't appear (`insta360_sdk_info` → `available: false`). Nothing here has run against a real camera yet — the shell's SDK build is the next step (LapWing `docs/insta360.md` has the on-device checklist).
- Deliberate v1 limits: preview only (no export/download/GPS sync), pose not persisted, a stream isn't restored on session reopen (the sync offset is, by file name), no pinch/zoom yet (`pinchToPose` is ready), Wi-Fi transport only.
- After merging, bump LapWing's `dataviewer` submodule to the BETA tip so the native build picks this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sK5Tb8pa8bZEtUNiprYiH

---
_Generated by [Claude Code](https://claude.ai/code/session_019sK5Tb8pa8bZEtUNiprYiH)_